### PR TITLE
Document key tooling decisions in ADRs

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+doc/architecture/decisions

--- a/doc/architecture/decisions/0001-record-architecture-decisions.md
+++ b/doc/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,21 @@
+# 1. Record architecture decisions
+
+Date: 2020-11-20
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael
+Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see
+Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/doc/architecture/decisions/0002-use-express.md
+++ b/doc/architecture/decisions/0002-use-express.md
@@ -1,0 +1,24 @@
+# 2. Use Express
+
+Date: 2020-11-20
+
+## Status
+
+Accepted
+
+## Context
+
+We want to build a web-based application in Node. Express is a minimal and
+flexible framework that sets up a lot basic configuration for us like routing
+and middleware, and makes it easy to incoporate the GOV UK design system UI
+components.
+
+## Decision
+
+We will use Express as the basis for this project.
+
+## Consequences
+
+We won't need to reinvent the wheel and can get a web application up and
+running quickly. Node and Express are common frameworks used at MOJ so will
+make it easy for new developers to be onboarded to the project in future.

--- a/doc/architecture/decisions/0003-use-typescript.md
+++ b/doc/architecture/decisions/0003-use-typescript.md
@@ -1,0 +1,24 @@
+# 3. Use TypeScript
+
+Date: 2020-11-20
+
+## Status
+
+Accepted
+
+## Context
+
+We want to be confident about the code we write, and for it to be
+self-documenting as much as possible. TypeScript is a compiled language with
+optional typing. It's a superset of JavaScript, so is familiar to developers
+who know JavaScript. It has wide editor support.
+
+## Decision
+
+We will use TypeScript by default.
+
+## Consequences
+
+This adds some overhead to developers, as they need to become familiar with
+TypeScript if they aren't. It can also add some overhead when using
+dependencies without existing type definitions.

--- a/doc/architecture/decisions/0004-use-eslint.md
+++ b/doc/architecture/decisions/0004-use-eslint.md
@@ -1,0 +1,31 @@
+# 4. use ESLint
+
+Date: 2020-11-20
+
+## Status
+
+Accepted
+
+## Context
+
+We want to enforce consistency in our code, and catch as many errors
+automatically as we are able to. Linting the code is good practice to achieve
+these aims. [ESLint](https://eslint.org/) is the standard linter for modern
+JavaScript, and has good support for TypeScript though plugins.
+
+## Decision
+
+We will check code style using ESLint.
+
+We will let Prettier have precedence when ESLint and Prettier conflict in their
+styles.
+
+We will use the recommended configuration for plugins where possible.
+
+We will run ESLint as part of the test suite.
+
+## Consequences
+
+ESLint enables us to agree on and enforce a code style without having to keep
+it in the heads of developers, meaning we shouldn't have to discuss individual
+code style violations as they come up.

--- a/doc/architecture/decisions/0005-use-prettier-to-format-typescript-code.md
+++ b/doc/architecture/decisions/0005-use-prettier-to-format-typescript-code.md
@@ -1,0 +1,32 @@
+# 5. Use Prettier to format TypeScript code
+
+Date: 2020-11-20
+
+## Status
+
+Accepted
+
+
+## Context
+
+We want to ensure we're all using one code style, that is familiar across
+projects. [Prettier](https://prettier.io/) is an opinionated code formatter with
+support for most, if not all, of the languages in the JavaScript ecosystem. As
+of writing, it is used by over
+[1 million repositories](https://github.com/prettier/prettier/network/dependents?package_id=UGFja2FnZS00OTAwMTEyNTI%3D)
+on GitHub, including React itself, and has become a standard.
+
+## Decision
+
+We will enforce that everything supported by Prettier has its style enforced by
+it.
+
+We will set up Git hooks to automatically run the formatter before committing.
+
+We will set continuous integration up to reject commits that are not correctly
+formatted.
+
+## Consequences
+
+This adds some overhead to developers committing code, but that can be mitigated
+using Git hooks and editor integrations.

--- a/doc/architecture/decisions/0006-use-jest-for-testing.md
+++ b/doc/architecture/decisions/0006-use-jest-for-testing.md
@@ -1,0 +1,16 @@
+# 6. Use Jest for testing
+
+Date: 2020-11-20
+
+## Status
+
+Accepted
+
+## Context
+
+We want a test framework that has good support for TypeScript and Node. Jest is
+a fast testing framework with good resources for mocking.
+
+## Decision
+
+We will use Jest as our testing framework.

--- a/doc/architecture/decisions/0007-use-cypress-for-integration-testing.md
+++ b/doc/architecture/decisions/0007-use-cypress-for-integration-testing.md
@@ -1,0 +1,28 @@
+# 7. Use Cypress for integration testing
+
+Date: 2020-11-20
+
+## Status
+
+Accepted
+
+## Context
+
+We want to be able to automate testing end-to-end user journeys through our
+application. Cypress is an alternative to Selenium that runs in the browser to
+do this for us, and is used across multiple projects at MOJ.
+
+## Decision
+
+We will use Cypress for integration tests.
+
+## Consequences
+
+There will be some overhead in writing tests in Cypress, but this will ensure
+we catch any regressions introduced by changes to the codebase.
+
+There are some limitations to using Cypress as an integration framework,
+particularly that it may not be possible to test situations in the browser
+where JavaScript is disabled for any reason, which presents some difficulties
+in trying to [build a resilient frontend using progressive
+enhancement](https://www.gov.uk/service-manual/technology/using-progressive-enhancement#building-more-complex-services).

--- a/doc/architecture/decisions/0008-use-snyk-to-scan-for-cves.md
+++ b/doc/architecture/decisions/0008-use-snyk-to-scan-for-cves.md
@@ -1,0 +1,29 @@
+# 8. Use Snyk to scan for CVEs
+
+Date: 2020-11-20
+
+## Status
+
+Accepted
+
+## Context
+
+We want to be aware of CVEs (Common Vulnerabilities and Exposures) before they
+end up in production, and make sure to block deployments with known high
+severity CVEs. Snyk allows us to scan our PRs for CVEs and fail builds if there
+are any vulnerabilities in the code we've written.
+
+## Decision
+
+We will use Snyk to:
+
+- Run scans on PRs provide results and fail builds if any known high severity
+  CVEs are found.
+- Run scans on main and fail builds on high severity CVEs, posting the results
+  to the Snyk platform for monitoring.
+- Run nightly scans on the docker image and app dependencies.
+
+## Consequences
+
+We will know of any CVEs present in the codebase before they get to production
+and ensure that our app is as secure as possible.

--- a/doc/architecture/decisions/0009-use-helmet-for-http-security.md
+++ b/doc/architecture/decisions/0009-use-helmet-for-http-security.md
@@ -1,0 +1,22 @@
+# 9. Use Helmet for HTTP security
+
+Date: 2020-11-20
+
+## Status
+
+Accepted
+
+## Context
+
+We want to make sure we're setting the correct HTTP headers for security e.g.
+Content Security Policy to protect against XSS attacks.
+[Helmet](https://helmetjs.github.io/) is a package that works well with Express
+to make it easy to set various HTTP headers for secutiy.
+
+## Decision
+
+We'll use Helmet to set secure HTTP headers.
+
+## Consequences
+
+Less risk of XSS attacks and exploits.


### PR DESCRIPTION
## What does this pull request do?

Adds a bunch of ADRs (Architecture decision records) to document what tools we're using and why.

## What is the intent behind these changes?

To document decisions we've made early on in the project and make sure there's a reason for using each tool. This may seem obvious to some, but will be useful for newcomers to the project or those less familiar with MOJ standard tooling.

## To add, if these are at all useful:

- Docker
- Kubernetes
- Helm
- Bunyan