### PR TITLE
IC-609 Create draft Referral

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -38,4 +38,34 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(referral.id).toBe('1')
     })
   })
+
+  describe('createReferral', () => {
+    beforeEach(async () => {
+      await provider.addInteraction({
+        // We're not sure what is an appropriate state here
+        state: 'a referral can be created',
+        uponReceiving: 'a POST request to create a referral',
+        withRequest: {
+          method: 'POST',
+          path: '/referrals',
+          headers: { Accept: 'application/json' },
+        },
+        willRespondWith: {
+          status: 201,
+          body: Matchers.like({
+            id: '1',
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Location: Matchers.like('/referrals/1'),
+          },
+        },
+      })
+    })
+
+    it('returns a referral', async () => {
+      const referral = await interventionsService.createReferral()
+      expect(referral.id).toBe('1')
+    })
+  })
 })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -20,4 +20,11 @@ export default class InterventionsService {
       headers: { Accept: 'application/json' },
     })) as Referral
   }
+
+  async createReferral(): Promise<Referral> {
+    return (await this.restClient('token').post({
+      path: `/referrals`,
+      headers: { Accept: 'application/json' },
+    })) as Referral
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds a client request to create an empty referral (with just an ID field), with a Pact test.

## What is the intent behind these changes?

This will give us an empty referral to add various fields to (e.g. `completion_date`) throughout the Referral Form journey.
