### PR TITLE
IC-670: Allow users to set complexity level on a draft referral

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -31,6 +31,7 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/start', (req, res) => referralsController.startReferral(req, res))
   post('/referrals', (req, res) => referralsController.createReferral(req, res))
   get('/referrals/:id/form', (req, res) => referralsController.viewReferralForm(req, res))
+  get('/referrals/:id/complexity-level', (req, res) => referralsController.viewComplexityLevel(req, res))
   get('/referrals/:id/completion-deadline', (req, res) => referralsController.viewCompletionDeadline(req, res))
   post('/referrals/:id/completion-deadline', (req, res) => referralsController.updateCompletionDeadline(req, res))
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -32,6 +32,7 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals', (req, res) => referralsController.createReferral(req, res))
   get('/referrals/:id/form', (req, res) => referralsController.viewReferralForm(req, res))
   get('/referrals/:id/complexity-level', (req, res) => referralsController.viewComplexityLevel(req, res))
+  post('/referrals/:id/complexity-level', (req, res) => referralsController.updateComplexityLevel(req, res))
   get('/referrals/:id/completion-deadline', (req, res) => referralsController.viewCompletionDeadline(req, res))
   post('/referrals/:id/completion-deadline', (req, res) => referralsController.updateCompletionDeadline(req, res))
 

--- a/server/routes/referrals/completionDeadlinePresenter.test.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.test.ts
@@ -11,6 +11,7 @@ describe('CompletionDeadlinePresenter', () => {
             id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
             name: 'social inclusion',
           },
+          complexityLevelId: null,
         })
 
         expect(presenter.day).toBe('')
@@ -28,6 +29,7 @@ describe('CompletionDeadlinePresenter', () => {
             id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
             name: 'social inclusion',
           },
+          complexityLevelId: null,
         })
 
         expect(presenter.day).toBe('12')
@@ -46,6 +48,7 @@ describe('CompletionDeadlinePresenter', () => {
               id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
               name: 'social inclusion',
             },
+            complexityLevelId: null,
           },
           null,
           {
@@ -71,6 +74,7 @@ describe('CompletionDeadlinePresenter', () => {
             id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
             name: 'social inclusion',
           },
+          complexityLevelId: null,
         })
 
         expect(presenter.errorMessage).toBeNull()
@@ -89,6 +93,7 @@ describe('CompletionDeadlinePresenter', () => {
               id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
               name: 'social inclusion',
             },
+            complexityLevelId: null,
           },
           {
             firstErroredField: 'month',
@@ -115,6 +120,7 @@ describe('CompletionDeadlinePresenter', () => {
           id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
           name: 'social inclusion',
         },
+        complexityLevelId: null,
       })
 
       expect(presenter.title).toEqual('What date does the social inclusion service need to be completed by?')
@@ -130,6 +136,7 @@ describe('CompletionDeadlinePresenter', () => {
           id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
           name: 'social inclusion',
         },
+        complexityLevelId: null,
       })
 
       expect(presenter.hint).toEqual('For example, 27 10 2021')

--- a/server/routes/referrals/completionDeadlinePresenter.test.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.test.ts
@@ -7,7 +7,10 @@ describe('CompletionDeadlinePresenter', () => {
         const presenter = new CompletionDeadlinePresenter({
           id: '1',
           completionDeadline: null,
-          serviceCategory: { name: 'social inclusion' },
+          serviceCategory: {
+            id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+            name: 'social inclusion',
+          },
         })
 
         expect(presenter.day).toBe('')
@@ -21,7 +24,10 @@ describe('CompletionDeadlinePresenter', () => {
         const presenter = new CompletionDeadlinePresenter({
           id: '1',
           completionDeadline: '2021-09-12',
-          serviceCategory: { name: 'social inclusion' },
+          serviceCategory: {
+            id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+            name: 'social inclusion',
+          },
         })
 
         expect(presenter.day).toBe('12')
@@ -33,7 +39,14 @@ describe('CompletionDeadlinePresenter', () => {
     describe('when there is user input data', () => {
       it('returns the user input data, or an empty string if a field is missing', () => {
         const presenter = new CompletionDeadlinePresenter(
-          { id: '1', completionDeadline: '2021-09-12', serviceCategory: { name: 'social inclusion' } },
+          {
+            id: '1',
+            completionDeadline: '2021-09-12',
+            serviceCategory: {
+              id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+              name: 'social inclusion',
+            },
+          },
           null,
           {
             'completion-deadline-day': 'egg',
@@ -54,7 +67,10 @@ describe('CompletionDeadlinePresenter', () => {
         const presenter = new CompletionDeadlinePresenter({
           id: '1',
           completionDeadline: null,
-          serviceCategory: { name: 'social inclusion' },
+          serviceCategory: {
+            id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+            name: 'social inclusion',
+          },
         })
 
         expect(presenter.errorMessage).toBeNull()
@@ -66,7 +82,14 @@ describe('CompletionDeadlinePresenter', () => {
     describe('when errors are passed in', () => {
       it('returns error information', () => {
         const presenter = new CompletionDeadlinePresenter(
-          { id: '1', completionDeadline: null, serviceCategory: { name: 'social inclusion' } },
+          {
+            id: '1',
+            completionDeadline: null,
+            serviceCategory: {
+              id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+              name: 'social inclusion',
+            },
+          },
           {
             firstErroredField: 'month',
             erroredFields: ['month', 'year'],
@@ -88,7 +111,10 @@ describe('CompletionDeadlinePresenter', () => {
       const presenter = new CompletionDeadlinePresenter({
         id: '1',
         completionDeadline: null,
-        serviceCategory: { name: 'social inclusion' },
+        serviceCategory: {
+          id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+          name: 'social inclusion',
+        },
       })
 
       expect(presenter.title).toEqual('What date does the social inclusion service need to be completed by?')
@@ -100,7 +126,10 @@ describe('CompletionDeadlinePresenter', () => {
       const presenter = new CompletionDeadlinePresenter({
         id: '1',
         completionDeadline: null,
-        serviceCategory: { name: 'social inclusion' },
+        serviceCategory: {
+          id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+          name: 'social inclusion',
+        },
       })
 
       expect(presenter.hint).toEqual('For example, 27 10 2021')

--- a/server/routes/referrals/complexityLevelForm.test.ts
+++ b/server/routes/referrals/complexityLevelForm.test.ts
@@ -1,0 +1,66 @@
+import { Request } from 'express'
+import ComplexityLevelForm from './complexityLevelForm'
+
+describe(ComplexityLevelForm, () => {
+  describe('isValid', () => {
+    it('returns true when the complexity-level-id property is present in the body', async () => {
+      const form = await ComplexityLevelForm.createForm({
+        body: { 'complexity-level-id': '43557c7a-c286-49c2-a994-d0a821295c7a' },
+      } as Request)
+
+      expect(form.isValid).toBe(true)
+    })
+
+    it('returns false when the complexity-level-id property is absent in the body', async () => {
+      const form = await ComplexityLevelForm.createForm({
+        body: {},
+      } as Request)
+
+      expect(form.isValid).toBe(false)
+    })
+
+    it('returns false when the complexity-level-id property is null in the body', async () => {
+      const form = await ComplexityLevelForm.createForm({
+        body: { 'complexity-level-id': null },
+      } as Request)
+
+      expect(form.isValid).toBe(false)
+    })
+  })
+
+  describe('error', () => {
+    it('returns null when the complexity-level-id property is present in the body', async () => {
+      const form = await ComplexityLevelForm.createForm({
+        body: { 'complexity-level-id': '43557c7a-c286-49c2-a994-d0a821295c7a' },
+      } as Request)
+
+      expect(form.error).toBe(null)
+    })
+
+    it('returns an error object when the complexity-level-id property is absent in the body', async () => {
+      const form = await ComplexityLevelForm.createForm({
+        body: {},
+      } as Request)
+
+      expect(form.error).toEqual({ message: 'Select a complexity level' })
+    })
+
+    it('returns an error object when the complexity-level-id property is null in the body', async () => {
+      const form = await ComplexityLevelForm.createForm({
+        body: { 'complexity-level-id': null },
+      } as Request)
+
+      expect(form.error).toEqual({ message: 'Select a complexity level' })
+    })
+  })
+
+  describe('paramsForUpdate', () => {
+    it('returns the params to be sent to the backend, when the data in the body is valid', async () => {
+      const form = await ComplexityLevelForm.createForm({
+        body: { 'complexity-level-id': '43557c7a-c286-49c2-a994-d0a821295c7a' },
+      } as Request)
+
+      expect(form.paramsForUpdate).toEqual({ complexityLevelId: '43557c7a-c286-49c2-a994-d0a821295c7a' })
+    })
+  })
+})

--- a/server/routes/referrals/complexityLevelForm.ts
+++ b/server/routes/referrals/complexityLevelForm.ts
@@ -1,0 +1,29 @@
+import { Request } from 'express'
+import { DraftReferral } from '../../services/interventionsService'
+import { ComplexityLevelError } from './complexityLevelPresenter'
+
+export default class ComplexityLevelForm {
+  private constructor(private readonly request: Request) {}
+
+  static async createForm(request: Request): Promise<ComplexityLevelForm> {
+    return new ComplexityLevelForm(request)
+  }
+
+  get paramsForUpdate(): Partial<DraftReferral> {
+    return {
+      complexityLevelId: this.request.body['complexity-level-id'],
+    }
+  }
+
+  get isValid(): boolean {
+    return this.request.body['complexity-level-id'] !== null && this.request.body['complexity-level-id'] !== undefined
+  }
+
+  get error(): ComplexityLevelError | null {
+    if (this.isValid) {
+      return null
+    }
+
+    return { message: 'Select a complexity level' }
+  }
+}

--- a/server/routes/referrals/complexityLevelPresenter.test.ts
+++ b/server/routes/referrals/complexityLevelPresenter.test.ts
@@ -1,0 +1,74 @@
+import { DraftReferral } from '../../services/interventionsService'
+import ComplexityLevelPresenter from './complexityLevelPresenter'
+
+describe('ComplexityLevelPresenter', () => {
+  const draftReferral: DraftReferral = {
+    id: '1',
+    completionDeadline: null,
+    serviceCategory: {
+      id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+      name: 'social inclusion',
+    },
+    complexityLevelId: null,
+  }
+
+  const socialInclusionComplexityLevels = [
+    {
+      id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+      title: 'Low complexity',
+      description:
+        'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
+    },
+    {
+      id: '110f2405-d944-4c15-836c-0c6684e2aa78',
+      title: 'Medium complexity',
+      description:
+        'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
+    },
+    {
+      id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
+      title: 'High complexity',
+      description:
+        'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
+    },
+  ]
+
+  describe('complexityDescriptions', () => {
+    it('sets each complexity level ID as the `value` on the presenter', () => {
+      const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels)
+
+      const expectedValues = presenter.complexityDescriptions.map(description => description.value).sort()
+      const complexityLevelIds = socialInclusionComplexityLevels.map(complexityLevel => complexityLevel.id).sort()
+
+      expect(expectedValues).toEqual(complexityLevelIds)
+    })
+
+    it('sets each complexity level title as the `title` on the presenter', () => {
+      const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels)
+
+      const expectedTitles = presenter.complexityDescriptions.map(description => description.title).sort()
+      const complexityLevelIds = socialInclusionComplexityLevels.map(complexityLevel => complexityLevel.title).sort()
+
+      expect(expectedTitles).toEqual(complexityLevelIds)
+    })
+
+    it('sets each complexity level description as the `hint` text on the presenter', () => {
+      const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels)
+
+      const expectedHints = presenter.complexityDescriptions.map(description => description.hint).sort()
+      const complexityLevelIds = socialInclusionComplexityLevels
+        .map(complexityLevel => complexityLevel.description)
+        .sort()
+
+      expect(expectedHints).toEqual(complexityLevelIds)
+    })
+  })
+
+  describe('title', () => {
+    it('returns a title', () => {
+      const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels)
+
+      expect(presenter.title).toEqual('What is the complexity level for the social inclusion service?')
+    })
+  })
+})

--- a/server/routes/referrals/complexityLevelPresenter.test.ts
+++ b/server/routes/referrals/complexityLevelPresenter.test.ts
@@ -62,6 +62,36 @@ describe('ComplexityLevelPresenter', () => {
 
       expect(expectedHints).toEqual(complexityLevelIds)
     })
+
+    describe('when the referral already has a selected complexity level', () => {
+      it('sets checked to true for the referral’s selected complexity level', () => {
+        draftReferral.complexityLevelId = '110f2405-d944-4c15-836c-0c6684e2aa78'
+        const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels)
+
+        expect(presenter.complexityDescriptions.map(description => description.checked)).toEqual([false, true, false])
+      })
+    })
+
+    describe('when there is user input data', () => {
+      it('sets checked to true for the complexity level that the user chose', () => {
+        const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels, null, {
+          'complexity-level': '110f2405-d944-4c15-836c-0c6684e2aa78',
+        })
+
+        expect(presenter.complexityDescriptions.map(description => description.checked)).toEqual([false, true, false])
+      })
+    })
+
+    describe('when the referral already has a selected complexity level and there is user input data', () => {
+      it('sets checked to true for the complexity level that the user chose', () => {
+        draftReferral.complexityLevelId = 'd0db50b0-4a50-4fc7-a006-9c97530e38b2'
+        const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels, null, {
+          'complexity-level': '110f2405-d944-4c15-836c-0c6684e2aa78',
+        })
+
+        expect(presenter.complexityDescriptions.map(description => description.checked)).toEqual([false, true, false])
+      })
+    })
   })
 
   describe('title', () => {

--- a/server/routes/referrals/complexityLevelPresenter.ts
+++ b/server/routes/referrals/complexityLevelPresenter.ts
@@ -8,20 +8,27 @@ export default class ComplexityLevelPresenter {
   constructor(
     private readonly referral: DraftReferral,
     private readonly complexityLevels: ComplexityLevel[],
-    readonly error?: ComplexityLevelError | null
+    readonly error?: ComplexityLevelError | null,
+    private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
   readonly complexityDescriptions: {
     title: string
     value: string
     hint: string
+    checked: boolean
   }[] = this.complexityLevels.map(complexityLevel => {
     return {
       title: complexityLevel.title,
       value: complexityLevel.id,
       hint: complexityLevel.description,
+      checked: this.selectedComplexityLevelId === complexityLevel.id,
     }
   })
+
+  private get selectedComplexityLevelId() {
+    return this.userInputData ? this.userInputData['complexity-level'] : this.referral.complexityLevelId
+  }
 
   readonly title = `What is the complexity level for the ${this.referral.serviceCategory.name} service?`
 }

--- a/server/routes/referrals/complexityLevelPresenter.ts
+++ b/server/routes/referrals/complexityLevelPresenter.ts
@@ -1,0 +1,27 @@
+import { ComplexityLevel, DraftReferral } from '../../services/interventionsService'
+
+export interface ComplexityLevelError {
+  message: string
+}
+
+export default class ComplexityLevelPresenter {
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly complexityLevels: ComplexityLevel[],
+    readonly error?: ComplexityLevelError | null
+  ) {}
+
+  readonly complexityDescriptions: {
+    title: string
+    value: string
+    hint: string
+  }[] = this.complexityLevels.map(complexityLevel => {
+    return {
+      title: complexityLevel.title,
+      value: complexityLevel.id,
+      hint: complexityLevel.description,
+    }
+  })
+
+  readonly title = `What is the complexity level for the ${this.referral.serviceCategory.name} service?`
+}

--- a/server/routes/referrals/complexityLevelView.ts
+++ b/server/routes/referrals/complexityLevelView.ts
@@ -1,0 +1,60 @@
+import ComplexityLevelPresenter from './complexityLevelPresenter'
+
+export default class ComplexityLevelView {
+  constructor(readonly presenter: ComplexityLevelPresenter) {}
+
+  get radioButtonArgs(): Record<string, unknown> {
+    const errorMessage = this.presenter.error ? { text: this.presenter.error.message } : null
+
+    return {
+      classes: 'govuk-radios',
+      idPrefix: 'complexity-level',
+      name: 'complexity-level',
+      fieldset: {
+        legend: {
+          text: this.presenter.title,
+          isPageHeading: true,
+          classes: 'govuk-fieldset__legend--xl',
+        },
+      },
+      errorMessage,
+      items: this.presenter.complexityDescriptions.map(complexityDescription => {
+        return {
+          value: complexityDescription.value,
+          text: complexityDescription.title,
+          hint: {
+            text: complexityDescription.hint,
+          },
+          checked: complexityDescription.checked,
+        }
+      }),
+    }
+  }
+
+  get errorSummaryArgs(): Record<string, unknown> | null {
+    if (!this.presenter.error) {
+      return null
+    }
+
+    return {
+      titleText: 'There is a problem',
+      errorList: [
+        {
+          text: this.presenter.error.message,
+          href: '#complexity-level',
+        },
+      ],
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/complexityLevel',
+      {
+        presenter: this.presenter,
+        radioButtonArgs: this.radioButtonArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -9,7 +9,7 @@ describe('ReferralFormPresenter', () => {
       const presenter = new ReferralFormPresenter({
         id: '1',
         completionDeadline: '2021-03-01',
-        serviceCategory: { name: 'social inclusion' },
+        serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'social inclusion' },
       })
 
       const expected = [

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -10,6 +10,7 @@ describe('ReferralFormPresenter', () => {
         id: '1',
         completionDeadline: '2021-03-01',
         serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'social inclusion' },
+        complexityLevelId: null,
       })
 
       const expected = [

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -101,7 +101,7 @@ describe('GET /referrals/:id/completion-deadline', () => {
     interventionsService.getDraftReferral.mockResolvedValue({
       id: '1',
       completionDeadline: null,
-      serviceCategory: { name: 'accommodation' },
+      serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' },
     })
   })
 
@@ -122,7 +122,7 @@ describe('POST /referrals/:id/completion-deadline', () => {
     interventionsService.getDraftReferral.mockResolvedValue({
       id: '1',
       completionDeadline: null,
-      serviceCategory: { name: 'accommodation' },
+      serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' },
     })
   })
 
@@ -131,7 +131,7 @@ describe('POST /referrals/:id/completion-deadline', () => {
       interventionsService.patchDraftReferral.mockResolvedValue({
         id: '1',
         completionDeadline: '2021-09-15',
-        serviceCategory: { name: 'social inclusion' },
+        serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'social inclusion' },
       })
 
       await request(app)

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -192,3 +192,41 @@ describe('POST /referrals/:id/completion-deadline', () => {
     })
   })
 })
+
+describe('GET /referrals/:id/complexity-level', () => {
+  beforeEach(() => {
+    interventionsService.getDraftReferral.mockResolvedValue({
+      id: '1',
+      completionDeadline: null,
+      serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' },
+      complexityLevelId: null,
+    })
+  })
+
+  it('renders a form page', async () => {
+    interventionsService.getComplexityLevels.mockResolvedValue([])
+
+    await request(app)
+      .get('/referrals/1/complexity-level')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('What is the complexity level for the accommodation service?')
+      })
+
+    expect(interventionsService.getComplexityLevels.mock.calls[0]).toEqual([
+      'token',
+      'b33c19d1-7414-4014-b543-e543e59c5b39',
+    ])
+  })
+
+  it('renders an error when the get complexity levels call fails', async () => {
+    interventionsService.getComplexityLevels.mockRejectedValue(new Error('Failed to get complexity levels'))
+
+    await request(app)
+      .get('/referrals/1/complexity-level')
+      .expect(500)
+      .expect(res => {
+        expect(res.text).toContain('Failed to get complexity levels')
+      })
+  })
+})

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -16,6 +16,7 @@ beforeEach(() => {
     id: '1',
     completionDeadline: null,
     serviceCategory: null,
+    complexityLevelId: null,
   })
 })
 
@@ -66,6 +67,7 @@ describe('GET /referrals/:id/form', () => {
       id: '1',
       completionDeadline: null,
       serviceCategory: null,
+      complexityLevelId: null,
     })
   })
 
@@ -102,6 +104,7 @@ describe('GET /referrals/:id/completion-deadline', () => {
       id: '1',
       completionDeadline: null,
       serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' },
+      complexityLevelId: null,
     })
   })
 
@@ -123,6 +126,7 @@ describe('POST /referrals/:id/completion-deadline', () => {
       id: '1',
       completionDeadline: null,
       serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' },
+      complexityLevelId: null,
     })
   })
 
@@ -132,6 +136,7 @@ describe('POST /referrals/:id/completion-deadline', () => {
         id: '1',
         completionDeadline: '2021-09-15',
         serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'social inclusion' },
+        complexityLevelId: null,
       })
 
       await request(app)

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -5,6 +5,8 @@ import CompletionDeadlinePresenter from './completionDeadlinePresenter'
 import ReferralFormView from './referralFormView'
 import CompletionDeadlineView from './completionDeadlineView'
 import CompletionDeadlineForm, { CompletionDeadlineErrors } from './completionDeadlineForm'
+import ComplexityLevelView from './complexityLevelView'
+import ComplexityLevelPresenter, { ComplexityLevelError } from './complexityLevelPresenter'
 
 export default class ReferralsController {
   constructor(private readonly interventionsService: InterventionsService) {}
@@ -24,6 +26,19 @@ export default class ReferralsController {
 
     const presenter = new ReferralFormPresenter(referral)
     const view = new ReferralFormView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async viewComplexityLevel(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+    const complexityLevels = await this.interventionsService.getComplexityLevels(
+      res.locals.user.token,
+      referral.serviceCategory.id
+    )
+
+    const presenter = new ComplexityLevelPresenter(referral, complexityLevels)
+    const view = new ComplexityLevelView(presenter)
 
     res.render(...view.renderArgs)
   }

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -70,7 +70,7 @@ export default class ReferralsController {
         referral.serviceCategory.id
       )
 
-      const presenter = new ComplexityLevelPresenter(referral, complexityLevels, error)
+      const presenter = new ComplexityLevelPresenter(referral, complexityLevels, error, req.body)
       const view = new ComplexityLevelView(presenter)
 
       res.status(400)

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -104,7 +104,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   })
 
   describe('patchDraftReferral', () => {
-    beforeEach(async () => {
+    it('returns the updated referral when setting the completion date', async () => {
       await provider.addInteraction({
         state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
         uponReceiving: 'a PATCH request to update the completion deadline',
@@ -129,14 +129,45 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         },
       })
-    })
 
-    it('returns the updated referral', async () => {
       const referral = await interventionsService.patchDraftReferral('token', 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
         completionDeadline: '2021-04-01',
       })
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.completionDeadline).toBe('2021-04-01')
+    })
+
+    it('returns the updated referral when selecting the complexity level', async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to update the complexity level ID',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer token',
+          },
+          body: { complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2' },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
+            complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral('token', 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.complexityLevelId).toBe('d0db50b0-4a50-4fc7-a006-9c97530e38b2')
     })
   })
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -55,6 +55,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             body: Matchers.like({
               id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
               serviceCategory: {
+                id: '428ee70f-3001-4399-95a6-ad25eaaede16',
                 name: 'accommodation',
               },
             }),
@@ -67,7 +68,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         const referral = await interventionsService.getDraftReferral('token', 'd496e4a7-7cc1-44ea-ba67-c295084f1962')
 
         expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
-        expect(referral.serviceCategory.name).toEqual('accommodation')
+        expect(referral.serviceCategory).toEqual({ id: '428ee70f-3001-4399-95a6-ad25eaaede16', name: 'accommodation' })
       })
     })
   })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2,9 +2,7 @@ import { pactWith } from 'jest-pact'
 import { Matchers } from '@pact-foundation/pact'
 
 import InterventionsService from './interventionsService'
-import HmppsAuthClient from '../data/hmppsAuthClient'
 import config from '../config'
-import MockedHmppsAuthClient from '../data/testutils/hmppsAuthClientSetup'
 
 jest.mock('../data/hmppsAuthClient')
 
@@ -139,6 +137,77 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.completionDeadline).toBe('2021-04-01')
+    })
+  })
+
+  describe('getComplexityLevels', () => {
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: 'a service category with ID 428ee70f-3001-4399-95a6-ad25eaaede16 exists',
+        uponReceiving: 'a GET request to fetch the service category’s complexity levels',
+        withRequest: {
+          method: 'GET',
+          path: '/service-category/428ee70f-3001-4399-95a6-ad25eaaede16/complexity-levels',
+          headers: {
+            Accept: 'application/json',
+            Authorization: 'Bearer token',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like([
+            {
+              id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+              title: 'Low complexity',
+              description:
+                'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
+            },
+            {
+              id: '110f2405-d944-4c15-836c-0c6684e2aa78',
+              title: 'Medium complexity',
+              description:
+                'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
+            },
+            {
+              id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
+              title: 'High complexity',
+              description:
+                'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
+            },
+          ]),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns a list of complexity levels', async () => {
+      const complexityLevels = await interventionsService.getComplexityLevels(
+        'token',
+        '428ee70f-3001-4399-95a6-ad25eaaede16'
+      )
+
+      expect(complexityLevels).toEqual([
+        {
+          id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+          title: 'Low complexity',
+          description:
+            'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
+        },
+        {
+          id: '110f2405-d944-4c15-836c-0c6684e2aa78',
+          title: 'Medium complexity',
+          description:
+            'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
+        },
+        {
+          id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
+          title: 'High complexity',
+          description:
+            'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
+        },
+      ])
     })
   })
 })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -1,7 +1,6 @@
 import RestClient from '../data/restClient'
 import logger from '../../log'
 import { ApiConfig } from '../config'
-import HmppsAuthClient from '../data/hmppsAuthClient'
 
 export interface DraftReferral {
   id: string

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -10,6 +10,7 @@ export interface DraftReferral {
 }
 
 export interface ServiceCategory {
+  id: string
   name: string
 }
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -7,11 +7,18 @@ export interface DraftReferral {
   id: string
   completionDeadline: string | null
   serviceCategory: ServiceCategory | null
+  complexityLevelId: string | null
 }
 
 export interface ServiceCategory {
   id: string
   name: string
+}
+
+export interface ComplexityLevel {
+  id: string
+  title: string
+  description: string
 }
 
 export default class InterventionsService {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -57,4 +57,13 @@ export default class InterventionsService {
       data: patch,
     })) as DraftReferral
   }
+
+  async getComplexityLevels(token: string, serviceCategoryId: string): Promise<ComplexityLevel[]> {
+    const restClient = await this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/service-category/${serviceCategoryId}/complexity-levels`,
+      headers: { Accept: 'application/json' },
+    })) as ComplexityLevel[]
+  }
 }

--- a/server/views/referrals/complexityLevel.njk
+++ b/server/views/referrals/complexityLevel.njk
@@ -1,0 +1,29 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {% if errorSummaryArgs !== null %}
+          {{ govukErrorSummary(errorSummaryArgs) }}
+        {% endif %}
+
+        {{ govukRadios(radioButtonArgs) }}
+
+        {{ govukButton({ text: "Save and continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a new page to the referral form `/referral/:draft-referral-id/complexity-level` where users can set the Complexity level for a referral.

There's a question of how we want to do validations on this - do we want to do them on the client side, or defer everything to the back-end? I've left in the client-side validations here for now.

## What is the intent behind these changes?

Allows users to add a Complexity Level to a Draft Referral.

## Screenshots

![image](https://user-images.githubusercontent.com/19826940/102108879-5aa1c880-3e2b-11eb-974a-0f752e9e2fd6.png)
