### PR TITLE
IC-666 Further information for service provider page

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -36,6 +36,7 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/:id/completion-deadline', (req, res) => referralsController.viewCompletionDeadline(req, res))
   post('/referrals/:id/completion-deadline', (req, res) => referralsController.updateCompletionDeadline(req, res))
   get('/referrals/:id/further-information', (req, res) => referralsController.viewFurtherInformation(req, res))
+  post('/referrals/:id/further-information', (req, res) => referralsController.updateFurtherInformation(req, res))
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -35,6 +35,7 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals/:id/complexity-level', (req, res) => referralsController.updateComplexityLevel(req, res))
   get('/referrals/:id/completion-deadline', (req, res) => referralsController.viewCompletionDeadline(req, res))
   post('/referrals/:id/completion-deadline', (req, res) => referralsController.updateCompletionDeadline(req, res))
+  get('/referrals/:id/further-information', (req, res) => referralsController.viewFurtherInformation(req, res))
 
   return router
 }

--- a/server/routes/referrals/furtherInformationPresenter.test.ts
+++ b/server/routes/referrals/furtherInformationPresenter.test.ts
@@ -1,0 +1,44 @@
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import FurtherInformationPresenter from './furtherInformationPresenter'
+
+describe('FurtherInformationPresenter', () => {
+  const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+
+  describe('title', () => {
+    it('returns a title', () => {
+      const presenter = new FurtherInformationPresenter(serviceCategory)
+      expect(presenter.title).toEqual(
+        'Do you have further information for the social inclusion service provider? (optional)'
+      )
+    })
+  })
+
+  describe('hint', () => {
+    it('returns a hint', () => {
+      const presenter = new FurtherInformationPresenter(serviceCategory)
+      expect(presenter.hint).toEqual(
+        'For example, relevant previous offences, previously completed programmes or further reasons for this referral'
+      )
+    })
+  })
+
+  describe('error information', () => {
+    describe('when no errors are passed in', () => {
+      it('returns no errors', () => {
+        const presenter = new FurtherInformationPresenter(serviceCategory)
+
+        expect(presenter.error).toBeNull()
+      })
+    })
+
+    describe('when errors are passed in', () => {
+      it('returns error information', () => {
+        const presenter = new FurtherInformationPresenter(serviceCategory, {
+          message: 'Something went wrong, please try again',
+        })
+
+        expect(presenter.error).toEqual({ message: 'Something went wrong, please try again' })
+      })
+    })
+  })
+})

--- a/server/routes/referrals/furtherInformationPresenter.test.ts
+++ b/server/routes/referrals/furtherInformationPresenter.test.ts
@@ -1,12 +1,14 @@
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import FurtherInformationPresenter from './furtherInformationPresenter'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
 
 describe('FurtherInformationPresenter', () => {
   const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+  const draftReferral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
 
   describe('title', () => {
     it('returns a title', () => {
-      const presenter = new FurtherInformationPresenter(serviceCategory)
+      const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
       expect(presenter.title).toEqual(
         'Do you have further information for the social inclusion service provider? (optional)'
       )
@@ -15,7 +17,7 @@ describe('FurtherInformationPresenter', () => {
 
   describe('hint', () => {
     it('returns a hint', () => {
-      const presenter = new FurtherInformationPresenter(serviceCategory)
+      const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
       expect(presenter.hint).toEqual(
         'For example, relevant previous offences, previously completed programmes or further reasons for this referral'
       )
@@ -25,7 +27,7 @@ describe('FurtherInformationPresenter', () => {
   describe('error information', () => {
     describe('when no errors are passed in', () => {
       it('returns no errors', () => {
-        const presenter = new FurtherInformationPresenter(serviceCategory)
+        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
 
         expect(presenter.error).toBeNull()
       })
@@ -33,11 +35,43 @@ describe('FurtherInformationPresenter', () => {
 
     describe('when errors are passed in', () => {
       it('returns error information', () => {
-        const presenter = new FurtherInformationPresenter(serviceCategory, {
+        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory, {
           message: 'Something went wrong, please try again',
         })
 
         expect(presenter.error).toEqual({ message: 'Something went wrong, please try again' })
+      })
+    })
+  })
+
+  describe('value', () => {
+    describe('when the referral already has further information set', () => {
+      it('uses that further information as the value attribute', () => {
+        draftReferral.furtherInformation = 'Some information about the service user'
+        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
+
+        expect(presenter.value).toEqual('Some information about the service user')
+      })
+    })
+
+    describe('when there is user input data', () => {
+      it('uses that further information as the value attribute', () => {
+        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory, null, {
+          'further-information': 'Some information about the service user',
+        })
+
+        expect(presenter.value).toEqual('Some information about the service user')
+      })
+    })
+
+    describe('when the referral already has further information and there is user input data', () => {
+      it('sets the new input data as the further information value', () => {
+        draftReferral.furtherInformation = 'Some old information about the service user'
+        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory, null, {
+          'further-information': 'Some new information about the service user',
+        })
+
+        expect(presenter.value).toEqual('Some new information about the service user')
       })
     })
   })

--- a/server/routes/referrals/furtherInformationPresenter.ts
+++ b/server/routes/referrals/furtherInformationPresenter.ts
@@ -1,4 +1,4 @@
-import { ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
 
 export interface FurtherInformationError {
   message: string
@@ -6,12 +6,26 @@ export interface FurtherInformationError {
 
 export default class FurtherInformationPresenter {
   constructor(
+    private readonly referral: DraftReferral,
     private readonly serviceCategory: ServiceCategory,
-    readonly error: FurtherInformationError | null = null
+    readonly error: FurtherInformationError | null = null,
+    private readonly userInputData: Record<string, string> | null = null
   ) {}
 
   readonly title = `Do you have further information for the ${this.serviceCategory.name} service provider? (optional)`
 
   readonly hint =
     'For example, relevant previous offences, previously completed programmes or further reasons for this referral'
+
+  get value(): string {
+    if (this.userInputData !== null) {
+      return this.userInputData['further-information'] ?? ''
+    }
+
+    if (this.referral.furtherInformation) {
+      return this.referral.furtherInformation
+    }
+
+    return ''
+  }
 }

--- a/server/routes/referrals/furtherInformationPresenter.ts
+++ b/server/routes/referrals/furtherInformationPresenter.ts
@@ -1,0 +1,17 @@
+import { ServiceCategory } from '../../services/interventionsService'
+
+export interface FurtherInformationError {
+  message: string
+}
+
+export default class FurtherInformationPresenter {
+  constructor(
+    private readonly serviceCategory: ServiceCategory,
+    readonly error: FurtherInformationError | null = null
+  ) {}
+
+  readonly title = `Do you have further information for the ${this.serviceCategory.name} service provider? (optional)`
+
+  readonly hint =
+    'For example, relevant previous offences, previously completed programmes or further reasons for this referral'
+}

--- a/server/routes/referrals/furtherInformationView.ts
+++ b/server/routes/referrals/furtherInformationView.ts
@@ -1,0 +1,50 @@
+import FurtherInformationPresenter from './furtherInformationPresenter'
+
+export default class FurtherInformationView {
+  constructor(private readonly presenter: FurtherInformationPresenter) {}
+
+  private get textAreaArgs(): Record<string, unknown> {
+    const errorMessage = this.presenter.error ? { text: this.presenter.error.message } : null
+
+    return {
+      name: 'further-information',
+      id: 'further-information',
+      label: {
+        text: this.presenter.title,
+        classes: 'govuk-label--xl',
+        isPageHeading: true,
+      },
+      errorMessage,
+      hint: {
+        text: this.presenter.hint,
+      },
+    }
+  }
+
+  get errorSummaryArgs(): Record<string, unknown> | null {
+    if (!this.presenter.error) {
+      return null
+    }
+
+    return {
+      titleText: 'There is a problem',
+      errorList: [
+        {
+          text: this.presenter.error.message,
+          href: '#further-information',
+        },
+      ],
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/furtherInformation',
+      {
+        presenter: this.presenter,
+        textAreaArgs: this.textAreaArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/referrals/furtherInformationView.ts
+++ b/server/routes/referrals/furtherInformationView.ts
@@ -18,6 +18,7 @@ export default class FurtherInformationView {
       hint: {
         text: this.presenter.hint,
       },
+      value: this.presenter.value,
     }
   }
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -283,3 +283,47 @@ describe('GET /referrals/:id/further-information', () => {
       })
   })
 })
+
+describe('POST /referrals/:id/further-information', () => {
+  beforeEach(() => {
+    const serviceCategory = serviceCategoryFactory.build()
+    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+  })
+
+  it('updates the referral on the backend and redirects to the referral form', async () => {
+    await request(app)
+      .post('/referrals/1/further-information')
+      .type('form')
+      .send({ 'further-information': 'Further information about the service user' })
+      .expect(302)
+      .expect('Location', '/referrals/1/form')
+
+    expect(interventionsService.patchDraftReferral.mock.calls[0]).toEqual([
+      'token',
+      '1',
+      { furtherInformation: 'Further information about the service user' },
+    ])
+  })
+
+  it('updates the referral on the backend and returns a 400 with an error message if the API call fails', async () => {
+    interventionsService.patchDraftReferral.mockRejectedValue(new Error('Backend error message'))
+
+    await request(app)
+      .post('/referrals/1/further-information')
+      .type('form')
+      .send({ 'further-information': 'Further information about the service user' })
+      .expect(400)
+      .expect(res => {
+        expect(res.text).toContain('Backend error message')
+      })
+
+    expect(interventionsService.patchDraftReferral.mock.calls[0]).toEqual([
+      'token',
+      '1',
+      { furtherInformation: 'Further information about the service user' },
+    ])
+  })
+})

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -264,3 +264,22 @@ describe('POST /referrals/:id/complexity-level', () => {
     ])
   })
 })
+
+describe('GET /referrals/:id/further-information', () => {
+  beforeEach(() => {
+    const serviceCategory = serviceCategoryFactory.build()
+    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+  })
+
+  it('renders a form page', async () => {
+    await request(app)
+      .get('/referrals/1/further-information')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Do you have further information for the accommodation service provider? (optional)')
+      })
+  })
+})

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -8,6 +8,8 @@ import CompletionDeadlineForm, { CompletionDeadlineErrors } from './completionDe
 import ComplexityLevelView from './complexityLevelView'
 import ComplexityLevelPresenter, { ComplexityLevelError } from './complexityLevelPresenter'
 import ComplexityLevelForm from './complexityLevelForm'
+import FurtherInformationPresenter from './furtherInformationPresenter'
+import FurtherInformationView from './furtherInformationView'
 
 export default class ReferralsController {
   constructor(private readonly interventionsService: InterventionsService) {}
@@ -147,5 +149,24 @@ export default class ReferralsController {
       res.status(400)
       res.render(...view.renderArgs)
     }
+  }
+
+  async viewFurtherInformation(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+    if (referral.serviceCategoryId === null) {
+      throw new Error('Attempting to view further information without service category selected')
+    }
+
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      res.locals.user.token,
+      referral.serviceCategoryId
+    )
+
+    const presenter = new FurtherInformationPresenter(serviceCategory)
+
+    const view = new FurtherInformationView(presenter)
+
+    res.render(...view.renderArgs)
   }
 }

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -163,7 +163,7 @@ export default class ReferralsController {
       referral.serviceCategoryId
     )
 
-    const presenter = new FurtherInformationPresenter(serviceCategory)
+    const presenter = new FurtherInformationPresenter(referral, serviceCategory)
 
     const view = new FurtherInformationView(presenter)
 
@@ -199,7 +199,7 @@ export default class ReferralsController {
         referral.serviceCategoryId
       )
 
-      const presenter = new FurtherInformationPresenter(serviceCategory, error)
+      const presenter = new FurtherInformationPresenter(referral, serviceCategory, error, req.body)
       const view = new FurtherInformationView(presenter)
 
       res.status(400)

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -173,6 +173,39 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.complexityLevelId).toBe('d0db50b0-4a50-4fc7-a006-9c97530e38b2')
     })
+
+    it('returns the updated referral adding further information', async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to update further information',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer token',
+          },
+          body: { furtherInformation: 'Some information about the service user' },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            id: 'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+            furtherInformation: 'Some information about the service user',
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral('token', 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        furtherInformation: 'Some information about the service user',
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.furtherInformation).toBe('Some information about the service user')
+    })
   })
 
   describe('getServiceCategory', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -8,6 +8,7 @@ export interface DraftReferral {
   completionDeadline: string | null
   serviceCategoryId: string | null
   complexityLevelId: string | null
+  furtherInformation: string | null
 }
 
 export interface ServiceCategory {

--- a/server/views/referrals/furtherInformation.njk
+++ b/server/views/referrals/furtherInformation.njk
@@ -1,0 +1,29 @@
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {% if errorSummaryArgs !== null %}
+          {{ govukErrorSummary(errorSummaryArgs) }}
+        {% endif %}
+
+        {{ govukTextarea(textAreaArgs) }}
+
+        {{ govukButton({ text: "Save and continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -21,4 +21,5 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   completionDeadline: null,
   serviceCategoryId: null,
   complexityLevelId: null,
+  furtherInformation: null,
 }))


### PR DESCRIPTION
## What does this pull request do?

Adds the "further information page" (see screenshot).

There are a couple of potentially outstanding things to think about here:
- We don't have any validations on the client side as this is an optional page, so we're rendering any server errors in the "error summary" component, which might not be quite right.
- Because of the above, I haven't used our normal pattern of creating a `form` component for this, as I thought it was probably overkill, but if things change, it shouldn't be too hard to write one and slot it in.
- I'm not 100% convinced by my own logic for the different conditionals around when there's user data and a user submits an empty form. The tests seem to pass but as we don't have any integration tests or a local environment that allows us to test this properly, I'd like to revisit this (and really, the whole form) once we've got proper back-end integration running locally.

## What is the intent behind these changes?

To allow users to add further information to a referral.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/102521764-380eea00-408d-11eb-9363-5a0c865aab4f.png)

