### PR TITLE
Fetch real API token in interventionsService

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,7 @@ import InterventionsService from './services/interventionsService'
 const hmppsAuthClient = new HmppsAuthClient()
 const userService = new UserService(hmppsAuthClient)
 const communityApiService = new CommunityApiService(hmppsAuthClient)
-const interventionsService = new InterventionsService(config.apis.interventionsService)
+const interventionsService = new InterventionsService(config.apis.interventionsService, hmppsAuthClient)
 
 const app = createApp(userService, communityApiService, interventionsService)
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -5,7 +5,7 @@ import appWithAllRoutes from '../testutils/appSetup'
 
 jest.mock('../../services/interventionsService')
 
-const interventionsService = new InterventionsService(null) as jest.Mocked<InterventionsService>
+const interventionsService = new InterventionsService(null, null) as jest.Mocked<InterventionsService>
 
 let app: Express
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2,14 +2,20 @@ import { pactWith } from 'jest-pact'
 import { Matchers } from '@pact-foundation/pact'
 
 import InterventionsService from './interventionsService'
+import HmppsAuthClient from '../data/hmppsAuthClient'
 import config from '../config'
+import MockedHmppsAuthClient from '../data/testutils/hmppsAuthClientSetup'
+
+jest.mock('../data/hmppsAuthClient')
 
 pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, provider => {
   let interventionsService: InterventionsService
 
   beforeEach(() => {
     const testConfig = { ...config.apis.interventionsService, url: provider.mockService.baseUrl }
-    interventionsService = new InterventionsService(testConfig)
+    const hmppsAuthClient = new MockedHmppsAuthClient() as jest.Mocked<HmppsAuthClient>
+    hmppsAuthClient.getApiClientToken.mockResolvedValue('mockedToken')
+    interventionsService = new InterventionsService(testConfig, hmppsAuthClient)
   })
 
   describe('getReferral', () => {
@@ -21,7 +27,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/draft-referral/ac386c25-52c8-41fa-9213-fcf42e24b0b5',
-          headers: { Accept: 'application/json' },
+          headers: { Accept: 'application/json', Authorization: 'Bearer mockedToken' },
         },
         willRespondWith: {
           status: 200,
@@ -48,7 +54,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: '/draft-referral',
-          headers: { Accept: 'application/json' },
+          headers: { Accept: 'application/json', Authorization: 'Bearer mockedToken' },
         },
         willRespondWith: {
           status: 201,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -1,28 +1,36 @@
 import RestClient from '../data/restClient'
 import logger from '../../log'
 import { ApiConfig } from '../config'
+import HmppsAuthClient from '../data/hmppsAuthClient'
 
 export interface Referral {
   id: string
 }
 
 export default class InterventionsService {
-  constructor(private readonly config: ApiConfig) {}
+  constructor(private readonly config: ApiConfig, private readonly hmppsAuthClient: HmppsAuthClient) {}
 
-  private restClient(token: string): RestClient {
+  private async createRestClient(): Promise<RestClient> {
+    const token = await this.hmppsAuthClient.getApiClientToken()
+
     return new RestClient('Interventions Service API Client', this.config, token)
   }
 
   async getReferral(id: string): Promise<Referral> {
     logger.info(`Getting draft referral with id ${id}`)
-    return (await this.restClient('token').get({
+
+    const restClient = await this.createRestClient()
+
+    return (await restClient.get({
       path: `/draft-referral/${id}`,
       headers: { Accept: 'application/json' },
     })) as Referral
   }
 
   async createReferral(): Promise<Referral> {
-    return (await this.restClient('token').post({
+    const restClient = await this.createRestClient()
+
+    return (await restClient.post({
       path: `/draft-referral`,
       headers: { Accept: 'application/json' },
     })) as Referral


### PR DESCRIPTION
## What does this pull request do?

When making calls to the interventions service, it now fetches an API client token from HMPPS auth service, and sends that token in the request.

We should have done this in 5607f25 and 0863f08, but we were just focused on trying to get Pact working and didn’t really think about tokens. The pattern is copied from `communityApiService`.

## What is the intent behind these changes?

To allow us to authenticate with the real interventions service.
