### PR TITLE
Put complexity level error message into usual file

### DIFF
--- a/server/routes/referrals/complexityLevelForm.ts
+++ b/server/routes/referrals/complexityLevelForm.ts
@@ -1,6 +1,7 @@
 import { Request } from 'express'
 import { DraftReferral } from '../../services/interventionsService'
 import { ComplexityLevelError } from './complexityLevelPresenter'
+import errorMessages from '../../utils/errorMessages'
 
 export default class ComplexityLevelForm {
   private constructor(private readonly request: Request) {}
@@ -24,6 +25,6 @@ export default class ComplexityLevelForm {
       return null
     }
 
-    return { message: 'Select a complexity level' }
+    return { message: errorMessages.complexityLevel.empty }
   }
 }

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -5,4 +5,7 @@ export default {
     yearEmpty: 'The date by which the service needs to be completed must include a year',
     invalidDate: 'The date by which the service needs to be completed must be a real date',
   },
+  complexityLevel: {
+    empty: 'Select a complexity level',
+  },
 }


### PR DESCRIPTION
## What does this pull request do?

Updates the complexity level form to pull the validation error message from the shared `errorMessages.ts` file.

## What is the intent behind these changes?

To handle validation error messages consistently across the app.