### PR TITLE
Fix ESLint issue which forbade declaring enums

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -104,6 +104,8 @@
         "semi": false,
         "arrowParens": "avoid"
       }
-    ]
+    ],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": "error"
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Replaces a piece of ESLint config which prevented us from declaring TypeScript enums. See commit message.

## What is the intent behind these changes?

To allow us to declare TypeScript enums, which seem lovely.