### PR TITLE
IC-666 Add "service user needs and requirements" page

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -39,6 +39,8 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals/:id/further-information', (req, res) => referralsController.updateFurtherInformation(req, res))
   get('/referrals/:id/desired-outcomes', (req, res) => referralsController.viewDesiredOutcomes(req, res))
   post('/referrals/:id/desired-outcomes', (req, res) => referralsController.updateDesiredOutcomes(req, res))
+  get('/referrals/:id/needs-and-requirements', (req, res) => referralsController.viewNeedsAndRequirements(req, res))
+  post('/referrals/:id/needs-and-requirements', (req, res) => referralsController.updateNeedsAndRequirements(req, res))
 
   return router
 }

--- a/server/routes/referrals/completionDeadlineForm.ts
+++ b/server/routes/referrals/completionDeadlineForm.ts
@@ -5,9 +5,7 @@ import CalendarDay from '../../utils/calendarDay'
 import errorMessages from '../../utils/errorMessages'
 
 export default class CompletionDeadlineForm {
-  private constructor(private readonly request: Request, private readonly result: Result<ValidationError>) {
-    this.result = validationResult(request)
-  }
+  private constructor(private readonly request: Request, private readonly result: Result<ValidationError>) {}
 
   static async createForm(request: Request): Promise<CompletionDeadlineForm> {
     await Promise.all(this.validations.map(validation => validation.run(request)))

--- a/server/routes/referrals/completionDeadlineView.ts
+++ b/server/routes/referrals/completionDeadlineView.ts
@@ -1,11 +1,10 @@
 import CompletionDeadlinePresenter from './completionDeadlinePresenter'
+import ViewUtils from '../../utils/viewUtils'
 
 export default class CompletionDeadlineView {
   constructor(private readonly presenter: CompletionDeadlinePresenter) {}
 
   private get dateInputArgs(): Record<string, unknown> {
-    const errorMessage = this.presenter.errorMessage ? { text: this.presenter.errorMessage } : null
-
     return {
       id: 'completion-deadline',
       namePrefix: 'completion-deadline',
@@ -19,7 +18,7 @@ export default class CompletionDeadlineView {
       hint: {
         text: this.presenter.hint,
       },
-      errorMessage,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
       items: [
         {
           classes: `govuk-input--width-2${this.presenter.erroredFields.includes('day') ? ' govuk-input--error' : ''}`,

--- a/server/routes/referrals/complexityLevelView.ts
+++ b/server/routes/referrals/complexityLevelView.ts
@@ -1,11 +1,10 @@
 import ComplexityLevelPresenter from './complexityLevelPresenter'
+import ViewUtils from '../../utils/viewUtils'
 
 export default class ComplexityLevelView {
   constructor(readonly presenter: ComplexityLevelPresenter) {}
 
   get radioButtonArgs(): Record<string, unknown> {
-    const errorMessage = this.presenter.error ? { text: this.presenter.error.message } : null
-
     return {
       classes: 'govuk-radios',
       idPrefix: 'complexity-level',
@@ -17,7 +16,7 @@ export default class ComplexityLevelView {
           classes: 'govuk-fieldset__legend--xl',
         },
       },
-      errorMessage,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.error?.message),
       items: this.presenter.complexityDescriptions.map(complexityDescription => {
         return {
           value: complexityDescription.value,

--- a/server/routes/referrals/needsAndRequirementsForm.test.ts
+++ b/server/routes/referrals/needsAndRequirementsForm.test.ts
@@ -1,0 +1,325 @@
+import { Request } from 'express'
+import NeedsAndRequirementsForm from './needsAndRequirementsForm'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
+
+describe('NeedsAndRequirementsForm', () => {
+  const referral = draftReferralFactory
+    .serviceCategorySelected()
+    .serviceUserSelected()
+    .build({ serviceUser: { firstName: 'Alex' } })
+
+  describe('errors', () => {
+    it('returns no error with all fields populated', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': 'Alex is currently sleeping on his aunt’s sofa',
+            'accessibility-needs': 'He uses a wheelchair',
+            'needs-interpreter': 'yes',
+            'interpreter-language': 'Spanish',
+            'has-additional-responsibilities': 'yes',
+            'when-unavailable': 'He works on Fridays 7am - midday',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.errors).toBeNull()
+    })
+
+    it('returns no error with the optional fields empty', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'yes',
+            'interpreter-language': 'Spanish',
+            'has-additional-responsibilities': 'yes',
+            'when-unavailable': 'He works on Fridays 7am - midday',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.errors).toBeNull()
+    })
+
+    it('returns multiple errors when there are multiple errors in the input', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.errors).toEqual([
+        {
+          field: 'needs-interpreter',
+          message: 'Select yes if Alex needs an interpreter',
+        },
+        {
+          field: 'has-additional-responsibilities',
+          message: 'Select yes if Alex has caring or employment responsibilities',
+        },
+      ])
+    })
+
+    it('returns an error when needs-interpreter is not answered', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'interpreter-language': '',
+            'has-additional-responsibilities': 'yes',
+            'when-unavailable': 'He works on Fridays 7am - midday',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.errors).toEqual([{ field: 'needs-interpreter', message: 'Select yes if Alex needs an interpreter' }])
+    })
+
+    it('returns an error when needs-interpreter is yes and interpreter-language is empty', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'yes',
+            'interpreter-language': '',
+            'has-additional-responsibilities': 'yes',
+            'when-unavailable': 'He works on Fridays 7am - midday',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.errors).toEqual([
+        { field: 'interpreter-language', message: 'Enter the language for which Alex needs an interpreter' },
+      ])
+    })
+
+    it('returns no error when needs-interpreter is no and interpreter-language is empty', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'no',
+            'interpreter-language': '     ',
+            'has-additional-responsibilities': 'yes',
+            'when-unavailable': 'He works on Fridays 7am - midday',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.errors).toBeNull()
+    })
+
+    it('returns an error when has-additional-responsibilities is not answered', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'yes',
+            'interpreter-language': 'Spanish',
+            'when-unavailable': '',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.errors).toEqual([
+        {
+          field: 'has-additional-responsibilities',
+          message: 'Select yes if Alex has caring or employment responsibilities',
+        },
+      ])
+    })
+
+    it('returns an error when has-additional-responsibilities is yes and when-unavailable is empty', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'yes',
+            'interpreter-language': 'Spanish',
+            'has-additional-responsibilities': 'yes',
+            'when-unavailable': '   ',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.errors).toEqual([
+        { field: 'when-unavailable', message: 'Enter details of when Alex will not be able to attend sessions' },
+      ])
+    })
+
+    it('returns no error when has-additional-responsibilities is no and when-unavailable is empty', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'no',
+            'interpreter-language': '',
+            'has-additional-responsibilities': 'no',
+            'when-unavailable': '',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.errors).toBeNull()
+    })
+  })
+
+  describe('paramsForUpdate', () => {
+    it('returns an object to be used for updating the draft referral via the interventions service', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': 'Alex is currently sleeping on his aunt’s sofa',
+            'accessibility-needs': 'He uses a wheelchair',
+            'needs-interpreter': 'yes',
+            'interpreter-language': 'Spanish',
+            'has-additional-responsibilities': 'yes',
+            'when-unavailable': 'He works on Fridays 7am - midday',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.paramsForUpdate).toEqual({
+        additionalNeedsInformation: 'Alex is currently sleeping on his aunt’s sofa',
+        accessibilityNeeds: 'He uses a wheelchair',
+        needsInterpreter: true,
+        interpreterLanguage: 'Spanish',
+        hasAdditionalResponsibilities: true,
+        whenUnavailable: 'He works on Fridays 7am - midday',
+      })
+    })
+
+    it('returns an empty string for additionalNeedsInformation when an empty additional-needs-information is submitted', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'no',
+            'interpreter-language': '',
+            'has-additional-responsibilities': 'no',
+            'when-unavailable': '',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.paramsForUpdate.additionalNeedsInformation).toBe('')
+    })
+
+    it('returns an empty string for accessibilityNeeds when an empty accessibility-needs is submitted', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'no',
+            'interpreter-language': '',
+            'has-additional-responsibilities': 'no',
+            'when-unavailable': '',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.paramsForUpdate.accessibilityNeeds).toBe('')
+    })
+
+    it('returns needsInterpreter true and a non-null interpreterLanguage when needs-interpreter is yes', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'yes',
+            'interpreter-language': 'Spanish',
+            'has-additional-responsibilities': 'no',
+            'when-unavailable': '',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.paramsForUpdate.needsInterpreter).toBe(true)
+      expect(form.paramsForUpdate.interpreterLanguage).toBe('Spanish')
+    })
+
+    it('returns needsInterpreter false and a null interpreterLanguage when needs-interpreter is no', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'no',
+            'interpreter-language': '',
+            'has-additional-responsibilities': 'no',
+            'when-unavailable': '',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.paramsForUpdate.needsInterpreter).toBe(false)
+      expect(form.paramsForUpdate.interpreterLanguage).toBeNull()
+    })
+
+    it('returns hasAdditionalResponsibilities true and a non-null whenUnavailable when has-additional-responsibilities is yes', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'no',
+            'interpreter-language': '',
+            'has-additional-responsibilities': 'yes',
+            'when-unavailable': 'He works on Fridays 7am - midday',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.paramsForUpdate.hasAdditionalResponsibilities).toBe(true)
+      expect(form.paramsForUpdate.whenUnavailable).toBe('He works on Fridays 7am - midday')
+    })
+
+    it('returns hasAdditionalResponsibilities false and a null whenUnavailable when has-additional-responsibilities is no', async () => {
+      const form = await NeedsAndRequirementsForm.createForm(
+        {
+          body: {
+            'additional-needs-information': '',
+            'accessibility-needs': '',
+            'needs-interpreter': 'no',
+            'interpreter-language': '',
+            'has-additional-responsibilities': 'no',
+            'when-unavailable': '',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.paramsForUpdate.hasAdditionalResponsibilities).toBe(false)
+      expect(form.paramsForUpdate.whenUnavailable).toBeNull()
+    })
+  })
+})

--- a/server/routes/referrals/needsAndRequirementsForm.ts
+++ b/server/routes/referrals/needsAndRequirementsForm.ts
@@ -1,0 +1,78 @@
+import { Request } from 'express'
+import { Result, ValidationChain, ValidationError } from 'express-validator'
+import { DraftReferral } from '../../services/interventionsService'
+import errorMessages from '../../utils/errorMessages'
+import FormUtils from '../../utils/formUtils'
+
+export default class NeedsAndRequirementsForm {
+  private constructor(
+    private readonly request: Request,
+    private readonly result: Result<ValidationError>,
+    private readonly referral: DraftReferral
+  ) {}
+
+  static async createForm(request: Request, referral: DraftReferral): Promise<NeedsAndRequirementsForm> {
+    return new NeedsAndRequirementsForm(
+      request,
+      await FormUtils.runValidations({ request, validations: this.validations(referral) }),
+      referral
+    )
+  }
+
+  static validations(referral: DraftReferral): ValidationChain[] {
+    const firstName = referral.serviceUser?.firstName ?? ''
+
+    return [
+      FormUtils.yesNoRadioWithConditionalInputValidationChain({
+        radioName: 'needs-interpreter',
+        inputName: 'interpreter-language',
+        notSelectedErrorMessage: errorMessages.needsInterpreter.empty(firstName),
+        inputValidator: chain =>
+          chain.notEmpty({ ignore_whitespace: true }).withMessage(errorMessages.interpreterLanguage.empty(firstName)),
+      }),
+      FormUtils.yesNoRadioWithConditionalInputValidationChain({
+        radioName: 'has-additional-responsibilities',
+        inputName: 'when-unavailable',
+        notSelectedErrorMessage: errorMessages.hasAdditionalResponsibilities.empty(firstName),
+        inputValidator: chain =>
+          chain.notEmpty({ ignore_whitespace: true }).withMessage(errorMessages.whenUnavailable.empty(firstName)),
+      }),
+    ].reduce((a, b) => a.concat(b), [])
+  }
+
+  get isValid(): boolean {
+    return this.errors == null
+  }
+
+  get paramsForUpdate(): Partial<DraftReferral> {
+    return {
+      additionalNeedsInformation: this.request.body['additional-needs-information'],
+      accessibilityNeeds: this.request.body['accessibility-needs'],
+      needsInterpreter: this.needsInterpeter,
+      interpreterLanguage: this.needsInterpeter ? this.request.body['interpreter-language'] : null,
+      hasAdditionalResponsibilities: this.hasAdditionalResponsibilities,
+      whenUnavailable: this.hasAdditionalResponsibilities ? this.request.body['when-unavailable'] : null,
+    }
+  }
+
+  private get needsInterpeter(): boolean {
+    return this.request.body['needs-interpreter'] === 'yes'
+  }
+
+  private get hasAdditionalResponsibilities(): boolean {
+    return this.request.body['has-additional-responsibilities'] === 'yes'
+  }
+
+  get errors(): NeedsAndRequirementsError[] | null {
+    if (this.result.isEmpty()) {
+      return null
+    }
+
+    return this.result.array().map(validationError => ({ field: validationError.param, message: validationError.msg }))
+  }
+}
+
+export interface NeedsAndRequirementsError {
+  field: string
+  message: string
+}

--- a/server/routes/referrals/needsAndRequirementsPresenter.test.ts
+++ b/server/routes/referrals/needsAndRequirementsPresenter.test.ts
@@ -1,0 +1,190 @@
+import NeedsAndRequirementsPresenter from './needsAndRequirementsPresenter'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
+
+describe('NeedsAndRequirementsPresenter', () => {
+  describe('summary', () => {
+    it('returns a summary of the service user’s details', () => {
+      const referral = draftReferralFactory.serviceCategorySelected().build()
+      const presenter = new NeedsAndRequirementsPresenter(referral)
+
+      expect(presenter.summary).toEqual([
+        { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], isList: true },
+        { key: 'Gender', lines: ['Male'], isList: false },
+      ])
+    })
+  })
+
+  describe('errorSummary', () => {
+    describe('when errors is null', () => {
+      it('returns null', () => {
+        const referral = draftReferralFactory.serviceCategorySelected().build()
+        const presenter = new NeedsAndRequirementsPresenter(referral, null)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when errors is not null', () => {
+      it('returns the errors sorted into the order their fields appear on the page', () => {
+        const referral = draftReferralFactory.serviceCategorySelected().build()
+        const presenter = new NeedsAndRequirementsPresenter(referral, [
+          { field: 'has-additional-responsibilities', message: 'has-additional-responsibilities msg' },
+          { field: 'needs-interpreter', message: 'needs-interpreter msg' },
+        ])
+
+        expect(presenter.errorSummary).toEqual([
+          { field: 'needs-interpreter', message: 'needs-interpreter msg' },
+          { field: 'has-additional-responsibilities', message: 'has-additional-responsibilities msg' },
+        ])
+      })
+    })
+  })
+
+  describe('text', () => {
+    it('returns content to be displayed on the page', () => {
+      const referral = draftReferralFactory
+        .serviceCategorySelected()
+        .serviceUserSelected()
+        .build({ serviceUser: { firstName: 'Geoffrey' } })
+      const presenter = new NeedsAndRequirementsPresenter(referral)
+
+      expect(presenter.text).toEqual({
+        accessibilityNeeds: {
+          errorMessage: null,
+          hint: 'For example, if they use a wheelchair, use a hearing aid or have a learning difficulty',
+          label: 'Does Geoffrey have any other mobility, disability or accessibility needs? (optional)',
+        },
+        additionalNeedsInformation: {
+          errorMessage: null,
+          label: 'Additional information about Geoffrey’s needs (optional)',
+        },
+        hasAdditionalResponsibilities: {
+          errorMessage: null,
+          hint: 'For example, times and dates when they are at work.',
+          label: 'Does Geoffrey have caring or employment responsibilities?',
+        },
+        interpreterLanguage: {
+          errorMessage: null,
+          label: 'What language?',
+        },
+        needsInterpreter: {
+          errorMessage: null,
+          label: 'Does Geoffrey need an interpreter?',
+        },
+        title: 'Geoffrey’s needs and requirements',
+        whenUnavailable: {
+          errorMessage: null,
+          label: 'Provide details of when Geoffrey will not be able to attend sessions',
+        },
+      })
+    })
+
+    describe('when there are errors', () => {
+      it('populates the error messages for the fields with errors', () => {
+        const referral = draftReferralFactory
+          .serviceCategorySelected()
+          .serviceUserSelected()
+          .build({ serviceUser: { firstName: 'Geoffrey' } })
+        const presenter = new NeedsAndRequirementsPresenter(referral, [
+          { field: 'accessibility-needs', message: 'accessibilityNeeds msg' },
+          { field: 'interpreter-language', message: 'interpreterLanguage msg' },
+        ])
+
+        expect(presenter.text).toMatchObject({
+          accessibilityNeeds: {
+            errorMessage: 'accessibilityNeeds msg',
+          },
+          additionalNeedsInformation: {
+            errorMessage: null,
+          },
+          hasAdditionalResponsibilities: {
+            errorMessage: null,
+          },
+          interpreterLanguage: {
+            errorMessage: 'interpreterLanguage msg',
+          },
+          needsInterpreter: {
+            errorMessage: null,
+          },
+          whenUnavailable: {
+            errorMessage: null,
+          },
+        })
+      })
+    })
+  })
+
+  // This is tested in detail in the tests for ReferralDataPresenterUtils.
+  // I’m just hoping to test a little here that things are glued together correctly.
+  describe('fields', () => {
+    describe('when there is no data on the referral', () => {
+      it('replays empty answers', () => {
+        const referral = draftReferralFactory.build()
+        const presenter = new NeedsAndRequirementsPresenter(referral)
+
+        expect(presenter.fields).toEqual({
+          additionalNeedsInformation: '',
+          accessibilityNeeds: '',
+          needsInterpreter: null,
+          interpreterLanguage: '',
+          hasAdditionalResponsibilities: null,
+          whenUnavailable: '',
+        })
+      })
+    })
+
+    describe('when there is data on the referral', () => {
+      it('replays the data from the referral', () => {
+        const referral = draftReferralFactory.build({
+          additionalNeedsInformation: 'She does not have a place to live',
+          accessibilityNeeds: 'She uses a wheelchair',
+          needsInterpreter: true,
+          interpreterLanguage: 'Spanish',
+          hasAdditionalResponsibilities: false,
+          whenUnavailable: null,
+        })
+        const presenter = new NeedsAndRequirementsPresenter(referral)
+
+        expect(presenter.fields).toEqual({
+          additionalNeedsInformation: 'She does not have a place to live',
+          accessibilityNeeds: 'She uses a wheelchair',
+          needsInterpreter: true,
+          interpreterLanguage: 'Spanish',
+          hasAdditionalResponsibilities: false,
+          whenUnavailable: '',
+        })
+      })
+    })
+
+    describe('when there is user input data', () => {
+      it('replays the user input data', () => {
+        const referral = draftReferralFactory.build({
+          additionalNeedsInformation: 'She does not have a place to live',
+          accessibilityNeeds: 'She uses a wheelchair',
+          needsInterpreter: true,
+          interpreterLanguage: 'Spanish',
+          hasAdditionalResponsibilities: false,
+          whenUnavailable: null,
+        })
+        const userInputData = {
+          'additional-needs-information': '',
+          'accessibility-needs': 'She has limited hearing',
+          'needs-interpreter': 'no',
+          'interpreter-language': '',
+          'has-additional-responsibilities': 'yes',
+          'when-unavailable': 'She works Fridays 9am - midday',
+        }
+        const presenter = new NeedsAndRequirementsPresenter(referral, null, userInputData)
+
+        expect(presenter.fields).toEqual({
+          additionalNeedsInformation: '',
+          accessibilityNeeds: 'She has limited hearing',
+          needsInterpreter: false,
+          interpreterLanguage: '',
+          hasAdditionalResponsibilities: true,
+          whenUnavailable: 'She works Fridays 9am - midday',
+        })
+      })
+    })
+  })
+})

--- a/server/routes/referrals/needsAndRequirementsPresenter.ts
+++ b/server/routes/referrals/needsAndRequirementsPresenter.ts
@@ -1,0 +1,76 @@
+import { DraftReferral } from '../../services/interventionsService'
+import { NeedsAndRequirementsError } from './needsAndRequirementsForm'
+import ReferralDataPresenterUtils from './referralDataPresenterUtils'
+
+export default class NeedsAndRequirementsPresenter {
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly errors: NeedsAndRequirementsError[] | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  readonly summary: { key: string; lines: string[]; isList: boolean }[] = [
+    { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], isList: true },
+    { key: 'Gender', lines: ['Male'], isList: false },
+    // TODO IC-746 populate with service user data once we have it
+  ]
+
+  private errorMessageForField(field: string): string | null {
+    return this.errors?.find(error => error.field === field)?.message ?? null
+  }
+
+  readonly text = {
+    title: `${this.referral.serviceUser?.firstName}’s needs and requirements`,
+    additionalNeedsInformation: {
+      label: `Additional information about ${this.referral.serviceUser?.firstName}’s needs (optional)`,
+      errorMessage: this.errorMessageForField('additional-needs-information'),
+    },
+    accessibilityNeeds: {
+      label: `Does ${this.referral.serviceUser?.firstName} have any other mobility, disability or accessibility needs? (optional)`,
+      hint: 'For example, if they use a wheelchair, use a hearing aid or have a learning difficulty',
+      errorMessage: this.errorMessageForField('accessibility-needs'),
+    },
+    needsInterpreter: {
+      label: `Does ${this.referral.serviceUser?.firstName} need an interpreter?`,
+      errorMessage: this.errorMessageForField('needs-interpreter'),
+    },
+    interpreterLanguage: {
+      label: 'What language?',
+      errorMessage: this.errorMessageForField('interpreter-language'),
+    },
+    hasAdditionalResponsibilities: {
+      label: `Does ${this.referral.serviceUser?.firstName} have caring or employment responsibilities?`,
+      hint: 'For example, times and dates when they are at work.',
+      errorMessage: this.errorMessageForField('has-additional-responsibilities'),
+    },
+    whenUnavailable: {
+      label: `Provide details of when ${this.referral.serviceUser?.firstName} will not be able to attend sessions`,
+      errorMessage: this.errorMessageForField('when-unavailable'),
+    },
+  }
+
+  readonly errorSummary = ReferralDataPresenterUtils.sortedErrors(this.errors, {
+    fieldOrder: [
+      'additional-needs-information',
+      'accessibility-needs',
+      'needs-interpreter',
+      'interpreter-language',
+      'has-additional-responsibilities',
+      'when-unavailable',
+    ],
+  })
+
+  private readonly utils = new ReferralDataPresenterUtils(this.referral, this.userInputData)
+
+  readonly fields = {
+    additionalNeedsInformation: this.utils.stringValue('additionalNeedsInformation', 'additional-needs-information'),
+    accessibilityNeeds: this.utils.stringValue('accessibilityNeeds', 'accessibility-needs'),
+    needsInterpreter: this.utils.booleanValue('needsInterpreter', 'needs-interpreter'),
+    interpreterLanguage: this.utils.stringValue('interpreterLanguage', 'interpreter-language'),
+    hasAdditionalResponsibilities: this.utils.booleanValue(
+      'hasAdditionalResponsibilities',
+      'has-additional-responsibilities'
+    ),
+    whenUnavailable: this.utils.stringValue('whenUnavailable', 'when-unavailable'),
+  }
+}

--- a/server/routes/referrals/needsAndRequirementsView.ts
+++ b/server/routes/referrals/needsAndRequirementsView.ts
@@ -1,0 +1,172 @@
+import NeedsAndRequirementsPresenter from './needsAndRequirementsPresenter'
+import ViewUtils from '../../utils/viewUtils'
+
+export default class NeedsAndRequirementsView {
+  constructor(private readonly presenter: NeedsAndRequirementsPresenter) {}
+
+  private get errorSummaryArgs() {
+    if (!this.presenter.errorSummary) {
+      return null
+    }
+
+    return {
+      titleText: 'There is a problem',
+      errorList: this.presenter.errorSummary.map(error => ({ text: error.message, href: `#${error.field}` })),
+    }
+  }
+
+  private get summaryListArgs() {
+    return {
+      rows: this.presenter.summary.map(item => {
+        return {
+          key: {
+            text: item.key,
+          },
+          value: (() => {
+            if (item.isList) {
+              const html = `<ul class="govuk-list">${item.lines
+                .map(line => `<li>${ViewUtils.escape(line)}</li>`)
+                .join('\n')}</ul>`
+              return { html }
+            }
+            if (item.lines.length > 1) {
+              const html = item.lines.map(line => `<p class="govuk-body">${ViewUtils.escape(line)}</p>`).join('\n')
+              return { html }
+            }
+            return { text: item.lines[0] || '' }
+          })(),
+        }
+      }),
+    }
+  }
+
+  private get additionalNeedsInformationTextareaArgs() {
+    return {
+      name: 'additional-needs-information',
+      id: 'additional-needs-information',
+      label: {
+        text: this.presenter.text.additionalNeedsInformation.label,
+        classes: 'govuk-label--s',
+      },
+      value: this.presenter.fields.additionalNeedsInformation,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.additionalNeedsInformation.errorMessage),
+    }
+  }
+
+  private get accessibilityNeedsTextareaArgs() {
+    return {
+      name: 'accessibility-needs',
+      id: 'accessibility-needs',
+      label: {
+        text: this.presenter.text.accessibilityNeeds.label,
+        classes: 'govuk-label--s',
+      },
+      hint: {
+        text: this.presenter.text.accessibilityNeeds.hint,
+      },
+      value: this.presenter.fields.accessibilityNeeds,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.accessibilityNeeds.errorMessage),
+    }
+  }
+
+  private interpreterRadiosArgs(yesHtml: string) {
+    return {
+      idPrefix: 'needs-interpreter',
+      name: 'needs-interpreter',
+      fieldset: {
+        legend: {
+          text: this.presenter.text.needsInterpreter.label,
+          classes: 'govuk-fieldset__legend--s',
+        },
+      },
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes',
+          checked: this.presenter.fields.needsInterpreter === true,
+          conditional: {
+            html: yesHtml,
+          },
+        },
+        {
+          value: 'no',
+          text: 'No',
+          checked: this.presenter.fields.needsInterpreter === false,
+        },
+      ],
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.needsInterpreter.errorMessage),
+    }
+  }
+
+  private get interpreterLanguageInputArgs() {
+    return {
+      id: 'interpreter-language',
+      name: 'interpreter-language',
+      classes: 'govuk-!-width-one-third',
+      label: {
+        text: this.presenter.text.interpreterLanguage.label,
+      },
+      value: this.presenter.fields.interpreterLanguage,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.interpreterLanguage.errorMessage),
+    }
+  }
+
+  private responsibilitiesRadiosArgs(yesHtml: string) {
+    return {
+      idPrefix: 'has-additional-responsibilities',
+      name: 'has-additional-responsibilities',
+      fieldset: {
+        legend: {
+          text: this.presenter.text.hasAdditionalResponsibilities.label,
+          classes: 'govuk-fieldset__legend--s',
+        },
+      },
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes',
+          checked: this.presenter.fields.hasAdditionalResponsibilities === true,
+          conditional: {
+            html: yesHtml,
+          },
+        },
+        {
+          value: 'no',
+          text: 'No',
+          checked: this.presenter.fields.hasAdditionalResponsibilities === false,
+        },
+      ],
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.hasAdditionalResponsibilities.errorMessage),
+    }
+  }
+
+  private get whenUnavailableInputArgs() {
+    return {
+      id: 'when-unavailable',
+      name: 'when-unavailable',
+      classes: 'govuk-!-width-one-third',
+      label: {
+        text: this.presenter.text.whenUnavailable.label,
+      },
+      value: this.presenter.fields.whenUnavailable,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.whenUnavailable.errorMessage),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/needsAndRequirements',
+      {
+        presenter: this.presenter,
+        errorSummaryArgs: this.errorSummaryArgs,
+        summaryListArgs: this.summaryListArgs,
+        additionalNeedsInformationTextareaArgs: this.additionalNeedsInformationTextareaArgs,
+        accessibilityNeedsTextareaArgs: this.accessibilityNeedsTextareaArgs,
+        interpreterRadiosArgs: this.interpreterRadiosArgs.bind(this),
+        interpreterLanguageInputArgs: this.interpreterLanguageInputArgs,
+        responsibilitiesRadiosArgs: this.responsibilitiesRadiosArgs.bind(this),
+        whenUnavailableInputArgs: this.whenUnavailableInputArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/referrals/referralDataPresenterUtils.test.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.test.ts
@@ -1,0 +1,252 @@
+import ReferralDataPresenterUtils from './referralDataPresenterUtils'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
+
+describe('ReferralDataPresenterUtils', () => {
+  describe('stringValue', () => {
+    describe('when the referral has a null value for the property', () => {
+      describe('when there is no user input data', () => {
+        it('returns an empty string', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: null })
+          const utils = new ReferralDataPresenterUtils(referral, null)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('')
+        })
+      })
+
+      describe('when there is user input data and the user input value for the property is null', () => {
+        it('returns an empty string', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: null })
+          const userInputData = { 'additional-needs-information': null }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('')
+        })
+      })
+
+      describe('when there is user input data and the property is absent from the user input data', () => {
+        it('returns an empty string', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: null })
+          const userInputData = {}
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('')
+        })
+      })
+
+      describe('when there is user input data and the user input value for the property is an empty string', () => {
+        it('returns an empty string', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: null })
+          const userInputData = { 'additional-needs-information': '' }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('')
+        })
+      })
+
+      describe('when there is user input data and the user input value for the property is a non-empty string', () => {
+        it('returns the user input value', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: null })
+          const userInputData = { 'additional-needs-information': 'bar' }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('bar')
+        })
+      })
+
+      describe('when there is user input data and the user input value for the property is present but neither a string nor null', () => {
+        it('returns the stringified user input value', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: null })
+          const userInputData = { 'additional-needs-information': 100 }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('100')
+        })
+      })
+    })
+
+    describe('when the referral has a non-null value for the property', () => {
+      describe('when there is no user input data', () => {
+        it('returns the value from the referral', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: 'foo' })
+          const utils = new ReferralDataPresenterUtils(referral, null)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('foo')
+        })
+      })
+
+      describe('when there is user input data and the user input value for the property is null', () => {
+        it('returns an empty string', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: 'foo' })
+          const userInputData = { 'additional-needs-information': null }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('')
+        })
+      })
+
+      describe('when there is user input data and the property is absent from the user input data', () => {
+        it('returns an empty string', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: 'foo' })
+          const userInputData = {}
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('')
+        })
+      })
+
+      describe('when there is user input data and the user input value for the property is an empty string', () => {
+        it('returns an empty string', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: 'foo' })
+          const userInputData = { 'additional-needs-information': '' }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('')
+        })
+      })
+
+      describe('when there is user input data and the user input value for the property is a non-empty string', () => {
+        it('returns the user input value', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: 'foo' })
+          const userInputData = { 'additional-needs-information': 'bar' }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('bar')
+        })
+      })
+
+      describe('when there is user input data and the user input value for the property is present but neither a string nor null', () => {
+        it('returns the stringified user input value', () => {
+          const referral = draftReferralFactory.build({ additionalNeedsInformation: 'foo' })
+          const userInputData = { 'additional-needs-information': 100 }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('100')
+        })
+      })
+    })
+  })
+
+  describe('booleanValue', () => {
+    describe('when the referral has a null value for the property', () => {
+      describe('when there is no user input data', () => {
+        it('returns null', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: null })
+          const utils = new ReferralDataPresenterUtils(referral, null)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBeNull()
+        })
+      })
+
+      describe('when there is user input data and the user input value for the property is null', () => {
+        it('returns null', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: null })
+          const userInputData = { 'needs-interpreter': null }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBeNull()
+        })
+      })
+
+      describe('when there is user input data and the property is absent from the user input data', () => {
+        it('returns null', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: null })
+          const userInputData = {}
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBe(null)
+        })
+      })
+
+      describe("when there is user input data and the user input value for the property is 'no'", () => {
+        it('returns false', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: null })
+          const userInputData = { 'needs-interpreter': 'no' }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBe(false)
+        })
+      })
+
+      describe("when there is user input data and the user input value for the property is 'yes'", () => {
+        it('returns true', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: null })
+          const userInputData = { 'needs-interpreter': 'yes' }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBe(true)
+        })
+      })
+
+      describe("when there is user input data and the user input value for the property is present but neither 'yes', 'no' nor null", () => {
+        it('returns null', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: null })
+          const userInputData = { 'needs-interpreter': true }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBeNull()
+        })
+      })
+    })
+
+    describe('when the referral has a non-null value for the property', () => {
+      describe('when there is no user input data', () => {
+        it('returns the value from the referral', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: false })
+          const utils = new ReferralDataPresenterUtils(referral, null)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBe(false)
+        })
+      })
+
+      describe('when there is user input data and the user input value for the property is null', () => {
+        it('returns null', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: false })
+          const userInputData = { 'needs-interpreter': null }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBeNull()
+        })
+      })
+
+      describe('when there is user input data and the property is absent from the user input data', () => {
+        it('returns null', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: false })
+          const userInputData = {}
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBe(null)
+        })
+      })
+
+      describe("when there is user input data and the user input value for the property is 'no'", () => {
+        it('returns false', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: false })
+          const userInputData = { 'needs-interpreter': 'no' }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBe(false)
+        })
+      })
+
+      describe("when there is user input data and the user input value for the property is 'yes'", () => {
+        it('returns true', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: false })
+          const userInputData = { 'needs-interpreter': 'yes' }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBe(true)
+        })
+      })
+
+      describe("when there is user input data and the user input value for the property is present but neither 'yes', 'no' nor null", () => {
+        it('returns null', () => {
+          const referral = draftReferralFactory.build({ needsInterpreter: false })
+          const userInputData = { 'needs-interpreter': true }
+          const utils = new ReferralDataPresenterUtils(referral, userInputData)
+
+          expect(utils.booleanValue('needsInterpreter', 'needs-interpreter')).toBeNull()
+        })
+      })
+    })
+  })
+})

--- a/server/routes/referrals/referralDataPresenterUtils.test.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.test.ts
@@ -249,4 +249,64 @@ describe('ReferralDataPresenterUtils', () => {
       })
     })
   })
+
+  describe('.sortedErrors', () => {
+    describe('with null errors', () => {
+      it('returns null', () => {
+        expect(ReferralDataPresenterUtils.sortedErrors(null, { fieldOrder: ['first', 'second', 'third'] })).toBeNull()
+      })
+    })
+
+    describe('when an empty array of errors', () => {
+      it('returns an empty array', () => {
+        expect(ReferralDataPresenterUtils.sortedErrors([], { fieldOrder: ['first', 'second', 'third'] })).toEqual([])
+      })
+    })
+
+    describe('with a non-empty array of errors', () => {
+      it('returns the errors ordered according to their fields’ positions in the fieldOrder array', () => {
+        expect(
+          ReferralDataPresenterUtils.sortedErrors(
+            [
+              { field: 'second', msg: 'second msg' },
+              { field: 'first', msg: 'first msg' },
+              { field: 'third', msg: 'third msg' },
+            ],
+            { fieldOrder: ['first', 'second', 'third'] }
+          )
+        ).toEqual([
+          { field: 'first', msg: 'first msg' },
+          { field: 'second', msg: 'second msg' },
+          { field: 'third', msg: 'third msg' },
+        ])
+      })
+
+      it('does not modify the original array', () => {
+        const original = [{ field: 'second' }, { field: 'first' }]
+        ReferralDataPresenterUtils.sortedErrors(original, { fieldOrder: ['first', 'second'] })
+        expect(original).toEqual([{ field: 'second' }, { field: 'first' }])
+      })
+
+      describe('when a field in the array of errors is missing from the fieldOrder array', () => {
+        it('places that field at the end of the return value', () => {
+          expect(
+            ReferralDataPresenterUtils.sortedErrors(
+              [
+                { field: 'second', msg: 'second msg' },
+                { field: 'first', msg: 'first msg' },
+                { field: 'fourth', msg: 'fourth msg' },
+                { field: 'third', msg: 'third msg' },
+              ],
+              { fieldOrder: ['first', 'second', 'third'] }
+            )
+          ).toEqual([
+            { field: 'first', msg: 'first msg' },
+            { field: 'second', msg: 'second msg' },
+            { field: 'third', msg: 'third msg' },
+            { field: 'fourth', msg: 'fourth msg' },
+          ])
+        })
+      })
+    })
+  })
 })

--- a/server/routes/referrals/referralDataPresenterUtils.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.ts
@@ -1,0 +1,35 @@
+import { DraftReferral } from '../../services/interventionsService'
+
+// This way of extracting all of a type’s properties of a particular type is taken from
+// https://stackoverflow.com/questions/56558289/typescript-generic-type-restriction-on-return-value-of-keyof
+type PropertiesOfType<TObj, TResult> = { [K in keyof TObj]: TObj[K] extends TResult ? K : never }[keyof TObj]
+
+export default class ReferralDataPresenterUtils {
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  stringValue<K extends PropertiesOfType<DraftReferral, string | null>>(referralKey: K, userInputKey: string): string {
+    if (this.userInputData === null) {
+      return this.referral[referralKey] ?? ''
+    }
+    return String(this.userInputData[userInputKey] ?? '')
+  }
+
+  booleanValue<K extends PropertiesOfType<DraftReferral, boolean | null>>(
+    referralKey: K,
+    userInputKey: string
+  ): boolean | null {
+    if (this.userInputData === null) {
+      return this.referral[referralKey]
+    }
+    if (this.userInputData[userInputKey] === 'yes') {
+      return true
+    }
+    if (this.userInputData[userInputKey] === 'no') {
+      return false
+    }
+    return null
+  }
+}

--- a/server/routes/referrals/referralDataPresenterUtils.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.ts
@@ -32,4 +32,26 @@ export default class ReferralDataPresenterUtils {
     }
     return null
   }
+
+  static sortedErrors<T extends { field: string }>(
+    errors: T[] | null,
+    { fieldOrder }: { fieldOrder: string[] }
+  ): T[] | null {
+    if (errors === null) {
+      return null
+    }
+
+    const copiedErrors = errors.slice()
+    return copiedErrors.sort((a, b) => {
+      const [aIndex, bIndex] = [fieldOrder.indexOf(a.field), fieldOrder.indexOf(b.field)]
+      if (aIndex === -1) {
+        return 1
+      }
+      if (bIndex === -1) {
+        return -1
+      }
+
+      return aIndex - bIndex
+    })
+  }
 }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -279,6 +279,189 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         '5352cfb6-c9ee-468c-b539-434a3e9b506e',
       ])
     })
+
+    it('returns the updated referral when setting additionalNeedsInformation and accessibilityNeeds', async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to set additionalNeedsInformation and accessibilityNeeds',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: {
+            accessibilityNeeds: 'She uses a wheelchair',
+            additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
+            accessibilityNeeds: 'She uses a wheelchair',
+            additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        accessibilityNeeds: 'She uses a wheelchair',
+        additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.accessibilityNeeds).toBe('She uses a wheelchair')
+      expect(referral.additionalNeedsInformation).toBe('Alex is currently sleeping on her aunt’s sofa')
+    })
+
+    it('returns the updated referral when setting needsInterpreter to true', async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to set needsInterpreter to true',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: { needsInterpreter: true, interpreterLanguage: 'Spanish' },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
+            needsInterpreter: true,
+            interpreterLanguage: 'Spanish',
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        needsInterpreter: true,
+        interpreterLanguage: 'Spanish',
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.needsInterpreter).toBe(true)
+      expect(referral.interpreterLanguage).toEqual('Spanish')
+    })
+
+    it('returns the updated referral when setting needsInterpreter to false', async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to set needsInterpreter to false',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: { needsInterpreter: false, interpreterLanguage: null },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
+            needsInterpreter: false,
+            interpreterLanguage: null,
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        needsInterpreter: false,
+        interpreterLanguage: null,
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.needsInterpreter).toBe(false)
+      expect(referral.interpreterLanguage).toBeNull()
+    })
+
+    it('returns the updated referral when setting hasAdditionalResponsibilities to true', async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to set hasAdditionalResponsibilities to true',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: { hasAdditionalResponsibilities: true, whenUnavailable: 'She works Mondays 9am - midday' },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
+            hasAdditionalResponsibilities: true,
+            whenUnavailable: 'She works Mondays 9am - midday',
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        hasAdditionalResponsibilities: true,
+        whenUnavailable: 'She works Mondays 9am - midday',
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.hasAdditionalResponsibilities).toBe(true)
+      expect(referral.whenUnavailable).toEqual('She works Mondays 9am - midday')
+    })
+
+    it('returns the updated referral when setting hasAdditionalResponsibilities to false', async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to set hasAdditionalResponsibilities to false',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: { hasAdditionalResponsibilities: false, whenUnavailable: null },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
+            hasAdditionalResponsibilities: false,
+            whenUnavailable: null,
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        hasAdditionalResponsibilities: false,
+        whenUnavailable: null,
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.hasAdditionalResponsibilities).toBe(false)
+      expect(referral.whenUnavailable).toBeNull()
+    })
   })
 
   describe('getServiceCategory', () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -106,6 +106,38 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         ])
       })
     })
+
+    describe('for a referral that has had a service user selected', () => {
+      beforeEach(async () => {
+        await provider.addInteraction({
+          state:
+            'There is an existing draft referral with ID of 1219a064-709b-4b6c-a11e-10b8cb3966f6, and it has had a service user selected',
+          uponReceiving: 'a request for that referral',
+          withRequest: {
+            method: 'GET',
+            path: '/draft-referral/1219a064-709b-4b6c-a11e-10b8cb3966f6',
+            headers: { Accept: 'application/json', Authorization: 'Bearer token' },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like({
+              id: '1219a064-709b-4b6c-a11e-10b8cb3966f6',
+              serviceUser: {
+                firstName: 'Alex',
+              },
+            }),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+      })
+
+      it('returns a referral for the given ID, with the service category id field populated', async () => {
+        const referral = await interventionsService.getDraftReferral('token', '1219a064-709b-4b6c-a11e-10b8cb3966f6')
+
+        expect(referral.id).toBe('1219a064-709b-4b6c-a11e-10b8cb3966f6')
+        expect(referral.serviceUser!.firstName).toEqual('Alex')
+      })
+    })
   })
 
   describe('createDraftReferral', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -16,6 +16,7 @@ export interface DraftReferral {
   interpreterLanguage: string | null
   hasAdditionalResponsibilities: boolean | null
   whenUnavailable: string | null
+  serviceUser: ServiceUser | null
 }
 
 export interface ServiceCategory {
@@ -34,6 +35,10 @@ export interface ComplexityLevel {
 export interface DesiredOutcome {
   id: string
   description: string
+}
+
+export interface ServiceUser {
+  firstName: string | null
 }
 
 export default class InterventionsService {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -10,6 +10,12 @@ export interface DraftReferral {
   complexityLevelId: string | null
   furtherInformation: string | null
   desiredOutcomesIds: string[] | null
+  additionalNeedsInformation: string | null
+  accessibilityNeeds: string | null
+  needsInterpreter: boolean | null
+  interpreterLanguage: string | null
+  hasAdditionalResponsibilities: boolean | null
+  whenUnavailable: string | null
 }
 
 export interface ServiceCategory {

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+// Explicit return types would make this file very messy and not much more
+// informational — everything returned is a string, since they’re messages!
+
 export default {
   completionDeadline: {
     dayEmpty: 'The date by which the service needs to be completed must include a day',
@@ -10,5 +14,17 @@ export default {
   },
   desiredOutcomes: {
     empty: 'Select desired outcomes',
+  },
+  needsInterpreter: {
+    empty: (name: string) => `Select yes if ${name} needs an interpreter`,
+  },
+  interpreterLanguage: {
+    empty: (name: string) => `Enter the language for which ${name} needs an interpreter`,
+  },
+  hasAdditionalResponsibilities: {
+    empty: (name: string) => `Select yes if ${name} has caring or employment responsibilities`,
+  },
+  whenUnavailable: {
+    empty: (name: string) => `Enter details of when ${name} will not be able to attend sessions`,
   },
 }

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -1,0 +1,85 @@
+import { Request } from 'express'
+import { body } from 'express-validator'
+import FormUtils from './formUtils'
+
+describe('FormUtils', () => {
+  describe('yesNoRadioWithConditionalInputValidationChain', () => {
+    async function validationResultForBody(requestBody: Record<string, unknown>) {
+      const validations = FormUtils.yesNoRadioWithConditionalInputValidationChain({
+        radioName: 'needs-interpreter',
+        inputName: 'interpreter-language',
+        notSelectedErrorMessage: 'Select yes if an interpreter is needed',
+        inputValidator: chain => chain.notEmpty().withMessage('Enter the language for which an interpreter is needed'),
+      })
+
+      const request = { body: requestBody } as Request
+
+      return FormUtils.runValidations({ request, validations })
+    }
+
+    it('returns an error when the radio buttons question is not answered', async () => {
+      const result = await validationResultForBody({ 'interpreter-language': '' })
+      expect(result.array()).toEqual([
+        {
+          param: 'needs-interpreter',
+          msg: 'Select yes if an interpreter is needed',
+          value: undefined,
+          location: 'body',
+        },
+      ])
+    })
+
+    it("returns an error when the radio buttons question is answered with neither 'yes' nor 'no'", async () => {
+      const result = await validationResultForBody({ 'needs-interpreter': 'true', 'interpreter-language': '' })
+      expect(result.array()).toEqual([
+        {
+          param: 'needs-interpreter',
+          msg: 'Select yes if an interpreter is needed',
+          value: 'true',
+          location: 'body',
+        },
+      ])
+    })
+
+    it("returns an error when the radio buttons answer is 'yes' and the input is invalid", async () => {
+      const result = await validationResultForBody({ 'needs-interpreter': 'yes', 'interpreter-language': '' })
+      expect(result.array()).toEqual([
+        {
+          param: 'interpreter-language',
+          msg: 'Enter the language for which an interpreter is needed',
+          value: '',
+          location: 'body',
+        },
+      ])
+    })
+
+    it("returns no error when the radio buttons answer is 'yes' and the input is valid", async () => {
+      const result = await validationResultForBody({ 'needs-interpreter': 'yes', 'interpreter-language': 'spanish' })
+      expect(result.array()).toEqual([])
+    })
+
+    it("returns no error when the radio buttons answer is 'no' and the input is invalid", async () => {
+      const result = await validationResultForBody({ 'needs-interpreter': 'no', 'interpreter-language': '' })
+      expect(result.array()).toEqual([])
+    })
+  })
+
+  describe('runValidations', () => {
+    it('runs all the validations on the request and returns a validation result', async () => {
+      const validations = [
+        body('field1').notEmpty().withMessage('field1 is empty'),
+        body('field2').notEmpty().withMessage('field2 is empty'),
+        body('field3').notEmpty().withMessage('field3 is empty'),
+      ]
+
+      const request = { body: { field1: 'Hello', field2: '', field3: '' } } as Request
+
+      const result = await FormUtils.runValidations({ request, validations })
+
+      expect(result.array()).toEqual([
+        { location: 'body', msg: 'field2 is empty', param: 'field2', value: '' },
+        { location: 'body', msg: 'field3 is empty', param: 'field3', value: '' },
+      ])
+    })
+  })
+})

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,0 +1,32 @@
+import { body, Result, ValidationChain, ValidationError, validationResult } from 'express-validator'
+import { Request } from 'express'
+
+export default class FormUtils {
+  static yesNoRadioWithConditionalInputValidationChain({
+    radioName,
+    inputName,
+    notSelectedErrorMessage,
+    inputValidator,
+  }: {
+    radioName: string
+    inputName: string
+    notSelectedErrorMessage: string
+    inputValidator: (chain: ValidationChain) => ValidationChain
+  }): ValidationChain[] {
+    return [
+      body(radioName).isIn(['yes', 'no']).withMessage(notSelectedErrorMessage),
+      inputValidator(body(inputName).if(body(radioName).equals('yes'))),
+    ]
+  }
+
+  static async runValidations({
+    request,
+    validations,
+  }: {
+    request: Request
+    validations: ValidationChain[]
+  }): Promise<Result<ValidationError>> {
+    await Promise.all(validations.map(validation => validation.run(request)))
+    return validationResult(request)
+  }
+}

--- a/server/utils/viewUtils.test.ts
+++ b/server/utils/viewUtils.test.ts
@@ -1,0 +1,13 @@
+import ViewUtils from './viewUtils'
+
+describe('ViewUtils', () => {
+  describe('escape', () => {
+    it('escapes HTML tags', () => {
+      expect(ViewUtils.escape('<ul class="foo">')).toBe('&lt;ul class=&quot;foo&quot;&gt;')
+    })
+
+    it('escapes HTML reserved characters', () => {
+      expect(ViewUtils.escape('It’s a great day for you & me')).toBe('It’s a great day for you &amp; me')
+    })
+  })
+})

--- a/server/utils/viewUtils.test.ts
+++ b/server/utils/viewUtils.test.ts
@@ -10,4 +10,30 @@ describe('ViewUtils', () => {
       expect(ViewUtils.escape('It’s a great day for you & me')).toBe('It’s a great day for you &amp; me')
     })
   })
+
+  describe('govukErrorMessage', () => {
+    describe('with a non-empty string', () => {
+      it('returns an error message object', () => {
+        expect(ViewUtils.govukErrorMessage('foo must be in the future')).toEqual({ text: 'foo must be in the future' })
+      })
+    })
+
+    describe('with an empty string', () => {
+      it('returns an error message object', () => {
+        expect(ViewUtils.govukErrorMessage('')).toEqual({ text: '' })
+      })
+    })
+
+    describe('with null', () => {
+      it('returns null', () => {
+        expect(ViewUtils.govukErrorMessage(null)).toBeNull()
+      })
+    })
+
+    describe('with undefined', () => {
+      it('returns null', () => {
+        expect(ViewUtils.govukErrorMessage(undefined)).toBeNull()
+      })
+    })
+  })
 })

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -5,4 +5,8 @@ export default class ViewUtils {
     const escape = new nunjucks.Environment().getFilter('escape')
     return escape(val).val
   }
+
+  static govukErrorMessage(message: string | null | undefined): { text: string } | null {
+    return message === null || message === undefined ? null : { text: message }
+  }
 }

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -1,0 +1,8 @@
+import * as nunjucks from 'nunjucks'
+
+export default class ViewUtils {
+  static escape(val: string): string {
+    const escape = new nunjucks.Environment().getFilter('escape')
+    return escape(val).val
+  }
+}

--- a/server/views/referrals/needsAndRequirements.njk
+++ b/server/views/referrals/needsAndRequirements.njk
@@ -1,0 +1,47 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      {{ govukSummaryList(summaryListArgs) }}
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {{ govukTextarea(additionalNeedsInformationTextareaArgs) }}
+        {{ govukTextarea(accessibilityNeedsTextareaArgs) }}
+
+        {% set interpreterLanguageHtml %}
+        {{ govukInput(interpreterLanguageInputArgs) }}
+        {% endset -%}
+        {{ govukRadios(interpreterRadiosArgs(interpreterLanguageHtml)) }}
+
+        {% set whenUnavailableHtml %}
+        {{ govukInput(whenUnavailableInputArgs) }}
+        {% endset -%}
+        {{ govukRadios(responsibilitiesRadiosArgs(whenUnavailableHtml)) }}
+
+        {{ govukButton({ text: "Save and continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -1,13 +1,15 @@
 import { Factory } from 'fishery'
 import { DraftReferral } from '../../server/services/interventionsService'
+import serviceCategoryFactory from './serviceCategory'
 
 class DraftReferralFactory extends Factory<DraftReferral> {
   justCreated() {
     return this
   }
 
-  serviceCategorySelected(serviceCategoryId: string) {
-    return this.params({ serviceCategoryId })
+  serviceCategorySelected(serviceCategoryId?: string) {
+    const resolvedServiceCategoryId = serviceCategoryId ?? serviceCategoryFactory.build().id
+    return this.params({ serviceCategoryId: resolvedServiceCategoryId })
   }
 
   completionDeadlineSet() {

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -25,4 +25,10 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   complexityLevelId: null,
   furtherInformation: null,
   desiredOutcomesIds: null,
+  additionalNeedsInformation: null,
+  accessibilityNeeds: null,
+  needsInterpreter: null,
+  interpreterLanguage: null,
+  hasAdditionalResponsibilities: null,
+  whenUnavailable: null,
 }))

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -15,6 +15,10 @@ class DraftReferralFactory extends Factory<DraftReferral> {
   completionDeadlineSet() {
     return this.params({ completionDeadline: '2021-08-24' })
   }
+
+  serviceUserSelected() {
+    return this.params({ serviceUser: { firstName: 'Marsha' } })
+  }
 }
 
 export default DraftReferralFactory.define(({ sequence }) => ({
@@ -31,4 +35,5 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   interpreterLanguage: null,
   hasAdditionalResponsibilities: null,
   whenUnavailable: null,
+  serviceUser: null,
 }))


### PR DESCRIPTION
## What does this pull request do?

Adds a page for specifying additional service user needs and requirements. For example, whether they need an interpreter.

It's our first page:
- with multiple inputs
- with conditional radio buttons

This page was initially quite painful to build due to a lot of repeated presenter logic and tests in particular. I've extracted some things to helper classes to avoid this boilerplate pain in the future. See commit messages.

## What is the intent behind these changes?

To build another page of the referral form, and to hopefully make it easier to build future pages.

## Screenshots

### Initial page

![Screenshot_2020-12-18 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/102611471-e450df00-4126-11eb-91c9-049e8aada169.png)

### Validation errors

![Screenshot_2020-12-18 HMPPS Interventions - GOV UK(1)](https://user-images.githubusercontent.com/53756884/102611479-e9159300-4126-11eb-9c9b-b5a3d6093548.png)