### PR TITLE
Use the Fishery package to create factories for test data

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -94,7 +94,10 @@
         "functions": "never"
       }
     ],
-    "import/no-extraneous-dependencies": ["error", { "devDependencies": ["**/*.test.js", "**/*.test.ts"] }],
+    "import/no-extraneous-dependencies": [
+      "error",
+      { "devDependencies": ["**/*.test.js", "**/*.test.ts", "testutils/factories/*.ts"] }
+    ],
     "prettier/prettier": [
       "error",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5729,6 +5729,15 @@
         "semver-regex": "^2.0.0"
       }
     },
+    "fishery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fishery/-/fishery-1.0.1.tgz",
+      "integrity": "sha512-VV8H4ZuCbZ9cCWkrYWLLPoAfpTp0t+hlJVoNWkRRHdXOgQ08wjd8ab9di8/Ed/QhgwxY3h7Y17HgDZ9osaHSSQ==",
+      "dev": true,
+      "requires": {
+        "lodash.mergewith": "^4.6.2"
+      }
+    },
     "flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -9010,6 +9019,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "lodash.omit": {

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "eslint-plugin-cypress": "^2.11.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.1.4",
+    "fishery": "^1.0.1",
     "husky": "^4.3.0",
     "jest": "^26.5.3",
     "jest-html-reporter": "^3.3.0",

--- a/server/routes/referrals/completionDeadlinePresenter.test.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.test.ts
@@ -1,18 +1,12 @@
 import CompletionDeadlinePresenter from './completionDeadlinePresenter'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
 
 describe('CompletionDeadlinePresenter', () => {
   describe('day, month, year', () => {
     describe('when the referral has no completion deadline and there is no user input data', () => {
       it('returns empty strings', () => {
-        const presenter = new CompletionDeadlinePresenter({
-          id: '1',
-          completionDeadline: null,
-          serviceCategory: {
-            id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
-            name: 'social inclusion',
-          },
-          complexityLevelId: null,
-        })
+        const referral = draftReferralFactory.serviceCategorySelected().build()
+        const presenter = new CompletionDeadlinePresenter(referral)
 
         expect(presenter.day).toBe('')
         expect(presenter.month).toBe('')
@@ -22,15 +16,8 @@ describe('CompletionDeadlinePresenter', () => {
 
     describe('when the referral has a completion deadline and there is no user input data', () => {
       it('returns the corresponding values from the completion deadline', () => {
-        const presenter = new CompletionDeadlinePresenter({
-          id: '1',
-          completionDeadline: '2021-09-12',
-          serviceCategory: {
-            id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
-            name: 'social inclusion',
-          },
-          complexityLevelId: null,
-        })
+        const referral = draftReferralFactory.serviceCategorySelected().build({ completionDeadline: '2021-09-12' })
+        const presenter = new CompletionDeadlinePresenter(referral)
 
         expect(presenter.day).toBe('12')
         expect(presenter.month).toBe('9')
@@ -40,22 +27,11 @@ describe('CompletionDeadlinePresenter', () => {
 
     describe('when there is user input data', () => {
       it('returns the user input data, or an empty string if a field is missing', () => {
-        const presenter = new CompletionDeadlinePresenter(
-          {
-            id: '1',
-            completionDeadline: '2021-09-12',
-            serviceCategory: {
-              id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
-              name: 'social inclusion',
-            },
-            complexityLevelId: null,
-          },
-          null,
-          {
-            'completion-deadline-day': 'egg',
-            'completion-deadline-month': 7,
-          }
-        )
+        const referral = draftReferralFactory.serviceCategorySelected().completionDeadlineSet().build()
+        const presenter = new CompletionDeadlinePresenter(referral, null, {
+          'completion-deadline-day': 'egg',
+          'completion-deadline-month': 7,
+        })
 
         expect(presenter.day).toBe('egg')
         expect(presenter.month).toBe('7')
@@ -67,15 +43,8 @@ describe('CompletionDeadlinePresenter', () => {
   describe('error information', () => {
     describe('when no errors are passed in', () => {
       it('returns no errors', () => {
-        const presenter = new CompletionDeadlinePresenter({
-          id: '1',
-          completionDeadline: null,
-          serviceCategory: {
-            id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
-            name: 'social inclusion',
-          },
-          complexityLevelId: null,
-        })
+        const referral = draftReferralFactory.serviceCategorySelected().build()
+        const presenter = new CompletionDeadlinePresenter(referral)
 
         expect(presenter.errorMessage).toBeNull()
         expect(presenter.erroredFields).toEqual([])
@@ -85,22 +54,12 @@ describe('CompletionDeadlinePresenter', () => {
 
     describe('when errors are passed in', () => {
       it('returns error information', () => {
-        const presenter = new CompletionDeadlinePresenter(
-          {
-            id: '1',
-            completionDeadline: null,
-            serviceCategory: {
-              id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
-              name: 'social inclusion',
-            },
-            complexityLevelId: null,
-          },
-          {
-            firstErroredField: 'month',
-            erroredFields: ['month', 'year'],
-            message: 'Please enter a month and a year',
-          }
-        )
+        const referral = draftReferralFactory.serviceCategorySelected().build()
+        const presenter = new CompletionDeadlinePresenter(referral, {
+          firstErroredField: 'month',
+          erroredFields: ['month', 'year'],
+          message: 'Please enter a month and a year',
+        })
 
         expect(presenter.errorMessage).toBe('Please enter a month and a year')
         expect(presenter.erroredFields).toEqual(['month', 'year'])
@@ -113,15 +72,10 @@ describe('CompletionDeadlinePresenter', () => {
 
   describe('title', () => {
     it('returns a title', () => {
-      const presenter = new CompletionDeadlinePresenter({
-        id: '1',
-        completionDeadline: null,
-        serviceCategory: {
-          id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
-          name: 'social inclusion',
-        },
-        complexityLevelId: null,
-      })
+      const referral = draftReferralFactory
+        .serviceCategorySelected()
+        .build({ serviceCategory: { name: 'social inclusion' } })
+      const presenter = new CompletionDeadlinePresenter(referral)
 
       expect(presenter.title).toEqual('What date does the social inclusion service need to be completed by?')
     })
@@ -129,15 +83,8 @@ describe('CompletionDeadlinePresenter', () => {
 
   describe('hint', () => {
     it('returns a hint', () => {
-      const presenter = new CompletionDeadlinePresenter({
-        id: '1',
-        completionDeadline: null,
-        serviceCategory: {
-          id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
-          name: 'social inclusion',
-        },
-        complexityLevelId: null,
-      })
+      const referral = draftReferralFactory.serviceCategorySelected().build()
+      const presenter = new CompletionDeadlinePresenter(referral)
 
       expect(presenter.hint).toEqual('For example, 27 10 2021')
     })

--- a/server/routes/referrals/complexityLevelPresenter.test.ts
+++ b/server/routes/referrals/complexityLevelPresenter.test.ts
@@ -1,16 +1,11 @@
 import { DraftReferral } from '../../services/interventionsService'
 import ComplexityLevelPresenter from './complexityLevelPresenter'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
 
 describe('ComplexityLevelPresenter', () => {
-  const draftReferral: DraftReferral = {
-    id: '1',
-    completionDeadline: null,
-    serviceCategory: {
-      id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
-      name: 'social inclusion',
-    },
-    complexityLevelId: null,
-  }
+  const draftReferral = draftReferralFactory
+    .serviceCategorySelected()
+    .build({ serviceCategory: { name: 'social inclusion' } })
 
   const socialInclusionComplexityLevels = [
     {

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -1,4 +1,5 @@
 import ReferralFormPresenter, { ReferralFormStatus } from './referralFormPresenter'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
 
 describe('ReferralFormPresenter', () => {
   describe('sections', () => {
@@ -6,12 +7,8 @@ describe('ReferralFormPresenter', () => {
     // as the task list starts to handle different referral states.
 
     it('returns an array of section presenters', () => {
-      const presenter = new ReferralFormPresenter({
-        id: '1',
-        completionDeadline: '2021-03-01',
-        serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'social inclusion' },
-        complexityLevelId: null,
-      })
+      const referral = draftReferralFactory.serviceCategorySelected().completionDeadlineSet().build()
+      const presenter = new ReferralFormPresenter(referral)
 
       const expected = [
         {

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest'
 import { Express } from 'express'
 import InterventionsService from '../../services/interventionsService'
 import appWithAllRoutes from '../testutils/appSetup'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
 
 jest.mock('../../services/interventionsService')
 
@@ -12,12 +13,8 @@ let app: Express
 beforeEach(() => {
   app = appWithAllRoutes({ overrides: { interventionsService } })
 
-  interventionsService.createDraftReferral.mockResolvedValue({
-    id: '1',
-    completionDeadline: null,
-    serviceCategory: null,
-    complexityLevelId: null,
-  })
+  const referral = draftReferralFactory.justCreated().build({ id: '1' })
+  interventionsService.createDraftReferral.mockResolvedValue(referral)
 })
 
 afterEach(() => {
@@ -63,12 +60,8 @@ describe('POST /referrals', () => {
 
 describe('GET /referrals/:id/form', () => {
   beforeEach(() => {
-    interventionsService.getDraftReferral.mockResolvedValue({
-      id: '1',
-      completionDeadline: null,
-      serviceCategory: null,
-      complexityLevelId: null,
-    })
+    const referral = draftReferralFactory.justCreated().build({ id: '1' })
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
   it('fetches the referral from the interventions service and renders a page with information about the referral', async () => {
@@ -100,12 +93,8 @@ describe('GET /referrals/:id/form', () => {
 
 describe('GET /referrals/:id/completion-deadline', () => {
   beforeEach(() => {
-    interventionsService.getDraftReferral.mockResolvedValue({
-      id: '1',
-      completionDeadline: null,
-      serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' },
-      complexityLevelId: null,
-    })
+    const referral = draftReferralFactory.serviceCategorySelected().build()
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
   it('renders a form page', async () => {
@@ -122,22 +111,14 @@ describe('GET /referrals/:id/completion-deadline', () => {
 
 describe('POST /referrals/:id/completion-deadline', () => {
   beforeEach(() => {
-    interventionsService.getDraftReferral.mockResolvedValue({
-      id: '1',
-      completionDeadline: null,
-      serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' },
-      complexityLevelId: null,
-    })
+    const referral = draftReferralFactory.serviceCategorySelected().build()
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
   describe('when the user inputs a valid date', () => {
     it('updates the referral on the backend and redirects to the referral form if the API call succeeds', async () => {
-      interventionsService.patchDraftReferral.mockResolvedValue({
-        id: '1',
-        completionDeadline: '2021-09-15',
-        serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'social inclusion' },
-        complexityLevelId: null,
-      })
+      const referral = draftReferralFactory.serviceCategorySelected().build({ completionDeadline: '2021-09-15' })
+      interventionsService.patchDraftReferral.mockResolvedValue(referral)
 
       await request(app)
         .post('/referrals/1/completion-deadline')
@@ -195,12 +176,10 @@ describe('POST /referrals/:id/completion-deadline', () => {
 
 describe('GET /referrals/:id/complexity-level', () => {
   beforeEach(() => {
-    interventionsService.getDraftReferral.mockResolvedValue({
-      id: '1',
-      completionDeadline: null,
-      serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' },
-      complexityLevelId: null,
-    })
+    const referral = draftReferralFactory
+      .serviceCategorySelected()
+      .build({ serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' } })
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
   it('renders a form page', async () => {
@@ -233,12 +212,8 @@ describe('GET /referrals/:id/complexity-level', () => {
 
 describe('POST /referrals/:id/complexity-level', () => {
   beforeEach(() => {
-    interventionsService.getDraftReferral.mockResolvedValue({
-      id: '1',
-      completionDeadline: null,
-      serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' },
-      complexityLevelId: null,
-    })
+    const referral = draftReferralFactory.serviceCategorySelected().build()
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
 
     interventionsService.getComplexityLevels.mockResolvedValue([
       {

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -1,0 +1,24 @@
+import { Factory } from 'fishery'
+import { DraftReferral } from '../../server/services/interventionsService'
+import serviceCategoryFactory from './serviceCategory'
+
+class DraftReferralFactory extends Factory<DraftReferral> {
+  justCreated() {
+    return this
+  }
+
+  serviceCategorySelected() {
+    return this.params({ serviceCategory: serviceCategoryFactory.build() })
+  }
+
+  completionDeadlineSet() {
+    return this.params({ completionDeadline: '2021-08-24' })
+  }
+}
+
+export default DraftReferralFactory.define(({ sequence }) => ({
+  id: sequence.toString(),
+  completionDeadline: null,
+  serviceCategory: null,
+  complexityLevelId: null,
+}))

--- a/testutils/factories/serviceCategory.ts
+++ b/testutils/factories/serviceCategory.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import { ServiceCategory } from '../../server/services/interventionsService'
+
+export default Factory.define<ServiceCategory>(({ sequence }) => ({
+  id: sequence.toString(),
+  name: 'accommodation',
+}))


### PR DESCRIPTION
## What does this pull request do?

Integrates the [Fishery](https://github.com/thoughtbot/fishery) package. It allows us to easily create model instances to use in our unit tests. I've changed all of the existing tests that use `DraftReferral` instances, to use the factory.

## What is the intent behind these changes?

To avoid having to make changes across the whole test suite every time we add a new property to `DraftReferral`.