### PR TITLE
Make referral form more realistic and useful

### DIFF
--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -39,8 +39,8 @@ describe('ReferralFormPresenter', () => {
           number: '3',
           status: ReferralFormStatus.Completed,
           tasks: [
-            { title: 'Service user’s risk information', url: '#' },
-            { title: 'Service user’s needs and requirements', url: '#' },
+            { title: 'Service user’s risk information', url: 'risk-information' },
+            { title: 'Service user’s needs and requirements', url: 'needs-and-requirements' },
           ],
         },
         {
@@ -54,11 +54,14 @@ describe('ReferralFormPresenter', () => {
               status: ReferralFormStatus.InProgress,
               tasks: [
                 { title: 'Select the relevant sentence for the accommodation referral', url: '#' },
-                { title: 'Select desired outcomes', url: '#' },
-                { title: 'Select required complexity level', url: '#' },
-                { title: 'What date does the accommodation service need to be completed by?', url: '#' },
-                { title: 'Enter RAR days used', url: null },
-                { title: 'Further information for service provider', url: null },
+                { title: 'Select desired outcomes', url: 'desired-outcomes' },
+                { title: 'Select required complexity level', url: 'complexity-level' },
+                {
+                  title: 'What date does the accommodation service need to be completed by?',
+                  url: 'completion-deadline',
+                },
+                { title: 'Enter RAR days used', url: 'rar-days' },
+                { title: 'Further information for service provider', url: 'further-information' },
               ],
             },
             {

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -19,8 +19,8 @@ describe('ReferralFormPresenter', () => {
           number: '1',
           status: ReferralFormStatus.Completed,
           tasks: [
-            { title: 'Enter service user case identifier', url: '#' },
-            { title: 'Confirm service user details', url: '#' },
+            { title: 'Enter service user case identifier', url: null },
+            { title: 'Confirm service user details', url: null },
           ],
         },
         {
@@ -29,8 +29,8 @@ describe('ReferralFormPresenter', () => {
           number: '2',
           status: ReferralFormStatus.Completed,
           tasks: [
-            { title: 'Find and select service user interventions', url: '#' },
-            { title: 'Confirm interventions', url: '#' },
+            { title: 'Find and select service user interventions', url: null },
+            { title: 'Confirm interventions', url: null },
           ],
         },
         {
@@ -53,7 +53,7 @@ describe('ReferralFormPresenter', () => {
               number: '4.1',
               status: ReferralFormStatus.InProgress,
               tasks: [
-                { title: 'Select the relevant sentence for the accommodation referral', url: '#' },
+                { title: 'Select the relevant sentence for the accommodation referral', url: null },
                 { title: 'Select desired outcomes', url: 'desired-outcomes' },
                 { title: 'Select required complexity level', url: 'complexity-level' },
                 {
@@ -69,7 +69,7 @@ describe('ReferralFormPresenter', () => {
               number: '4.2',
               status: ReferralFormStatus.NotStarted,
               tasks: [
-                { title: 'Select the relevant sentence for the social inclusion referral', url: '#' },
+                { title: 'Select the relevant sentence for the social inclusion referral', url: null },
                 { title: 'Select desired outcomes', url: null },
                 { title: 'Select required complexity level', url: null },
                 { title: 'What date does the social inclusion service need to be completed by?', url: null },
@@ -84,7 +84,7 @@ describe('ReferralFormPresenter', () => {
           title: 'Review responsible officer’s information',
           number: '5',
           status: ReferralFormStatus.NotStarted,
-          tasks: [{ title: 'Responsible officer information', url: '#' }],
+          tasks: [{ title: 'Responsible officer information', url: null }],
         },
         {
           type: 'single',

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -64,19 +64,6 @@ describe('ReferralFormPresenter', () => {
                 { title: 'Further information for service provider', url: 'further-information' },
               ],
             },
-            {
-              title: 'Social inclusion referral',
-              number: '4.2',
-              status: ReferralFormStatus.NotStarted,
-              tasks: [
-                { title: 'Select the relevant sentence for the social inclusion referral', url: null },
-                { title: 'Select desired outcomes', url: null },
-                { title: 'Select required complexity level', url: null },
-                { title: 'What date does the social inclusion service need to be completed by?', url: null },
-                { title: 'Enter RAR days used', url: null },
-                { title: 'Further information for service provider', url: null },
-              ],
-            },
           ],
         },
         {

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -50,11 +50,11 @@ export default class ReferralFormPresenter {
         tasks: [
           {
             title: 'Service user’s risk information',
-            url: '#',
+            url: 'risk-information',
           },
           {
             title: 'Service user’s needs and requirements',
-            url: '#',
+            url: 'needs-and-requirements',
           },
         ],
       },
@@ -74,23 +74,23 @@ export default class ReferralFormPresenter {
               },
               {
                 title: 'Select desired outcomes',
-                url: '#',
+                url: 'desired-outcomes',
               },
               {
                 title: 'Select required complexity level',
-                url: '#',
+                url: 'complexity-level',
               },
               {
                 title: 'What date does the accommodation service need to be completed by?',
-                url: '#',
+                url: 'completion-deadline',
               },
               {
                 title: 'Enter RAR days used',
-                url: null,
+                url: 'rar-days',
               },
               {
                 title: 'Further information for service provider',
-                url: null,
+                url: 'further-information',
               },
             ],
           },

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -18,11 +18,11 @@ export default class ReferralFormPresenter {
         tasks: [
           {
             title: 'Enter service user case identifier',
-            url: '#',
+            url: null,
           },
           {
             title: 'Confirm service user details',
-            url: '#',
+            url: null,
           },
         ],
       },
@@ -34,11 +34,11 @@ export default class ReferralFormPresenter {
         tasks: [
           {
             title: 'Find and select service user interventions',
-            url: '#',
+            url: null,
           },
           {
             title: 'Confirm interventions',
-            url: '#',
+            url: null,
           },
         ],
       },
@@ -70,7 +70,7 @@ export default class ReferralFormPresenter {
             tasks: [
               {
                 title: 'Select the relevant sentence for the accommodation referral',
-                url: '#',
+                url: null,
               },
               {
                 title: 'Select desired outcomes',
@@ -101,7 +101,7 @@ export default class ReferralFormPresenter {
             tasks: [
               {
                 title: 'Select the relevant sentence for the social inclusion referral',
-                url: '#',
+                url: null,
               },
               {
                 title: 'Select desired outcomes',
@@ -135,7 +135,7 @@ export default class ReferralFormPresenter {
         tasks: [
           {
             title: 'Responsible officer information',
-            url: '#',
+            url: null,
           },
         ],
       },

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -94,37 +94,6 @@ export default class ReferralFormPresenter {
               },
             ],
           },
-          {
-            title: 'Social inclusion referral',
-            number: '4.2',
-            status: ReferralFormStatus.NotStarted,
-            tasks: [
-              {
-                title: 'Select the relevant sentence for the social inclusion referral',
-                url: null,
-              },
-              {
-                title: 'Select desired outcomes',
-                url: null,
-              },
-              {
-                title: 'Select required complexity level',
-                url: null,
-              },
-              {
-                title: 'What date does the social inclusion service need to be completed by?',
-                url: null,
-              },
-              {
-                title: 'Enter RAR days used',
-                url: null,
-              },
-              {
-                title: 'Further information for service provider',
-                url: null,
-              },
-            ],
-          },
         ],
       },
       {


### PR DESCRIPTION
## What does this pull request do?

- adds links on the referral form for all the pages we've built so far
- removes links to pages we've not yet built
- removes the second service category from the referral form

## What is the intent behind these changes?

To surface the work that we've done so far and to make the form look closer to the finished thing.