### PR TITLE
Add service user risk information form page

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -41,6 +41,8 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals/:id/desired-outcomes', (req, res) => referralsController.updateDesiredOutcomes(req, res))
   get('/referrals/:id/needs-and-requirements', (req, res) => referralsController.viewNeedsAndRequirements(req, res))
   post('/referrals/:id/needs-and-requirements', (req, res) => referralsController.updateNeedsAndRequirements(req, res))
+  get('/referrals/:id/risk-information', (req, res) => referralsController.viewRiskInformation(req, res))
+  post('/referrals/:id/risk-information', (req, res) => referralsController.updateRiskInformation(req, res))
 
   return router
 }

--- a/server/routes/referrals/needsAndRequirementsPresenter.ts
+++ b/server/routes/referrals/needsAndRequirementsPresenter.ts
@@ -16,7 +16,7 @@ export default class NeedsAndRequirementsPresenter {
   ]
 
   private errorMessageForField(field: string): string | null {
-    return this.errors?.find(error => error.field === field)?.message ?? null
+    return ReferralDataPresenterUtils.errorMessage(this.errors, field)
   }
 
   readonly text = {

--- a/server/routes/referrals/referralDataPresenterUtils.test.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.test.ts
@@ -309,4 +309,29 @@ describe('ReferralDataPresenterUtils', () => {
       })
     })
   })
+
+  describe('.errorMessage', () => {
+    describe('when errors is null', () => {
+      it('returns null', () => {
+        expect(ReferralDataPresenterUtils.errorMessage(null, 'my-field')).toBeNull()
+      })
+    })
+
+    describe('when errors is non-null and contains an error for that field', () => {
+      it('returns the message for that error', () => {
+        const errors = [
+          { field: 'other-field', message: 'other message' },
+          { field: 'my-field', message: 'my message' },
+        ]
+        expect(ReferralDataPresenterUtils.errorMessage(errors, 'my-field')).toEqual('my message')
+      })
+    })
+
+    describe('when errors is non-null and doesn’t contain an error for that field', () => {
+      it('returns null', () => {
+        const errors = [{ field: 'other-field', message: 'other message' }]
+        expect(ReferralDataPresenterUtils.errorMessage(errors, 'my-field')).toBeNull()
+      })
+    })
+  })
 })

--- a/server/routes/referrals/referralDataPresenterUtils.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.ts
@@ -54,4 +54,8 @@ export default class ReferralDataPresenterUtils {
       return aIndex - bIndex
     })
   }
+
+  static errorMessage(errors: { field: string; message: string }[] | null, field: string): string | null {
+    return errors?.find(error => error.field === field)?.message ?? null
+  }
 }

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -1,0 +1,117 @@
+import RiskInformationPresenter from './riskInformationPresenter'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
+
+describe('RiskInformationPresenter', () => {
+  describe('text', () => {
+    it('returns content to be displayed on the page', () => {
+      const referral = draftReferralFactory
+        .serviceCategorySelected()
+        .serviceUserSelected()
+        .build({ serviceUser: { firstName: 'Geoffrey' } })
+      const presenter = new RiskInformationPresenter(referral)
+
+      expect(presenter.text).toEqual({
+        title: 'Geoffrey’s risk information',
+        additionalRiskInformation: {
+          errorMessage: null,
+          label: 'Additional information for the provider about Geoffrey’s risks (optional)',
+        },
+      })
+    })
+
+    describe('when there are errors', () => {
+      it('populates error messages for the fields with errors', () => {
+        const referral = draftReferralFactory
+          .serviceCategorySelected()
+          .serviceUserSelected()
+          .build({ serviceUser: { firstName: 'Geoffrey' } })
+        const presenter = new RiskInformationPresenter(referral, [
+          { field: 'additional-risk-information', message: 'additionalRiskInformation msg' },
+        ])
+
+        expect(presenter.text).toMatchObject({
+          additionalRiskInformation: {
+            errorMessage: 'additionalRiskInformation msg',
+          },
+        })
+      })
+    })
+  })
+
+  // This is tested in detail in the tests for ReferralDataPresenterUtils.
+  // I’m just hoping to test a little here that things are glued together correctly.
+  describe('fields', () => {
+    describe('when the referral has no additional risk information', () => {
+      it('replays empty answers', () => {
+        const referral = draftReferralFactory.serviceUserSelected().build()
+        const presenter = new RiskInformationPresenter(referral)
+
+        expect(presenter.fields).toEqual({
+          additionalRiskInformation: '',
+        })
+      })
+    })
+
+    describe('when the referral has additional risk information and there’s no user input', () => {
+      it('replays the value from the referral', () => {
+        const referral = draftReferralFactory
+          .serviceUserSelected()
+          .build({ additionalRiskInformation: 'Risk to the elderly' })
+        const presenter = new RiskInformationPresenter(referral)
+
+        expect(presenter.fields).toEqual({
+          additionalRiskInformation: 'Risk to the elderly',
+        })
+      })
+    })
+
+    describe('when there’s user input', () => {
+      it('replays the user input', () => {
+        const referral = draftReferralFactory.serviceUserSelected().build()
+        const presenter = new RiskInformationPresenter(referral, null, {
+          'additional-risk-information': 'Risk to the vulnerable',
+        })
+
+        expect(presenter.fields).toEqual({
+          additionalRiskInformation: 'Risk to the vulnerable',
+        })
+      })
+    })
+  })
+
+  describe('errorSummary', () => {
+    describe('when errors is null', () => {
+      it('returns null', () => {
+        const referral = draftReferralFactory.serviceUserSelected().build()
+        const presenter = new RiskInformationPresenter(referral, null)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when errors is not null', () => {
+      it('returns the errors', () => {
+        const referral = draftReferralFactory.serviceUserSelected().build()
+        const presenter = new RiskInformationPresenter(referral, [
+          { field: 'additional-risk-information', message: 'msg' },
+        ])
+
+        expect(presenter.errorSummary).toEqual([{ field: 'additional-risk-information', message: 'msg' }])
+      })
+    })
+  })
+
+  describe('summary', () => {
+    it('returns a summary of the service user’s risk scores', () => {
+      const referral = draftReferralFactory.serviceUserSelected().build()
+      const presenter = new RiskInformationPresenter(referral)
+
+      expect(presenter.summary).toEqual([
+        { key: 'OGRS score', text: '50' },
+        { key: 'ROSHA score', text: 'Medium' },
+        { key: 'RM2000 score', text: 'Medium' },
+        { key: 'SARA score', text: 'Low' },
+      ])
+    })
+  })
+})

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -1,0 +1,34 @@
+import { DraftReferral } from '../../services/interventionsService'
+import ReferralDataPresenterUtils from './referralDataPresenterUtils'
+
+export default class RiskInformationPresenter {
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly errors: { field: string; message: string }[] | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  readonly summary = [
+    { key: 'OGRS score', text: '50' },
+    { key: 'ROSHA score', text: 'Medium' },
+    { key: 'RM2000 score', text: 'Medium' },
+    { key: 'SARA score', text: 'Low' },
+    // TODO IC-806 populate with service user data once we have it
+  ]
+
+  readonly text = {
+    title: `${this.referral.serviceUser?.firstName}’s risk information`,
+    additionalRiskInformation: {
+      label: `Additional information for the provider about ${this.referral.serviceUser?.firstName}’s risks (optional)`,
+      errorMessage: ReferralDataPresenterUtils.errorMessage(this.errors, 'additional-risk-information'),
+    },
+  }
+
+  readonly errorSummary = this.errors
+
+  private readonly utils = new ReferralDataPresenterUtils(this.referral, this.userInputData)
+
+  readonly fields = {
+    additionalRiskInformation: this.utils.stringValue('additionalRiskInformation', 'additional-risk-information'),
+  }
+}

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -1,0 +1,53 @@
+import RiskInformationPresenter from './riskInformationPresenter'
+import ViewUtils from '../../utils/viewUtils'
+
+export default class RiskInformationView {
+  constructor(private readonly presenter: RiskInformationPresenter) {}
+
+  private get errorSummaryArgs() {
+    if (!this.presenter.errorSummary) {
+      return null
+    }
+
+    return {
+      titleText: 'There is a problem',
+      errorList: this.presenter.errorSummary.map(error => ({ text: error.message, href: `#${error.field}` })),
+    }
+  }
+
+  private get summaryListArgs() {
+    return {
+      rows: this.presenter.summary.map(item => {
+        return {
+          key: { text: item.key },
+          value: { text: item.text },
+        }
+      }),
+    }
+  }
+
+  private get additionalRiskInformationTextareaArgs() {
+    return {
+      name: 'additional-risk-information',
+      id: 'additional-risk-information',
+      label: {
+        text: this.presenter.text.additionalRiskInformation.label,
+        classes: 'govuk-label--s',
+      },
+      value: this.presenter.fields.additionalRiskInformation,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.additionalRiskInformation.errorMessage),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/riskInformation',
+      {
+        presenter: this.presenter,
+        errorSummaryArgs: this.errorSummaryArgs,
+        summaryListArgs: this.summaryListArgs,
+        additionalRiskInformationTextareaArgs: this.additionalRiskInformationTextareaArgs,
+      },
+    ]
+  }
+}

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -494,6 +494,39 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(referral.hasAdditionalResponsibilities).toBe(false)
       expect(referral.whenUnavailable).toBeNull()
     })
+
+    it('returns the updated referral when setting additionalRiskInformation', async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to update additionalRiskInformation',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: { additionalRiskInformation: 'A danger to the elderly' },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
+            additionalRiskInformation: 'A danger to the elderly',
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        additionalRiskInformation: 'A danger to the elderly',
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.additionalRiskInformation).toEqual('A danger to the elderly')
+    })
   })
 
   describe('getServiceCategory', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -17,6 +17,7 @@ export interface DraftReferral {
   hasAdditionalResponsibilities: boolean | null
   whenUnavailable: string | null
   serviceUser: ServiceUser | null
+  additionalRiskInformation: string | null
 }
 
 export interface ServiceCategory {

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -1,0 +1,34 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      {{ govukSummaryList(summaryListArgs) }}
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {{ govukTextarea(additionalRiskInformationTextareaArgs) }}
+
+        {{ govukButton({ text: "Save and continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -36,4 +36,5 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   hasAdditionalResponsibilities: null,
   whenUnavailable: null,
   serviceUser: null,
+  additionalRiskInformation: null,
 }))


### PR DESCRIPTION
## What does this pull request do?

Adds a page for entering additional information about the service user’s risk.

Note that the summary list of risk information is currently just showing static data.

## What is the intent behind these changes?

To continue building the referral form.

## Screenshot

![Screenshot_2021-01-05 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/103653178-10a89000-4f5c-11eb-8a2a-cb78f7bf4eb4.png)
