### PR TITLE
IC-669: Allow users to select desired outcomes

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -37,6 +37,7 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals/:id/completion-deadline', (req, res) => referralsController.updateCompletionDeadline(req, res))
   get('/referrals/:id/further-information', (req, res) => referralsController.viewFurtherInformation(req, res))
   post('/referrals/:id/further-information', (req, res) => referralsController.updateFurtherInformation(req, res))
+  get('/referrals/:id/desired-outcomes', (req, res) => referralsController.viewDesiredOutcomes(req, res))
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -38,6 +38,7 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/:id/further-information', (req, res) => referralsController.viewFurtherInformation(req, res))
   post('/referrals/:id/further-information', (req, res) => referralsController.updateFurtherInformation(req, res))
   get('/referrals/:id/desired-outcomes', (req, res) => referralsController.viewDesiredOutcomes(req, res))
+  post('/referrals/:id/desired-outcomes', (req, res) => referralsController.updateDesiredOutcomes(req, res))
 
   return router
 }

--- a/server/routes/referrals/desiredOutcomesForm.test.ts
+++ b/server/routes/referrals/desiredOutcomesForm.test.ts
@@ -1,0 +1,74 @@
+import { Request } from 'express'
+import DesiredOutcomesForm from './desiredOutcomesForm'
+
+describe(DesiredOutcomesForm, () => {
+  describe('isValid', () => {
+    it('returns true when the desired-outcomes-ids property is present and not empty in the body', async () => {
+      const form = await DesiredOutcomesForm.createForm({
+        body: {
+          'desired-outcomes-ids': ['29843fdf-8b88-4b08-a0f9-dfbd3208fd2e', '43557c7a-c286-49c2-a994-d0a821295c7a'],
+        },
+      } as Request)
+
+      expect(form.isValid).toBe(true)
+    })
+
+    it('returns false when the desired-outcomes-ids property is absent in the body', async () => {
+      const form = await DesiredOutcomesForm.createForm({
+        body: {},
+      } as Request)
+
+      expect(form.isValid).toBe(false)
+    })
+
+    it('returns false when the desired-outcomes-ids property is null in the body', async () => {
+      const form = await DesiredOutcomesForm.createForm({
+        body: { 'desired-outcomes-ids': null },
+      } as Request)
+
+      expect(form.isValid).toBe(false)
+    })
+  })
+
+  describe('error', () => {
+    it('returns null when the desired-outcomes-ids property is present in the body', async () => {
+      const form = await DesiredOutcomesForm.createForm({
+        body: {
+          'desired-outcomes-ids': ['29843fdf-8b88-4b08-a0f9-dfbd3208fd2e', '43557c7a-c286-49c2-a994-d0a821295c7a'],
+        },
+      } as Request)
+
+      expect(form.error).toBe(null)
+    })
+
+    it('returns an error object when the desired-outcomes-ids property is absent in the body', async () => {
+      const form = await DesiredOutcomesForm.createForm({
+        body: {},
+      } as Request)
+
+      expect(form.error).toEqual({ message: 'Select desired outcomes' })
+    })
+
+    it('returns an error object when the desired-outcomes-ids property is null in the body', async () => {
+      const form = await DesiredOutcomesForm.createForm({
+        body: { 'desired-outcomes-ids': null },
+      } as Request)
+
+      expect(form.error).toEqual({ message: 'Select desired outcomes' })
+    })
+  })
+
+  describe('paramsForUpdate', () => {
+    it('returns the params to be sent to the backend, when the data in the body is valid', async () => {
+      const form = await DesiredOutcomesForm.createForm({
+        body: {
+          'desired-outcomes-ids': ['29843fdf-8b88-4b08-a0f9-dfbd3208fd2e', '43557c7a-c286-49c2-a994-d0a821295c7a'],
+        },
+      } as Request)
+
+      expect(form.paramsForUpdate).toEqual({
+        desiredOutcomesIds: ['29843fdf-8b88-4b08-a0f9-dfbd3208fd2e', '43557c7a-c286-49c2-a994-d0a821295c7a'],
+      })
+    })
+  })
+})

--- a/server/routes/referrals/desiredOutcomesForm.ts
+++ b/server/routes/referrals/desiredOutcomesForm.ts
@@ -1,0 +1,30 @@
+import { Request } from 'express'
+import { DraftReferral } from '../../services/interventionsService'
+import { DesiredOutcomesError } from './desiredOutcomesPresenter'
+import errorMessages from '../../utils/errorMessages'
+
+export default class DesiredOutcomesForm {
+  private constructor(private readonly request: Request) {}
+
+  static async createForm(request: Request): Promise<DesiredOutcomesForm> {
+    return new DesiredOutcomesForm(request)
+  }
+
+  get paramsForUpdate(): Partial<DraftReferral> {
+    return {
+      desiredOutcomesIds: this.request.body['desired-outcomes-ids'],
+    }
+  }
+
+  get isValid(): boolean {
+    return this.request.body['desired-outcomes-ids'] !== null && this.request.body['desired-outcomes-ids'] !== undefined
+  }
+
+  get error(): DesiredOutcomesError | null {
+    if (this.isValid) {
+      return null
+    }
+
+    return { message: errorMessages.desiredOutcomes.empty }
+  }
+}

--- a/server/routes/referrals/desiredOutcomesPresenter.test.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.test.ts
@@ -1,12 +1,35 @@
 import DesiredOutcomesPresenter from './desiredOutcomesPresenter'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 
 describe('DesiredOutcomesPresenter', () => {
-  const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+  const serviceCategory = serviceCategoryFactory.build({
+    name: 'social inclusion',
+    desiredOutcomes: [
+      {
+        id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+        description:
+          'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+      },
+      {
+        id: '65924ac6-9724-455b-ad30-906936291421',
+        description: 'Service User makes progress in obtaining accommodation',
+      },
+      {
+        id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
+        description: 'Service User is helped to secure social or supported housing',
+      },
+      {
+        id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
+        description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+      },
+    ],
+  })
+  const draftReferral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
 
   describe('desiredOutcomes', () => {
     it('sets each the id of each desired outcome as the `value` on the presenter', () => {
-      const presenter = new DesiredOutcomesPresenter(serviceCategory)
+      const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory)
 
       const expectedValues = presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.value).sort()
       const desiredOutcomeIds = serviceCategory.desiredOutcomes.map(desiredOutcome => desiredOutcome.id).sort()
@@ -15,7 +38,7 @@ describe('DesiredOutcomesPresenter', () => {
     })
 
     it('sets the description of each desired outcome as the `text` on the presenter', () => {
-      const presenter = new DesiredOutcomesPresenter(serviceCategory)
+      const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory)
 
       const presenterTexts = presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.text).sort()
       const desiredOutcomeDescriptions = serviceCategory.desiredOutcomes
@@ -29,7 +52,7 @@ describe('DesiredOutcomesPresenter', () => {
   describe('error information', () => {
     describe('when no errors are passed in', () => {
       it('returns no errors', () => {
-        const presenter = new DesiredOutcomesPresenter(serviceCategory)
+        const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory)
 
         expect(presenter.error).toBeNull()
       })
@@ -37,7 +60,7 @@ describe('DesiredOutcomesPresenter', () => {
 
     describe('when errors are passed in', () => {
       it('returns error information', () => {
-        const presenter = new DesiredOutcomesPresenter(serviceCategory, {
+        const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory, {
           message: 'Select desired outcomes',
         })
 
@@ -46,9 +69,81 @@ describe('DesiredOutcomesPresenter', () => {
     })
   })
 
+  describe('when the referral already has selected desired outcomes', () => {
+    it('sets checked to true for the referral’s selected desired outcomes', () => {
+      draftReferral.desiredOutcomesIds = [serviceCategory.desiredOutcomes[0].id, serviceCategory.desiredOutcomes[1].id]
+      const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory)
+
+      expect(presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.checked)).toEqual([
+        true,
+        true,
+        false,
+        false,
+      ])
+    })
+  })
+
+  describe('when there is user input data', () => {
+    it('sets checked to true for the desired outcomes that the user chose', () => {
+      const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory, null, {
+        'desired-outcomes-ids': [serviceCategory.desiredOutcomes[0].id, serviceCategory.desiredOutcomes[1].id],
+      })
+
+      expect(presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.checked)).toEqual([
+        true,
+        true,
+        false,
+        false,
+      ])
+    })
+
+    describe('when the user input data doesn’t contain a desired-outcomes-ids key', () => {
+      it('doesn’t set any of the desired outcomes as checked', () => {
+        const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory, null, {})
+
+        expect(presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.checked)).toEqual([
+          false,
+          false,
+          false,
+          false,
+        ])
+      })
+    })
+  })
+
+  describe('when the referral already has a selected desired outcomes and there is user input data', () => {
+    it('sets checked to true for the desired outcomes that the user chose', () => {
+      draftReferral.desiredOutcomesIds = [serviceCategory.desiredOutcomes[0].id]
+      const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory, null, {
+        'desired-outcomes-ids': [serviceCategory.desiredOutcomes[1].id, serviceCategory.desiredOutcomes[2].id],
+      })
+
+      expect(presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.checked)).toEqual([
+        false,
+        true,
+        true,
+        false,
+      ])
+    })
+
+    describe('when the user input data doesn’t contain a desired-outcomes-ids key', () => {
+      it('doesn’t set any of the desired outcomes as checked', () => {
+        draftReferral.desiredOutcomesIds = [serviceCategory.desiredOutcomes[0].id]
+        const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory, null, {})
+
+        expect(presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.checked)).toEqual([
+          false,
+          false,
+          false,
+          false,
+        ])
+      })
+    })
+  })
+
   describe('title', () => {
     it('returns a title', () => {
-      const presenter = new DesiredOutcomesPresenter(serviceCategory)
+      const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory)
 
       expect(presenter.title).toEqual('What are the desired outcomes for the social inclusion service?')
     })

--- a/server/routes/referrals/desiredOutcomesPresenter.test.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.test.ts
@@ -26,6 +26,26 @@ describe('DesiredOutcomesPresenter', () => {
     })
   })
 
+  describe('error information', () => {
+    describe('when no errors are passed in', () => {
+      it('returns no errors', () => {
+        const presenter = new DesiredOutcomesPresenter(serviceCategory)
+
+        expect(presenter.error).toBeNull()
+      })
+    })
+
+    describe('when errors are passed in', () => {
+      it('returns error information', () => {
+        const presenter = new DesiredOutcomesPresenter(serviceCategory, {
+          message: 'Select desired outcomes',
+        })
+
+        expect(presenter.error).toEqual({ message: 'Select desired outcomes' })
+      })
+    })
+  })
+
   describe('title', () => {
     it('returns a title', () => {
       const presenter = new DesiredOutcomesPresenter(serviceCategory)

--- a/server/routes/referrals/desiredOutcomesPresenter.test.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.test.ts
@@ -1,0 +1,36 @@
+import DesiredOutcomesPresenter from './desiredOutcomesPresenter'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+
+describe('DesiredOutcomesPresenter', () => {
+  const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+
+  describe('desiredOutcomes', () => {
+    it('sets each the id of each desired outcome as the `value` on the presenter', () => {
+      const presenter = new DesiredOutcomesPresenter(serviceCategory)
+
+      const expectedValues = presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.value).sort()
+      const desiredOutcomeIds = serviceCategory.desiredOutcomes.map(desiredOutcome => desiredOutcome.id).sort()
+
+      expect(expectedValues).toEqual(desiredOutcomeIds)
+    })
+
+    it('sets the description of each desired outcome as the `text` on the presenter', () => {
+      const presenter = new DesiredOutcomesPresenter(serviceCategory)
+
+      const presenterTexts = presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.text).sort()
+      const desiredOutcomeDescriptions = serviceCategory.desiredOutcomes
+        .map(desiredOutcome => desiredOutcome.description)
+        .sort()
+
+      expect(presenterTexts).toEqual(desiredOutcomeDescriptions)
+    })
+  })
+
+  describe('title', () => {
+    it('returns a title', () => {
+      const presenter = new DesiredOutcomesPresenter(serviceCategory)
+
+      expect(presenter.title).toEqual('What are the desired outcomes for the social inclusion service?')
+    })
+  })
+})

--- a/server/routes/referrals/desiredOutcomesPresenter.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.ts
@@ -1,7 +1,11 @@
 import { ServiceCategory } from '../../services/interventionsService'
 
+export interface DesiredOutcomesError {
+  message: string
+}
+
 export default class DesiredOutcomesPresenter {
-  constructor(private readonly serviceCategory: ServiceCategory) {}
+  constructor(private readonly serviceCategory: ServiceCategory, readonly error: DesiredOutcomesError | null = null) {}
 
   readonly desiredOutcomes: { value: string; text: string }[] = this.serviceCategory.desiredOutcomes.map(
     desiredOutcome => {

--- a/server/routes/referrals/desiredOutcomesPresenter.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.ts
@@ -1,20 +1,36 @@
-import { ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
 
 export interface DesiredOutcomesError {
   message: string
 }
 
 export default class DesiredOutcomesPresenter {
-  constructor(private readonly serviceCategory: ServiceCategory, readonly error: DesiredOutcomesError | null = null) {}
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly serviceCategory: ServiceCategory,
+    readonly error: DesiredOutcomesError | null = null,
+    private readonly userInputData: Record<string, string[]> | null = null
+  ) {}
 
-  readonly desiredOutcomes: { value: string; text: string }[] = this.serviceCategory.desiredOutcomes.map(
-    desiredOutcome => {
-      return {
-        value: desiredOutcome.id,
-        text: desiredOutcome.description,
-      }
+  readonly desiredOutcomes: {
+    value: string
+    text: string
+    checked: boolean
+  }[] = this.serviceCategory.desiredOutcomes.map(desiredOutcome => {
+    return {
+      value: desiredOutcome.id,
+      text: desiredOutcome.description,
+      checked: this.selectedDesiredOutcomeIds.includes(desiredOutcome.id),
     }
-  )
+  })
+
+  private get selectedDesiredOutcomeIds(): string[] {
+    if (this.userInputData) {
+      return this.userInputData['desired-outcomes-ids'] ?? []
+    }
+
+    return this.referral.desiredOutcomesIds ?? []
+  }
 
   readonly title = `What are the desired outcomes for the ${this.serviceCategory.name} service?`
 }

--- a/server/routes/referrals/desiredOutcomesPresenter.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.ts
@@ -1,0 +1,16 @@
+import { ServiceCategory } from '../../services/interventionsService'
+
+export default class DesiredOutcomesPresenter {
+  constructor(private readonly serviceCategory: ServiceCategory) {}
+
+  readonly desiredOutcomes: { value: string; text: string }[] = this.serviceCategory.desiredOutcomes.map(
+    desiredOutcome => {
+      return {
+        value: desiredOutcome.id,
+        text: desiredOutcome.description,
+      }
+    }
+  )
+
+  readonly title = `What are the desired outcomes for the ${this.serviceCategory.name} service?`
+}

--- a/server/routes/referrals/desiredOutcomesView.ts
+++ b/server/routes/referrals/desiredOutcomesView.ts
@@ -24,6 +24,7 @@ export default class DesiredOutcomesView {
         return {
           value: desiredOutcome.value,
           text: desiredOutcome.text,
+          checked: desiredOutcome.checked,
         }
       }),
     }

--- a/server/routes/referrals/desiredOutcomesView.ts
+++ b/server/routes/referrals/desiredOutcomesView.ts
@@ -1,0 +1,38 @@
+import DesiredOutcomesPresenter from './desiredOutcomesPresenter'
+
+export default class DesiredOutcomesView {
+  constructor(readonly presenter: DesiredOutcomesPresenter) {}
+
+  get checkboxArgs(): Record<string, unknown> {
+    return {
+      idPrefix: 'desired-outcomes-ids',
+      name: 'desired-outcomes-ids',
+      fieldset: {
+        legend: {
+          text: this.presenter.title,
+          isPageHeading: true,
+          classes: 'govuk-fieldset__legend--xl',
+        },
+      },
+      hint: {
+        text: 'Select all that apply.',
+      },
+      items: this.presenter.desiredOutcomes.map(desiredOutcome => {
+        return {
+          value: desiredOutcome.value,
+          text: desiredOutcome.text,
+        }
+      }),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/desiredOutcomes',
+      {
+        presenter: this.presenter,
+        checkboxArgs: this.checkboxArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/referrals/desiredOutcomesView.ts
+++ b/server/routes/referrals/desiredOutcomesView.ts
@@ -4,6 +4,8 @@ export default class DesiredOutcomesView {
   constructor(readonly presenter: DesiredOutcomesPresenter) {}
 
   get checkboxArgs(): Record<string, unknown> {
+    const errorMessage = this.presenter.error ? { text: this.presenter.error.message } : null
+
     return {
       idPrefix: 'desired-outcomes-ids',
       name: 'desired-outcomes-ids',
@@ -14,6 +16,7 @@ export default class DesiredOutcomesView {
           classes: 'govuk-fieldset__legend--xl',
         },
       },
+      errorMessage,
       hint: {
         text: 'Select all that apply.',
       },
@@ -26,12 +29,29 @@ export default class DesiredOutcomesView {
     }
   }
 
+  get errorSummaryArgs(): Record<string, unknown> | null {
+    if (!this.presenter.error) {
+      return null
+    }
+
+    return {
+      titleText: 'There is a problem',
+      errorList: [
+        {
+          text: this.presenter.error.message,
+          href: '#desired-outcomes-ids',
+        },
+      ],
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/desiredOutcomes',
       {
         presenter: this.presenter,
         checkboxArgs: this.checkboxArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
       },
     ]
   }

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -327,3 +327,41 @@ describe('POST /referrals/:id/further-information', () => {
     ])
   })
 })
+
+describe('GET /referrals/:id/desired-outcomes', () => {
+  beforeEach(() => {
+    const serviceCategory = serviceCategoryFactory.build({
+      id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+      name: 'social inclusion',
+    })
+    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+  })
+
+  it('renders a form page', async () => {
+    await request(app)
+      .get('/referrals/1/desired-outcomes')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('What are the desired outcomes for the social inclusion service?')
+      })
+
+    expect(interventionsService.getServiceCategory.mock.calls[0]).toEqual([
+      'token',
+      'b33c19d1-7414-4014-b543-e543e59c5b39',
+    ])
+  })
+
+  it('renders an error when the request for a service category fails', async () => {
+    interventionsService.getServiceCategory.mockRejectedValue(new Error('Failed to get service category'))
+
+    await request(app)
+      .get('/referrals/1/desired-outcomes')
+      .expect(500)
+      .expect(res => {
+        expect(res.text).toContain('Failed to get service category')
+      })
+  })
+})

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -209,7 +209,7 @@ describe('GET /referrals/:id/complexity-level', () => {
     ])
   })
 
-  it('renders an error when the get complexity levels call fails', async () => {
+  it('renders an error when the request for a service category fails', async () => {
     interventionsService.getServiceCategory.mockRejectedValue(new Error('Failed to get service category'))
 
     await request(app)

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -10,6 +10,8 @@ import ComplexityLevelPresenter, { ComplexityLevelError } from './complexityLeve
 import ComplexityLevelForm from './complexityLevelForm'
 import FurtherInformationPresenter, { FurtherInformationError } from './furtherInformationPresenter'
 import FurtherInformationView from './furtherInformationView'
+import DesiredOutcomesPresenter from './desiredOutcomesPresenter'
+import DesiredOutcomesView from './desiredOutcomesView'
 
 export default class ReferralsController {
   constructor(private readonly interventionsService: InterventionsService) {}
@@ -205,5 +207,23 @@ export default class ReferralsController {
       res.status(400)
       res.render(...view.renderArgs)
     }
+  }
+
+  async viewDesiredOutcomes(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+    if (!referral.serviceCategoryId) {
+      throw new Error('Attempting to view desired outcomes without service category selected')
+    }
+
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      res.locals.user.token,
+      referral.serviceCategoryId
+    )
+
+    const presenter = new DesiredOutcomesPresenter(serviceCategory)
+    const view = new DesiredOutcomesView(presenter)
+
+    res.render(...view.renderArgs)
   }
 }

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -222,7 +222,7 @@ export default class ReferralsController {
       referral.serviceCategoryId
     )
 
-    const presenter = new DesiredOutcomesPresenter(serviceCategory)
+    const presenter = new DesiredOutcomesPresenter(referral, serviceCategory)
     const view = new DesiredOutcomesView(presenter)
 
     res.render(...view.renderArgs)
@@ -259,7 +259,7 @@ export default class ReferralsController {
         referral.serviceCategoryId
       )
 
-      const presenter = new DesiredOutcomesPresenter(serviceCategory, error) // , req.body)
+      const presenter = new DesiredOutcomesPresenter(referral, serviceCategory, error, req.body)
       const view = new DesiredOutcomesView(presenter)
 
       res.status(400)

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -10,8 +10,9 @@ import ComplexityLevelPresenter, { ComplexityLevelError } from './complexityLeve
 import ComplexityLevelForm from './complexityLevelForm'
 import FurtherInformationPresenter, { FurtherInformationError } from './furtherInformationPresenter'
 import FurtherInformationView from './furtherInformationView'
-import DesiredOutcomesPresenter from './desiredOutcomesPresenter'
+import DesiredOutcomesPresenter, { DesiredOutcomesError } from './desiredOutcomesPresenter'
 import DesiredOutcomesView from './desiredOutcomesView'
+import DesiredOutcomesForm from './desiredOutcomesForm'
 
 export default class ReferralsController {
   constructor(private readonly interventionsService: InterventionsService) {}
@@ -225,5 +226,44 @@ export default class ReferralsController {
     const view = new DesiredOutcomesView(presenter)
 
     res.render(...view.renderArgs)
+  }
+
+  async updateDesiredOutcomes(req: Request, res: Response): Promise<void> {
+    const form = await DesiredOutcomesForm.createForm(req)
+
+    let error: DesiredOutcomesError | null = null
+
+    if (form.isValid) {
+      try {
+        await this.interventionsService.patchDraftReferral(res.locals.user.token, req.params.id, form.paramsForUpdate)
+      } catch (e) {
+        error = {
+          message: e.message,
+        }
+      }
+    } else {
+      error = form.error
+    }
+
+    if (!error) {
+      res.redirect(`/referrals/${req.params.id}/form`)
+    } else {
+      const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+      if (!referral.serviceCategoryId) {
+        throw new Error('Attempting to view desired outcomes without service category selected')
+      }
+
+      const serviceCategory = await this.interventionsService.getServiceCategory(
+        res.locals.user.token,
+        referral.serviceCategoryId
+      )
+
+      const presenter = new DesiredOutcomesPresenter(serviceCategory, error) // , req.body)
+      const view = new DesiredOutcomesView(presenter)
+
+      res.status(400)
+      res.render(...view.renderArgs)
+    }
   }
 }

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -29,7 +29,7 @@ function appSetup(route: Router, production: boolean): Express {
 
   app.use(cookieSession({ keys: [''] }))
   app.use(bodyParser.json())
-  app.use(bodyParser.urlencoded({ extended: false }))
+  app.use(bodyParser.urlencoded({ extended: true }))
   app.use('/', route)
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(production))

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -206,6 +206,44 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.furtherInformation).toBe('Some information about the service user')
     })
+
+    it('returns the updated referral when selecting desired outcomes', async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to update desired outcomes IDs',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer token',
+          },
+          body: {
+            desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
+            desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral('token', 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.desiredOutcomesIds).toEqual([
+        '3415a6f2-38ef-4613-bb95-33355deff17e',
+        '5352cfb6-c9ee-468c-b539-434a3e9b506e',
+      ])
+    })
   })
 
   describe('getServiceCategory', () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -209,6 +209,63 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   })
 
   describe('getServiceCategory', () => {
+    const complexityLevels = [
+      {
+        id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+        title: 'Low complexity',
+        description:
+          'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
+      },
+      {
+        id: '110f2405-d944-4c15-836c-0c6684e2aa78',
+        title: 'Medium complexity',
+        description:
+          'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
+      },
+      {
+        id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
+        title: 'High complexity',
+        description:
+          'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
+      },
+    ]
+    const desiredOutcomes = [
+      {
+        id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+        description:
+          'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+      },
+      {
+        id: '65924ac6-9724-455b-ad30-906936291421',
+        description: 'Service User makes progress in obtaining accommodation',
+      },
+      {
+        id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
+        description: 'Service User is helped to secure social or supported housing',
+      },
+      {
+        id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
+        description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+      },
+      {
+        id: '19d5ef58-5cfc-41fe-894c-acd705dc1325',
+        description: 'Service User is helped to sustain existing accommodation',
+      },
+      {
+        id: 'f6f70273-16a2-4dc7-aafc-9bc74215e713',
+        description: 'Service User is prevented from becoming homeless',
+      },
+      {
+        id: '449a93d7-e705-4340-9936-c859644abd52',
+        description:
+          'Settled accommodation is sustained for a period of at least 6 months or until the end of sentence, whichever occurs first (including for those serving custodial sentences of less than 6 months)',
+      },
+      {
+        id: '55a9cf76-428d-4409-8a57-aaa523f3b631',
+        description: 'Service User at risk of losing their tenancy are successfully helped to retain it',
+      },
+    ]
+
     beforeEach(async () => {
       await provider.addInteraction({
         state: 'a service category with ID 428ee70f-3001-4399-95a6-ad25eaaede16 exists',
@@ -226,26 +283,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           body: Matchers.like({
             id: '428ee70f-3001-4399-95a6-ad25eaaede16',
             name: 'accommodation',
-            complexityLevels: [
-              {
-                id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
-                title: 'Low complexity',
-                description:
-                  'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
-              },
-              {
-                id: '110f2405-d944-4c15-836c-0c6684e2aa78',
-                title: 'Medium complexity',
-                description:
-                  'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
-              },
-              {
-                id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
-                title: 'High complexity',
-                description:
-                  'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
-              },
-            ],
+            complexityLevels,
+            desiredOutcomes,
           }),
           headers: {
             'Content-Type': 'application/json',
@@ -262,26 +301,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
       expect(serviceCategory.id).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
       expect(serviceCategory.name).toEqual('accommodation')
-      expect(serviceCategory.complexityLevels).toEqual([
-        {
-          id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
-          title: 'Low complexity',
-          description:
-            'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
-        },
-        {
-          id: '110f2405-d944-4c15-836c-0c6684e2aa78',
-          title: 'Medium complexity',
-          description:
-            'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
-        },
-        {
-          id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
-          title: 'High complexity',
-          description:
-            'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
-        },
-      ])
+      expect(serviceCategory.complexityLevels).toEqual(complexityLevels)
+      expect(serviceCategory.desiredOutcomes).toEqual(desiredOutcomes)
     })
   })
 })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -71,6 +71,41 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         expect(referral.serviceCategoryId).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
       })
     })
+
+    describe('for a referral that has had desired outcomes selected', () => {
+      beforeEach(async () => {
+        await provider.addInteraction({
+          state:
+            'There is an existing draft referral with ID of 037cc90b-beaa-4a32-9ab7-7f79136e1d27, and it has had desired outcomes selected',
+          uponReceiving: 'a request for that referral',
+          withRequest: {
+            method: 'GET',
+            path: '/draft-referral/037cc90b-beaa-4a32-9ab7-7f79136e1d27',
+            headers: { Accept: 'application/json', Authorization: 'Bearer token' },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like({
+              id: '037cc90b-beaa-4a32-9ab7-7f79136e1d27',
+              serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+              desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+              complexityLevelId: null,
+            }),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+      })
+
+      it('returns a referral for the given ID, with the desired outcomes selected', async () => {
+        const referral = await interventionsService.getDraftReferral('token', '037cc90b-beaa-4a32-9ab7-7f79136e1d27')
+
+        expect(referral.id).toBe('037cc90b-beaa-4a32-9ab7-7f79136e1d27')
+        expect(referral.desiredOutcomesIds).toEqual([
+          '301ead30-30a4-4c7c-8296-2768abfb59b5',
+          '65924ac6-9724-455b-ad30-906936291421',
+        ])
+      })
+    })
   })
 
   describe('createDraftReferral', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -9,6 +9,7 @@ export interface DraftReferral {
   serviceCategoryId: string | null
   complexityLevelId: string | null
   furtherInformation: string | null
+  desiredOutcomesIds: string[] | null
 }
 
 export interface ServiceCategory {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -15,11 +15,17 @@ export interface ServiceCategory {
   id: string
   name: string
   complexityLevels: ComplexityLevel[]
+  desiredOutcomes: DesiredOutcome[]
 }
 
 export interface ComplexityLevel {
   id: string
   title: string
+  description: string
+}
+
+export interface DesiredOutcome {
+  id: string
   description: string
 }
 

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -8,4 +8,7 @@ export default {
   complexityLevel: {
     empty: 'Select a complexity level',
   },
+  desiredOutcomes: {
+    empty: 'Select desired outcomes',
+  },
 }

--- a/server/views/referrals/desiredOutcomes.njk
+++ b/server/views/referrals/desiredOutcomes.njk
@@ -1,0 +1,24 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {{ govukCheckboxes(checkboxArgs) }}
+
+        {{ govukButton({ text: "Save and continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/referrals/desiredOutcomes.njk
+++ b/server/views/referrals/desiredOutcomes.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -14,6 +15,10 @@
     <div class="govuk-grid-column-two-thirds">
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {% if errorSummaryArgs !== null %}
+          {{ govukErrorSummary(errorSummaryArgs) }}
+        {% endif %}
 
         {{ govukCheckboxes(checkboxArgs) }}
 

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -22,4 +22,5 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   serviceCategoryId: null,
   complexityLevelId: null,
   furtherInformation: null,
+  desiredOutcomesIds: null,
 }))

--- a/testutils/factories/serviceCategory.ts
+++ b/testutils/factories/serviceCategory.ts
@@ -24,4 +24,23 @@ export default Factory.define<ServiceCategory>(({ sequence }) => ({
         'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
     },
   ],
+  desiredOutcomes: [
+    {
+      id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+      description:
+        'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+    },
+    {
+      id: '65924ac6-9724-455b-ad30-906936291421',
+      description: 'Service User makes progress in obtaining accommodation',
+    },
+    {
+      id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
+      description: 'Service User is helped to secure social or supported housing',
+    },
+    {
+      id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
+      description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+    },
+  ],
 }))


### PR DESCRIPTION
## What does this pull request do?

Adds a page to set the desired outcomes on a draft referral when making a referral. These desired outcomes will come from the service category API request.

If a user selects no desired outcomes, the page will display an error (see screenshot below).

If a user has already selected desired outcomes (e.g. if they are changing their answers), the checkboxes will already be checked.

### Possible issue:

If a user has selected desired outcomes, then goes back to this page to change their answers and doesn't select any boxes, the page renders the error "Please select desired outcomes" but because it hasn't updated the referral, the boxes are still "checked" - I'm not quite sure about what to do here, we could have some logic that clears all checkboxes in this case, but I don't know how much of an urgent issue it is to solve now. It just looks a bit weird (see the "**is this a problem?**" screenshot).

## What is the intent behind these changes?

To allow users to select desired outcomes when making a referral.

## Screenshots
![image](https://user-images.githubusercontent.com/19826940/102483656-f5cdb480-405c-11eb-9e5c-1c8e527fe9d2.png)

### Error

![image](https://user-images.githubusercontent.com/19826940/102484041-97550600-405d-11eb-908e-8107df228e8c.png)

### Is this a problem?

![image](https://user-images.githubusercontent.com/19826940/102484346-092d4f80-405e-11eb-83fa-2c6b5517ad9f.png)

