### PR TITLE
IC-734 - Change `ServiceCategory` structure and endpoint

### DIFF
--- a/server/routes/referrals/completionDeadlinePresenter.test.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.test.ts
@@ -1,12 +1,14 @@
 import CompletionDeadlinePresenter from './completionDeadlinePresenter'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 
 describe('CompletionDeadlinePresenter', () => {
   describe('day, month, year', () => {
     describe('when the referral has no completion deadline and there is no user input data', () => {
       it('returns empty strings', () => {
-        const referral = draftReferralFactory.serviceCategorySelected().build()
-        const presenter = new CompletionDeadlinePresenter(referral)
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+        const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
 
         expect(presenter.day).toBe('')
         expect(presenter.month).toBe('')
@@ -16,8 +18,11 @@ describe('CompletionDeadlinePresenter', () => {
 
     describe('when the referral has a completion deadline and there is no user input data', () => {
       it('returns the corresponding values from the completion deadline', () => {
-        const referral = draftReferralFactory.serviceCategorySelected().build({ completionDeadline: '2021-09-12' })
-        const presenter = new CompletionDeadlinePresenter(referral)
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory
+          .serviceCategorySelected(serviceCategory.id)
+          .build({ completionDeadline: '2021-09-12' })
+        const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
 
         expect(presenter.day).toBe('12')
         expect(presenter.month).toBe('9')
@@ -27,8 +32,12 @@ describe('CompletionDeadlinePresenter', () => {
 
     describe('when there is user input data', () => {
       it('returns the user input data, or an empty string if a field is missing', () => {
-        const referral = draftReferralFactory.serviceCategorySelected().completionDeadlineSet().build()
-        const presenter = new CompletionDeadlinePresenter(referral, null, {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory
+          .serviceCategorySelected(serviceCategory.id)
+          .completionDeadlineSet()
+          .build()
+        const presenter = new CompletionDeadlinePresenter(referral, serviceCategory, null, {
           'completion-deadline-day': 'egg',
           'completion-deadline-month': 7,
         })
@@ -43,8 +52,9 @@ describe('CompletionDeadlinePresenter', () => {
   describe('error information', () => {
     describe('when no errors are passed in', () => {
       it('returns no errors', () => {
-        const referral = draftReferralFactory.serviceCategorySelected().build()
-        const presenter = new CompletionDeadlinePresenter(referral)
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+        const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
 
         expect(presenter.errorMessage).toBeNull()
         expect(presenter.erroredFields).toEqual([])
@@ -54,8 +64,9 @@ describe('CompletionDeadlinePresenter', () => {
 
     describe('when errors are passed in', () => {
       it('returns error information', () => {
-        const referral = draftReferralFactory.serviceCategorySelected().build()
-        const presenter = new CompletionDeadlinePresenter(referral, {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+        const presenter = new CompletionDeadlinePresenter(referral, serviceCategory, {
           firstErroredField: 'month',
           erroredFields: ['month', 'year'],
           message: 'Please enter a month and a year',
@@ -72,10 +83,9 @@ describe('CompletionDeadlinePresenter', () => {
 
   describe('title', () => {
     it('returns a title', () => {
-      const referral = draftReferralFactory
-        .serviceCategorySelected()
-        .build({ serviceCategory: { name: 'social inclusion' } })
-      const presenter = new CompletionDeadlinePresenter(referral)
+      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+      const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+      const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
 
       expect(presenter.title).toEqual('What date does the social inclusion service need to be completed by?')
     })
@@ -83,8 +93,9 @@ describe('CompletionDeadlinePresenter', () => {
 
   describe('hint', () => {
     it('returns a hint', () => {
-      const referral = draftReferralFactory.serviceCategorySelected().build()
-      const presenter = new CompletionDeadlinePresenter(referral)
+      const serviceCategory = serviceCategoryFactory.build()
+      const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+      const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
 
       expect(presenter.hint).toEqual('For example, 27 10 2021')
     })

--- a/server/routes/referrals/completionDeadlinePresenter.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.ts
@@ -1,4 +1,4 @@
-import { DraftReferral } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
 import { CompletionDeadlineErrors } from './completionDeadlineForm'
 import CalendarDay from '../../utils/calendarDay'
 
@@ -15,17 +15,20 @@ export default class CompletionDeadlinePresenter {
 
   readonly errorSummary: CompletionDeadlineErrorSummaryPresenter | null
 
-  readonly title = `What date does the ${this.referral.serviceCategory.name} service need to be completed by?`
+  readonly title = `What date does the ${this.serviceCategory.name} service need to be completed by?`
 
   readonly hint = 'For example, 27 10 2021'
 
   constructor(
     private readonly referral: DraftReferral,
+    private readonly serviceCategory: ServiceCategory,
     errors: CompletionDeadlineErrors | null = null,
     userInputData: Record<string, unknown> | null = null
   ) {
     if (!userInputData) {
-      const calendarDay = referral.completionDeadline ? CalendarDay.parseIso8601(referral.completionDeadline) : null
+      const calendarDay = referral.completionDeadline
+        ? CalendarDay.parseIso8601(this.referral.completionDeadline)
+        : null
 
       if (!calendarDay) {
         this.day = ''

--- a/server/routes/referrals/complexityLevelPresenter.test.ts
+++ b/server/routes/referrals/complexityLevelPresenter.test.ts
@@ -48,7 +48,7 @@ describe('ComplexityLevelPresenter', () => {
     describe('when there is user input data', () => {
       it('sets checked to true for the complexity level that the user chose', () => {
         const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory, null, {
-          'complexity-level': serviceCategory.complexityLevels[1].id,
+          'complexity-level-id': serviceCategory.complexityLevels[1].id,
         })
 
         expect(presenter.complexityDescriptions.map(description => description.checked)).toEqual([false, true, false])
@@ -59,7 +59,7 @@ describe('ComplexityLevelPresenter', () => {
       it('sets checked to true for the complexity level that the user chose', () => {
         draftReferral.complexityLevelId = serviceCategory.complexityLevels[0].id
         const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory, null, {
-          'complexity-level': serviceCategory.complexityLevels[1].id,
+          'complexity-level-id': serviceCategory.complexityLevels[1].id,
         })
 
         expect(presenter.complexityDescriptions.map(description => description.checked)).toEqual([false, true, false])

--- a/server/routes/referrals/complexityLevelPresenter.test.ts
+++ b/server/routes/referrals/complexityLevelPresenter.test.ts
@@ -1,57 +1,35 @@
-import { DraftReferral } from '../../services/interventionsService'
 import ComplexityLevelPresenter from './complexityLevelPresenter'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 
 describe('ComplexityLevelPresenter', () => {
-  const draftReferral = draftReferralFactory
-    .serviceCategorySelected()
-    .build({ serviceCategory: { name: 'social inclusion' } })
-
-  const socialInclusionComplexityLevels = [
-    {
-      id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
-      title: 'Low complexity',
-      description:
-        'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
-    },
-    {
-      id: '110f2405-d944-4c15-836c-0c6684e2aa78',
-      title: 'Medium complexity',
-      description:
-        'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
-    },
-    {
-      id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
-      title: 'High complexity',
-      description:
-        'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
-    },
-  ]
+  const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+  const draftReferral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
 
   describe('complexityDescriptions', () => {
     it('sets each complexity level ID as the `value` on the presenter', () => {
-      const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels)
+      const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory)
 
       const expectedValues = presenter.complexityDescriptions.map(description => description.value).sort()
-      const complexityLevelIds = socialInclusionComplexityLevels.map(complexityLevel => complexityLevel.id).sort()
+      const complexityLevelIds = serviceCategory.complexityLevels.map(complexityLevel => complexityLevel.id).sort()
 
       expect(expectedValues).toEqual(complexityLevelIds)
     })
 
     it('sets each complexity level title as the `title` on the presenter', () => {
-      const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels)
+      const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory)
 
       const expectedTitles = presenter.complexityDescriptions.map(description => description.title).sort()
-      const complexityLevelIds = socialInclusionComplexityLevels.map(complexityLevel => complexityLevel.title).sort()
+      const complexityLevelIds = serviceCategory.complexityLevels.map(complexityLevel => complexityLevel.title).sort()
 
       expect(expectedTitles).toEqual(complexityLevelIds)
     })
 
     it('sets each complexity level description as the `hint` text on the presenter', () => {
-      const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels)
+      const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory)
 
       const expectedHints = presenter.complexityDescriptions.map(description => description.hint).sort()
-      const complexityLevelIds = socialInclusionComplexityLevels
+      const complexityLevelIds = serviceCategory.complexityLevels
         .map(complexityLevel => complexityLevel.description)
         .sort()
 
@@ -60,8 +38,8 @@ describe('ComplexityLevelPresenter', () => {
 
     describe('when the referral already has a selected complexity level', () => {
       it('sets checked to true for the referral’s selected complexity level', () => {
-        draftReferral.complexityLevelId = '110f2405-d944-4c15-836c-0c6684e2aa78'
-        const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels)
+        draftReferral.complexityLevelId = serviceCategory.complexityLevels[1].id
+        const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory)
 
         expect(presenter.complexityDescriptions.map(description => description.checked)).toEqual([false, true, false])
       })
@@ -69,8 +47,8 @@ describe('ComplexityLevelPresenter', () => {
 
     describe('when there is user input data', () => {
       it('sets checked to true for the complexity level that the user chose', () => {
-        const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels, null, {
-          'complexity-level': '110f2405-d944-4c15-836c-0c6684e2aa78',
+        const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory, null, {
+          'complexity-level': serviceCategory.complexityLevels[1].id,
         })
 
         expect(presenter.complexityDescriptions.map(description => description.checked)).toEqual([false, true, false])
@@ -79,9 +57,9 @@ describe('ComplexityLevelPresenter', () => {
 
     describe('when the referral already has a selected complexity level and there is user input data', () => {
       it('sets checked to true for the complexity level that the user chose', () => {
-        draftReferral.complexityLevelId = 'd0db50b0-4a50-4fc7-a006-9c97530e38b2'
-        const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels, null, {
-          'complexity-level': '110f2405-d944-4c15-836c-0c6684e2aa78',
+        draftReferral.complexityLevelId = serviceCategory.complexityLevels[0].id
+        const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory, null, {
+          'complexity-level': serviceCategory.complexityLevels[1].id,
         })
 
         expect(presenter.complexityDescriptions.map(description => description.checked)).toEqual([false, true, false])
@@ -91,7 +69,7 @@ describe('ComplexityLevelPresenter', () => {
 
   describe('title', () => {
     it('returns a title', () => {
-      const presenter = new ComplexityLevelPresenter(draftReferral, socialInclusionComplexityLevels)
+      const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory)
 
       expect(presenter.title).toEqual('What is the complexity level for the social inclusion service?')
     })

--- a/server/routes/referrals/complexityLevelPresenter.ts
+++ b/server/routes/referrals/complexityLevelPresenter.ts
@@ -27,7 +27,7 @@ export default class ComplexityLevelPresenter {
   })
 
   private get selectedComplexityLevelId() {
-    return this.userInputData ? this.userInputData['complexity-level'] : this.referral.complexityLevelId
+    return this.userInputData ? this.userInputData['complexity-level-id'] : this.referral.complexityLevelId
   }
 
   readonly title = `What is the complexity level for the ${this.serviceCategory.name} service?`

--- a/server/routes/referrals/complexityLevelPresenter.ts
+++ b/server/routes/referrals/complexityLevelPresenter.ts
@@ -1,4 +1,4 @@
-import { ComplexityLevel, DraftReferral } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
 
 export interface ComplexityLevelError {
   message: string
@@ -7,7 +7,7 @@ export interface ComplexityLevelError {
 export default class ComplexityLevelPresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly complexityLevels: ComplexityLevel[],
+    private readonly serviceCategory: ServiceCategory,
     readonly error?: ComplexityLevelError | null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
@@ -17,7 +17,7 @@ export default class ComplexityLevelPresenter {
     value: string
     hint: string
     checked: boolean
-  }[] = this.complexityLevels.map(complexityLevel => {
+  }[] = this.serviceCategory.complexityLevels.map(complexityLevel => {
     return {
       title: complexityLevel.title,
       value: complexityLevel.id,
@@ -30,5 +30,5 @@ export default class ComplexityLevelPresenter {
     return this.userInputData ? this.userInputData['complexity-level'] : this.referral.complexityLevelId
   }
 
-  readonly title = `What is the complexity level for the ${this.referral.serviceCategory.name} service?`
+  readonly title = `What is the complexity level for the ${this.serviceCategory.name} service?`
 }

--- a/server/routes/referrals/complexityLevelView.ts
+++ b/server/routes/referrals/complexityLevelView.ts
@@ -9,7 +9,7 @@ export default class ComplexityLevelView {
     return {
       classes: 'govuk-radios',
       idPrefix: 'complexity-level',
-      name: 'complexity-level',
+      name: 'complexity-level-id',
       fieldset: {
         legend: {
           text: this.presenter.title,

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -1,5 +1,6 @@
 import ReferralFormPresenter, { ReferralFormStatus } from './referralFormPresenter'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 
 describe('ReferralFormPresenter', () => {
   describe('sections', () => {
@@ -7,7 +8,8 @@ describe('ReferralFormPresenter', () => {
     // as the task list starts to handle different referral states.
 
     it('returns an array of section presenters', () => {
-      const referral = draftReferralFactory.serviceCategorySelected().completionDeadlineSet().build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).completionDeadlineSet().build()
       const presenter = new ReferralFormPresenter(referral)
 
       const expected = [

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -3,6 +3,7 @@ import { Express } from 'express'
 import InterventionsService from '../../services/interventionsService'
 import appWithAllRoutes from '../testutils/appSetup'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 
 jest.mock('../../services/interventionsService')
 
@@ -93,8 +94,11 @@ describe('GET /referrals/:id/form', () => {
 
 describe('GET /referrals/:id/completion-deadline', () => {
   beforeEach(() => {
-    const referral = draftReferralFactory.serviceCategorySelected().build()
+    const serviceCategory = serviceCategoryFactory.build()
+    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+
     interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
   })
 
   it('renders a form page', async () => {
@@ -111,13 +115,20 @@ describe('GET /referrals/:id/completion-deadline', () => {
 
 describe('POST /referrals/:id/completion-deadline', () => {
   beforeEach(() => {
-    const referral = draftReferralFactory.serviceCategorySelected().build()
+    const serviceCategory = serviceCategoryFactory.build()
+    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+
     interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
   })
 
   describe('when the user inputs a valid date', () => {
     it('updates the referral on the backend and redirects to the referral form if the API call succeeds', async () => {
-      const referral = draftReferralFactory.serviceCategorySelected().build({ completionDeadline: '2021-09-15' })
+      const serviceCategory = serviceCategoryFactory.build()
+      const referral = draftReferralFactory
+        .serviceCategorySelected(serviceCategory.id)
+        .build({ completionDeadline: '2021-09-15' })
+
       interventionsService.patchDraftReferral.mockResolvedValue(referral)
 
       await request(app)
@@ -176,15 +187,14 @@ describe('POST /referrals/:id/completion-deadline', () => {
 
 describe('GET /referrals/:id/complexity-level', () => {
   beforeEach(() => {
-    const referral = draftReferralFactory
-      .serviceCategorySelected()
-      .build({ serviceCategory: { id: 'b33c19d1-7414-4014-b543-e543e59c5b39', name: 'accommodation' } })
+    const serviceCategory = serviceCategoryFactory.build({ id: 'b33c19d1-7414-4014-b543-e543e59c5b39' })
+    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+
     interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
   })
 
   it('renders a form page', async () => {
-    interventionsService.getComplexityLevels.mockResolvedValue([])
-
     await request(app)
       .get('/referrals/1/complexity-level')
       .expect(200)
@@ -192,49 +202,31 @@ describe('GET /referrals/:id/complexity-level', () => {
         expect(res.text).toContain('What is the complexity level for the accommodation service?')
       })
 
-    expect(interventionsService.getComplexityLevels.mock.calls[0]).toEqual([
+    expect(interventionsService.getServiceCategory.mock.calls[0]).toEqual([
       'token',
       'b33c19d1-7414-4014-b543-e543e59c5b39',
     ])
   })
 
   it('renders an error when the get complexity levels call fails', async () => {
-    interventionsService.getComplexityLevels.mockRejectedValue(new Error('Failed to get complexity levels'))
+    interventionsService.getServiceCategory.mockRejectedValue(new Error('Failed to get service category'))
 
     await request(app)
       .get('/referrals/1/complexity-level')
       .expect(500)
       .expect(res => {
-        expect(res.text).toContain('Failed to get complexity levels')
+        expect(res.text).toContain('Failed to get service category')
       })
   })
 })
 
 describe('POST /referrals/:id/complexity-level', () => {
   beforeEach(() => {
-    const referral = draftReferralFactory.serviceCategorySelected().build()
-    interventionsService.getDraftReferral.mockResolvedValue(referral)
+    const serviceCategory = serviceCategoryFactory.build()
+    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
 
-    interventionsService.getComplexityLevels.mockResolvedValue([
-      {
-        id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
-        title: 'Low complexity',
-        description:
-          'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
-      },
-      {
-        id: '110f2405-d944-4c15-836c-0c6684e2aa78',
-        title: 'Medium complexity',
-        description:
-          'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
-      },
-      {
-        id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
-        title: 'High complexity',
-        description:
-          'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
-      },
-    ])
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
   })
 
   it('updates the referral on the backend and redirects to the referral form', async () => {

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -33,12 +33,12 @@ export default class ReferralsController {
 
   async viewComplexityLevel(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
-    const complexityLevels = await this.interventionsService.getComplexityLevels(
+    const serviceCategory = await this.interventionsService.getServiceCategory(
       res.locals.user.token,
-      referral.serviceCategory.id
+      referral.serviceCategoryId
     )
 
-    const presenter = new ComplexityLevelPresenter(referral, complexityLevels)
+    const presenter = new ComplexityLevelPresenter(referral, serviceCategory)
     const view = new ComplexityLevelView(presenter)
 
     res.render(...view.renderArgs)
@@ -65,12 +65,12 @@ export default class ReferralsController {
       res.redirect(`/referrals/${req.params.id}/form`)
     } else {
       const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
-      const complexityLevels = await this.interventionsService.getComplexityLevels(
+      const serviceCategory = await this.interventionsService.getServiceCategory(
         res.locals.user.token,
-        referral.serviceCategory.id
+        referral.serviceCategoryId
       )
 
-      const presenter = new ComplexityLevelPresenter(referral, complexityLevels, error, req.body)
+      const presenter = new ComplexityLevelPresenter(referral, serviceCategory, error, req.body)
       const view = new ComplexityLevelView(presenter)
 
       res.status(400)
@@ -80,8 +80,13 @@ export default class ReferralsController {
 
   async viewCompletionDeadline(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      res.locals.user.token,
+      referral.serviceCategoryId
+    )
 
-    const presenter = new CompletionDeadlinePresenter(referral)
+    const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
+
     const view = new CompletionDeadlineView(presenter)
 
     res.render(...view.renderArgs)
@@ -111,8 +116,12 @@ export default class ReferralsController {
       res.redirect(`/referrals/${req.params.id}/form`)
     } else {
       const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+      const serviceCategory = await this.interventionsService.getServiceCategory(
+        res.locals.user.token,
+        referral.serviceCategoryId
+      )
 
-      const presenter = new CompletionDeadlinePresenter(referral, errors, req.body)
+      const presenter = new CompletionDeadlinePresenter(referral, serviceCategory, errors, req.body)
       const view = new CompletionDeadlineView(presenter)
 
       res.status(400)

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -52,21 +52,19 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             status: 200,
             body: Matchers.like({
               id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
-              serviceCategory: {
-                id: '428ee70f-3001-4399-95a6-ad25eaaede16',
-                name: 'accommodation',
-              },
+              serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+              complexityLevelId: null,
             }),
             headers: { 'Content-Type': 'application/json' },
           },
         })
       })
 
-      it('returns a referral for the given ID, with the service category fields populated', async () => {
+      it('returns a referral for the given ID, with the service category id field populated', async () => {
         const referral = await interventionsService.getDraftReferral('token', 'd496e4a7-7cc1-44ea-ba67-c295084f1962')
 
         expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
-        expect(referral.serviceCategory).toEqual({ id: '428ee70f-3001-4399-95a6-ad25eaaede16', name: 'accommodation' })
+        expect(referral.serviceCategoryId).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
       })
     })
   })
@@ -171,14 +169,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('getComplexityLevels', () => {
+  describe('getServiceCategory', () => {
     beforeEach(async () => {
       await provider.addInteraction({
         state: 'a service category with ID 428ee70f-3001-4399-95a6-ad25eaaede16 exists',
-        uponReceiving: 'a GET request to fetch the service category’s complexity levels',
+        uponReceiving: 'a GET request to fetch the service category',
         withRequest: {
           method: 'GET',
-          path: '/service-category/428ee70f-3001-4399-95a6-ad25eaaede16/complexity-levels',
+          path: '/service-category/428ee70f-3001-4399-95a6-ad25eaaede16',
           headers: {
             Accept: 'application/json',
             Authorization: 'Bearer token',
@@ -186,26 +184,30 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
         willRespondWith: {
           status: 200,
-          body: Matchers.like([
-            {
-              id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
-              title: 'Low complexity',
-              description:
-                'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
-            },
-            {
-              id: '110f2405-d944-4c15-836c-0c6684e2aa78',
-              title: 'Medium complexity',
-              description:
-                'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
-            },
-            {
-              id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
-              title: 'High complexity',
-              description:
-                'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
-            },
-          ]),
+          body: Matchers.like({
+            id: '428ee70f-3001-4399-95a6-ad25eaaede16',
+            name: 'accommodation',
+            complexityLevels: [
+              {
+                id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+                title: 'Low complexity',
+                description:
+                  'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
+              },
+              {
+                id: '110f2405-d944-4c15-836c-0c6684e2aa78',
+                title: 'Medium complexity',
+                description:
+                  'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
+              },
+              {
+                id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
+                title: 'High complexity',
+                description:
+                  'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
+              },
+            ],
+          }),
           headers: {
             'Content-Type': 'application/json',
           },
@@ -213,13 +215,15 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
     })
 
-    it('returns a list of complexity levels', async () => {
-      const complexityLevels = await interventionsService.getComplexityLevels(
+    it('returns a service category', async () => {
+      const serviceCategory = await interventionsService.getServiceCategory(
         'token',
         '428ee70f-3001-4399-95a6-ad25eaaede16'
       )
 
-      expect(complexityLevels).toEqual([
+      expect(serviceCategory.id).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
+      expect(serviceCategory.name).toEqual('accommodation')
+      expect(serviceCategory.complexityLevels).toEqual([
         {
           id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
           title: 'Low complexity',

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -5,13 +5,14 @@ import { ApiConfig } from '../config'
 export interface DraftReferral {
   id: string
   completionDeadline: string | null
-  serviceCategory: ServiceCategory | null
+  serviceCategoryId: string | null
   complexityLevelId: string | null
 }
 
 export interface ServiceCategory {
   id: string
   name: string
+  complexityLevels: ComplexityLevel[]
 }
 
 export interface ComplexityLevel {
@@ -57,12 +58,12 @@ export default class InterventionsService {
     })) as DraftReferral
   }
 
-  async getComplexityLevels(token: string, serviceCategoryId: string): Promise<ComplexityLevel[]> {
-    const restClient = await this.createRestClient(token)
+  async getServiceCategory(token: string, serviceCategoryId: string): Promise<ServiceCategory> {
+    const restClient = this.createRestClient(token)
 
     return (await restClient.get({
-      path: `/service-category/${serviceCategoryId}/complexity-levels`,
+      path: `/service-category/${serviceCategoryId}`,
       headers: { Accept: 'application/json' },
-    })) as ComplexityLevel[]
+    })) as ServiceCategory
   }
 }

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -1,14 +1,13 @@
 import { Factory } from 'fishery'
 import { DraftReferral } from '../../server/services/interventionsService'
-import serviceCategoryFactory from './serviceCategory'
 
 class DraftReferralFactory extends Factory<DraftReferral> {
   justCreated() {
     return this
   }
 
-  serviceCategorySelected() {
-    return this.params({ serviceCategory: serviceCategoryFactory.build() })
+  serviceCategorySelected(serviceCategoryId: string) {
+    return this.params({ serviceCategoryId })
   }
 
   completionDeadlineSet() {
@@ -19,6 +18,6 @@ class DraftReferralFactory extends Factory<DraftReferral> {
 export default DraftReferralFactory.define(({ sequence }) => ({
   id: sequence.toString(),
   completionDeadline: null,
-  serviceCategory: null,
+  serviceCategoryId: null,
   complexityLevelId: null,
 }))

--- a/testutils/factories/serviceCategory.ts
+++ b/testutils/factories/serviceCategory.ts
@@ -4,4 +4,24 @@ import { ServiceCategory } from '../../server/services/interventionsService'
 export default Factory.define<ServiceCategory>(({ sequence }) => ({
   id: sequence.toString(),
   name: 'accommodation',
+  complexityLevels: [
+    {
+      id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+      title: 'Low complexity',
+      description:
+        'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
+    },
+    {
+      id: '110f2405-d944-4c15-836c-0c6684e2aa78',
+      title: 'Medium complexity',
+      description:
+        'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
+    },
+    {
+      id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
+      title: 'High complexity',
+      description:
+        'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
+    },
+  ],
 }))


### PR DESCRIPTION
## What does this pull request do?

Updates service category structure and endpoint so we're no longer storing parts of it on the referral, other than its ID.

## What is the intent behind these changes?

We previously had a `serviceCategory` object on the `DraftReferral` that
had its own ID, and then would make a separate request for the
`complexityLevels` for that `serviceCategory`. Now we're adding more
fields to the `serviceCategory`, it feels as though we might want it to
be a more fully-fledged object, and to store a reference to its `id` on
the `Referral` instead.

Now, a request to `service-category/:id` will return:
```
  {
    id: 'uuid',
    name: 'accommodation',
    complexityLevels: [
     {
       'id': 'uuid',
       'title': 'low complexity',
       'description': 'complexity level description',
     }
    ]
  }
```

The `referral` has a `serviceCategoryId` instead of the whole service
category.

This does mean we're making more requests to the API for both entities,
so we might want to consider the performance implications of this.

For further context, see:
https://github.com/ministryofjustice/hmpps-interventions-ui/pull/44#discussion_r543222831
