### PR TITLE
adds a list of in progress draft referrals to the start referral page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   integration:
     docker:
-      - image: circleci/node:10-buster-browsers
+      - image: circleci/node:14-stretch-browsers
       - image: rodolpheche/wiremock:2.27.2-alpine
         command: ["--port", "9091"]
       - image: bitnami/redis:6.0
@@ -20,7 +20,9 @@ jobs:
     environment:
       PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
       PACT_BROKER_USERNAME: "interventions"
-    executor: hmpps/node
+    executor:
+      name: hmpps/node
+      tag: 14-stretch-browsers
     steps:
       - checkout
       - node/install-npm
@@ -57,7 +59,9 @@ jobs:
           path: integration_tests/screenshots
 
   vulnerability_scan:
-    executor: hmpps/node
+    executor:
+      name: hmpps/node
+      tag: 14-stretch-browsers
     parameters:
       monitor:
         type: boolean

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -46,7 +46,10 @@ function getApiClientTokenFromHmppsAuth(username?: string): Promise<superagent.R
 
 interface User {
   name: string
-  activeCaseLoadId: string
+  userId: string
+  username: string
+  authSource: string
+  active: boolean
 }
 
 interface UserRole {

--- a/server/routes/referrals/draftReferralsListPresenter.test.ts
+++ b/server/routes/referrals/draftReferralsListPresenter.test.ts
@@ -1,0 +1,23 @@
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import DraftReferralsListPresenter from './draftReferralsListPresenter'
+
+describe('DraftReferralsListPresenter', () => {
+  describe('orderedReferrals', () => {
+    it('returns an ordered list of draft referrals with formatted dates', () => {
+      const referrals = [
+        draftReferralFactory.createdAt(new Date('2021-01-02T12:00:00Z')).build(),
+        draftReferralFactory.createdAt(new Date('2021-01-03T12:00:00Z')).build(),
+        draftReferralFactory.createdAt(new Date('2021-01-01T12:00:00Z')).build(),
+      ]
+
+      const presenter = new DraftReferralsListPresenter(referrals)
+
+      // referrals are ordered oldest first
+      expect(presenter.orderedReferrals).toEqual([
+        expect.objectContaining({ createdAt: '01/01/2021' }),
+        expect.objectContaining({ createdAt: '02/01/2021' }),
+        expect.objectContaining({ createdAt: '03/01/2021' }),
+      ])
+    })
+  })
+})

--- a/server/routes/referrals/draftReferralsListPresenter.ts
+++ b/server/routes/referrals/draftReferralsListPresenter.ts
@@ -1,0 +1,23 @@
+import { DraftReferral } from '../../services/interventionsService'
+
+export default class DraftReferralsListPresenter {
+  constructor(private readonly draftReferrals: DraftReferral[]) {}
+
+  get orderedReferrals(): DraftReferralSummaryPresenter[] {
+    return this.draftReferrals
+      .sort((a, b) => (new Date(a.createdAt) < new Date(b.createdAt) ? -1 : 1))
+      .map(referral => ({
+        id: referral.id.slice(0, 8), // this is totally arbitrary, and probably meaningless to the user
+        createdAt: new Date(referral.createdAt).toLocaleDateString('en-GB'),
+        url: `/referrals/${referral.id}/form`,
+      }))
+  }
+
+  readonly emptyText = 'You do not have any draft referrals at this moment.'
+}
+
+interface DraftReferralSummaryPresenter {
+  id: string
+  createdAt: string
+  url: string
+}

--- a/server/routes/referrals/referralStartView.ts
+++ b/server/routes/referrals/referralStartView.ts
@@ -1,0 +1,25 @@
+import DraftReferralsListPresenter from './draftReferralsListPresenter'
+
+export default class ReferralStartView {
+  constructor(private readonly presenter: DraftReferralsListPresenter) {}
+
+  private get tableArgs(): Record<string, unknown> {
+    return {
+      firstCellIsHeader: true,
+      head: [{ text: 'ID' }, { text: 'Started on' }, { text: 'Link' }],
+      rows: this.presenter.orderedReferrals.map(referral => {
+        return [{ text: referral.id }, { text: referral.createdAt }, { html: `<a href="${referral.url}">Continue</a>` }]
+      }),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/start',
+      {
+        presenter: this.presenter,
+        tableArgs: this.tableArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -24,6 +24,10 @@ afterEach(() => {
 })
 
 describe('GET /referrals/start', () => {
+  beforeEach(() => {
+    interventionsService.getDraftReferralsForUser.mockResolvedValue([])
+  })
+
   it('renders a start page', () => {
     return request(app)
       .get('/referrals/start')

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import InterventionsService from '../../services/interventionsService'
 import ReferralFormPresenter from './referralFormPresenter'
+import DraftReferralsListPresenter from './draftReferralsListPresenter'
 import CompletionDeadlinePresenter from './completionDeadlinePresenter'
 import ReferralFormView from './referralFormView'
 import CompletionDeadlineView from './completionDeadlineView'
@@ -21,12 +22,18 @@ import RiskInformationView from './riskInformationView'
 import RarDaysView from './rarDaysView'
 import RarDaysPresenter from './rarDaysPresenter'
 import RarDaysForm from './rarDaysForm'
+import ReferralStartView from './referralStartView'
 
 export default class ReferralsController {
   constructor(private readonly interventionsService: InterventionsService) {}
 
   async startReferral(req: Request, res: Response): Promise<void> {
-    res.render('referrals/start')
+    const { token, userId } = res.locals.user
+    const existingDraftReferrals = await this.interventionsService.getDraftReferralsForUser(token, userId)
+    const presenter = new DraftReferralsListPresenter(existingDraftReferrals)
+    const view = new ReferralStartView(presenter)
+
+    res.render(...view.renderArgs)
   }
 
   async createReferral(req: Request, res: Response): Promise<void> {

--- a/server/routes/testutils/mocks/mockUserService.ts
+++ b/server/routes/testutils/mocks/mockUserService.ts
@@ -9,6 +9,7 @@ export const user = {
   displayName: 'John Smith',
   token: 'token',
   authSource: 'nomis',
+  userId: '123',
 }
 
 export class MockUserService extends UserService {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -31,7 +31,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           status: 200,
           body: Matchers.like({
             id: 'ac386c25-52c8-41fa-9213-fcf42e24b0b5',
-            created: '2020-12-07T18:02:01.599803Z',
+            createdAt: '2020-12-07T18:02:01.599803Z',
           }),
           headers: { 'Content-Type': 'application/json' },
         },
@@ -155,7 +155,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           status: 201,
           body: Matchers.like({
             id: 'dfb64747-f658-40e0-a827-87b4b0bdcfed',
-            created: '2020-12-07T20:45:21.986389Z',
+            createdAt: '2020-12-07T20:45:21.986389Z',
           }),
           headers: {
             'Content-Type': 'application/json',
@@ -192,7 +192,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           status: 200,
           body: {
             id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
-            created: '2020-12-07T20:45:21.986389Z',
+            createdAt: '2020-12-07T20:45:21.986389Z',
             completionDeadline: '2021-04-01',
           },
           headers: {
@@ -696,6 +696,73 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(serviceCategory.name).toEqual('accommodation')
       expect(serviceCategory.complexityLevels).toEqual(complexityLevels)
       expect(serviceCategory.desiredOutcomes).toEqual(desiredOutcomes)
+    })
+  })
+
+  describe('getDraftReferralsForUser', () => {
+    it('returns a list of draft referrals for a given userID', async () => {
+      await provider.addInteraction({
+        state: 'a referral for user with ID 2500128586 exists',
+        uponReceiving: 'a GET request to return the referrals for that user ID',
+        withRequest: {
+          method: 'GET',
+          path: '/draft-referrals',
+          query: 'userID=2500128586',
+          headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: [
+            {
+              id: 'ac386c25-52c8-41fa-9213-fcf42e24b0b5',
+              createdAt: '2020-12-07T18:02:01.599803Z',
+              createdByUserID: '2500128586',
+            },
+            {
+              id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
+              createdAt: '2020-12-24 09:32:32.871623+00',
+              createdByUserID: '2500128586',
+            },
+          ],
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referrals = await interventionsService.getDraftReferralsForUser(token, '2500128586')
+      expect(referrals.length).toBe(2)
+      expect(referrals[0].id).toBe('ac386c25-52c8-41fa-9213-fcf42e24b0b5')
+      expect(referrals[1].id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
+    })
+
+    it('returns an empty list for an unknown user ID', async () => {
+      await provider.addInteraction({
+        state: 'a referral does not exist for user with ID 123344556',
+        uponReceiving: 'a GET request to return the referrals for that user ID',
+        withRequest: {
+          method: 'GET',
+          path: '/draft-referrals',
+          query: 'userID=123344556',
+          headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: [],
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referrals = await interventionsService.getDraftReferralsForUser(token, '123344556')
+      expect(referrals.length).toBe(0)
     })
   })
 })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -54,7 +54,7 @@ export default class InterventionsService {
   async getDraftReferral(token: string, id: string): Promise<DraftReferral> {
     logger.info(`Getting draft referral with id ${id}`)
 
-    const restClient = await this.createRestClient(token)
+    const restClient = this.createRestClient(token)
 
     return (await restClient.get({
       path: `/draft-referral/${id}`,
@@ -63,7 +63,7 @@ export default class InterventionsService {
   }
 
   async createDraftReferral(token: string): Promise<DraftReferral> {
-    const restClient = await this.createRestClient(token)
+    const restClient = this.createRestClient(token)
 
     return (await restClient.post({
       path: `/draft-referral`,
@@ -72,7 +72,7 @@ export default class InterventionsService {
   }
 
   async patchDraftReferral(token: string, id: string, patch: Partial<DraftReferral>): Promise<DraftReferral> {
-    const restClient = await this.createRestClient(token)
+    const restClient = this.createRestClient(token)
 
     return (await restClient.patch({
       path: `/draft-referral/${id}`,
@@ -88,5 +88,15 @@ export default class InterventionsService {
       path: `/service-category/${serviceCategoryId}`,
       headers: { Accept: 'application/json' },
     })) as ServiceCategory
+  }
+
+  async getDraftReferralsForUser(token: string, userId: string): Promise<DraftReferral[]> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: '/draft-referrals',
+      query: `userID=${userId}`,
+      headers: { Accept: 'application/json' },
+    })) as DraftReferral[]
   }
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -15,7 +15,13 @@ describe('User service', () => {
       userService = new UserService(hmppsAuthClient)
     })
     it('Retrieves and formats user name', async () => {
-      hmppsAuthClient.getUser.mockResolvedValue({ name: 'john smith', activeCaseLoadId: '1' })
+      hmppsAuthClient.getUser.mockResolvedValue({
+        name: 'john smith',
+        authSource: 'delius',
+        username: 'johnsmith',
+        userId: '123',
+        active: true,
+      })
 
       const result = await userService.getUser(token)
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -4,6 +4,7 @@ import type HmppsAuthClient from '../data/hmppsAuthClient'
 export interface UserDetails {
   name: string
   displayName: string
+  userId: string
 }
 
 export default class UserService {

--- a/server/views/referrals/start.njk
+++ b/server/views/referrals/start.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = "HMPPS Interventions" %}
@@ -25,6 +27,15 @@
           </svg>
         </button>
       </form>
+
+      <h2 class="govuk-heading-l">
+        Draft referrals
+      </h2>
+      {% if presenter.orderedReferrals | length %}
+        {{ govukTable(tableArgs) }}
+      {% else %}
+        <p class="govuk-body-m">{{ presenter.emptyText }}</p>
+      {% endif %}
     </div>
   </div>
 

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -7,6 +7,10 @@ class DraftReferralFactory extends Factory<DraftReferral> {
     return this
   }
 
+  createdAt(date: Date) {
+    return this.params({ createdAt: date.toISOString() })
+  }
+
   serviceCategorySelected(serviceCategoryId?: string) {
     const resolvedServiceCategoryId = serviceCategoryId ?? serviceCategoryFactory.build().id
     return this.params({ serviceCategoryId: resolvedServiceCategoryId })


### PR DESCRIPTION
## What does this pull request do?

adds a list of "in progress" draft referrals to the start referral page. 

the referrals are ordered by the date and time they were created, with the oldest first. each row contains a link to continue filling out the referral form. the design is still not really defined. 

## What is the intent behind these changes?

