### PR TITLE
Disable HTML 5 validation for completion deadline

### DIFF
--- a/server/views/referrals/completionDeadline.njk
+++ b/server/views/referrals/completionDeadline.njk
@@ -13,7 +13,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form method="post">
+      <form method="post" novalidate>
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
         {% if errorSummaryArgs !== null %}


### PR DESCRIPTION
## What does this pull request do?

This disables the browser-native error messages that are given for
non-numeric day / month / year values, and means that we always use the
GOV.UK error messages.

This is the approach recommended by the GOV.UK Design System:
https://design-system.service.gov.uk/patterns/validation/#turn-off-html5-validation

## What is the intent behind these changes?

To follow the guidance of the Design System.