### PR TITLE
Add interventions service API call to set / update completion deadline

### DIFF
--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -6,7 +6,7 @@ describe('ReferralFormPresenter', () => {
     // as the task list starts to handle different referral states.
 
     it('returns an array of section presenters', () => {
-      const presenter = new ReferralFormPresenter({ id: '1' })
+      const presenter = new ReferralFormPresenter({ id: '1', completionDeadline: '2021-03-01' })
 
       const expected = [
         {

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -1,7 +1,7 @@
-import { Referral } from '../../services/interventionsService'
+import { DraftReferral } from '../../services/interventionsService'
 
 export default class ReferralFormPresenter {
-  constructor(private readonly referral: Referral) {}
+  constructor(private readonly referral: DraftReferral) {}
 
   // This is just temporary, will remove it once we get rid of the referral ID output in the template
   get referralID(): string {

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -14,10 +14,12 @@ beforeEach(() => {
 
   interventionsService.createDraftReferral.mockResolvedValue({
     id: '1',
+    completionDeadline: null,
   })
 
   interventionsService.getDraftReferral.mockResolvedValue({
     id: '1',
+    completionDeadline: null,
   })
 })
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -12,11 +12,11 @@ let app: Express
 beforeEach(() => {
   app = appWithAllRoutes({ overrides: { interventionsService } })
 
-  interventionsService.createReferral.mockResolvedValue({
+  interventionsService.createDraftReferral.mockResolvedValue({
     id: '1',
   })
 
-  interventionsService.getReferral.mockResolvedValue({
+  interventionsService.getDraftReferral.mockResolvedValue({
     id: '1',
   })
 })
@@ -41,12 +41,12 @@ describe('POST /referrals', () => {
   it('creates a referral on the interventions service and redirects to the referral form', async () => {
     await request(app).post('/referrals').expect(303).expect('Location', '/referrals/1/form')
 
-    expect(interventionsService.createReferral).toHaveBeenCalledTimes(1)
+    expect(interventionsService.createDraftReferral).toHaveBeenCalledTimes(1)
   })
 
   describe('when the interventions service returns an error', () => {
     beforeEach(() => {
-      interventionsService.createReferral.mockRejectedValue(new Error('Failed to create intervention'))
+      interventionsService.createDraftReferral.mockRejectedValue(new Error('Failed to create intervention'))
     })
 
     it('displays an error page', async () => {
@@ -57,7 +57,7 @@ describe('POST /referrals', () => {
           expect(res.text).toContain('Failed to create intervention')
         })
 
-      expect(interventionsService.createReferral).toHaveBeenCalledTimes(1)
+      expect(interventionsService.createDraftReferral).toHaveBeenCalledTimes(1)
     })
   })
 })
@@ -71,12 +71,12 @@ describe('GET /referrals/:id/form', () => {
         expect(res.text).toContain('Viewing referral with ID 1')
       })
 
-    expect(interventionsService.getReferral.mock.calls[0]).toEqual(['1'])
+    expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['1'])
   })
 
   describe('when the interventions service returns an error', () => {
     beforeEach(() => {
-      interventionsService.getReferral.mockRejectedValue(new Error('Failed to get intervention'))
+      interventionsService.getDraftReferral.mockRejectedValue(new Error('Failed to get intervention'))
     })
 
     it('displays an error page', async () => {

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -11,13 +11,13 @@ export default class ReferralsController {
   }
 
   async createReferral(req: Request, res: Response): Promise<void> {
-    const referral = await this.interventionsService.createReferral()
+    const referral = await this.interventionsService.createDraftReferral()
 
     res.redirect(303, `/referrals/${referral.id}/form`)
   }
 
   async viewReferralForm(req: Request, res: Response): Promise<void> {
-    const referral = await this.interventionsService.getReferral(req.params.id)
+    const referral = await this.interventionsService.getDraftReferral(req.params.id)
 
     const presenter = new ReferralFormPresenter(referral)
     const view = new ReferralFormView(presenter)

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -76,4 +76,41 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
     })
   })
+
+  describe('patchDraftReferral', () => {
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to update the completion deadline',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer mockedToken',
+          },
+          body: { completionDeadline: '2021-04-01' },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
+            completionDeadline: '2021-04-01',
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns the updated referral', async () => {
+      const referral = await interventionsService.patchDraftReferral('dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        completionDeadline: '2021-04-01',
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.completionDeadline).toBe('2021-04-01')
+    })
+  })
 })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -18,11 +18,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     interventionsService = new InterventionsService(testConfig, hmppsAuthClient)
   })
 
-  describe('getReferral', () => {
+  describe('getDraftReferral', () => {
     beforeEach(async () => {
       // This is just an example for getting Pact set up; we’ll properly design this endpoint later
       await provider.addInteraction({
-        state: 'There is an existing referral with ID of ac386c25-52c8-41fa-9213-fcf42e24b0b5',
+        state: 'There is an existing draft referral with ID of ac386c25-52c8-41fa-9213-fcf42e24b0b5',
         uponReceiving: 'a request for that referral',
         withRequest: {
           method: 'GET',
@@ -40,17 +40,17 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
 
     it('returns a referral for the given ID', async () => {
-      const referral = await interventionsService.getReferral('ac386c25-52c8-41fa-9213-fcf42e24b0b5')
+      const referral = await interventionsService.getDraftReferral('ac386c25-52c8-41fa-9213-fcf42e24b0b5')
       expect(referral.id).toBe('ac386c25-52c8-41fa-9213-fcf42e24b0b5')
     })
   })
 
-  describe('createReferral', () => {
+  describe('createDraftReferral', () => {
     beforeEach(async () => {
       await provider.addInteraction({
         // We're not sure what is an appropriate state here
-        state: 'a referral can be created',
-        uponReceiving: 'a POST request to create a referral',
+        state: 'a draft referral can be created',
+        uponReceiving: 'a POST request to create a draft referral',
         withRequest: {
           method: 'POST',
           path: '/draft-referral',
@@ -72,7 +72,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
 
     it('returns a referral', async () => {
-      const referral = await interventionsService.createReferral()
+      const referral = await interventionsService.createDraftReferral()
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
     })
   })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -36,4 +36,14 @@ export default class InterventionsService {
       headers: { Accept: 'application/json' },
     })) as DraftReferral
   }
+
+  async patchDraftReferral(id: string, patch: Partial<DraftReferral>): Promise<DraftReferral> {
+    const restClient = await this.createRestClient()
+
+    return (await restClient.patch({
+      path: `/draft-referral/${id}`,
+      headers: { Accept: 'application/json' },
+      data: patch,
+    })) as DraftReferral
+  }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -5,6 +5,7 @@ import HmppsAuthClient from '../data/hmppsAuthClient'
 
 export interface DraftReferral {
   id: string
+  completionDeadline: string | null
 }
 
 export default class InterventionsService {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -3,7 +3,7 @@ import logger from '../../log'
 import { ApiConfig } from '../config'
 import HmppsAuthClient from '../data/hmppsAuthClient'
 
-export interface Referral {
+export interface DraftReferral {
   id: string
 }
 
@@ -16,7 +16,7 @@ export default class InterventionsService {
     return new RestClient('Interventions Service API Client', this.config, token)
   }
 
-  async getReferral(id: string): Promise<Referral> {
+  async getDraftReferral(id: string): Promise<DraftReferral> {
     logger.info(`Getting draft referral with id ${id}`)
 
     const restClient = await this.createRestClient()
@@ -24,15 +24,15 @@ export default class InterventionsService {
     return (await restClient.get({
       path: `/draft-referral/${id}`,
       headers: { Accept: 'application/json' },
-    })) as Referral
+    })) as DraftReferral
   }
 
-  async createReferral(): Promise<Referral> {
+  async createDraftReferral(): Promise<DraftReferral> {
     const restClient = await this.createRestClient()
 
     return (await restClient.post({
       path: `/draft-referral`,
       headers: { Accept: 'application/json' },
-    })) as Referral
+    })) as DraftReferral
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Proposes the API contract for how we would update a draft referral. It adds a `completionDeadline` property and shows how we'd update this from the frontend. I'm seeking feedback on whether a `PATCH` or a `PUT` is more appropriate - see commit message for thinking.

## What is the intent behind these changes?

To provide us with the API call that we need in order to allow a user to fill out the referral form.