### PR TITLE
Turn on TypeScript’s strict mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,7 +55,8 @@
             "semi": false,
             "arrowParens": "avoid"
           }
-        ]
+        ],
+        "@typescript-eslint/no-non-null-assertion": 0
       }
     }
   ],

--- a/server/app.ts
+++ b/server/app.ts
@@ -162,7 +162,7 @@ export default function createApp(
   // Update a value in the cookie so that the set-cookie will be sent.
   // Only changes every minute so that it's not sent with every request.
   app.use((req, res, next) => {
-    req.session.nowInMinutes = Math.floor(Date.now() / 60e3)
+    req.session!.nowInMinutes = Math.floor(Date.now() / 60e3)
     next()
   })
 
@@ -175,7 +175,7 @@ export default function createApp(
 
   app.get('/login/callback', (req, res, next) =>
     passport.authenticate('oauth2', {
-      successReturnToOrRedirect: req.session.returnTo || '/',
+      successReturnToOrRedirect: req.session!.returnTo || '/',
       failureRedirect: '/autherror',
     })(req, res, next)
   )
@@ -185,7 +185,7 @@ export default function createApp(
   app.use('/logout', (req, res) => {
     if (req.user) {
       req.logout()
-      req.session.destroy(() => res.redirect(authLogoutUrl))
+      req.session!.destroy(() => res.redirect(authLogoutUrl))
       return
     }
     res.redirect(authLogoutUrl)

--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -23,7 +23,7 @@ const authenticationMiddleware: AuthenticationMiddleware = verifyToken => {
     if (req.isAuthenticated() && (await verifyToken(req as VerifiableRequest))) {
       return next()
     }
-    req.session.returnTo = req.originalUrl
+    req.session!.returnTo = req.originalUrl
     return res.redirect('/login')
   }
 }

--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -19,8 +19,8 @@ passport.deserializeUser((user, done) => {
 export type AuthenticationMiddleware = (tokenVerifier: TokenVerifier) => RequestHandler
 
 const authenticationMiddleware: AuthenticationMiddleware = verifyToken => {
-  return async (req: VerifiableRequest, res, next) => {
-    if (req.isAuthenticated() && (await verifyToken(req))) {
+  return async (req, res, next) => {
+    if (req.isAuthenticated() && (await verifyToken(req as VerifiableRequest))) {
       return next()
     }
     req.session.returnTo = req.originalUrl

--- a/server/config.ts
+++ b/server/config.ts
@@ -4,8 +4,9 @@ dotenv.config()
 const production = process.env.NODE_ENV === 'production'
 
 function get<T>(name: string, fallback: T, options = { requireInProduction: false }): T | string {
-  if (process.env[name]) {
-    return process.env[name]
+  const fromEnv = process.env[name]
+  if (fromEnv !== undefined) {
+    return fromEnv
   }
   if (fallback !== undefined && (!production || !options.requireInProduction)) {
     return fallback

--- a/server/config.ts
+++ b/server/config.ts
@@ -17,11 +17,11 @@ function get<T>(name: string, fallback: T, options = { requireInProduction: fals
 const requiredInProduction = { requireInProduction: true }
 
 export class AgentConfig {
-  maxSockets: 100
+  maxSockets = 100
 
-  maxFreeSockets: 10
+  maxFreeSockets = 10
 
-  freeSocketTimeout: 30000
+  freeSocketTimeout = 30000
 }
 
 export interface ApiConfig {

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -22,7 +22,7 @@ interface MockRedis {
 
 const mockRedis = (redis as unknown) as MockRedis
 
-function givenRedisResponse(storedToken: string) {
+function givenRedisResponse(storedToken: string | null) {
   mockRedis.get.mockImplementation((key, callback) => callback(null, storedToken))
 }
 

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -23,7 +23,7 @@ redisClient.on('error', error => {
 })
 
 const getRedisAsync = promisify(redisClient.get).bind(redisClient)
-const setRedisAsync = promisify(redisClient.set).bind(redisClient)
+const setRedisAsync = promisify<string, string, string, number>(redisClient.set).bind(redisClient)
 
 function getApiClientTokenFromHmppsAuth(username?: string): Promise<superagent.Response> {
   const clientToken = generateOauthClientToken(config.apis.hmppsAuth.apiClientId, config.apis.hmppsAuth.apiClientSecret)

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -48,7 +48,7 @@ export default class RestClient {
     logger.warn(sanitiseError(error), `Error calling ${this.name}`)
   }
 
-  async get({ path = null, query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {
+  async get({ path, query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {
     logger.info(`Get using user credentials: calling ${this.name}: ${path} ${query}`)
     try {
       const result = await superagent
@@ -72,9 +72,7 @@ export default class RestClient {
     }
   }
 
-  async post({ path = null, headers = {}, responseType = '', data = {}, raw = false }: PostRequest = {}): Promise<
-    unknown
-  > {
+  async post({ path, headers = {}, responseType = '', data = {}, raw = false }: PostRequest = {}): Promise<unknown> {
     logger.info(`Post using user credentials: calling ${this.name}: ${path}`)
     try {
       const result = await superagent
@@ -99,9 +97,7 @@ export default class RestClient {
   }
 
   // This is copied from the post method above
-  async patch({ path = null, headers = {}, responseType = '', data = {}, raw = false }: PostRequest = {}): Promise<
-    unknown
-  > {
+  async patch({ path, headers = {}, responseType = '', data = {}, raw = false }: PostRequest = {}): Promise<unknown> {
     logger.info(`Patch using user credentials: calling ${this.name}: ${path}`)
     try {
       const result = await superagent
@@ -125,9 +121,7 @@ export default class RestClient {
     }
   }
 
-  async stream({ path = null, headers = {}, errorLogger = this.defaultErrorLogger }: StreamRequest = {}): Promise<
-    unknown
-  > {
+  async stream({ path, headers = {}, errorLogger = this.defaultErrorLogger }: StreamRequest = {}): Promise<unknown> {
     logger.info(`Get using user credentials: calling ${this.name}: ${path}`)
     return new Promise((resolve, reject) => {
       superagent

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -16,7 +16,7 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
       return next()
     }
 
-    req.session.returnTo = req.originalUrl
+    req.session!.returnTo = req.originalUrl
     return res.redirect('/login')
   }
 }

--- a/server/routes/referrals/completionDeadlineForm.ts
+++ b/server/routes/referrals/completionDeadlineForm.ts
@@ -47,6 +47,10 @@ export default class CompletionDeadlineForm {
   }
 
   get paramsForUpdate(): Partial<DraftReferral> {
+    if (this.completionDeadline === null) {
+      return {}
+    }
+
     return {
       completionDeadline: this.completionDeadline.iso8601,
     }

--- a/server/routes/referrals/completionDeadlinePresenter.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.ts
@@ -26,7 +26,7 @@ export default class CompletionDeadlinePresenter {
     userInputData: Record<string, unknown> | null = null
   ) {
     if (!userInputData) {
-      const calendarDay = referral.completionDeadline
+      const calendarDay = this.referral.completionDeadline
         ? CalendarDay.parseIso8601(this.referral.completionDeadline)
         : null
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -4,10 +4,11 @@ import InterventionsService from '../../services/interventionsService'
 import appWithAllRoutes from '../testutils/appSetup'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import apiConfig from '../../config'
 
 jest.mock('../../services/interventionsService')
 
-const interventionsService = new InterventionsService(null) as jest.Mocked<InterventionsService>
+const interventionsService = new InterventionsService(apiConfig.apis.hmppsAuth) as jest.Mocked<InterventionsService>
 
 let app: Express
 

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -33,6 +33,11 @@ export default class ReferralsController {
 
   async viewComplexityLevel(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+    if (referral.serviceCategoryId === null) {
+      throw new Error('Attempting to view complexity level without service category selected')
+    }
+
     const serviceCategory = await this.interventionsService.getServiceCategory(
       res.locals.user.token,
       referral.serviceCategoryId
@@ -47,7 +52,7 @@ export default class ReferralsController {
   async updateComplexityLevel(req: Request, res: Response): Promise<void> {
     const form = await ComplexityLevelForm.createForm(req)
 
-    let error: ComplexityLevelError | null
+    let error: ComplexityLevelError | null = null
 
     if (form.isValid) {
       try {
@@ -65,6 +70,11 @@ export default class ReferralsController {
       res.redirect(`/referrals/${req.params.id}/form`)
     } else {
       const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+      if (referral.serviceCategoryId === null) {
+        throw new Error('Attempting to view complexity level without service category selected')
+      }
+
       const serviceCategory = await this.interventionsService.getServiceCategory(
         res.locals.user.token,
         referral.serviceCategoryId
@@ -80,6 +90,11 @@ export default class ReferralsController {
 
   async viewCompletionDeadline(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+    if (referral.serviceCategoryId === null) {
+      throw new Error('Attempting to view completion deadline without service category selected')
+    }
+
     const serviceCategory = await this.interventionsService.getServiceCategory(
       res.locals.user.token,
       referral.serviceCategoryId
@@ -116,6 +131,11 @@ export default class ReferralsController {
       res.redirect(`/referrals/${req.params.id}/form`)
     } else {
       const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+      if (referral.serviceCategoryId === null) {
+        throw new Error('Attempting to view completion deadline without service category selected')
+      }
+
       const serviceCategory = await this.interventionsService.getServiceCategory(
         res.locals.user.token,
         referral.serviceCategoryId

--- a/server/routes/testutils/mocks/mockCommunityApiService.ts
+++ b/server/routes/testutils/mocks/mockCommunityApiService.ts
@@ -1,8 +1,9 @@
 import CommunityApiService, { DeliusUser } from '../../../services/communityApiService'
+import MockedHmppsAuthClient from '../../../data/testutils/hmppsAuthClientSetup'
 
 export = class MockCommunityApiService extends CommunityApiService {
   constructor() {
-    super(undefined)
+    super(new MockedHmppsAuthClient())
   }
 
   async getUserByUsername(username: string): Promise<DeliusUser> {

--- a/server/routes/testutils/mocks/mockUserService.ts
+++ b/server/routes/testutils/mocks/mockUserService.ts
@@ -1,4 +1,5 @@
 import UserService from '../../../services/userService'
+import MockedHmppsAuthClient from '../../../data/testutils/hmppsAuthClientSetup'
 
 export const user = {
   name: 'john smith',
@@ -11,13 +12,13 @@ export const user = {
 
 export class MockUserService extends UserService {
   constructor() {
-    super(undefined)
+    super(new MockedHmppsAuthClient())
   }
 
   async getUser(token: string) {
     return {
-      token,
       ...user,
+      token,
     }
   }
 }

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -5,7 +5,7 @@ interface SanitisedError {
   status?: number
   headers?: unknown
   data?: unknown
-  stack: string
+  stack?: string
   message: string
 }
 

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -25,7 +25,7 @@ export function initialiseAppInsights(): void {
   }
 }
 
-export function buildAppInsightsClient(name = defaultName()): TelemetryClient {
+export function buildAppInsightsClient(name = defaultName()): TelemetryClient | null {
   if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
     defaultClient.context.tags['ai.cloud.role'] = name
     defaultClient.context.tags['ai.application.ver'] = version()

--- a/server/utils/calendarDay.test.ts
+++ b/server/utils/calendarDay.test.ts
@@ -3,7 +3,7 @@ import CalendarDay from './calendarDay'
 describe('CalendarDay', () => {
   describe('iso8601', () => {
     it('returns an ISO 8601 formatted date describing the day', () => {
-      const calendarDay = CalendarDay.fromComponents(15, 9, 1992)
+      const calendarDay = CalendarDay.fromComponents(15, 9, 1992)!
 
       expect(calendarDay.iso8601).toBe('1992-09-15')
     })
@@ -11,7 +11,7 @@ describe('CalendarDay', () => {
 
   describe('.fromComponents', () => {
     it('returns a date when given components for a day that exists', () => {
-      const date = CalendarDay.fromComponents(15, 9, 1992)
+      const date = CalendarDay.fromComponents(15, 9, 1992)!
 
       expect(date.day).toBe(15)
       expect(date.month).toBe(9)

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -2,7 +2,7 @@ function properCase(word: string): string {
   return word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
 }
 
-function isBlank(str: string): boolean {
+function isBlank(str: string | null): boolean {
   return !str || /^\s*$/.test(str)
 }
 
@@ -16,6 +16,6 @@ function properCaseName(name: string): string {
   return isBlank(name) ? '' : name.split('-').map(properCase).join('-')
 }
 
-export default function convertToTitleCase(sentence: string): string {
-  return isBlank(sentence) ? '' : sentence.split(' ').map(properCaseName).join(' ')
+export default function convertToTitleCase(sentence: string | null): string {
+  return isBlank(sentence) ? '' : sentence!.split(' ').map(properCaseName).join(' ')
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
-    "strictBindCallApply": true
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true
   },
   "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist"],
   "include": ["**/*.js", "**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "experimentalDecorators": true,
     "noImplicitAny": true,
     "strictBindCallApply": true,
-    "strictFunctionTypes": true
+    "strictFunctionTypes": true,
+    "strictNullChecks": true
   },
   "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist"],
   "include": ["**/*.js", "**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "noImplicitAny": true,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true
   },
   "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist"],
   "include": ["**/*.js", "**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "noImplicitAny": true,
-    "strictBindCallApply": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true
+    "strict": true
   },
   "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist"],
   "include": ["**/*.js", "**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "strictBindCallApply": true
   },
   "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist"],
   "include": ["**/*.js", "**/*.ts"]


### PR DESCRIPTION
## What does this pull request do?

Turns on TypeScript’s [`strict` mode](https://www.typescriptlang.org/tsconfig#strict), and fixes the resulting build failures along the way.

## What is the intent behind these changes?

To get the most out of using a compiled language, allowing the compiler to get rid of some common classes of programmer error and to get the richest type information possible.