### PR TITLE
add snyk scanning of node dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
         default: false
     steps:
       - checkout
-      - npm install -q
+      - run: npm install -q
       - snyk/scan:
           project: '${CIRCLE_PROJECT_REPONAME}'
           monitor-on-build: << parameters.monitor >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   hmpps: ministryofjustice/hmpps@1.1.3
+  snyk: snyk/snyk@0.0.12
 
 jobs:
   build:
@@ -38,10 +39,25 @@ jobs:
             - build-info.json
             - dist
             - assets/stylesheets
+  vulnerability_scan:
+    executor: hmpps/node
+    parameters:
+      monitor:
+        type: boolean
+        default: false
+    steps:
+      - checkout
+      - npm install -q
+      - snyk/scan:
+          project: '${CIRCLE_PROJECT_REPONAME}'
+          monitor-on-build: << parameters.monitor >>
+          organization: "digital-probation-services"
+          severity-threshold: "high" # note: this does not affect snyk 'monitor' commands
+          fail-on-issues: true
 
 workflows:
   version: 2
-  build-test-and-deploy:
+  build_test_and_deploy:
     jobs:
       - build:
         filters:
@@ -49,6 +65,18 @@ workflows:
             ignore: /.*/
 #      - hmpps/helm_lint:
 #          name: helm_lint
+      - vulnerability_scan:
+          name: vulnerability_scan_and_monitor
+          monitor: true
+          filters:
+            branches:
+              only:
+                - main
+      - vulnerability_scan:
+          filters:
+            branches:
+              ignore:
+                - main
       - hmpps/build_docker:
           name: build_docker_publish
           snyk-scan: false # fixme!
@@ -74,14 +102,21 @@ workflows:
           requires:
 #            - helm_lint
             - build_docker_publish
+            - vulnerability_scan_and_monitor
 
-  scheduled:
+  nightly:
     triggers:
       - schedule:
-          cron: "0 6 * * 1-5"
+          cron: "0 7 * * 1-5"
           filters:
             branches:
               only:
                 - main
     jobs:
       - hmpps/npm_security_audit
+      - vulnerability_scan:
+          name: vulnerability_scan_and_monitor
+          monitor: true
+      - hmpps/build_docker:
+          publish: false
+          snyk-scan: true


### PR DESCRIPTION
## What does this pull request do?

adds snyk scanning to build and nightly pipelines:

- scans on PRs show results and fail builds if any known high severity CVEs are found.
- scans on main also fail builds on high severity CVEs, but also post the results to the snyk platform for monitoring
- nightly scans run on the docker image and app dependencies


the job runs on every branch, but only pushes results to the snyk platform on main. 

the build is failed if high severity CVEs are found. 

## What is the intent behind these changes?

be aware of CVEs before they end up in production. block deploys with known high severity CVEs.
