### PR TITLE
IC-673: Add the “Are you using RAR days?” question page

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -43,6 +43,8 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals/:id/needs-and-requirements', (req, res) => referralsController.updateNeedsAndRequirements(req, res))
   get('/referrals/:id/risk-information', (req, res) => referralsController.viewRiskInformation(req, res))
   post('/referrals/:id/risk-information', (req, res) => referralsController.updateRiskInformation(req, res))
+  get('/referrals/:id/rar-days', (req, res) => referralsController.viewRarDays(req, res))
+  post('/referrals/:id/rar-days', (req, res) => referralsController.updateRarDays(req, res))
 
   return router
 }

--- a/server/routes/referrals/rarDaysForm.test.ts
+++ b/server/routes/referrals/rarDaysForm.test.ts
@@ -1,0 +1,152 @@
+import { Request } from 'express'
+import RarDaysForm from './rarDaysForm'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+
+describe(RarDaysForm, () => {
+  const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+
+  describe('isValid', () => {
+    describe('when there are no errors in the form', () => {
+      it('returns true', async () => {
+        const form = await RarDaysForm.createForm({ body: { 'using-rar-days': 'no' } } as Request, serviceCategory)
+
+        expect(form.isValid).toBe(true)
+      })
+    })
+
+    describe('when there are errors in the form', () => {
+      it('returns false', async () => {
+        const form = await RarDaysForm.createForm({ body: {} } as Request, serviceCategory)
+
+        expect(form.isValid).toBe(false)
+      })
+    })
+  })
+
+  describe('errors', () => {
+    describe('when no answer is selected for using-rar-days', () => {
+      it('gives an error for using-rar-days', async () => {
+        const form = await RarDaysForm.createForm({ body: {} } as Request, serviceCategory)
+
+        expect(form.errors).toEqual([
+          { field: 'using-rar-days', message: 'Select yes if you are using RAR days for the accommodation service' },
+        ])
+      })
+    })
+
+    describe('when choosing no for using-rar-days', () => {
+      it('gives no error', async () => {
+        const form = await RarDaysForm.createForm({ body: { 'using-rar-days': 'no' } } as Request, serviceCategory)
+
+        expect(form.errors).toBeNull()
+      })
+    })
+
+    describe('when choosing yes for using-rar-days', () => {
+      describe('with a valid value for maximum-rar-days', () => {
+        it('gives no error', async () => {
+          const form = await RarDaysForm.createForm(
+            { body: { 'using-rar-days': 'yes', 'maximum-rar-days': '10' } } as Request,
+            serviceCategory
+          )
+
+          expect(form.errors).toBeNull()
+        })
+      })
+
+      describe('with a valid value for maximum-rar-days which contains whitespace', () => {
+        it('gives no error', async () => {
+          const form = await RarDaysForm.createForm(
+            { body: { 'using-rar-days': 'yes', 'maximum-rar-days': ' 10  ' } } as Request,
+            serviceCategory
+          )
+
+          expect(form.errors).toBeNull()
+        })
+      })
+
+      describe('with a blank value for maximum-rar-days', () => {
+        it('gives an error for maximum-rar-days', async () => {
+          const form = await RarDaysForm.createForm(
+            { body: { 'using-rar-days': 'yes', 'maximum-rar-days': '' } } as Request,
+            serviceCategory
+          )
+
+          expect(form.errors).toEqual([
+            {
+              field: 'maximum-rar-days',
+              message: 'Enter the maximum number of RAR days for the accommodation service',
+            },
+          ])
+        })
+      })
+
+      describe('with a non-numeric value for maximum-rar-days', () => {
+        it('gives an error for maximum-rar-days', async () => {
+          const form = await RarDaysForm.createForm(
+            { body: { 'using-rar-days': 'yes', 'maximum-rar-days': 'blah' } } as Request,
+            serviceCategory
+          )
+
+          expect(form.errors).toEqual([
+            {
+              field: 'maximum-rar-days',
+              message: 'The maximum number of RAR days for the accommodation service must be a number, like 5',
+            },
+          ])
+        })
+      })
+
+      describe('with a non-whole number value for maximum-rar-days', () => {
+        it('gives an error for maximum-rar-days', async () => {
+          const form = await RarDaysForm.createForm(
+            { body: { 'using-rar-days': 'yes', 'maximum-rar-days': '3.5' } } as Request,
+            serviceCategory
+          )
+
+          expect(form.errors).toEqual([
+            {
+              field: 'maximum-rar-days',
+              message: 'The maximum number of RAR days for the accommodation service must be a whole number, like 5',
+            },
+          ])
+        })
+      })
+    })
+  })
+
+  describe('paramsForUpdate', () => {
+    describe('when using RAR days', () => {
+      it('returns true for usingRarDays, and a non-null maximumRarDays', async () => {
+        const form = await RarDaysForm.createForm(
+          { body: { 'using-rar-days': 'yes', 'maximum-rar-days': '3' } } as Request,
+          serviceCategory
+        )
+
+        expect(form.paramsForUpdate).toEqual({ usingRarDays: true, maximumRarDays: 3 })
+      })
+    })
+
+    describe('when not using RAR days', () => {
+      it('returns false for usingRarDays, and a null maximumRarDays', async () => {
+        const form = await RarDaysForm.createForm(
+          { body: { 'using-rar-days': 'no', 'maximum-rar-days': '' } } as Request,
+          serviceCategory
+        )
+
+        expect(form.paramsForUpdate).toEqual({ usingRarDays: false, maximumRarDays: null })
+      })
+    })
+
+    describe('when the submitted maximum-rar-days contains whitespace', () => {
+      it('correctly converts it to a number', async () => {
+        const form = await RarDaysForm.createForm(
+          { body: { 'using-rar-days': 'yes', 'maximum-rar-days': '  3  ' } } as Request,
+          serviceCategory
+        )
+
+        expect(form.paramsForUpdate).toEqual({ usingRarDays: true, maximumRarDays: 3 })
+      })
+    })
+  })
+})

--- a/server/routes/referrals/rarDaysForm.ts
+++ b/server/routes/referrals/rarDaysForm.ts
@@ -1,0 +1,60 @@
+import { Request } from 'express'
+import { Result, ValidationChain, ValidationError } from 'express-validator'
+import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import errorMessages from '../../utils/errorMessages'
+import FormUtils from '../../utils/formUtils'
+
+export default class RarDaysForm {
+  private constructor(private readonly request: Request, private readonly result: Result<ValidationError>) {}
+
+  static async createForm(request: Request, serviceCategory: ServiceCategory): Promise<RarDaysForm> {
+    return new RarDaysForm(
+      request,
+      await FormUtils.runValidations({ request, validations: this.validations(serviceCategory) })
+    )
+  }
+
+  static validations(serviceCategory: ServiceCategory): ValidationChain[] {
+    const firstName = serviceCategory.name
+
+    return FormUtils.yesNoRadioWithConditionalInputValidationChain({
+      radioName: 'using-rar-days',
+      inputName: 'maximum-rar-days',
+      notSelectedErrorMessage: errorMessages.usingRarDays.empty(firstName),
+      inputValidator: chain =>
+        chain
+          .notEmpty({ ignore_whitespace: true })
+          .withMessage(errorMessages.maximumRarDays.empty(serviceCategory.name))
+          .bail()
+          .trim()
+          .isNumeric()
+          .withMessage(errorMessages.maximumRarDays.notNumber(serviceCategory.name))
+          .bail()
+          .isInt()
+          .withMessage(errorMessages.maximumRarDays.notWholeNumber(serviceCategory.name)),
+    })
+  }
+
+  get isValid(): boolean {
+    return this.errors == null
+  }
+
+  get paramsForUpdate(): Partial<DraftReferral> {
+    return {
+      usingRarDays: this.usingRarDays,
+      maximumRarDays: this.usingRarDays ? Number(this.request.body['maximum-rar-days']) : null,
+    }
+  }
+
+  private get usingRarDays(): boolean {
+    return this.request.body['using-rar-days'] === 'yes'
+  }
+
+  get errors(): { field: string; message: string }[] | null {
+    if (this.result.isEmpty()) {
+      return null
+    }
+
+    return this.result.array().map(validationError => ({ field: validationError.param, message: validationError.msg }))
+  }
+}

--- a/server/routes/referrals/rarDaysPresenter.test.ts
+++ b/server/routes/referrals/rarDaysPresenter.test.ts
@@ -1,0 +1,140 @@
+import RarDaysPresenter from './rarDaysPresenter'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+
+describe(RarDaysPresenter, () => {
+  describe('text', () => {
+    it('returns text to be displayed', () => {
+      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const referral = draftReferralFactory.build()
+
+      const presenter = new RarDaysPresenter(referral, serviceCategory)
+
+      expect(presenter.text).toEqual({
+        title: 'Are you using RAR days for the accommodation service?',
+        usingRarDays: {
+          errorMessage: null,
+        },
+        maximumRarDays: {
+          label: 'What is the maximum number of RAR days for the accommodation service?',
+          errorMessage: null,
+        },
+      })
+    })
+
+    describe('when some fields have errors', () => {
+      it('includes error messages for those fields', () => {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.build()
+
+        const presenter = new RarDaysPresenter(referral, serviceCategory, [
+          { field: 'using-rar-days', message: 'usingRarDays msg' },
+          { field: 'maximum-rar-days', message: 'maximumRarDays msg' },
+        ])
+
+        expect(presenter.text).toMatchObject({
+          usingRarDays: {
+            errorMessage: 'usingRarDays msg',
+          },
+          maximumRarDays: {
+            errorMessage: 'maximumRarDays msg',
+          },
+        })
+      })
+    })
+  })
+
+  describe('fields', () => {
+    describe('when the answers are null on the referral and there is no user input data', () => {
+      it('returns values corresponding to no selection', () => {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.build()
+
+        const presenter = new RarDaysPresenter(referral, serviceCategory)
+
+        expect(presenter.fields).toEqual({
+          usingRarDays: null,
+          maximumRarDays: '',
+        })
+      })
+    })
+
+    describe('when the answers are present on the referral', () => {
+      it('returns the values from the referral', () => {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.build({ usingRarDays: true, maximumRarDays: 10 })
+
+        const presenter = new RarDaysPresenter(referral, serviceCategory)
+
+        expect(presenter.fields).toEqual({
+          usingRarDays: true,
+          maximumRarDays: '10',
+        })
+      })
+    })
+
+    describe('when there is user input data', () => {
+      it('returns the user input values', () => {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.build()
+
+        const presenter = new RarDaysPresenter(referral, serviceCategory, null, {
+          'using-rar-days': 'yes',
+          'maximum-rar-days': 'blah',
+        })
+
+        expect(presenter.fields).toEqual({
+          usingRarDays: true,
+          maximumRarDays: 'blah',
+        })
+      })
+    })
+
+    describe('when there is user input data and the answers are present on the referral', () => {
+      it('returns the user input values', () => {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.build({ usingRarDays: false, maximumRarDays: null })
+
+        const presenter = new RarDaysPresenter(referral, serviceCategory, null, {
+          'using-rar-days': 'yes',
+          'maximum-rar-days': 'blah',
+        })
+
+        expect(presenter.fields).toEqual({
+          usingRarDays: true,
+          maximumRarDays: 'blah',
+        })
+      })
+    })
+  })
+
+  describe('errorSummary', () => {
+    describe('when errors is null', () => {
+      it('returns null', () => {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.build()
+
+        const presenter = new RarDaysPresenter(referral, serviceCategory)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when errors is not null', () => {
+      it('returns the errors sorted by the order the fields appear on the page', () => {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.build()
+
+        const presenter = new RarDaysPresenter(referral, serviceCategory, [
+          { field: 'maximum-rar-days', message: 'maximumRarDays msg' },
+          { field: 'using-rar-days', message: 'usingRarDays msg' },
+        ])
+
+        expect(presenter.errorSummary).toEqual([
+          { field: 'using-rar-days', message: 'usingRarDays msg' },
+          { field: 'maximum-rar-days', message: 'maximumRarDays msg' },
+        ])
+      })
+    })
+  })
+})

--- a/server/routes/referrals/rarDaysPresenter.ts
+++ b/server/routes/referrals/rarDaysPresenter.ts
@@ -1,0 +1,33 @@
+import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import ReferralDataPresenterUtils from './referralDataPresenterUtils'
+
+export default class RarDaysPresenter {
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly serviceCategory: ServiceCategory,
+    private readonly errors: { field: string; message: string }[] | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  readonly errorSummary = ReferralDataPresenterUtils.sortedErrors(this.errors, {
+    fieldOrder: ['using-rar-days', 'maximum-rar-days'],
+  })
+
+  readonly text = {
+    title: `Are you using RAR days for the ${this.serviceCategory.name} service?`,
+    usingRarDays: {
+      errorMessage: ReferralDataPresenterUtils.errorMessage(this.errors, 'using-rar-days'),
+    },
+    maximumRarDays: {
+      label: `What is the maximum number of RAR days for the ${this.serviceCategory.name} service?`,
+      errorMessage: ReferralDataPresenterUtils.errorMessage(this.errors, 'maximum-rar-days'),
+    },
+  }
+
+  private readonly utils = new ReferralDataPresenterUtils(this.referral, this.userInputData)
+
+  readonly fields = {
+    usingRarDays: this.utils.booleanValue('usingRarDays', 'using-rar-days'),
+    maximumRarDays: this.utils.stringValue('maximumRarDays', 'maximum-rar-days'),
+  }
+}

--- a/server/routes/referrals/rarDaysView.ts
+++ b/server/routes/referrals/rarDaysView.ts
@@ -1,0 +1,74 @@
+import ViewUtils from '../../utils/viewUtils'
+import RarDaysPresenter from './rarDaysPresenter'
+
+export default class RarDaysView {
+  constructor(private readonly presenter: RarDaysPresenter) {}
+
+  private get errorSummaryArgs() {
+    if (!this.presenter.errorSummary) {
+      return null
+    }
+
+    return {
+      titleText: 'There is a problem',
+      errorList: this.presenter.errorSummary.map(error => ({ text: error.message, href: `#${error.field}` })),
+    }
+  }
+
+  private usingRarDaysRadiosArgs(yesHtml: string) {
+    return {
+      idPrefix: 'using-rar-days',
+      name: 'using-rar-days',
+      fieldset: {
+        legend: {
+          text: this.presenter.text.title,
+          classes: 'govuk-fieldset__legend--xl',
+          isPageHeading: true,
+        },
+      },
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes',
+          checked: this.presenter.fields.usingRarDays === true,
+          conditional: {
+            html: yesHtml,
+          },
+        },
+        {
+          value: 'no',
+          text: 'No',
+          checked: this.presenter.fields.usingRarDays === false,
+        },
+      ],
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.usingRarDays.errorMessage),
+    }
+  }
+
+  private get maximumRarDaysInputArgs() {
+    return {
+      id: 'maximum-rar-days',
+      name: 'maximum-rar-days',
+      classes: 'govuk-input--width-4',
+      label: {
+        text: this.presenter.text.maximumRarDays.label,
+      },
+      value: this.presenter.fields.maximumRarDays,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.maximumRarDays.errorMessage),
+      inputmode: 'numeric',
+      pattern: '[0-9]*',
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/rarDays',
+      {
+        presenter: this.presenter,
+        errorSummaryArgs: this.errorSummaryArgs,
+        usingRarDaysRadiosArgs: this.usingRarDaysRadiosArgs.bind(this),
+        maximumRarDaysInputArgs: this.maximumRarDaysInputArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/referrals/referralDataPresenterUtils.test.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.test.ts
@@ -66,11 +66,22 @@ describe('ReferralDataPresenterUtils', () => {
 
     describe('when the referral has a non-null value for the property', () => {
       describe('when there is no user input data', () => {
-        it('returns the value from the referral', () => {
-          const referral = draftReferralFactory.build({ additionalNeedsInformation: 'foo' })
-          const utils = new ReferralDataPresenterUtils(referral, null)
+        describe('when the referral’s value is a string', () => {
+          it('returns the value from the referral', () => {
+            const referral = draftReferralFactory.build({ additionalNeedsInformation: 'foo' })
+            const utils = new ReferralDataPresenterUtils(referral, null)
 
-          expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('foo')
+            expect(utils.stringValue('additionalNeedsInformation', 'additional-needs-information')).toBe('foo')
+          })
+        })
+
+        describe('when the referral’s value is a number', () => {
+          it('returns the formatted value from the referral', () => {
+            const referral = draftReferralFactory.build({ maximumRarDays: 10 })
+            const utils = new ReferralDataPresenterUtils(referral, null)
+
+            expect(utils.stringValue('maximumRarDays', 'maximum-rar-days')).toBe('10')
+          })
         })
       })
 

--- a/server/routes/referrals/referralDataPresenterUtils.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.ts
@@ -10,9 +10,12 @@ export default class ReferralDataPresenterUtils {
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
-  stringValue<K extends PropertiesOfType<DraftReferral, string | null>>(referralKey: K, userInputKey: string): string {
+  stringValue<K extends PropertiesOfType<DraftReferral, string | number | null>>(
+    referralKey: K,
+    userInputKey: string
+  ): string {
     if (this.userInputData === null) {
-      return this.referral[referralKey] ?? ''
+      return String(this.referral[referralKey] ?? '')
     }
     return String(this.userInputData[userInputKey] ?? '')
   }

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -27,4 +27,13 @@ export default {
   whenUnavailable: {
     empty: (name: string) => `Enter details of when ${name} will not be able to attend sessions`,
   },
+  usingRarDays: {
+    empty: (name: string) => `Select yes if you are using RAR days for the ${name} service`,
+  },
+  maximumRarDays: {
+    empty: (name: string) => `Enter the maximum number of RAR days for the ${name} service`,
+    notNumber: (name: string) => `The maximum number of RAR days for the ${name} service must be a number, like 5`,
+    notWholeNumber: (name: string) =>
+      `The maximum number of RAR days for the ${name} service must be a whole number, like 5`,
+  },
 }

--- a/server/views/referrals/rarDays.njk
+++ b/server/views/referrals/rarDays.njk
@@ -1,0 +1,34 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form method="post" novalidate>
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {% if errorSummaryArgs !== null %}
+          {{ govukErrorSummary(errorSummaryArgs) }}
+        {% endif %}
+
+        {% set maximumDaysHtml %}
+          {{ govukInput(maximumRarDaysInputArgs) }}
+        {% endset -%}
+        {{ govukRadios(usingRarDaysRadiosArgs(maximumDaysHtml)) }}
+
+        {{ govukButton({ text: "Save and continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a page allowing the probation practitioner to state whether they are using RAR days for the intervention, and what is the maximum number of days that should be used.

The Jira story also uses the terminology "enforceable days", but says that we should go with what's in the prototype for now so that's what I've done.

## What is the intent behind these changes?

To continue building out the referral form.

## Screenshot

![image](https://user-images.githubusercontent.com/53756884/103763414-b79b3380-5011-11eb-9f98-462e861f01de.png)
