### PR TITLE
Add task list to referral form

### DIFF
--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -1,0 +1,94 @@
+import ReferralFormPresenter, { ReferralFormStatus } from './referralFormPresenter'
+
+describe('ReferralFormPresenter', () => {
+  describe('sections', () => {
+    // This is not a very exciting test at the moment but will become more useful
+    // as the task list starts to handle different referral states.
+
+    it('returns an array of section presenters', () => {
+      const presenter = new ReferralFormPresenter({ id: '1' })
+
+      const expected = [
+        {
+          type: 'single',
+          title: 'Retrieve service user record',
+          number: '1',
+          status: ReferralFormStatus.Completed,
+          tasks: [
+            { title: 'Enter service user case identifier', url: '#' },
+            { title: 'Confirm service user details', url: '#' },
+          ],
+        },
+        {
+          type: 'single',
+          title: 'Find and select service user interventions',
+          number: '2',
+          status: ReferralFormStatus.Completed,
+          tasks: [
+            { title: 'Find and select service user interventions', url: '#' },
+            { title: 'Confirm interventions', url: '#' },
+          ],
+        },
+        {
+          type: 'single',
+          title: 'Review service user’s information',
+          number: '3',
+          status: ReferralFormStatus.Completed,
+          tasks: [
+            { title: 'Service user’s risk information', url: '#' },
+            { title: 'Service user’s needs and requirements', url: '#' },
+          ],
+        },
+        {
+          type: 'multi',
+          title: 'Add intervention referrals detail',
+          number: '4',
+          taskListSections: [
+            {
+              title: 'Accommodation referral',
+              number: '4.1',
+              status: ReferralFormStatus.InProgress,
+              tasks: [
+                { title: 'Select the relevant sentence for the accommodation referral', url: '#' },
+                { title: 'Select desired outcomes', url: '#' },
+                { title: 'Select required complexity level', url: '#' },
+                { title: 'What date does the accommodation service need to be completed by?', url: '#' },
+                { title: 'Enter RAR days used', url: null },
+                { title: 'Further information for service provider', url: null },
+              ],
+            },
+            {
+              title: 'Social inclusion referral',
+              number: '4.2',
+              status: ReferralFormStatus.NotStarted,
+              tasks: [
+                { title: 'Select the relevant sentence for the social inclusion referral', url: '#' },
+                { title: 'Select desired outcomes', url: null },
+                { title: 'Select required complexity level', url: null },
+                { title: 'What date does the social inclusion service need to be completed by?', url: null },
+                { title: 'Enter RAR days used', url: null },
+                { title: 'Further information for service provider', url: null },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'single',
+          title: 'Review responsible officer’s information',
+          number: '5',
+          status: ReferralFormStatus.NotStarted,
+          tasks: [{ title: 'Responsible officer information', url: '#' }],
+        },
+        {
+          type: 'single',
+          title: 'Check your answers',
+          number: '6',
+          status: ReferralFormStatus.CannotStartYet,
+          tasks: [{ title: 'Check your answers', url: null }],
+        },
+      ]
+
+      expect(presenter.sections).toEqual(expected)
+    })
+  })
+})

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -1,0 +1,188 @@
+import { Referral } from '../../services/interventionsService'
+
+export default class ReferralFormPresenter {
+  constructor(private readonly referral: Referral) {}
+
+  // This is just temporary, will remove it once we get rid of the referral ID output in the template
+  get referralID(): string {
+    return this.referral.id
+  }
+
+  get sections(): ReferralFormSectionPresenter[] {
+    return [
+      {
+        type: 'single',
+        title: 'Retrieve service user record',
+        number: '1',
+        status: ReferralFormStatus.Completed,
+        tasks: [
+          {
+            title: 'Enter service user case identifier',
+            url: '#',
+          },
+          {
+            title: 'Confirm service user details',
+            url: '#',
+          },
+        ],
+      },
+      {
+        type: 'single',
+        title: 'Find and select service user interventions',
+        number: '2',
+        status: ReferralFormStatus.Completed,
+        tasks: [
+          {
+            title: 'Find and select service user interventions',
+            url: '#',
+          },
+          {
+            title: 'Confirm interventions',
+            url: '#',
+          },
+        ],
+      },
+      {
+        type: 'single',
+        title: 'Review service user’s information',
+        number: '3',
+        status: ReferralFormStatus.Completed,
+        tasks: [
+          {
+            title: 'Service user’s risk information',
+            url: '#',
+          },
+          {
+            title: 'Service user’s needs and requirements',
+            url: '#',
+          },
+        ],
+      },
+      {
+        type: 'multi',
+        title: 'Add intervention referrals detail',
+        number: '4',
+        taskListSections: [
+          {
+            title: 'Accommodation referral',
+            number: '4.1',
+            status: ReferralFormStatus.InProgress,
+            tasks: [
+              {
+                title: 'Select the relevant sentence for the accommodation referral',
+                url: '#',
+              },
+              {
+                title: 'Select desired outcomes',
+                url: '#',
+              },
+              {
+                title: 'Select required complexity level',
+                url: '#',
+              },
+              {
+                title: 'What date does the accommodation service need to be completed by?',
+                url: '#',
+              },
+              {
+                title: 'Enter RAR days used',
+                url: null,
+              },
+              {
+                title: 'Further information for service provider',
+                url: null,
+              },
+            ],
+          },
+          {
+            title: 'Social inclusion referral',
+            number: '4.2',
+            status: ReferralFormStatus.NotStarted,
+            tasks: [
+              {
+                title: 'Select the relevant sentence for the social inclusion referral',
+                url: '#',
+              },
+              {
+                title: 'Select desired outcomes',
+                url: null,
+              },
+              {
+                title: 'Select required complexity level',
+                url: null,
+              },
+              {
+                title: 'What date does the social inclusion service need to be completed by?',
+                url: null,
+              },
+              {
+                title: 'Enter RAR days used',
+                url: null,
+              },
+              {
+                title: 'Further information for service provider',
+                url: null,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'single',
+        title: 'Review responsible officer’s information',
+        number: '5',
+        status: ReferralFormStatus.NotStarted,
+        tasks: [
+          {
+            title: 'Responsible officer information',
+            url: '#',
+          },
+        ],
+      },
+      {
+        type: 'single',
+        title: 'Check your answers',
+        number: '6',
+        status: ReferralFormStatus.CannotStartYet,
+        tasks: [
+          {
+            title: 'Check your answers',
+            url: null,
+          },
+        ],
+      },
+    ]
+  }
+}
+
+type ReferralFormSectionPresenter = ReferralFormSingleListSectionPresenter | ReferralFormMultiListSectionPresenter
+
+interface ReferralFormSingleListSectionPresenter extends ReferralFormTaskListSectionPresenter {
+  type: 'single'
+}
+
+interface ReferralFormMultiListSectionPresenter {
+  type: 'multi'
+  title: string
+  number: string
+  taskListSections: ReferralFormTaskListSectionPresenter[]
+}
+
+interface ReferralFormTaskListSectionPresenter {
+  title: string
+  number: string
+  tasks: ReferralFormTaskPresenter[]
+  status: ReferralFormStatus
+}
+
+export enum ReferralFormStatus {
+  NotStarted = 'Not started',
+  CannotStartYet = 'Cannot start yet',
+  InProgress = 'In progress',
+  Completed = 'Completed',
+}
+
+interface ReferralFormTaskPresenter {
+  title: string
+  url: string | null
+}

--- a/server/routes/referrals/referralFormView.ts
+++ b/server/routes/referrals/referralFormView.ts
@@ -1,0 +1,30 @@
+import ReferralFormPresenter, { ReferralFormStatus } from './referralFormPresenter'
+
+export default class ReferralFormView {
+  constructor(private readonly presenter: ReferralFormPresenter) {}
+
+  private static helpers = {
+    classForStatus(status: ReferralFormStatus): string {
+      switch (status) {
+        case ReferralFormStatus.NotStarted:
+        case ReferralFormStatus.CannotStartYet:
+          return 'govuk-tag govuk-tag--grey'
+        case ReferralFormStatus.InProgress:
+        case ReferralFormStatus.Completed:
+          return 'govuk-tag'
+        default:
+          return ''
+      }
+    },
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/form',
+      {
+        presenter: this.presenter,
+        ...ReferralFormView.helpers,
+      },
+    ]
+  }
+}

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from 'express'
 import InterventionsService from '../../services/interventionsService'
+import ReferralFormPresenter from './referralFormPresenter'
+import ReferralFormView from './referralFormView'
 
 export default class ReferralsController {
   constructor(private readonly interventionsService: InterventionsService) {}
@@ -17,6 +19,9 @@ export default class ReferralsController {
   async viewReferralForm(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getReferral(req.params.id)
 
-    res.render('referrals/form', { referral })
+    const presenter = new ReferralFormPresenter(referral)
+    const view = new ReferralFormView(presenter)
+
+    res.render(...view.renderArgs)
   }
 }

--- a/server/views/referrals/form.njk
+++ b/server/views/referrals/form.njk
@@ -1,1 +1,45 @@
-Viewing referral with ID {{referral.id}}
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Make a referral
+      </h1>
+
+      <p class="govuk-body-m">Viewing referral with ID {{ presenter.referralID }}</p>
+
+      <ol class="moj-task-list">
+        {% for section in presenter.sections %}
+          {% if section.type === 'multi' %}
+            <li>
+              <h2 class="moj-task-list__section">
+                <span class="moj-task-list__section-number">{{ section.number }}.</span>
+                {{ section.title }}
+              </h2>
+            </li>
+
+            {% for taskListSection in section.taskListSections %}
+              <li class="govuk-!-margin-left-5">
+                {% set nested = true %}
+                {% include "./partials/taskListSection.njk" %}
+              </li>
+            {% endfor %}
+          {% elif section.type === 'single' %}
+            <li>
+              {% set taskListSection = section %}
+              {% set nested = false %}
+              {% include "./partials/taskListSection.njk" %}
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ol>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/referrals/partials/taskListSection.njk
+++ b/server/views/referrals/partials/taskListSection.njk
@@ -1,0 +1,26 @@
+{#
+Our use of the task-completed class is a misuse - we’re just using
+it to get a right-floated tag. There’s a broader question of whether
+we’ve mis-implemented the MoJ task list pattern, in which tags are
+only used on individual completed tasks. Needs some design review.
+#}
+<strong class="{{ classForStatus(taskListSection.status) }} moj-task-list__task-completed">
+  {{ taskListSection.status }}
+</strong>
+
+<h2 class="moj-task-list__section">
+  <span class="moj-task-list__section-number {{ "govuk-!-padding-right-2" if nested }}">{{ taskListSection.number }}.</span>
+  {{ taskListSection.title }}
+</h2>
+
+<ul class="moj-task-list__items">
+  {% for task in taskListSection.tasks %}
+    <li class="moj-task-list__item">
+      {% if task.url !== null %}
+        <a class="moj-task-list__task-name" href="{{ task.url }}">{{ task.title }}</a>
+      {% else %}
+        <span class="app-task-list__task-name">{{ task.title }}</span>
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
## What does this pull request do?

Populates the referral form with a task list which currently shows a single fixed state - the user has half filled the referral form, and the next thing for them to do is to fill in the desired completion date for the accommodation intervention.

It proposes some architecture that will allow us to (hopefully) easily turn this into a dynamic form as we start to work with an actual referral. See commit message for more details.

## What is the intent behind these changes?

To provide a starting point for building out the rest of the referral form UI, and to propose an architecture for future UI work.

## Screenshot

![Screenshot_2020-12-04 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/101155896-b5634500-361f-11eb-910d-e3b09aed525d.png)

