### PR TITLE
Treat ESLint warnings as errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "int-test-ui": "cypress open",
     "record-build-info": "node ./bin/record-build-info",
     "security_audit": "npx audit-ci --config audit-ci.json",
-    "lint": "eslint . --cache --max-warnings 200",
+    "lint": "eslint . --cache --max-warnings 0",
     "clean": "rm -rf dist build node_modules stylesheets"
   },
   "engines": {
@@ -80,7 +80,7 @@
   "lint-staged": {
     "*.{ts,js,css}": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --fix --max-warnings 0"
     ],
     "*.{json}": [
       "prettier --write"

--- a/server/authentication/clientCredentials.ts
+++ b/server/authentication/clientCredentials.ts
@@ -1,5 +1,3 @@
-import config from '../config'
-
 export default function generateOauthClientToken(clientId: string, clientSecret: string): string {
   // create a base64 encoded basic auth header for oauth2 token requests
   const token = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')

--- a/server/routes/integrationSamples.ts
+++ b/server/routes/integrationSamples.ts
@@ -2,7 +2,9 @@ import { Request, Response } from 'express'
 import CommunityApiService from '../services/communityApiService'
 
 // fixme: this is just sample code to validate secure API access
-export default function IntegrationSamplesRoutes(communityApiService: CommunityApiService) {
+export default function IntegrationSamplesRoutes(
+  communityApiService: CommunityApiService
+): { viewDeliusUserSample: (req: Request, res: Response) => Promise<void> } {
   return {
     viewDeliusUserSample: async (req: Request, res: Response) => {
       const deliusUser = await communityApiService.getUserByUsername(req.query.username as string)

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -12,7 +12,6 @@ import * as auth from '../../authentication/auth'
 import { user, MockUserService } from './mocks/mockUserService'
 import MockCommunityApiService from './mocks/mockCommunityApiService'
 import InterventionsService from '../../services/interventionsService'
-import CommunityApiService from '../../services/communityApiService'
 
 function appSetup(route: Router, production: boolean): Express {
   const app = express()

--- a/server/routes/testutils/mocks/mockCommunityApiService.ts
+++ b/server/routes/testutils/mocks/mockCommunityApiService.ts
@@ -6,7 +6,7 @@ export = class MockCommunityApiService extends CommunityApiService {
     super(new MockedHmppsAuthClient())
   }
 
-  async getUserByUsername(username: string): Promise<DeliusUser> {
+  async getUserByUsername(_username: string): Promise<DeliusUser> {
     return {
       userId: '987123876',
       username: 'maijam',

--- a/server/routes/testutils/mocks/mockUserService.ts
+++ b/server/routes/testutils/mocks/mockUserService.ts
@@ -1,4 +1,4 @@
-import UserService from '../../../services/userService'
+import UserService, { UserDetails } from '../../../services/userService'
 import MockedHmppsAuthClient from '../../../data/testutils/hmppsAuthClientSetup'
 
 export const user = {
@@ -8,6 +8,7 @@ export const user = {
   username: 'user1',
   displayName: 'John Smith',
   token: 'token',
+  authSource: 'nomis',
 }
 
 export class MockUserService extends UserService {
@@ -15,10 +16,9 @@ export class MockUserService extends UserService {
     super(new MockedHmppsAuthClient())
   }
 
-  async getUser(token: string) {
+  async getUser(_token: string): Promise<UserDetails> {
     return {
       ...user,
-      token,
     }
   }
 }

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,7 +1,7 @@
 import convertToTitleCase from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
 
-interface UserDetails {
+export interface UserDetails {
   name: string
   displayName: string
 }


### PR DESCRIPTION
## What does this pull request do?

Fails the linting step if ESLint encounters any warnings. This effectively prevents us from introducing ESLint warnings.

(And I fix the current ESLint warnings in our codebase.)

## What is the intent behind these changes?

So that we notice potential code quality problems as they occur. See commit message for more details.