### PR TITLE
use login tokens for interventions API access

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,7 @@ import InterventionsService from './services/interventionsService'
 const hmppsAuthClient = new HmppsAuthClient()
 const userService = new UserService(hmppsAuthClient)
 const communityApiService = new CommunityApiService(hmppsAuthClient)
-const interventionsService = new InterventionsService(config.apis.interventionsService, hmppsAuthClient)
+const interventionsService = new InterventionsService(config.apis.interventionsService)
 
 const app = createApp(userService, communityApiService, interventionsService)
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -5,7 +5,7 @@ import appWithAllRoutes from '../testutils/appSetup'
 
 jest.mock('../../services/interventionsService')
 
-const interventionsService = new InterventionsService(null, null) as jest.Mocked<InterventionsService>
+const interventionsService = new InterventionsService(null) as jest.Mocked<InterventionsService>
 
 let app: Express
 
@@ -73,7 +73,7 @@ describe('GET /referrals/:id/form', () => {
         expect(res.text).toContain('Viewing referral with ID 1')
       })
 
-    expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['1'])
+    expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['token', '1'])
   })
 
   describe('when the interventions service returns an error', () => {

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -11,13 +11,13 @@ export default class ReferralsController {
   }
 
   async createReferral(req: Request, res: Response): Promise<void> {
-    const referral = await this.interventionsService.createDraftReferral()
+    const referral = await this.interventionsService.createDraftReferral(res.locals.user.token)
 
     res.redirect(303, `/referrals/${referral.id}/form`)
   }
 
   async viewReferralForm(req: Request, res: Response): Promise<void> {
-    const referral = await this.interventionsService.getDraftReferral(req.params.id)
+    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
 
     const presenter = new ReferralFormPresenter(referral)
     const view = new ReferralFormView(presenter)

--- a/server/routes/testutils/mocks/mockUserService.ts
+++ b/server/routes/testutils/mocks/mockUserService.ts
@@ -6,6 +6,7 @@ export const user = {
   lastName: 'smith',
   username: 'user1',
   displayName: 'John Smith',
+  token: 'token',
 }
 
 export class MockUserService extends UserService {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -13,9 +13,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
   beforeEach(() => {
     const testConfig = { ...config.apis.interventionsService, url: provider.mockService.baseUrl }
-    const hmppsAuthClient = new MockedHmppsAuthClient() as jest.Mocked<HmppsAuthClient>
-    hmppsAuthClient.getApiClientToken.mockResolvedValue('mockedToken')
-    interventionsService = new InterventionsService(testConfig, hmppsAuthClient)
+    interventionsService = new InterventionsService(testConfig)
   })
 
   describe('getDraftReferral', () => {
@@ -27,7 +25,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/draft-referral/ac386c25-52c8-41fa-9213-fcf42e24b0b5',
-          headers: { Accept: 'application/json', Authorization: 'Bearer mockedToken' },
+          headers: { Accept: 'application/json', Authorization: 'Bearer token' },
         },
         willRespondWith: {
           status: 200,
@@ -40,7 +38,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
 
     it('returns a referral for the given ID', async () => {
-      const referral = await interventionsService.getDraftReferral('ac386c25-52c8-41fa-9213-fcf42e24b0b5')
+      const referral = await interventionsService.getDraftReferral('token', 'ac386c25-52c8-41fa-9213-fcf42e24b0b5')
       expect(referral.id).toBe('ac386c25-52c8-41fa-9213-fcf42e24b0b5')
     })
   })
@@ -54,7 +52,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: '/draft-referral',
-          headers: { Accept: 'application/json', Authorization: 'Bearer mockedToken' },
+          headers: { Accept: 'application/json', Authorization: 'Bearer token' },
         },
         willRespondWith: {
           status: 201,
@@ -72,7 +70,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
 
     it('returns a referral', async () => {
-      const referral = await interventionsService.createDraftReferral()
+      const referral = await interventionsService.createDraftReferral('token')
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
     })
   })
@@ -88,7 +86,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: 'Bearer mockedToken',
+            Authorization: 'Bearer token',
           },
           body: { completionDeadline: '2021-04-01' },
         },
@@ -106,7 +104,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
 
     it('returns the updated referral', async () => {
-      const referral = await interventionsService.patchDraftReferral('dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+      const referral = await interventionsService.patchDraftReferral('token', 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
         completionDeadline: '2021-04-01',
       })
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -9,18 +9,16 @@ export interface DraftReferral {
 }
 
 export default class InterventionsService {
-  constructor(private readonly config: ApiConfig, private readonly hmppsAuthClient: HmppsAuthClient) {}
+  constructor(private readonly config: ApiConfig) {}
 
-  private async createRestClient(): Promise<RestClient> {
-    const token = await this.hmppsAuthClient.getApiClientToken()
-
+  private createRestClient(token: string): RestClient {
     return new RestClient('Interventions Service API Client', this.config, token)
   }
 
-  async getDraftReferral(id: string): Promise<DraftReferral> {
+  async getDraftReferral(token: string, id: string): Promise<DraftReferral> {
     logger.info(`Getting draft referral with id ${id}`)
 
-    const restClient = await this.createRestClient()
+    const restClient = await this.createRestClient(token)
 
     return (await restClient.get({
       path: `/draft-referral/${id}`,
@@ -28,8 +26,8 @@ export default class InterventionsService {
     })) as DraftReferral
   }
 
-  async createDraftReferral(): Promise<DraftReferral> {
-    const restClient = await this.createRestClient()
+  async createDraftReferral(token: string): Promise<DraftReferral> {
+    const restClient = await this.createRestClient(token)
 
     return (await restClient.post({
       path: `/draft-referral`,
@@ -37,8 +35,8 @@ export default class InterventionsService {
     })) as DraftReferral
   }
 
-  async patchDraftReferral(id: string, patch: Partial<DraftReferral>): Promise<DraftReferral> {
-    const restClient = await this.createRestClient()
+  async patchDraftReferral(token: string, id: string, patch: Partial<DraftReferral>): Promise<DraftReferral> {
+    const restClient = await this.createRestClient(token)
 
     return (await restClient.patch({
       path: `/draft-referral/${id}`,


### PR DESCRIPTION
## What does this pull request do?

instead of using the client_credentials token for the interventions service calls, use the logged in user's token, which provides username details and roles to the downstream service.

## What is the intent behind these changes?

 this allows granular role management and user-authenticated HMPPS Auth API calls at the API layer. it also allows the interventions API to associate calls with logged in users.
