### PR TITLE
Turn on deployment notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ workflows:
           name: deploy_dev
           env: "dev"
           retrieve_secrets: "none"
+          slack_notification: true
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,8 @@ workflows:
               only:
                 - main
           requires:
+            - build
+            - integration_test
             - hmpps/helm_lint
             - build_docker_publish
             - vulnerability_scan_and_monitor


### PR DESCRIPTION
## What does this pull request do?

Turns on deployment notifications and ties deployment to successful tests.

## What is the intent behind these changes?

To let us know if a deployment happens, or more importantly when it fails.