### PR TITLE
IC-641: Upload pact files to the pact broker after tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ executors:
 
 jobs:
   build:
+    environment:
+      PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
+      PACT_BROKER_USERNAME: "interventions"
     executor: hmpps/node
     steps:
       - checkout
@@ -25,6 +28,13 @@ jobs:
       - run: npm run test
       - store_artifacts:
           path: 'pact/pacts'
+      - run:
+          name: Upload pact files to broker
+          command: |
+            npx pact-broker publish pact/pacts \
+              --broker-base-url $PACT_BROKER_BASE_URL \
+              --consumer-app-version $CIRCLE_SHA1 --tag $CIRCLE_BRANCH \
+              -u $PACT_BROKER_USERNAME -p $PACT_BROKER_PASSWORD
       - run: npm run build
       - run: npm run lint
 


### PR DESCRIPTION
## What does this pull request do?

Upload pact files to the pact broker after tests.

The [documentation](https://docs.pact.io/pact_broker/tags/) recommends that

> Tag with the branch name when you publish pacts or verification results, and tag with the environment name when you deploy.

This PR implements for the former.

![image](https://user-images.githubusercontent.com/1526295/101203639-e5800780-3662-11eb-95f3-36e4ed334c48.png)

## What is the intent behind these changes?

So that we can validate them at a later stage (from the provider side).