### PR TITLE
remove repeated slashes in URLs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -104,6 +104,8 @@
         "semi": false,
         "arrowParens": "avoid"
       }
-    ]
+    ],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": "error"
   }
 }

--- a/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
@@ -5,7 +5,7 @@ Environment variables for web and worker containers
 {{- define "deployment.envs" }}
 env:
   - name: INGRESS_URL
-    value: "https://{{ .Values.ingress.host }}/"
+    value: "https://{{ .Values.ingress.host }}"
 
   - name: API_CLIENT_ID
     valueFrom:
@@ -54,6 +54,12 @@ env:
 
   - name: HMPPS_AUTH_URL
     value: {{ .Values.env.HMPPS_AUTH_URL | quote }}
+
+  - name: COMMUNITY_API_URL
+    value: {{ .Values.env.COMMUNITY_API_URL | quote }}
+
+  - name: INTERVENTIONS_SERVICE_URL
+    value: {{ .Values.env.INTERVENTIONS_SERVICE_URL | quote }}
 
   - name: TOKEN_VERIFICATION_API_URL
     value: {{ .Values.env.TOKEN_VERIFICATION_API_URL | quote }}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,9 +15,9 @@ ingress:
   path: /
 
 env:
-  HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth/
-  HMPPS_COOKIE_NAME: hmpps-session-dev
+  HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+  COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
+  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true
-  REDIS_ENABLED: true
   REDIS_TLS_ENABLED: true

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,7 @@ import InterventionsService from './services/interventionsService'
 const hmppsAuthClient = new HmppsAuthClient()
 const userService = new UserService(hmppsAuthClient)
 const communityApiService = new CommunityApiService(hmppsAuthClient)
-const interventionsService = new InterventionsService(config.apis.interventionsService)
+const interventionsService = new InterventionsService(config.apis.interventionsService, hmppsAuthClient)
 
 const app = createApp(userService, communityApiService, interventionsService)
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -5,7 +5,7 @@ import appWithAllRoutes from '../testutils/appSetup'
 
 jest.mock('../../services/interventionsService')
 
-const interventionsService = new InterventionsService(null) as jest.Mocked<InterventionsService>
+const interventionsService = new InterventionsService(null, null) as jest.Mocked<InterventionsService>
 
 let app: Express
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2,14 +2,20 @@ import { pactWith } from 'jest-pact'
 import { Matchers } from '@pact-foundation/pact'
 
 import InterventionsService from './interventionsService'
+import HmppsAuthClient from '../data/hmppsAuthClient'
 import config from '../config'
+import MockedHmppsAuthClient from '../data/testutils/hmppsAuthClientSetup'
+
+jest.mock('../data/hmppsAuthClient')
 
 pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, provider => {
   let interventionsService: InterventionsService
 
   beforeEach(() => {
     const testConfig = { ...config.apis.interventionsService, url: provider.mockService.baseUrl }
-    interventionsService = new InterventionsService(testConfig)
+    const hmppsAuthClient = new MockedHmppsAuthClient() as jest.Mocked<HmppsAuthClient>
+    hmppsAuthClient.getApiClientToken.mockResolvedValue('mockedToken')
+    interventionsService = new InterventionsService(testConfig, hmppsAuthClient)
   })
 
   describe('getReferral', () => {
@@ -21,7 +27,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/draft-referral/ac386c25-52c8-41fa-9213-fcf42e24b0b5',
-          headers: { Accept: 'application/json' },
+          headers: { Accept: 'application/json', Authorization: 'Bearer mockedToken' },
         },
         willRespondWith: {
           status: 200,
@@ -48,7 +54,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: '/draft-referral',
-          headers: { Accept: 'application/json' },
+          headers: { Accept: 'application/json', Authorization: 'Bearer mockedToken' },
         },
         willRespondWith: {
           status: 201,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -1,28 +1,36 @@
 import RestClient from '../data/restClient'
 import logger from '../../log'
 import { ApiConfig } from '../config'
+import HmppsAuthClient from '../data/hmppsAuthClient'
 
 export interface Referral {
   id: string
 }
 
 export default class InterventionsService {
-  constructor(private readonly config: ApiConfig) {}
+  constructor(private readonly config: ApiConfig, private readonly hmppsAuthClient: HmppsAuthClient) {}
 
-  private restClient(token: string): RestClient {
+  private async createRestClient(): Promise<RestClient> {
+    const token = await this.hmppsAuthClient.getApiClientToken()
+
     return new RestClient('Interventions Service API Client', this.config, token)
   }
 
   async getReferral(id: string): Promise<Referral> {
     logger.info(`Getting draft referral with id ${id}`)
-    return (await this.restClient('token').get({
+
+    const restClient = await this.createRestClient()
+
+    return (await restClient.get({
       path: `/draft-referral/${id}`,
       headers: { Accept: 'application/json' },
     })) as Referral
   }
 
   async createReferral(): Promise<Referral> {
-    return (await this.restClient('token').post({
+    const restClient = await this.createRestClient()
+
+    return (await restClient.post({
       path: `/draft-referral`,
       headers: { Accept: 'application/json' },
     })) as Referral


### PR DESCRIPTION
## What does this pull request do?

repeated slashes cause issues for redirecting to HMPPS Auth, as well as the redirect URI parameter to the authorize endpoint in HMPP Auth

## What is the intent behind these changes?

fix the login in dev environment 
