### PR TITLE
add serviceCategoryId to newly created draft referrals to enable better testing in dev environment

### DIFF
--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -39,6 +39,12 @@ export default class ReferralsController {
   async createReferral(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.createDraftReferral(res.locals.user.token)
 
+    // fixme: this sets some static data for the new referral which will need to be
+    //  changed to allow these fields to be set properly
+    await this.interventionsService.patchDraftReferral(res.locals.user.token, referral.id, {
+      serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+    })
+
     res.redirect(303, `/referrals/${referral.id}/form`)
   }
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -141,7 +141,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   })
 
   describe('createDraftReferral', () => {
-    beforeEach(async () => {
+    it('returns a newly created draft referral', async () => {
       await provider.addInteraction({
         // We're not sure what is an appropriate state here
         state: 'a draft referral can be created',
@@ -165,9 +165,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         },
       })
-    })
 
-    it('returns a referral', async () => {
       const referral = await interventionsService.createDraftReferral(token)
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
     })
@@ -526,6 +524,40 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.additionalRiskInformation).toEqual('A danger to the elderly')
+    })
+
+    it('returns the updated referral when setting the service category ID', async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists',
+        uponReceiving: 'a PATCH request to update the service category ID',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: { serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16' },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: Matchers.like('dfb64747-f658-40e0-a827-87b4b0bdcfed'),
+            createdAt: '2020-12-07T20:45:21.986389Z',
+            serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+      })
+      expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.serviceCategoryId).toBe('428ee70f-3001-4399-95a6-ad25eaaede16')
     })
 
     it('returns the updated referral when setting usingRarDays to true', async () => {


### PR DESCRIPTION
## What does this pull request do?

sets some static data on newly created draft referrals.

## What is the intent behind these changes?

currently we will not have a way to specify the service category or service user crn until the discover/find work has commenced. this change means every newly created referral has a service category selected which allows us to use the referral form to fill in the rest of the detials. 
