### PR TITLE
Create start page for referral, and an empty referral form

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -24,12 +24,14 @@ import standardRouter from './routes/standardRouter'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
 import type UserService from './services/userService'
 import CommunityApiService from './services/communityApiService'
+import InterventionsService from './services/interventionsService'
 
 const RedisStore = connectRedis(session)
 
 export default function createApp(
   userService: UserService,
-  communityApiService: CommunityApiService
+  communityApiService: CommunityApiService,
+  interventionsService: InterventionsService
 ): express.Application {
   const app = express()
 
@@ -188,7 +190,7 @@ export default function createApp(
   })
 
   app.use(authorisationMiddleware())
-  app.use('/', indexRoutes(standardRouter(userService), communityApiService))
+  app.use('/', indexRoutes(standardRouter(userService), { communityApiService, interventionsService }))
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(config.production))
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -71,7 +71,7 @@ export default {
       loginClientSecret: get('LOGIN_CLIENT_SECRET', 'clientsecret', requiredInProduction),
     },
     interventionsService: {
-      url: 'http://localhost:8091',
+      url: get('INTERVENTIONS_SERVICE_URL', 'http://localhost:8092', requiredInProduction),
       timeout: {
         response: 10000,
         deadline: 10000,

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,11 +2,14 @@ import createApp from './app'
 import HmppsAuthClient from './data/hmppsAuthClient'
 import UserService from './services/userService'
 import CommunityApiService from './services/communityApiService'
+import config from './config'
+import InterventionsService from './services/interventionsService'
 
 const hmppsAuthClient = new HmppsAuthClient()
 const userService = new UserService(hmppsAuthClient)
 const communityApiService = new CommunityApiService(hmppsAuthClient)
+const interventionsService = new InterventionsService(config.apis.interventionsService)
 
-const app = createApp(userService, communityApiService)
+const app = createApp(userService, communityApiService, interventionsService)
 
 export default app

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -2,16 +2,22 @@ import type { RequestHandler, Router } from 'express'
 
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import CommunityApiService from '../services/communityApiService'
+import InterventionsService from '../services/interventionsService'
 import IntegrationSamplesRoutes from './integrationSamples'
 
 interface RouteProvider {
   [key: string]: RequestHandler
 }
 
-export default function routes(router: Router, communityApiService: CommunityApiService): Router {
+export interface Services {
+  communityApiService: CommunityApiService
+  interventionsService: InterventionsService
+}
+
+export default function routes(router: Router, services: Services): Router {
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  const integrationSamples: RouteProvider = IntegrationSamplesRoutes(communityApiService)
+  const integrationSamples: RouteProvider = IntegrationSamplesRoutes(services.communityApiService)
 
   get('/', (req, res, next) => {
     res.render('pages/index')

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4,6 +4,7 @@ import asyncMiddleware from '../middleware/asyncMiddleware'
 import CommunityApiService from '../services/communityApiService'
 import InterventionsService from '../services/interventionsService'
 import IntegrationSamplesRoutes from './integrationSamples'
+import ReferralsController from './referrals/referralsController'
 
 interface RouteProvider {
   [key: string]: RequestHandler
@@ -16,14 +17,20 @@ export interface Services {
 
 export default function routes(router: Router, services: Services): Router {
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+  const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
 
   const integrationSamples: RouteProvider = IntegrationSamplesRoutes(services.communityApiService)
+  const referralsController = new ReferralsController(services.interventionsService)
 
   get('/', (req, res, next) => {
     res.render('pages/index')
   })
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
+
+  get('/referrals/start', (req, res) => referralsController.startReferral(req, res))
+  post('/referrals', (req, res) => referralsController.createReferral(req, res))
+  get('/referrals/:id/form', (req, res) => referralsController.viewReferralForm(req, res))
 
   return router
 }

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -1,0 +1,90 @@
+import request from 'supertest'
+import InterventionsService from '../../services/interventionsService'
+import appWithAllRoutes from '../testutils/appSetup'
+
+jest.mock('../../services/interventionsService')
+
+const interventionsService = new InterventionsService(null) as jest.Mocked<InterventionsService>
+
+let app
+
+beforeEach(() => {
+  app = appWithAllRoutes({ overrides: { interventionsService } })
+
+  interventionsService.createReferral.mockResolvedValue({
+    id: '1',
+  })
+
+  interventionsService.getReferral.mockResolvedValue({
+    id: '1',
+  })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET /referrals/start', () => {
+  it('renders a start page', () => {
+    return request(app)
+      .get('/referrals/start')
+      .expect('Content-Type', /html/)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('You can make a new referral here')
+      })
+  })
+})
+
+describe('POST /referrals', () => {
+  it('creates a referral on the interventions service and redirects to the referral form', async () => {
+    await request(app).post('/referrals').expect(303).expect('Location', '/referrals/1/form')
+
+    expect(interventionsService.createReferral).toHaveBeenCalledTimes(1)
+  })
+
+  describe('when the interventions service returns an error', () => {
+    beforeEach(() => {
+      interventionsService.createReferral.mockRejectedValue(new Error('Failed to create intervention'))
+    })
+
+    it('displays an error page', async () => {
+      await request(app)
+        .post('/referrals')
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain('Failed to create intervention')
+        })
+
+      expect(interventionsService.createReferral).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('GET /referrals/:id/form', () => {
+  it('fetches the referral from the interventions service and renders a page with information about the referral', async () => {
+    await request(app)
+      .get('/referrals/1/form')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Viewing referral with ID 1')
+      })
+
+    expect(interventionsService.getReferral.mock.calls[0]).toEqual(['1'])
+  })
+
+  describe('when the interventions service returns an error', () => {
+    beforeEach(() => {
+      interventionsService.getReferral.mockRejectedValue(new Error('Failed to get intervention'))
+    })
+
+    it('displays an error page', async () => {
+      await request(app)
+        .get('/referrals/1/form')
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain('Failed to get intervention')
+        })
+    })
+  })
+})

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -1,0 +1,21 @@
+import InterventionsService from '../../services/interventionsService'
+
+export default class ReferralsController {
+  constructor(private readonly interventionsService: InterventionsService) {}
+
+  async startReferral(req, res): Promise<void> {
+    res.render('referrals/start')
+  }
+
+  async createReferral(req, res): Promise<void> {
+    const referral = await this.interventionsService.createReferral()
+
+    res.redirect(303, `/referrals/${referral.id}/form`)
+  }
+
+  async viewReferralForm(req, res): Promise<void> {
+    const referral = await this.interventionsService.getReferral(req.params.id)
+
+    res.render('referrals/form', { referral })
+  }
+}

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -4,13 +4,15 @@ import cookieSession from 'cookie-session'
 import createError from 'http-errors'
 import path from 'path'
 
-import allRoutes from '../index'
+import allRoutes, { Services } from '../index'
 import nunjucksSetup from '../../utils/nunjucksSetup'
 import errorHandler from '../../errorHandler'
 import standardRouter from '../standardRouter'
 import * as auth from '../../authentication/auth'
 import { user, MockUserService } from './mocks/mockUserService'
 import MockCommunityApiService from './mocks/mockCommunityApiService'
+import InterventionsService from '../../services/interventionsService'
+import CommunityApiService from '../../services/communityApiService'
 
 function appSetup(route: Router, production: boolean): Express {
   const app = express()
@@ -36,7 +38,20 @@ function appSetup(route: Router, production: boolean): Express {
   return app
 }
 
-export default function appWithAllRoutes({ production = false }: { production?: boolean }): Express {
+export default function appWithAllRoutes({
+  production = false,
+  overrides = {},
+}: {
+  production?: boolean
+  overrides?: Partial<Services>
+}): Express {
   auth.default.authenticationMiddleware = () => (req, res, next) => next()
-  return appSetup(allRoutes(standardRouter(new MockUserService()), new MockCommunityApiService()), production)
+  return appSetup(
+    allRoutes(standardRouter(new MockUserService()), {
+      communityApiService: new MockCommunityApiService(),
+      interventionsService: {} as InterventionsService,
+      ...overrides,
+    }),
+    production
+  )
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -2,7 +2,7 @@ import RestClient from '../data/restClient'
 import logger from '../../log'
 import { ApiConfig } from '../config'
 
-interface Referral {
+export interface Referral {
   id: string
 }
 

--- a/server/views/referrals/form.njk
+++ b/server/views/referrals/form.njk
@@ -1,0 +1,1 @@
+Viewing referral with ID {{referral.id}}

--- a/server/views/referrals/start.njk
+++ b/server/views/referrals/start.njk
@@ -1,0 +1,31 @@
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Make a referral
+      </h1>
+
+      <p class="govuk-body-m">You can make a new referral here:</p>
+
+      <form action="/referrals" method="POST">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        <button role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+          Start now
+          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
+          </svg>
+        </button>
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Our first piece of user-facing functionality. Allows a user to create an empty referral and view a screen that will become the referral form.

## What is the intent behind these changes?

To give us a base to start building the referral form on top of.

## Screenshots

### Start page

![Screenshot_2020-12-02 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/100863752-ed864e80-348c-11eb-971b-cd01c405203a.png)

### Referral form (beautiful)

![Screenshot_2020-12-02 Screenshot](https://user-images.githubusercontent.com/53756884/100863794-fb3bd400-348c-11eb-8d76-0aebf7843ddf.png)
