### PR TITLE
IC-643: Amend deployment probes to respond quicker and avoid warnings

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/templates/deployment.yaml
+++ b/helm_deploy/hmpps-interventions-ui/templates/deployment.yaml
@@ -41,15 +41,13 @@ spec:
             - containerPort: {{ .Values.image.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /ping
+            tcpSocket:
               port: {{ .Values.image.port }}
             initialDelaySeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
           readinessProbe:
-            httpGet:
-              path: /ping
+            tcpSocket:
               port: {{ .Values.image.port }}
             initialDelaySeconds: 10
             timeoutSeconds: 5

--- a/helm_deploy/hmpps-interventions-ui/templates/deployment.yaml
+++ b/helm_deploy/hmpps-interventions-ui/templates/deployment.yaml
@@ -44,16 +44,14 @@ spec:
             httpGet:
               path: /ping
               port: {{ .Values.image.port }}
-            periodSeconds: 30
-            initialDelaySeconds: 90
-            timeoutSeconds: 20
-            failureThreshold: 10
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /ping
               port: {{ .Values.image.port }}
-            periodSeconds: 20
-            initialDelaySeconds: 60
-            timeoutSeconds: 30
-            failureThreshold: 15
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
 {{ include "deployment.envs" . | nindent 10 }}


### PR DESCRIPTION
## What does this pull request do?

Reduces the initial delay at deployment and warnings by switching to a TCP probe.

Locally, a `helm upgrade` now takes a total of 24 seconds for me (down from 1m24s on CircleCI).

### Reducing delay

A deployment for the UI always takes over one minute, however, the pods are up within seconds:

```
$ k get pod/hmpps-interventions-ui-7c7695fd9b-mkvd9  -ojson \
    | jq '.status | .startTime, .containerStatuses[].state.running.startedAt'
"2020-12-07T09:33:30Z"
"2020-12-07T09:33:37Z"
```

To avoid stalling the deploy for 60 seconds (the value of the `readinessProbe.initialDelaySeconds`) we can set it to 10 seconds.

I feel the default 10 seconds value for `periodSeconds` (the delay between probe runs) also makes sense.

### Switching to TCP probe from `/ping`

The `/ping` endpoint does not exist on this application.

This results in probe warnings:

```
$ k describe pod/...
<snip>
Events:
  Type     Reason        Age                     From               Message
  ----     ------        ----                    ----               -------
<snip>
  Normal   Started       11m                     kubelet            Started container hmpps-interventions-ui
  Warning  ProbeWarning  5m37s (x14 over 9m57s)  kubelet            Readiness probe warning:
  Warning  ProbeWarning  78s (x17 over 9m18s)    kubelet            Liveness probe warning:
```

I would use `/health` but it checks downstream services, and while it's great to check the overall health of the application, it shouldn't be used to determine whether to route traffic to or when to restart our application.

From the [TCP liveness probe documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-tcp-liveness-probe):

> With this configuration, the kubelet will attempt to open a socket to your container on the specified port. If it can establish a connection, the container is considered healthy, if it can't it is considered a failure.

## What is the intent behind these changes?

To make deployments quicker and more reliable.