### PR TITLE
Remove pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
     "delay": 2500,
     "ext": "js,json,html,njk"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
   "lint-staged": {
     "*.{ts,js,css}": [
       "prettier --write",

--- a/package.json
+++ b/package.json
@@ -72,11 +72,6 @@
     "delay": 2500,
     "ext": "js,json,html,njk"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged && tsc && npm test"
-    }
-  },
   "lint-staged": {
     "*.{ts,js,css}": [
       "prettier --write",


### PR DESCRIPTION
## What does this pull request do?

Removes the husky pre-commit hook that runs all tests and linting before code can be committed.

## What is the intent behind these changes?

Although ideally we'd have all tests passing on every commit, we'd like to leave it down to individual devs to run tests locally, or on CI, as running them on every commit slows the development process down.
