### PR TITLE
remove default params from `generateOauthClientToken`

### DIFF
--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -39,15 +39,18 @@ export interface UserRequest extends Request {
 }
 
 function init(): void {
+  const authConfig = config.apis.hmppsAuth
   const strategy = new Strategy(
     {
-      authorizationURL: `${config.apis.hmppsAuth.url}/oauth/authorize`,
-      tokenURL: `${config.apis.hmppsAuth.url}/oauth/token`,
-      clientID: config.apis.hmppsAuth.loginClientId,
-      clientSecret: config.apis.hmppsAuth.loginClientSecret,
+      authorizationURL: `${authConfig.url}/oauth/authorize`,
+      tokenURL: `${authConfig.url}/oauth/token`,
+      clientID: authConfig.loginClientId,
+      clientSecret: authConfig.loginClientSecret,
       callbackURL: `${config.domain}/login/callback`,
       state: true,
-      customHeaders: { Authorization: generateOauthClientToken() },
+      customHeaders: {
+        Authorization: generateOauthClientToken(authConfig.loginClientId, authConfig.loginClientSecret),
+      },
     },
     (token, refreshToken, params, profile, done) => {
       return done(null, { token, username: params.user_name, authSource: params.auth_source })

--- a/server/authentication/clientCredentials.ts
+++ b/server/authentication/clientCredentials.ts
@@ -1,9 +1,7 @@
 import config from '../config'
 
-export default function generateOauthClientToken(
-  clientId: string = config.apis.hmppsAuth.apiClientId,
-  clientSecret: string = config.apis.hmppsAuth.apiClientSecret
-): string {
+export default function generateOauthClientToken(clientId: string, clientSecret: string): string {
+  // create a base64 encoded basic auth header for oauth2 token requests
   const token = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
   return `Basic ${token}`
 }


### PR DESCRIPTION
## What does this pull request do?

removes the default params from the `generateOauthClientToken` function to ensure all callers pass the credentials explicitly.

change the credentials used by passport to fix the login token request.

## What is the intent behind these changes?

fix the currently broken login in dev. 
