### PR TITLE
IC-614: User can set the completion deadline on a draft referral

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5426,6 +5426,15 @@
         }
       }
     },
+    "express-validator": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.8.0.tgz",
+      "integrity": "sha512-zEHxjly2Rx0vzJOgWJBCTk1vNNwxqp0a8S8WtKaW912oTmnQGSdh/XuuNzkt+tRBgw66z9u+ah+Sv8SH5SJyUQ==",
+      "requires": {
+        "lodash": "^4.17.20",
+        "validator": "^13.5.1"
+      }
+    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -8935,8 +8944,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -12845,6 +12853,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.1.tgz",
+      "integrity": "sha512-s+7LW1Xi0OzPNfGN7Hb2vk0YB/epp9KFHHGC5JtqZOE1dUkN4ULPFZAQ1inCu7ceAsWmOJu6sn9cnwm3R+ghWQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "express": "^4.17.1",
     "express-request-id": "^1.4.1",
     "express-session": "^1.17.1",
+    "express-validator": "^6.8.0",
     "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^3.9.0",
     "helmet": "^4.1.1",

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -31,6 +31,8 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/start', (req, res) => referralsController.startReferral(req, res))
   post('/referrals', (req, res) => referralsController.createReferral(req, res))
   get('/referrals/:id/form', (req, res) => referralsController.viewReferralForm(req, res))
+  get('/referrals/:id/completion-deadline', (req, res) => referralsController.viewCompletionDeadline(req, res))
+  post('/referrals/:id/completion-deadline', (req, res) => referralsController.updateCompletionDeadline(req, res))
 
   return router
 }

--- a/server/routes/referrals/completionDeadlineForm.test.ts
+++ b/server/routes/referrals/completionDeadlineForm.test.ts
@@ -1,0 +1,144 @@
+import { Request } from 'express'
+import CompletionDeadlineForm from './completionDeadlineForm'
+
+describe('CompletionDeadlineForm', () => {
+  describe('createForm', () => {
+    it('returns a form and sanitizes the request body', async () => {
+      const req = {
+        body: {
+          'completion-deadline-year': '2021',
+          'completion-deadline-month': '09',
+          'completion-deadline-day': '12',
+        },
+      } as Request
+
+      await CompletionDeadlineForm.createForm(req)
+
+      expect(req.body['completion-deadline-year']).toBe(2021)
+      expect(req.body['completion-deadline-month']).toBe(9)
+      expect(req.body['completion-deadline-day']).toBe(12)
+    })
+
+    describe('with invalid data', () => {
+      it('does not modify the invalid fields', async () => {
+        const req = {
+          body: {
+            'completion-deadline-year': '2021',
+            'completion-deadline-month': '09',
+            'completion-deadline-day': 'hello',
+          },
+        } as Request
+
+        await CompletionDeadlineForm.createForm(req)
+
+        expect(req.body['completion-deadline-year']).toBe(2021)
+        expect(req.body['completion-deadline-month']).toBe(9)
+        expect(req.body['completion-deadline-day']).toBe('hello')
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('returns null with valid data', async () => {
+      const req = {
+        body: {
+          'completion-deadline-year': '2021',
+          'completion-deadline-month': '09',
+          'completion-deadline-day': '12',
+        },
+      } as Request
+
+      const form = await CompletionDeadlineForm.createForm(req)
+
+      expect(form.errors).toBeNull()
+    })
+
+    it('returns an error when a field is empty', async () => {
+      const req = {
+        body: {
+          'completion-deadline-year': '',
+          'completion-deadline-month': '09',
+          'completion-deadline-day': '12',
+        },
+      } as Request
+
+      const form = await CompletionDeadlineForm.createForm(req)
+
+      expect(form.errors).toEqual({
+        firstErroredField: 'day',
+        erroredFields: ['day', 'month', 'year'],
+        message: 'The date by which the service needs to be completed must be a real date',
+      })
+    })
+
+    it('returns an error when a field is just whitespace', async () => {
+      const req = {
+        body: {
+          'completion-deadline-year': '2021',
+          'completion-deadline-month': '     ',
+          'completion-deadline-day': '12',
+        },
+      } as Request
+
+      const form = await CompletionDeadlineForm.createForm(req)
+
+      expect(form.errors).toEqual({
+        firstErroredField: 'day',
+        erroredFields: ['day', 'month', 'year'],
+        message: 'The date by which the service needs to be completed must be a real date',
+      })
+    })
+
+    it('returns an error when a field is non-numeric', async () => {
+      const req = {
+        body: {
+          'completion-deadline-year': '2021',
+          'completion-deadline-month': '09',
+          'completion-deadline-day': 'hello',
+        },
+      } as Request
+
+      const form = await CompletionDeadlineForm.createForm(req)
+
+      expect(form.errors).toEqual({
+        firstErroredField: 'day',
+        erroredFields: ['day', 'month', 'year'],
+        message: 'The date by which the service needs to be completed must be a real date',
+      })
+    })
+
+    it('returns an error when the date specified does not exist', async () => {
+      const req = {
+        body: {
+          'completion-deadline-year': '2011',
+          'completion-deadline-month': '02',
+          'completion-deadline-day': '31',
+        },
+      } as Request
+
+      const form = await CompletionDeadlineForm.createForm(req)
+
+      expect(form.errors).toEqual({
+        firstErroredField: 'day',
+        erroredFields: ['day', 'month', 'year'],
+        message: 'The date by which the service needs to be completed must be a real date',
+      })
+    })
+  })
+
+  describe('paramsForUpdate', () => {
+    it('returns an object with the completionDeadline key and an ISO-formatted date', async () => {
+      const req = {
+        body: {
+          'completion-deadline-year': '2021',
+          'completion-deadline-month': '09',
+          'completion-deadline-day': '12',
+        },
+      } as Request
+
+      const form = await CompletionDeadlineForm.createForm(req)
+
+      expect(form.paramsForUpdate).toEqual({ completionDeadline: '2021-09-12' })
+    })
+  })
+})

--- a/server/routes/referrals/completionDeadlineForm.ts
+++ b/server/routes/referrals/completionDeadlineForm.ts
@@ -1,0 +1,87 @@
+import { Request } from 'express'
+import { body, Result, SanitizationChain, ValidationError, validationResult } from 'express-validator'
+import { DraftReferral } from '../../services/interventionsService'
+import CalendarDay from '../../utils/calendarDay'
+import errorMessages from '../../utils/errorMessages'
+
+export default class CompletionDeadlineForm {
+  private constructor(private readonly request: Request, private readonly result: Result<ValidationError>) {
+    this.result = validationResult(request)
+  }
+
+  static async createForm(request: Request): Promise<CompletionDeadlineForm> {
+    await Promise.all(this.validations.map(validation => validation.run(request)))
+
+    const result = validationResult(request)
+
+    return new CompletionDeadlineForm(request, result)
+  }
+
+  static get validations(): SanitizationChain[] {
+    return [
+      // TODO decide whether we like the fact that express-validator is mutating the request?
+      // e.g. the `bail` before toInt() is so that we don’t end up replaying NaN back to the user
+      // if they enter a blank input
+      body('completion-deadline-day')
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(errorMessages.completionDeadline.dayEmpty)
+        .isInt()
+        .withMessage(errorMessages.completionDeadline.invalidDate)
+        .bail()
+        .toInt(),
+      body('completion-deadline-month')
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(errorMessages.completionDeadline.monthEmpty)
+        .isInt()
+        .withMessage(errorMessages.completionDeadline.invalidDate)
+        .bail()
+        .toInt(),
+      body('completion-deadline-year')
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(errorMessages.completionDeadline.yearEmpty)
+        .isInt()
+        .withMessage(errorMessages.completionDeadline.invalidDate)
+        .bail()
+        .toInt(),
+    ]
+  }
+
+  get paramsForUpdate(): Partial<DraftReferral> {
+    return {
+      completionDeadline: this.completionDeadline.iso8601,
+    }
+  }
+
+  get isValid(): boolean {
+    return this.errors === null
+  }
+
+  get errors(): CompletionDeadlineErrors | null {
+    if (this.result.isEmpty() && this.completionDeadline) {
+      return null
+    }
+
+    // TODO (IC-706) use `result`, implement all the rules of the GOV.UK Design
+    // System date input component error handling
+    return {
+      firstErroredField: 'day',
+      erroredFields: ['day', 'month', 'year'],
+      message: errorMessages.completionDeadline.invalidDate,
+    }
+  }
+
+  private get completionDeadline(): CalendarDay | null {
+    return CalendarDay.fromComponents(
+      this.request.body['completion-deadline-day'],
+      this.request.body['completion-deadline-month'],
+      this.request.body['completion-deadline-year']
+    )
+  }
+}
+
+// This interface is up for debate
+export interface CompletionDeadlineErrors {
+  firstErroredField: 'day' | 'month' | 'year'
+  erroredFields: ('day' | 'month' | 'year')[]
+  message: string
+}

--- a/server/routes/referrals/completionDeadlinePresenter.test.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.test.ts
@@ -1,0 +1,109 @@
+import CompletionDeadlinePresenter from './completionDeadlinePresenter'
+
+describe('CompletionDeadlinePresenter', () => {
+  describe('day, month, year', () => {
+    describe('when the referral has no completion deadline and there is no user input data', () => {
+      it('returns empty strings', () => {
+        const presenter = new CompletionDeadlinePresenter({
+          id: '1',
+          completionDeadline: null,
+          serviceCategory: { name: 'social inclusion' },
+        })
+
+        expect(presenter.day).toBe('')
+        expect(presenter.month).toBe('')
+        expect(presenter.year).toBe('')
+      })
+    })
+
+    describe('when the referral has a completion deadline and there is no user input data', () => {
+      it('returns the corresponding values from the completion deadline', () => {
+        const presenter = new CompletionDeadlinePresenter({
+          id: '1',
+          completionDeadline: '2021-09-12',
+          serviceCategory: { name: 'social inclusion' },
+        })
+
+        expect(presenter.day).toBe('12')
+        expect(presenter.month).toBe('9')
+        expect(presenter.year).toBe('2021')
+      })
+    })
+
+    describe('when there is user input data', () => {
+      it('returns the user input data, or an empty string if a field is missing', () => {
+        const presenter = new CompletionDeadlinePresenter(
+          { id: '1', completionDeadline: '2021-09-12', serviceCategory: { name: 'social inclusion' } },
+          null,
+          {
+            'completion-deadline-day': 'egg',
+            'completion-deadline-month': 7,
+          }
+        )
+
+        expect(presenter.day).toBe('egg')
+        expect(presenter.month).toBe('7')
+        expect(presenter.year).toBe('')
+      })
+    })
+  })
+
+  describe('error information', () => {
+    describe('when no errors are passed in', () => {
+      it('returns no errors', () => {
+        const presenter = new CompletionDeadlinePresenter({
+          id: '1',
+          completionDeadline: null,
+          serviceCategory: { name: 'social inclusion' },
+        })
+
+        expect(presenter.errorMessage).toBeNull()
+        expect(presenter.erroredFields).toEqual([])
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when errors are passed in', () => {
+      it('returns error information', () => {
+        const presenter = new CompletionDeadlinePresenter(
+          { id: '1', completionDeadline: null, serviceCategory: { name: 'social inclusion' } },
+          {
+            firstErroredField: 'month',
+            erroredFields: ['month', 'year'],
+            message: 'Please enter a month and a year',
+          }
+        )
+
+        expect(presenter.errorMessage).toBe('Please enter a month and a year')
+        expect(presenter.erroredFields).toEqual(['month', 'year'])
+        expect(presenter.errorSummary).toEqual({
+          errors: [{ message: 'Please enter a month and a year', linkedField: 'month' }],
+        })
+      })
+    })
+  })
+
+  describe('title', () => {
+    it('returns a title', () => {
+      const presenter = new CompletionDeadlinePresenter({
+        id: '1',
+        completionDeadline: null,
+        serviceCategory: { name: 'social inclusion' },
+      })
+
+      expect(presenter.title).toEqual('What date does the social inclusion service need to be completed by?')
+    })
+  })
+
+  describe('hint', () => {
+    it('returns a hint', () => {
+      const presenter = new CompletionDeadlinePresenter({
+        id: '1',
+        completionDeadline: null,
+        serviceCategory: { name: 'social inclusion' },
+      })
+
+      expect(presenter.hint).toEqual('For example, 27 10 2021')
+    })
+  })
+})

--- a/server/routes/referrals/completionDeadlinePresenter.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.ts
@@ -1,0 +1,61 @@
+import { DraftReferral } from '../../services/interventionsService'
+import { CompletionDeadlineErrors } from './completionDeadlineForm'
+import CalendarDay from '../../utils/calendarDay'
+
+export default class CompletionDeadlinePresenter {
+  readonly day: string
+
+  readonly month: string
+
+  readonly year: string
+
+  readonly errorMessage: string | null
+
+  readonly erroredFields: ('day' | 'month' | 'year')[]
+
+  readonly errorSummary: CompletionDeadlineErrorSummaryPresenter | null
+
+  readonly title = `What date does the ${this.referral.serviceCategory.name} service need to be completed by?`
+
+  readonly hint = 'For example, 27 10 2021'
+
+  constructor(
+    private readonly referral: DraftReferral,
+    errors: CompletionDeadlineErrors | null = null,
+    userInputData: Record<string, unknown> | null = null
+  ) {
+    if (!userInputData) {
+      const calendarDay = referral.completionDeadline ? CalendarDay.parseIso8601(referral.completionDeadline) : null
+
+      if (!calendarDay) {
+        this.day = ''
+        this.month = ''
+        this.year = ''
+      } else {
+        this.day = String(calendarDay.day)
+        this.month = String(calendarDay.month)
+        this.year = String(calendarDay.year)
+      }
+    } else {
+      this.day = String(userInputData['completion-deadline-day'] || '')
+      this.month = String(userInputData['completion-deadline-month'] || '')
+      this.year = String(userInputData['completion-deadline-year'] || '')
+    }
+
+    if (!errors) {
+      this.errorSummary = null
+      this.errorMessage = null
+      this.erroredFields = []
+    } else {
+      this.errorSummary = {
+        errors: [{ message: errors.message, linkedField: errors.firstErroredField }],
+      }
+      this.errorMessage = errors.message
+      this.erroredFields = errors.erroredFields
+    }
+  }
+}
+
+export interface CompletionDeadlineErrorSummaryPresenter {
+  errors: { message: string; linkedField: 'day' | 'month' | 'year' }[]
+}

--- a/server/routes/referrals/completionDeadlineView.ts
+++ b/server/routes/referrals/completionDeadlineView.ts
@@ -1,0 +1,69 @@
+import CompletionDeadlinePresenter from './completionDeadlinePresenter'
+
+export default class CompletionDeadlineView {
+  constructor(private readonly presenter: CompletionDeadlinePresenter) {}
+
+  private get dateInputArgs(): Record<string, unknown> {
+    const errorMessage = this.presenter.errorMessage ? { text: this.presenter.errorMessage } : null
+
+    return {
+      id: 'completion-deadline',
+      namePrefix: 'completion-deadline',
+      fieldset: {
+        legend: {
+          text: this.presenter.title,
+          isPageHeading: true,
+          classes: 'govuk-fieldset__legend--xl',
+        },
+      },
+      hint: {
+        text: this.presenter.hint,
+      },
+      errorMessage,
+      items: [
+        {
+          classes: `govuk-input--width-2${this.presenter.erroredFields.includes('day') ? ' govuk-input--error' : ''}`,
+          name: 'day',
+          value: this.presenter.day,
+        },
+        {
+          classes: `govuk-input--width-2${this.presenter.erroredFields.includes('month') ? ' govuk-input--error' : ''}`,
+          name: 'month',
+          value: this.presenter.month,
+        },
+        {
+          classes: `govuk-input--width-4${this.presenter.erroredFields.includes('year') ? ' govuk-input--error' : ''}`,
+          name: 'year',
+          value: this.presenter.year,
+        },
+      ],
+    }
+  }
+
+  private get errorSummaryArgs(): Record<string, unknown> | null {
+    if (this.presenter.errorSummary === null) {
+      return null
+    }
+
+    return {
+      titleText: 'There is a problem',
+      errorList: this.presenter.errorSummary.errors.map(error => {
+        return {
+          text: error.message,
+          href: `#completion-deadline-${error.linkedField}`,
+        }
+      }),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/completionDeadline',
+      {
+        presenter: this.presenter,
+        dateInputArgs: this.dateInputArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -6,7 +6,11 @@ describe('ReferralFormPresenter', () => {
     // as the task list starts to handle different referral states.
 
     it('returns an array of section presenters', () => {
-      const presenter = new ReferralFormPresenter({ id: '1', completionDeadline: '2021-03-01' })
+      const presenter = new ReferralFormPresenter({
+        id: '1',
+        completionDeadline: '2021-03-01',
+        serviceCategory: { name: 'social inclusion' },
+      })
 
       const expected = [
         {

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -15,11 +15,7 @@ beforeEach(() => {
   interventionsService.createDraftReferral.mockResolvedValue({
     id: '1',
     completionDeadline: null,
-  })
-
-  interventionsService.getDraftReferral.mockResolvedValue({
-    id: '1',
-    completionDeadline: null,
+    serviceCategory: null,
   })
 })
 
@@ -65,6 +61,14 @@ describe('POST /referrals', () => {
 })
 
 describe('GET /referrals/:id/form', () => {
+  beforeEach(() => {
+    interventionsService.getDraftReferral.mockResolvedValue({
+      id: '1',
+      completionDeadline: null,
+      serviceCategory: null,
+    })
+  })
+
   it('fetches the referral from the interventions service and renders a page with information about the referral', async () => {
     await request(app)
       .get('/referrals/1/form')

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -1,7 +1,10 @@
 import { Request, Response } from 'express'
 import InterventionsService from '../../services/interventionsService'
 import ReferralFormPresenter from './referralFormPresenter'
+import CompletionDeadlinePresenter from './completionDeadlinePresenter'
 import ReferralFormView from './referralFormView'
+import CompletionDeadlineView from './completionDeadlineView'
+import CompletionDeadlineForm, { CompletionDeadlineErrors } from './completionDeadlineForm'
 
 export default class ReferralsController {
   constructor(private readonly interventionsService: InterventionsService) {}
@@ -23,5 +26,47 @@ export default class ReferralsController {
     const view = new ReferralFormView(presenter)
 
     res.render(...view.renderArgs)
+  }
+
+  async viewCompletionDeadline(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+    const presenter = new CompletionDeadlinePresenter(referral)
+    const view = new CompletionDeadlineView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async updateCompletionDeadline(req: Request, res: Response): Promise<void> {
+    const form = await CompletionDeadlineForm.createForm(req)
+
+    let errors: CompletionDeadlineErrors | null = null
+
+    if (form.isValid) {
+      try {
+        await this.interventionsService.patchDraftReferral(res.locals.user.token, req.params.id, form.paramsForUpdate)
+      } catch (e) {
+        errors = {
+          firstErroredField: 'day',
+          erroredFields: ['day', 'month', 'year'],
+          // TODO (IC-615) there’s probably a more appropriate message to use from the response
+          message: e.message,
+        }
+      }
+    } else {
+      errors = form.errors
+    }
+
+    if (errors === null) {
+      res.redirect(`/referrals/${req.params.id}/form`)
+    } else {
+      const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+      const presenter = new CompletionDeadlinePresenter(referral, errors, req.body)
+      const view = new CompletionDeadlineView(presenter)
+
+      res.status(400)
+      res.render(...view.renderArgs)
+    }
   }
 }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -17,8 +17,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   })
 
   describe('getDraftReferral', () => {
-    beforeEach(async () => {
-      // This is just an example for getting Pact set up; we’ll properly design this endpoint later
+    it('returns a referral for the given ID', async () => {
       await provider.addInteraction({
         state: 'There is an existing draft referral with ID of ac386c25-52c8-41fa-9213-fcf42e24b0b5',
         uponReceiving: 'a request for that referral',
@@ -35,11 +34,41 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: { 'Content-Type': 'application/json' },
         },
       })
-    })
 
-    it('returns a referral for the given ID', async () => {
       const referral = await interventionsService.getDraftReferral('token', 'ac386c25-52c8-41fa-9213-fcf42e24b0b5')
       expect(referral.id).toBe('ac386c25-52c8-41fa-9213-fcf42e24b0b5')
+    })
+
+    describe('for a referral that has had a service category selected', () => {
+      beforeEach(async () => {
+        await provider.addInteraction({
+          state:
+            'There is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962, and it has had a service category selected',
+          uponReceiving: 'a request for that referral',
+          withRequest: {
+            method: 'GET',
+            path: '/draft-referral/d496e4a7-7cc1-44ea-ba67-c295084f1962',
+            headers: { Accept: 'application/json', Authorization: 'Bearer token' },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like({
+              id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
+              serviceCategory: {
+                name: 'accommodation',
+              },
+            }),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+      })
+
+      it('returns a referral for the given ID, with the service category fields populated', async () => {
+        const referral = await interventionsService.getDraftReferral('token', 'd496e4a7-7cc1-44ea-ba67-c295084f1962')
+
+        expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
+        expect(referral.serviceCategory.name).toEqual('accommodation')
+      })
     })
   })
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -6,6 +6,11 @@ import HmppsAuthClient from '../data/hmppsAuthClient'
 export interface DraftReferral {
   id: string
   completionDeadline: string | null
+  serviceCategory: ServiceCategory | null
+}
+
+export interface ServiceCategory {
+  name: string
 }
 
 export default class InterventionsService {

--- a/server/utils/calendarDay.test.ts
+++ b/server/utils/calendarDay.test.ts
@@ -1,0 +1,63 @@
+import CalendarDay from './calendarDay'
+
+describe('CalendarDay', () => {
+  describe('iso8601', () => {
+    it('returns an ISO 8601 formatted date describing the day', () => {
+      const calendarDay = CalendarDay.fromComponents(15, 9, 1992)
+
+      expect(calendarDay.iso8601).toBe('1992-09-15')
+    })
+  })
+
+  describe('.fromComponents', () => {
+    it('returns a date when given components for a day that exists', () => {
+      const date = CalendarDay.fromComponents(15, 9, 1992)
+
+      expect(date.day).toBe(15)
+      expect(date.month).toBe(9)
+      expect(date.year).toBe(1992)
+    })
+
+    it('returns null when given 31st February in a non-leap year', () => {
+      expect(CalendarDay.fromComponents(2011, 2, 31)).toBeNull()
+    })
+
+    it('returns null when given a month out of bounds', () => {
+      expect(CalendarDay.fromComponents(2011, 13, 1)).toBeNull()
+    })
+
+    it('returns null when given a day out of bounds for any month', () => {
+      expect(CalendarDay.fromComponents(2011, 1, 32)).toBeNull()
+    })
+
+    it('returns null when given a day out of bounds for the month', () => {
+      expect(CalendarDay.fromComponents(2011, 6, 31)).toBeNull()
+    })
+  })
+
+  describe('.parseIso8601', () => {
+    it('returns a calendar day when given a valid ISO 8601 formatted date', () => {
+      expect(CalendarDay.parseIso8601('1992-09-15')).toEqual(CalendarDay.fromComponents(15, 9, 1992))
+    })
+
+    it('returns null when given something other than an ISO 8601 formatted date', () => {
+      expect(CalendarDay.parseIso8601('19920915')).toBeNull()
+    })
+
+    it('returns null when given 31st February in a non-leap year', () => {
+      expect(CalendarDay.parseIso8601('2011-02-31')).toBeNull()
+    })
+
+    it('returns null when given a month out of bounds', () => {
+      expect(CalendarDay.parseIso8601('2011-13-01')).toBeNull()
+    })
+
+    it('returns null when given a day out of bounds for any month', () => {
+      expect(CalendarDay.parseIso8601('2011-01-32')).toBeNull()
+    })
+
+    it('returns null when given a day out of bounds for the month', () => {
+      expect(CalendarDay.parseIso8601('2011-06-31')).toBeNull()
+    })
+  })
+})

--- a/server/utils/calendarDay.ts
+++ b/server/utils/calendarDay.ts
@@ -1,0 +1,39 @@
+export default class CalendarDay {
+  private constructor(readonly day: number, readonly month: number, readonly year: number) {}
+
+  static fromComponents(day: number, month: number, year: number): CalendarDay | null {
+    return isValidDate(day, month, year) ? new CalendarDay(day, month, year) : null
+  }
+
+  static parseIso8601(val: string): CalendarDay | null {
+    const result = /^(\d{4})-(\d{2})-(\d{2})$/.exec(val)
+
+    if (result === null) {
+      return null
+    }
+
+    const [year, month, day] = result.slice(1).map(Number)
+
+    if (!isValidDate(day, month, year)) {
+      return null
+    }
+
+    return new CalendarDay(day, month, year)
+  }
+
+  get iso8601(): string {
+    return [
+      String(this.year).padStart(4, '0'),
+      String(this.month).padStart(2, '0'),
+      String(this.day).padStart(2, '0'),
+    ].join('-')
+  }
+}
+
+function isValidDate(day: number, month: number, year: number) {
+  // Date(Date.UTC(…)) will always return a valid date regardless of input, so if
+  // [day, month, year] aren’t the components of a valid date then they won’t
+  // match the components of this result.
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return year === date.getUTCFullYear() && month === date.getUTCMonth() + 1 && day === date.getUTCDate()
+}

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -1,0 +1,8 @@
+export default {
+  completionDeadline: {
+    dayEmpty: 'The date by which the service needs to be completed must include a day',
+    monthEmpty: 'The date by which the service needs to be completed must include a month',
+    yearEmpty: 'The date by which the service needs to be completed must include a year',
+    invalidDate: 'The date by which the service needs to be completed must be a real date',
+  },
+}

--- a/server/views/referrals/completionDeadline.njk
+++ b/server/views/referrals/completionDeadline.njk
@@ -1,0 +1,29 @@
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {% if errorSummaryArgs !== null %}
+          {{ govukErrorSummary(errorSummaryArgs) }}
+        {% endif %}
+
+        {{ govukDateInput(dateInputArgs) }}
+
+        {{ govukButton({ text: "Save and continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a page `/draft-referrals/:id/completion-deadline` which allows the user to set the completion deadline on a draft referral. It's the first time that we've built a UI to allow the user to set / update data on the backend, so we’re trying out some patterns to see what works. See commit messages for more details.

## What is the intent behind these changes?

To allow the user to set a completion deadline on a referral.

## Screenshots

![Screenshot_2020-12-10 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/101779343-0de98500-3aed-11eb-9a55-9fbfde9b5521.png)
![Screenshot_2020-12-10 HMPPS Interventions - GOV UK(1)](https://user-images.githubusercontent.com/53756884/101779349-104bdf00-3aed-11eb-8784-ed722dc0e5fe.png)
