### PR TITLE
Handle validation errors from the interventions service

### DIFF
--- a/server/routes/referrals/completionDeadlineForm.test.ts
+++ b/server/routes/referrals/completionDeadlineForm.test.ts
@@ -50,7 +50,7 @@ describe('CompletionDeadlineForm', () => {
 
       const form = await CompletionDeadlineForm.createForm(req)
 
-      expect(form.errors).toBeNull()
+      expect(form.error).toBeNull()
     })
 
     it('returns an error when a field is empty', async () => {
@@ -64,10 +64,14 @@ describe('CompletionDeadlineForm', () => {
 
       const form = await CompletionDeadlineForm.createForm(req)
 
-      expect(form.errors).toEqual({
-        firstErroredField: 'day',
-        erroredFields: ['day', 'month', 'year'],
-        message: 'The date by which the service needs to be completed must be a real date',
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'completion-deadline-day',
+            formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
+            message: 'The date by which the service needs to be completed must be a real date',
+          },
+        ],
       })
     })
 
@@ -82,10 +86,14 @@ describe('CompletionDeadlineForm', () => {
 
       const form = await CompletionDeadlineForm.createForm(req)
 
-      expect(form.errors).toEqual({
-        firstErroredField: 'day',
-        erroredFields: ['day', 'month', 'year'],
-        message: 'The date by which the service needs to be completed must be a real date',
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'completion-deadline-day',
+            formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
+            message: 'The date by which the service needs to be completed must be a real date',
+          },
+        ],
       })
     })
 
@@ -100,10 +108,14 @@ describe('CompletionDeadlineForm', () => {
 
       const form = await CompletionDeadlineForm.createForm(req)
 
-      expect(form.errors).toEqual({
-        firstErroredField: 'day',
-        erroredFields: ['day', 'month', 'year'],
-        message: 'The date by which the service needs to be completed must be a real date',
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'completion-deadline-day',
+            formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
+            message: 'The date by which the service needs to be completed must be a real date',
+          },
+        ],
       })
     })
 
@@ -118,10 +130,14 @@ describe('CompletionDeadlineForm', () => {
 
       const form = await CompletionDeadlineForm.createForm(req)
 
-      expect(form.errors).toEqual({
-        firstErroredField: 'day',
-        erroredFields: ['day', 'month', 'year'],
-        message: 'The date by which the service needs to be completed must be a real date',
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'completion-deadline-day',
+            formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
+            message: 'The date by which the service needs to be completed must be a real date',
+          },
+        ],
       })
     })
   })

--- a/server/routes/referrals/completionDeadlineForm.ts
+++ b/server/routes/referrals/completionDeadlineForm.ts
@@ -3,6 +3,7 @@ import { body, Result, SanitizationChain, ValidationError, validationResult } fr
 import { DraftReferral } from '../../services/interventionsService'
 import CalendarDay from '../../utils/calendarDay'
 import errorMessages from '../../utils/errorMessages'
+import { FormValidationError } from '../../utils/formValidationError'
 
 export default class CompletionDeadlineForm {
   private constructor(private readonly request: Request, private readonly result: Result<ValidationError>) {}
@@ -55,10 +56,10 @@ export default class CompletionDeadlineForm {
   }
 
   get isValid(): boolean {
-    return this.errors === null
+    return this.error === null
   }
 
-  get errors(): CompletionDeadlineErrors | null {
+  get error(): FormValidationError | null {
     if (this.result.isEmpty() && this.completionDeadline) {
       return null
     }
@@ -66,9 +67,13 @@ export default class CompletionDeadlineForm {
     // TODO (IC-706) use `result`, implement all the rules of the GOV.UK Design
     // System date input component error handling
     return {
-      firstErroredField: 'day',
-      erroredFields: ['day', 'month', 'year'],
-      message: errorMessages.completionDeadline.invalidDate,
+      errors: [
+        {
+          errorSummaryLinkedField: 'completion-deadline-day',
+          formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
+          message: errorMessages.completionDeadline.invalidDate,
+        },
+      ],
     }
   }
 
@@ -79,11 +84,4 @@ export default class CompletionDeadlineForm {
       this.request.body['completion-deadline-year']
     )
   }
-}
-
-// This interface is up for debate
-export interface CompletionDeadlineErrors {
-  firstErroredField: 'day' | 'month' | 'year'
-  erroredFields: ('day' | 'month' | 'year')[]
-  message: string
 }

--- a/server/routes/referrals/completionDeadlinePresenter.test.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.test.ts
@@ -50,33 +50,41 @@ describe('CompletionDeadlinePresenter', () => {
   })
 
   describe('error information', () => {
-    describe('when no errors are passed in', () => {
+    describe('when a null error is passed in', () => {
       it('returns no errors', () => {
         const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
         const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
 
         expect(presenter.errorMessage).toBeNull()
-        expect(presenter.erroredFields).toEqual([])
+        expect(presenter.hasDayError).toEqual(false)
+        expect(presenter.hasMonthError).toEqual(false)
+        expect(presenter.hasYearError).toEqual(false)
         expect(presenter.errorSummary).toBeNull()
       })
     })
 
-    describe('when errors are passed in', () => {
+    describe('when a non-null error is passed in', () => {
       it('returns error information', () => {
         const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
         const presenter = new CompletionDeadlinePresenter(referral, serviceCategory, {
-          firstErroredField: 'month',
-          erroredFields: ['month', 'year'],
-          message: 'Please enter a month and a year',
+          errors: [
+            {
+              errorSummaryLinkedField: 'completion-deadline-month',
+              formFields: ['completion-deadline-month', 'completion-deadline-year'],
+              message: 'Please enter a month and a year',
+            },
+          ],
         })
 
         expect(presenter.errorMessage).toBe('Please enter a month and a year')
-        expect(presenter.erroredFields).toEqual(['month', 'year'])
-        expect(presenter.errorSummary).toEqual({
-          errors: [{ message: 'Please enter a month and a year', linkedField: 'month' }],
-        })
+        expect(presenter.hasDayError).toEqual(false)
+        expect(presenter.hasMonthError).toEqual(true)
+        expect(presenter.hasYearError).toEqual(true)
+        expect(presenter.errorSummary).toEqual([
+          { message: 'Please enter a month and a year', field: 'completion-deadline-month' },
+        ])
       })
     })
   })

--- a/server/routes/referrals/completionDeadlinePresenter.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.ts
@@ -1,6 +1,7 @@
 import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
-import { CompletionDeadlineErrors } from './completionDeadlineForm'
 import CalendarDay from '../../utils/calendarDay'
+import { FormValidationError } from '../../utils/formValidationError'
+import ReferralDataPresenterUtils from './referralDataPresenterUtils'
 
 export default class CompletionDeadlinePresenter {
   readonly day: string
@@ -11,9 +12,13 @@ export default class CompletionDeadlinePresenter {
 
   readonly errorMessage: string | null
 
-  readonly erroredFields: ('day' | 'month' | 'year')[]
+  readonly hasMonthError: boolean
 
-  readonly errorSummary: CompletionDeadlineErrorSummaryPresenter | null
+  readonly hasDayError: boolean
+
+  readonly hasYearError: boolean
+
+  readonly errorSummary: { field: string; message: string }[] | null
 
   readonly title = `What date does the ${this.serviceCategory.name} service need to be completed by?`
 
@@ -22,7 +27,7 @@ export default class CompletionDeadlinePresenter {
   constructor(
     private readonly referral: DraftReferral,
     private readonly serviceCategory: ServiceCategory,
-    errors: CompletionDeadlineErrors | null = null,
+    error: FormValidationError | null = null,
     userInputData: Record<string, unknown> | null = null
   ) {
     if (!userInputData) {
@@ -45,20 +50,14 @@ export default class CompletionDeadlinePresenter {
       this.year = String(userInputData['completion-deadline-year'] || '')
     }
 
-    if (!errors) {
-      this.errorSummary = null
-      this.errorMessage = null
-      this.erroredFields = []
-    } else {
-      this.errorSummary = {
-        errors: [{ message: errors.message, linkedField: errors.firstErroredField }],
-      }
-      this.errorMessage = errors.message
-      this.erroredFields = errors.erroredFields
-    }
-  }
-}
+    this.errorSummary = ReferralDataPresenterUtils.errorSummary(error)
+    this.errorMessage =
+      ReferralDataPresenterUtils.errorMessage(error, 'completion-deadline-day') ??
+      ReferralDataPresenterUtils.errorMessage(error, 'completion-deadline-month') ??
+      ReferralDataPresenterUtils.errorMessage(error, 'completion-deadline-year')
 
-export interface CompletionDeadlineErrorSummaryPresenter {
-  errors: { message: string; linkedField: 'day' | 'month' | 'year' }[]
+    this.hasDayError = ReferralDataPresenterUtils.hasError(error, 'completion-deadline-day')
+    this.hasMonthError = ReferralDataPresenterUtils.hasError(error, 'completion-deadline-month')
+    this.hasYearError = ReferralDataPresenterUtils.hasError(error, 'completion-deadline-year')
+  }
 }

--- a/server/routes/referrals/completionDeadlineView.ts
+++ b/server/routes/referrals/completionDeadlineView.ts
@@ -21,17 +21,17 @@ export default class CompletionDeadlineView {
       errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
       items: [
         {
-          classes: `govuk-input--width-2${this.presenter.erroredFields.includes('day') ? ' govuk-input--error' : ''}`,
+          classes: `govuk-input--width-2${this.presenter.hasDayError ? ' govuk-input--error' : ''}`,
           name: 'day',
           value: this.presenter.day,
         },
         {
-          classes: `govuk-input--width-2${this.presenter.erroredFields.includes('month') ? ' govuk-input--error' : ''}`,
+          classes: `govuk-input--width-2${this.presenter.hasMonthError ? ' govuk-input--error' : ''}`,
           name: 'month',
           value: this.presenter.month,
         },
         {
-          classes: `govuk-input--width-4${this.presenter.erroredFields.includes('year') ? ' govuk-input--error' : ''}`,
+          classes: `govuk-input--width-4${this.presenter.hasYearError ? ' govuk-input--error' : ''}`,
           name: 'year',
           value: this.presenter.year,
         },
@@ -39,21 +39,7 @@ export default class CompletionDeadlineView {
     }
   }
 
-  private get errorSummaryArgs(): Record<string, unknown> | null {
-    if (this.presenter.errorSummary === null) {
-      return null
-    }
-
-    return {
-      titleText: 'There is a problem',
-      errorList: this.presenter.errorSummary.errors.map(error => {
-        return {
-          text: error.message,
-          href: `#completion-deadline-${error.linkedField}`,
-        }
-      }),
-    }
-  }
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [

--- a/server/routes/referrals/complexityLevelForm.test.ts
+++ b/server/routes/referrals/complexityLevelForm.test.ts
@@ -42,7 +42,15 @@ describe(ComplexityLevelForm, () => {
         body: {},
       } as Request)
 
-      expect(form.error).toEqual({ message: 'Select a complexity level' })
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'complexity-level-id',
+            formFields: ['complexity-level-id'],
+            message: 'Select a complexity level',
+          },
+        ],
+      })
     })
 
     it('returns an error object when the complexity-level-id property is null in the body', async () => {
@@ -50,7 +58,15 @@ describe(ComplexityLevelForm, () => {
         body: { 'complexity-level-id': null },
       } as Request)
 
-      expect(form.error).toEqual({ message: 'Select a complexity level' })
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'complexity-level-id',
+            formFields: ['complexity-level-id'],
+            message: 'Select a complexity level',
+          },
+        ],
+      })
     })
   })
 

--- a/server/routes/referrals/complexityLevelForm.ts
+++ b/server/routes/referrals/complexityLevelForm.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express'
 import { DraftReferral } from '../../services/interventionsService'
-import { ComplexityLevelError } from './complexityLevelPresenter'
 import errorMessages from '../../utils/errorMessages'
+import { FormValidationError } from '../../utils/formValidationError'
 
 export default class ComplexityLevelForm {
   private constructor(private readonly request: Request) {}
@@ -20,11 +20,19 @@ export default class ComplexityLevelForm {
     return this.request.body['complexity-level-id'] !== null && this.request.body['complexity-level-id'] !== undefined
   }
 
-  get error(): ComplexityLevelError | null {
+  get error(): FormValidationError | null {
     if (this.isValid) {
       return null
     }
 
-    return { message: errorMessages.complexityLevel.empty }
+    return {
+      errors: [
+        {
+          formFields: ['complexity-level-id'],
+          errorSummaryLinkedField: 'complexity-level-id',
+          message: errorMessages.complexityLevel.empty,
+        },
+      ],
+    }
   }
 }

--- a/server/routes/referrals/complexityLevelPresenter.ts
+++ b/server/routes/referrals/complexityLevelPresenter.ts
@@ -1,16 +1,18 @@
 import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
-
-export interface ComplexityLevelError {
-  message: string
-}
+import { FormValidationError } from '../../utils/formValidationError'
+import ReferralDataPresenterUtils from './referralDataPresenterUtils'
 
 export default class ComplexityLevelPresenter {
   constructor(
     private readonly referral: DraftReferral,
     private readonly serviceCategory: ServiceCategory,
-    readonly error?: ComplexityLevelError | null,
+    private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
+
+  readonly errorMessage = ReferralDataPresenterUtils.errorMessage(this.error, 'complexity-level-id')
+
+  readonly errorSummary = ReferralDataPresenterUtils.errorSummary(this.error)
 
   readonly complexityDescriptions: {
     title: string

--- a/server/routes/referrals/complexityLevelView.ts
+++ b/server/routes/referrals/complexityLevelView.ts
@@ -7,7 +7,7 @@ export default class ComplexityLevelView {
   get radioButtonArgs(): Record<string, unknown> {
     return {
       classes: 'govuk-radios',
-      idPrefix: 'complexity-level',
+      idPrefix: 'complexity-level-id',
       name: 'complexity-level-id',
       fieldset: {
         legend: {
@@ -16,7 +16,7 @@ export default class ComplexityLevelView {
           classes: 'govuk-fieldset__legend--xl',
         },
       },
-      errorMessage: ViewUtils.govukErrorMessage(this.presenter.error?.message),
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
       items: this.presenter.complexityDescriptions.map(complexityDescription => {
         return {
           value: complexityDescription.value,
@@ -30,21 +30,7 @@ export default class ComplexityLevelView {
     }
   }
 
-  get errorSummaryArgs(): Record<string, unknown> | null {
-    if (!this.presenter.error) {
-      return null
-    }
-
-    return {
-      titleText: 'There is a problem',
-      errorList: [
-        {
-          text: this.presenter.error.message,
-          href: '#complexity-level',
-        },
-      ],
-    }
-  }
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [

--- a/server/routes/referrals/desiredOutcomesForm.test.ts
+++ b/server/routes/referrals/desiredOutcomesForm.test.ts
@@ -46,7 +46,15 @@ describe(DesiredOutcomesForm, () => {
         body: {},
       } as Request)
 
-      expect(form.error).toEqual({ message: 'Select desired outcomes' })
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'desired-outcomes-ids',
+            formFields: ['desired-outcomes-ids'],
+            message: 'Select desired outcomes',
+          },
+        ],
+      })
     })
 
     it('returns an error object when the desired-outcomes-ids property is null in the body', async () => {
@@ -54,7 +62,15 @@ describe(DesiredOutcomesForm, () => {
         body: { 'desired-outcomes-ids': null },
       } as Request)
 
-      expect(form.error).toEqual({ message: 'Select desired outcomes' })
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'desired-outcomes-ids',
+            formFields: ['desired-outcomes-ids'],
+            message: 'Select desired outcomes',
+          },
+        ],
+      })
     })
   })
 

--- a/server/routes/referrals/desiredOutcomesForm.ts
+++ b/server/routes/referrals/desiredOutcomesForm.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express'
 import { DraftReferral } from '../../services/interventionsService'
-import { DesiredOutcomesError } from './desiredOutcomesPresenter'
 import errorMessages from '../../utils/errorMessages'
+import { FormValidationError } from '../../utils/formValidationError'
 
 export default class DesiredOutcomesForm {
   private constructor(private readonly request: Request) {}
@@ -20,11 +20,19 @@ export default class DesiredOutcomesForm {
     return this.request.body['desired-outcomes-ids'] !== null && this.request.body['desired-outcomes-ids'] !== undefined
   }
 
-  get error(): DesiredOutcomesError | null {
+  get error(): FormValidationError | null {
     if (this.isValid) {
       return null
     }
 
-    return { message: errorMessages.desiredOutcomes.empty }
+    return {
+      errors: [
+        {
+          errorSummaryLinkedField: 'desired-outcomes-ids',
+          formFields: ['desired-outcomes-ids'],
+          message: errorMessages.desiredOutcomes.empty,
+        },
+      ],
+    }
   }
 }

--- a/server/routes/referrals/desiredOutcomesPresenter.test.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.test.ts
@@ -49,22 +49,54 @@ describe('DesiredOutcomesPresenter', () => {
     })
   })
 
-  describe('error information', () => {
-    describe('when no errors are passed in', () => {
-      it('returns no errors', () => {
+  describe('errorMessage', () => {
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
         const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory)
 
-        expect(presenter.error).toBeNull()
+        expect(presenter.errorMessage).toBeNull()
       })
     })
 
-    describe('when errors are passed in', () => {
+    describe('when an error is passed in', () => {
       it('returns error information', () => {
         const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory, {
-          message: 'Select desired outcomes',
+          errors: [
+            {
+              formFields: ['desired-outcomes-ids'],
+              errorSummaryLinkedField: 'desired-outcomes-ids',
+              message: 'Select desired outcomes',
+            },
+          ],
         })
 
-        expect(presenter.error).toEqual({ message: 'Select desired outcomes' })
+        expect(presenter.errorMessage).toEqual('Select desired outcomes')
+      })
+    })
+  })
+
+  describe('errorSummary', () => {
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
+        const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when an error is passed in', () => {
+      it('returns error information', () => {
+        const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory, {
+          errors: [
+            {
+              formFields: ['desired-outcomes-ids'],
+              errorSummaryLinkedField: 'desired-outcomes-ids',
+              message: 'Select desired outcomes',
+            },
+          ],
+        })
+
+        expect(presenter.errorSummary).toEqual([{ field: 'desired-outcomes-ids', message: 'Select desired outcomes' }])
       })
     })
   })

--- a/server/routes/referrals/desiredOutcomesPresenter.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.ts
@@ -1,16 +1,18 @@
 import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
-
-export interface DesiredOutcomesError {
-  message: string
-}
+import { FormValidationError } from '../../utils/formValidationError'
+import ReferralDataPresenterUtils from './referralDataPresenterUtils'
 
 export default class DesiredOutcomesPresenter {
   constructor(
     private readonly referral: DraftReferral,
     private readonly serviceCategory: ServiceCategory,
-    readonly error: DesiredOutcomesError | null = null,
+    private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, string[]> | null = null
   ) {}
+
+  readonly errorMessage = ReferralDataPresenterUtils.errorMessage(this.error, 'desired-outcomes-ids')
+
+  readonly errorSummary = ReferralDataPresenterUtils.errorSummary(this.error)
 
   readonly desiredOutcomes: {
     value: string

--- a/server/routes/referrals/desiredOutcomesView.ts
+++ b/server/routes/referrals/desiredOutcomesView.ts
@@ -1,10 +1,11 @@
+import ViewUtils from '../../utils/viewUtils'
 import DesiredOutcomesPresenter from './desiredOutcomesPresenter'
 
 export default class DesiredOutcomesView {
   constructor(readonly presenter: DesiredOutcomesPresenter) {}
 
   get checkboxArgs(): Record<string, unknown> {
-    const errorMessage = this.presenter.error ? { text: this.presenter.error.message } : null
+    const errorMessage = this.presenter.errorMessage ? { text: this.presenter.errorMessage } : null
 
     return {
       idPrefix: 'desired-outcomes-ids',
@@ -30,21 +31,7 @@ export default class DesiredOutcomesView {
     }
   }
 
-  get errorSummaryArgs(): Record<string, unknown> | null {
-    if (!this.presenter.error) {
-      return null
-    }
-
-    return {
-      titleText: 'There is a problem',
-      errorList: [
-        {
-          text: this.presenter.error.message,
-          href: '#desired-outcomes-ids',
-        },
-      ],
-    }
-  }
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [

--- a/server/routes/referrals/desiredOutcomesView.ts
+++ b/server/routes/referrals/desiredOutcomesView.ts
@@ -5,8 +5,6 @@ export default class DesiredOutcomesView {
   constructor(readonly presenter: DesiredOutcomesPresenter) {}
 
   get checkboxArgs(): Record<string, unknown> {
-    const errorMessage = this.presenter.errorMessage ? { text: this.presenter.errorMessage } : null
-
     return {
       idPrefix: 'desired-outcomes-ids',
       name: 'desired-outcomes-ids',
@@ -17,7 +15,7 @@ export default class DesiredOutcomesView {
           classes: 'govuk-fieldset__legend--xl',
         },
       },
-      errorMessage,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
       hint: {
         text: 'Select all that apply.',
       },

--- a/server/routes/referrals/furtherInformationPresenter.test.ts
+++ b/server/routes/referrals/furtherInformationPresenter.test.ts
@@ -24,22 +24,59 @@ describe('FurtherInformationPresenter', () => {
     })
   })
 
-  describe('error information', () => {
-    describe('when no errors are passed in', () => {
-      it('returns no errors', () => {
+  describe('errorMessage', () => {
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
         const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
 
-        expect(presenter.error).toBeNull()
+        expect(presenter.errorMessage).toBeNull()
       })
     })
 
-    describe('when errors are passed in', () => {
-      it('returns error information', () => {
+    describe('when an error is passed in', () => {
+      it('returns an error message', () => {
         const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory, {
-          message: 'Something went wrong, please try again',
+          errors: [
+            {
+              formFields: ['further-information'],
+              errorSummaryLinkedField: 'further-information',
+              message: 'Something went wrong, please try again',
+            },
+          ],
         })
 
-        expect(presenter.error).toEqual({ message: 'Something went wrong, please try again' })
+        expect(presenter.errorMessage).toEqual('Something went wrong, please try again')
+      })
+    })
+  })
+
+  describe('errorSummary', () => {
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
+        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when an error is passed in', () => {
+      it('returns error information', () => {
+        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory, {
+          errors: [
+            {
+              formFields: ['further-information'],
+              errorSummaryLinkedField: 'further-information',
+              message: 'Something went wrong, please try again',
+            },
+          ],
+        })
+
+        expect(presenter.errorSummary).toEqual([
+          {
+            field: 'further-information',
+            message: 'Something went wrong, please try again',
+          },
+        ])
       })
     })
   })

--- a/server/routes/referrals/furtherInformationPresenter.ts
+++ b/server/routes/referrals/furtherInformationPresenter.ts
@@ -1,14 +1,12 @@
 import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
-
-export interface FurtherInformationError {
-  message: string
-}
+import { FormValidationError } from '../../utils/formValidationError'
+import ReferralDataPresenterUtils from './referralDataPresenterUtils'
 
 export default class FurtherInformationPresenter {
   constructor(
     private readonly referral: DraftReferral,
     private readonly serviceCategory: ServiceCategory,
-    readonly error: FurtherInformationError | null = null,
+    private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, string> | null = null
   ) {}
 
@@ -16,6 +14,10 @@ export default class FurtherInformationPresenter {
 
   readonly hint =
     'For example, relevant previous offences, previously completed programmes or further reasons for this referral'
+
+  readonly errorMessage = ReferralDataPresenterUtils.errorMessage(this.error, 'further-information')
+
+  readonly errorSummary = ReferralDataPresenterUtils.errorSummary(this.error)
 
   get value(): string {
     if (this.userInputData !== null) {

--- a/server/routes/referrals/furtherInformationView.ts
+++ b/server/routes/referrals/furtherInformationView.ts
@@ -1,10 +1,11 @@
+import ViewUtils from '../../utils/viewUtils'
 import FurtherInformationPresenter from './furtherInformationPresenter'
 
 export default class FurtherInformationView {
   constructor(private readonly presenter: FurtherInformationPresenter) {}
 
   private get textAreaArgs(): Record<string, unknown> {
-    const errorMessage = this.presenter.error ? { text: this.presenter.error.message } : null
+    const errorMessage = this.presenter.errorMessage ? { text: this.presenter.errorMessage } : null
 
     return {
       name: 'further-information',
@@ -22,21 +23,7 @@ export default class FurtherInformationView {
     }
   }
 
-  get errorSummaryArgs(): Record<string, unknown> | null {
-    if (!this.presenter.error) {
-      return null
-    }
-
-    return {
-      titleText: 'There is a problem',
-      errorList: [
-        {
-          text: this.presenter.error.message,
-          href: '#further-information',
-        },
-      ],
-    }
-  }
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [

--- a/server/routes/referrals/furtherInformationView.ts
+++ b/server/routes/referrals/furtherInformationView.ts
@@ -5,8 +5,6 @@ export default class FurtherInformationView {
   constructor(private readonly presenter: FurtherInformationPresenter) {}
 
   private get textAreaArgs(): Record<string, unknown> {
-    const errorMessage = this.presenter.errorMessage ? { text: this.presenter.errorMessage } : null
-
     return {
       name: 'further-information',
       id: 'further-information',
@@ -15,7 +13,7 @@ export default class FurtherInformationView {
         classes: 'govuk-label--xl',
         isPageHeading: true,
       },
-      errorMessage,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
       hint: {
         text: this.presenter.hint,
       },

--- a/server/routes/referrals/needsAndRequirementsForm.test.ts
+++ b/server/routes/referrals/needsAndRequirementsForm.test.ts
@@ -24,7 +24,7 @@ describe('NeedsAndRequirementsForm', () => {
         referral
       )
 
-      expect(form.errors).toBeNull()
+      expect(form.error).toBeNull()
     })
 
     it('returns no error with the optional fields empty', async () => {
@@ -42,7 +42,7 @@ describe('NeedsAndRequirementsForm', () => {
         referral
       )
 
-      expect(form.errors).toBeNull()
+      expect(form.error).toBeNull()
     })
 
     it('returns multiple errors when there are multiple errors in the input', async () => {
@@ -56,16 +56,20 @@ describe('NeedsAndRequirementsForm', () => {
         referral
       )
 
-      expect(form.errors).toEqual([
-        {
-          field: 'needs-interpreter',
-          message: 'Select yes if Alex needs an interpreter',
-        },
-        {
-          field: 'has-additional-responsibilities',
-          message: 'Select yes if Alex has caring or employment responsibilities',
-        },
-      ])
+      expect(form.error).toEqual({
+        errors: [
+          {
+            formFields: ['needs-interpreter'],
+            errorSummaryLinkedField: 'needs-interpreter',
+            message: 'Select yes if Alex needs an interpreter',
+          },
+          {
+            formFields: ['has-additional-responsibilities'],
+            errorSummaryLinkedField: 'has-additional-responsibilities',
+            message: 'Select yes if Alex has caring or employment responsibilities',
+          },
+        ],
+      })
     })
 
     it('returns an error when needs-interpreter is not answered', async () => {
@@ -82,7 +86,15 @@ describe('NeedsAndRequirementsForm', () => {
         referral
       )
 
-      expect(form.errors).toEqual([{ field: 'needs-interpreter', message: 'Select yes if Alex needs an interpreter' }])
+      expect(form.error).toEqual({
+        errors: [
+          {
+            formFields: ['needs-interpreter'],
+            errorSummaryLinkedField: 'needs-interpreter',
+            message: 'Select yes if Alex needs an interpreter',
+          },
+        ],
+      })
     })
 
     it('returns an error when needs-interpreter is yes and interpreter-language is empty', async () => {
@@ -100,9 +112,15 @@ describe('NeedsAndRequirementsForm', () => {
         referral
       )
 
-      expect(form.errors).toEqual([
-        { field: 'interpreter-language', message: 'Enter the language for which Alex needs an interpreter' },
-      ])
+      expect(form.error).toEqual({
+        errors: [
+          {
+            formFields: ['interpreter-language'],
+            errorSummaryLinkedField: 'interpreter-language',
+            message: 'Enter the language for which Alex needs an interpreter',
+          },
+        ],
+      })
     })
 
     it('returns no error when needs-interpreter is no and interpreter-language is empty', async () => {
@@ -120,7 +138,7 @@ describe('NeedsAndRequirementsForm', () => {
         referral
       )
 
-      expect(form.errors).toBeNull()
+      expect(form.error).toBeNull()
     })
 
     it('returns an error when has-additional-responsibilities is not answered', async () => {
@@ -137,12 +155,15 @@ describe('NeedsAndRequirementsForm', () => {
         referral
       )
 
-      expect(form.errors).toEqual([
-        {
-          field: 'has-additional-responsibilities',
-          message: 'Select yes if Alex has caring or employment responsibilities',
-        },
-      ])
+      expect(form.error).toEqual({
+        errors: [
+          {
+            formFields: ['has-additional-responsibilities'],
+            errorSummaryLinkedField: 'has-additional-responsibilities',
+            message: 'Select yes if Alex has caring or employment responsibilities',
+          },
+        ],
+      })
     })
 
     it('returns an error when has-additional-responsibilities is yes and when-unavailable is empty', async () => {
@@ -160,9 +181,15 @@ describe('NeedsAndRequirementsForm', () => {
         referral
       )
 
-      expect(form.errors).toEqual([
-        { field: 'when-unavailable', message: 'Enter details of when Alex will not be able to attend sessions' },
-      ])
+      expect(form.error).toEqual({
+        errors: [
+          {
+            formFields: ['when-unavailable'],
+            errorSummaryLinkedField: 'when-unavailable',
+            message: 'Enter details of when Alex will not be able to attend sessions',
+          },
+        ],
+      })
     })
 
     it('returns no error when has-additional-responsibilities is no and when-unavailable is empty', async () => {
@@ -180,7 +207,7 @@ describe('NeedsAndRequirementsForm', () => {
         referral
       )
 
-      expect(form.errors).toBeNull()
+      expect(form.error).toBeNull()
     })
   })
 

--- a/server/routes/referrals/needsAndRequirementsForm.ts
+++ b/server/routes/referrals/needsAndRequirementsForm.ts
@@ -3,6 +3,7 @@ import { Result, ValidationChain, ValidationError } from 'express-validator'
 import { DraftReferral } from '../../services/interventionsService'
 import errorMessages from '../../utils/errorMessages'
 import FormUtils from '../../utils/formUtils'
+import { FormValidationError } from '../../utils/formValidationError'
 
 export default class NeedsAndRequirementsForm {
   private constructor(
@@ -41,7 +42,7 @@ export default class NeedsAndRequirementsForm {
   }
 
   get isValid(): boolean {
-    return this.errors == null
+    return this.error == null
   }
 
   get paramsForUpdate(): Partial<DraftReferral> {
@@ -63,16 +64,17 @@ export default class NeedsAndRequirementsForm {
     return this.request.body['has-additional-responsibilities'] === 'yes'
   }
 
-  get errors(): NeedsAndRequirementsError[] | null {
+  get error(): FormValidationError | null {
     if (this.result.isEmpty()) {
       return null
     }
 
-    return this.result.array().map(validationError => ({ field: validationError.param, message: validationError.msg }))
+    return {
+      errors: this.result.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
   }
-}
-
-export interface NeedsAndRequirementsError {
-  field: string
-  message: string
 }

--- a/server/routes/referrals/needsAndRequirementsPresenter.test.ts
+++ b/server/routes/referrals/needsAndRequirementsPresenter.test.ts
@@ -15,7 +15,7 @@ describe('NeedsAndRequirementsPresenter', () => {
   })
 
   describe('errorSummary', () => {
-    describe('when errors is null', () => {
+    describe('when error is null', () => {
       it('returns null', () => {
         const referral = draftReferralFactory.serviceCategorySelected().build()
         const presenter = new NeedsAndRequirementsPresenter(referral, null)
@@ -24,13 +24,23 @@ describe('NeedsAndRequirementsPresenter', () => {
       })
     })
 
-    describe('when errors is not null', () => {
-      it('returns the errors sorted into the order their fields appear on the page', () => {
+    describe('when error is not null', () => {
+      it('returns a summary of the errors sorted into the order their fields appear on the page', () => {
         const referral = draftReferralFactory.serviceCategorySelected().build()
-        const presenter = new NeedsAndRequirementsPresenter(referral, [
-          { field: 'has-additional-responsibilities', message: 'has-additional-responsibilities msg' },
-          { field: 'needs-interpreter', message: 'needs-interpreter msg' },
-        ])
+        const presenter = new NeedsAndRequirementsPresenter(referral, {
+          errors: [
+            {
+              formFields: ['has-additional-responsibilities'],
+              errorSummaryLinkedField: 'has-additional-responsibilities',
+              message: 'has-additional-responsibilities msg',
+            },
+            {
+              formFields: ['needs-interpreter'],
+              errorSummaryLinkedField: 'needs-interpreter',
+              message: 'needs-interpreter msg',
+            },
+          ],
+        })
 
         expect(presenter.errorSummary).toEqual([
           { field: 'needs-interpreter', message: 'needs-interpreter msg' },
@@ -85,10 +95,20 @@ describe('NeedsAndRequirementsPresenter', () => {
           .serviceCategorySelected()
           .serviceUserSelected()
           .build({ serviceUser: { firstName: 'Geoffrey' } })
-        const presenter = new NeedsAndRequirementsPresenter(referral, [
-          { field: 'accessibility-needs', message: 'accessibilityNeeds msg' },
-          { field: 'interpreter-language', message: 'interpreterLanguage msg' },
-        ])
+        const presenter = new NeedsAndRequirementsPresenter(referral, {
+          errors: [
+            {
+              formFields: ['accessibility-needs'],
+              errorSummaryLinkedField: 'accessibility-needs',
+              message: 'accessibilityNeeds msg',
+            },
+            {
+              formFields: ['interpreter-language'],
+              errorSummaryLinkedField: 'interpreter-language',
+              message: 'interpreterLanguage msg',
+            },
+          ],
+        })
 
         expect(presenter.text).toMatchObject({
           accessibilityNeeds: {

--- a/server/routes/referrals/needsAndRequirementsPresenter.ts
+++ b/server/routes/referrals/needsAndRequirementsPresenter.ts
@@ -1,11 +1,11 @@
 import { DraftReferral } from '../../services/interventionsService'
-import { NeedsAndRequirementsError } from './needsAndRequirementsForm'
+import { FormValidationError } from '../../utils/formValidationError'
 import ReferralDataPresenterUtils from './referralDataPresenterUtils'
 
 export default class NeedsAndRequirementsPresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly errors: NeedsAndRequirementsError[] | null = null,
+    private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
@@ -16,7 +16,7 @@ export default class NeedsAndRequirementsPresenter {
   ]
 
   private errorMessageForField(field: string): string | null {
-    return ReferralDataPresenterUtils.errorMessage(this.errors, field)
+    return ReferralDataPresenterUtils.errorMessage(this.error, field)
   }
 
   readonly text = {
@@ -49,7 +49,7 @@ export default class NeedsAndRequirementsPresenter {
     },
   }
 
-  readonly errorSummary = ReferralDataPresenterUtils.sortedErrors(this.errors, {
+  readonly errorSummary = ReferralDataPresenterUtils.errorSummary(this.error, {
     fieldOrder: [
       'additional-needs-information',
       'accessibility-needs',

--- a/server/routes/referrals/needsAndRequirementsView.ts
+++ b/server/routes/referrals/needsAndRequirementsView.ts
@@ -4,16 +4,7 @@ import ViewUtils from '../../utils/viewUtils'
 export default class NeedsAndRequirementsView {
   constructor(private readonly presenter: NeedsAndRequirementsPresenter) {}
 
-  private get errorSummaryArgs() {
-    if (!this.presenter.errorSummary) {
-      return null
-    }
-
-    return {
-      titleText: 'There is a problem',
-      errorList: this.presenter.errorSummary.map(error => ({ text: error.message, href: `#${error.field}` })),
-    }
-  }
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   private get summaryListArgs() {
     return {

--- a/server/routes/referrals/rarDaysForm.test.ts
+++ b/server/routes/referrals/rarDaysForm.test.ts
@@ -28,9 +28,15 @@ describe(RarDaysForm, () => {
       it('gives an error for using-rar-days', async () => {
         const form = await RarDaysForm.createForm({ body: {} } as Request, serviceCategory)
 
-        expect(form.errors).toEqual([
-          { field: 'using-rar-days', message: 'Select yes if you are using RAR days for the accommodation service' },
-        ])
+        expect(form.error).toEqual({
+          errors: [
+            {
+              formFields: ['using-rar-days'],
+              errorSummaryLinkedField: 'using-rar-days',
+              message: 'Select yes if you are using RAR days for the accommodation service',
+            },
+          ],
+        })
       })
     })
 
@@ -38,7 +44,7 @@ describe(RarDaysForm, () => {
       it('gives no error', async () => {
         const form = await RarDaysForm.createForm({ body: { 'using-rar-days': 'no' } } as Request, serviceCategory)
 
-        expect(form.errors).toBeNull()
+        expect(form.error).toBeNull()
       })
     })
 
@@ -50,7 +56,7 @@ describe(RarDaysForm, () => {
             serviceCategory
           )
 
-          expect(form.errors).toBeNull()
+          expect(form.error).toBeNull()
         })
       })
 
@@ -61,7 +67,7 @@ describe(RarDaysForm, () => {
             serviceCategory
           )
 
-          expect(form.errors).toBeNull()
+          expect(form.error).toBeNull()
         })
       })
 
@@ -72,12 +78,15 @@ describe(RarDaysForm, () => {
             serviceCategory
           )
 
-          expect(form.errors).toEqual([
-            {
-              field: 'maximum-rar-days',
-              message: 'Enter the maximum number of RAR days for the accommodation service',
-            },
-          ])
+          expect(form.error).toEqual({
+            errors: [
+              {
+                formFields: ['maximum-rar-days'],
+                errorSummaryLinkedField: 'maximum-rar-days',
+                message: 'Enter the maximum number of RAR days for the accommodation service',
+              },
+            ],
+          })
         })
       })
 
@@ -88,12 +97,15 @@ describe(RarDaysForm, () => {
             serviceCategory
           )
 
-          expect(form.errors).toEqual([
-            {
-              field: 'maximum-rar-days',
-              message: 'The maximum number of RAR days for the accommodation service must be a number, like 5',
-            },
-          ])
+          expect(form.error).toEqual({
+            errors: [
+              {
+                formFields: ['maximum-rar-days'],
+                errorSummaryLinkedField: 'maximum-rar-days',
+                message: 'The maximum number of RAR days for the accommodation service must be a number, like 5',
+              },
+            ],
+          })
         })
       })
 
@@ -104,12 +116,15 @@ describe(RarDaysForm, () => {
             serviceCategory
           )
 
-          expect(form.errors).toEqual([
-            {
-              field: 'maximum-rar-days',
-              message: 'The maximum number of RAR days for the accommodation service must be a whole number, like 5',
-            },
-          ])
+          expect(form.error).toEqual({
+            errors: [
+              {
+                formFields: ['maximum-rar-days'],
+                errorSummaryLinkedField: 'maximum-rar-days',
+                message: 'The maximum number of RAR days for the accommodation service must be a whole number, like 5',
+              },
+            ],
+          })
         })
       })
     })

--- a/server/routes/referrals/rarDaysForm.ts
+++ b/server/routes/referrals/rarDaysForm.ts
@@ -3,6 +3,7 @@ import { Result, ValidationChain, ValidationError } from 'express-validator'
 import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
 import errorMessages from '../../utils/errorMessages'
 import FormUtils from '../../utils/formUtils'
+import { FormValidationError } from '../../utils/formValidationError'
 
 export default class RarDaysForm {
   private constructor(private readonly request: Request, private readonly result: Result<ValidationError>) {}
@@ -36,7 +37,7 @@ export default class RarDaysForm {
   }
 
   get isValid(): boolean {
-    return this.errors == null
+    return this.error == null
   }
 
   get paramsForUpdate(): Partial<DraftReferral> {
@@ -50,11 +51,17 @@ export default class RarDaysForm {
     return this.request.body['using-rar-days'] === 'yes'
   }
 
-  get errors(): { field: string; message: string }[] | null {
+  get error(): FormValidationError | null {
     if (this.result.isEmpty()) {
       return null
     }
 
-    return this.result.array().map(validationError => ({ field: validationError.param, message: validationError.msg }))
+    return {
+      errors: this.result.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
   }
 }

--- a/server/routes/referrals/rarDaysPresenter.test.ts
+++ b/server/routes/referrals/rarDaysPresenter.test.ts
@@ -27,10 +27,16 @@ describe(RarDaysPresenter, () => {
         const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.build()
 
-        const presenter = new RarDaysPresenter(referral, serviceCategory, [
-          { field: 'using-rar-days', message: 'usingRarDays msg' },
-          { field: 'maximum-rar-days', message: 'maximumRarDays msg' },
-        ])
+        const presenter = new RarDaysPresenter(referral, serviceCategory, {
+          errors: [
+            { formFields: ['using-rar-days'], errorSummaryLinkedField: 'using-rar-days', message: 'usingRarDays msg' },
+            {
+              formFields: ['maximum-rar-days'],
+              errorSummaryLinkedField: 'maximum-rar-days',
+              message: 'maximumRarDays msg',
+            },
+          ],
+        })
 
         expect(presenter.text).toMatchObject({
           usingRarDays: {
@@ -109,7 +115,7 @@ describe(RarDaysPresenter, () => {
   })
 
   describe('errorSummary', () => {
-    describe('when errors is null', () => {
+    describe('when error is null', () => {
       it('returns null', () => {
         const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.build()
@@ -120,15 +126,21 @@ describe(RarDaysPresenter, () => {
       })
     })
 
-    describe('when errors is not null', () => {
-      it('returns the errors sorted by the order the fields appear on the page', () => {
+    describe('when error is not null', () => {
+      it('returns a summary of the errors sorted by the order the fields appear on the page', () => {
         const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.build()
 
-        const presenter = new RarDaysPresenter(referral, serviceCategory, [
-          { field: 'maximum-rar-days', message: 'maximumRarDays msg' },
-          { field: 'using-rar-days', message: 'usingRarDays msg' },
-        ])
+        const presenter = new RarDaysPresenter(referral, serviceCategory, {
+          errors: [
+            {
+              formFields: ['maximum-rar-days'],
+              errorSummaryLinkedField: 'maximum-rar-days',
+              message: 'maximumRarDays msg',
+            },
+            { formFields: ['using-rar-days'], errorSummaryLinkedField: 'using-rar-days', message: 'usingRarDays msg' },
+          ],
+        })
 
         expect(presenter.errorSummary).toEqual([
           { field: 'using-rar-days', message: 'usingRarDays msg' },

--- a/server/routes/referrals/rarDaysPresenter.ts
+++ b/server/routes/referrals/rarDaysPresenter.ts
@@ -1,15 +1,16 @@
 import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import { FormValidationError } from '../../utils/formValidationError'
 import ReferralDataPresenterUtils from './referralDataPresenterUtils'
 
 export default class RarDaysPresenter {
   constructor(
     private readonly referral: DraftReferral,
     private readonly serviceCategory: ServiceCategory,
-    private readonly errors: { field: string; message: string }[] | null = null,
+    private readonly errors: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
-  readonly errorSummary = ReferralDataPresenterUtils.sortedErrors(this.errors, {
+  readonly errorSummary = ReferralDataPresenterUtils.errorSummary(this.errors, {
     fieldOrder: ['using-rar-days', 'maximum-rar-days'],
   })
 

--- a/server/routes/referrals/rarDaysView.ts
+++ b/server/routes/referrals/rarDaysView.ts
@@ -4,16 +4,7 @@ import RarDaysPresenter from './rarDaysPresenter'
 export default class RarDaysView {
   constructor(private readonly presenter: RarDaysPresenter) {}
 
-  private get errorSummaryArgs() {
-    if (!this.presenter.errorSummary) {
-      return null
-    }
-
-    return {
-      titleText: 'There is a problem',
-      errorList: this.presenter.errorSummary.map(error => ({ text: error.message, href: `#${error.field}` })),
-    }
-  }
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   private usingRarDaysRadiosArgs(yesHtml: string) {
     return {

--- a/server/routes/referrals/referralDataPresenterUtils.test.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.test.ts
@@ -261,60 +261,76 @@ describe('ReferralDataPresenterUtils', () => {
     })
   })
 
-  describe('.sortedErrors', () => {
-    describe('with null errors', () => {
+  describe('.errorSummary', () => {
+    describe('with null error', () => {
       it('returns null', () => {
-        expect(ReferralDataPresenterUtils.sortedErrors(null, { fieldOrder: ['first', 'second', 'third'] })).toBeNull()
+        expect(ReferralDataPresenterUtils.errorSummary(null, { fieldOrder: ['first', 'second', 'third'] })).toBeNull()
       })
     })
 
-    describe('when an empty array of errors', () => {
+    describe('with an empty errors array', () => {
       it('returns an empty array', () => {
-        expect(ReferralDataPresenterUtils.sortedErrors([], { fieldOrder: ['first', 'second', 'third'] })).toEqual([])
+        expect(
+          ReferralDataPresenterUtils.errorSummary({ errors: [] }, { fieldOrder: ['first', 'second', 'third'] })
+        ).toEqual([])
       })
     })
 
-    describe('with a non-empty array of errors', () => {
-      it('returns the errors ordered according to their fields’ positions in the fieldOrder array', () => {
+    describe('when the errors array is non-empty', () => {
+      it('returns an error summary ordered according to the errorSummaryLinkedFields’ positions in the fieldOrder array', () => {
         expect(
-          ReferralDataPresenterUtils.sortedErrors(
-            [
-              { field: 'second', msg: 'second msg' },
-              { field: 'first', msg: 'first msg' },
-              { field: 'third', msg: 'third msg' },
-            ],
+          ReferralDataPresenterUtils.errorSummary(
+            {
+              errors: [
+                { errorSummaryLinkedField: 'second', message: 'second msg' },
+                { errorSummaryLinkedField: 'first', message: 'first msg' },
+                { errorSummaryLinkedField: 'third', message: 'third msg' },
+              ],
+            },
             { fieldOrder: ['first', 'second', 'third'] }
           )
         ).toEqual([
-          { field: 'first', msg: 'first msg' },
-          { field: 'second', msg: 'second msg' },
-          { field: 'third', msg: 'third msg' },
+          { field: 'first', message: 'first msg' },
+          { field: 'second', message: 'second msg' },
+          { field: 'third', message: 'third msg' },
         ])
       })
 
-      it('does not modify the original array', () => {
-        const original = [{ field: 'second' }, { field: 'first' }]
-        ReferralDataPresenterUtils.sortedErrors(original, { fieldOrder: ['first', 'second'] })
-        expect(original).toEqual([{ field: 'second' }, { field: 'first' }])
+      it('does not modify the error', () => {
+        const original = {
+          errors: [
+            { errorSummaryLinkedField: 'second', message: '' },
+            { errorSummaryLinkedField: 'first', message: '' },
+          ],
+        }
+
+        ReferralDataPresenterUtils.errorSummary(original, { fieldOrder: ['first', 'second'] })
+
+        expect(original.errors).toEqual([
+          { errorSummaryLinkedField: 'second', message: '' },
+          { errorSummaryLinkedField: 'first', message: '' },
+        ])
       })
 
       describe('when a field in the array of errors is missing from the fieldOrder array', () => {
         it('places that field at the end of the return value', () => {
           expect(
-            ReferralDataPresenterUtils.sortedErrors(
-              [
-                { field: 'second', msg: 'second msg' },
-                { field: 'first', msg: 'first msg' },
-                { field: 'fourth', msg: 'fourth msg' },
-                { field: 'third', msg: 'third msg' },
-              ],
+            ReferralDataPresenterUtils.errorSummary(
+              {
+                errors: [
+                  { errorSummaryLinkedField: 'second', message: 'second msg' },
+                  { errorSummaryLinkedField: 'first', message: 'first msg' },
+                  { errorSummaryLinkedField: 'fourth', message: 'fourth msg' },
+                  { errorSummaryLinkedField: 'third', message: 'third msg' },
+                ],
+              },
               { fieldOrder: ['first', 'second', 'third'] }
             )
           ).toEqual([
-            { field: 'first', msg: 'first msg' },
-            { field: 'second', msg: 'second msg' },
-            { field: 'third', msg: 'third msg' },
-            { field: 'fourth', msg: 'fourth msg' },
+            { field: 'first', message: 'first msg' },
+            { field: 'second', message: 'second msg' },
+            { field: 'third', message: 'third msg' },
+            { field: 'fourth', message: 'fourth msg' },
           ])
         })
       })
@@ -322,26 +338,59 @@ describe('ReferralDataPresenterUtils', () => {
   })
 
   describe('.errorMessage', () => {
-    describe('when errors is null', () => {
+    describe('when error is null', () => {
       it('returns null', () => {
         expect(ReferralDataPresenterUtils.errorMessage(null, 'my-field')).toBeNull()
       })
     })
 
-    describe('when errors is non-null and contains an error for that field', () => {
+    describe('when error is non-null and contains an error for that field', () => {
       it('returns the message for that error', () => {
-        const errors = [
-          { field: 'other-field', message: 'other message' },
-          { field: 'my-field', message: 'my message' },
-        ]
-        expect(ReferralDataPresenterUtils.errorMessage(errors, 'my-field')).toEqual('my message')
+        const error = {
+          errors: [
+            { formFields: ['other-field'], message: 'other message' },
+            { formFields: ['my-field', 'yet-another-field'], message: 'my message' },
+          ],
+        }
+        expect(ReferralDataPresenterUtils.errorMessage(error, 'my-field')).toEqual('my message')
       })
     })
 
-    describe('when errors is non-null and doesn’t contain an error for that field', () => {
+    describe('when error is non-null and doesn’t contain an error for that field', () => {
       it('returns null', () => {
-        const errors = [{ field: 'other-field', message: 'other message' }]
-        expect(ReferralDataPresenterUtils.errorMessage(errors, 'my-field')).toBeNull()
+        const error = {
+          errors: [{ formFields: ['other-field'], message: 'other message' }],
+        }
+        expect(ReferralDataPresenterUtils.errorMessage(error, 'my-field')).toBeNull()
+      })
+    })
+  })
+
+  describe('.errorMessage', () => {
+    describe('when error is null', () => {
+      it('returns false', () => {
+        expect(ReferralDataPresenterUtils.hasError(null, 'my-field')).toBe(false)
+      })
+    })
+
+    describe('when error is non-null and contains an error for that field', () => {
+      it('return true', () => {
+        const error = {
+          errors: [
+            { formFields: ['other-field'], message: 'other message' },
+            { formFields: ['my-field', 'yet-another-field'], message: 'my message' },
+          ],
+        }
+        expect(ReferralDataPresenterUtils.hasError(error, 'my-field')).toBe(true)
+      })
+    })
+
+    describe('when error is non-null and doesn’t contain an error for that field', () => {
+      it('returns false', () => {
+        const error = {
+          errors: [{ formFields: ['other-field'], message: 'other message' }],
+        }
+        expect(ReferralDataPresenterUtils.hasError(error, 'my-field')).toBe(false)
       })
     })
   })

--- a/server/routes/referrals/referralDataPresenterUtils.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.ts
@@ -36,17 +36,13 @@ export default class ReferralDataPresenterUtils {
     return null
   }
 
-  static sortedErrors<T extends { field: string }>(
-    errors: T[] | null,
-    { fieldOrder }: { fieldOrder: string[] }
-  ): T[] | null {
-    if (errors === null) {
-      return null
-    }
-
+  private static sortedErrors<T extends { errorSummaryLinkedField: string }>(errors: T[], fieldOrder: string[]): T[] {
     const copiedErrors = errors.slice()
     return copiedErrors.sort((a, b) => {
-      const [aIndex, bIndex] = [fieldOrder.indexOf(a.field), fieldOrder.indexOf(b.field)]
+      const [aIndex, bIndex] = [
+        fieldOrder.indexOf(a.errorSummaryLinkedField),
+        fieldOrder.indexOf(b.errorSummaryLinkedField),
+      ]
       if (aIndex === -1) {
         return 1
       }
@@ -58,7 +54,39 @@ export default class ReferralDataPresenterUtils {
     })
   }
 
-  static errorMessage(errors: { field: string; message: string }[] | null, field: string): string | null {
-    return errors?.find(error => error.field === field)?.message ?? null
+  static errorSummary(
+    error: { errors: { errorSummaryLinkedField: string; message: string }[] } | null,
+    options: { fieldOrder: string[] } = { fieldOrder: [] }
+  ): { field: string; message: string }[] | null {
+    if (error === null) {
+      return null
+    }
+
+    const sortedErrors = this.sortedErrors(error.errors, options.fieldOrder)
+
+    return sortedErrors.map(subError => {
+      return { field: subError.errorSummaryLinkedField, message: subError.message }
+    })
+  }
+
+  static errorMessage(
+    error: { errors: { formFields: string[]; message: string }[] } | null,
+    field: string
+  ): string | null {
+    if (error === null) {
+      return null
+    }
+
+    const errorForField = error.errors.find(subError => subError.formFields.includes(field))
+
+    return errorForField?.message ?? null
+  }
+
+  static hasError(error: { errors: { formFields: string[]; message: string }[] } | null, field: string): boolean {
+    if (error === null) {
+      return false
+    }
+
+    return !!error.errors.find(subError => subError.formFields.includes(field))
   }
 }

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import InterventionsService from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
+import createFormValidationErrorOrRethrow from '../../utils/interventionsFormError'
 import ReferralFormPresenter from './referralFormPresenter'
 import DraftReferralsListPresenter from './draftReferralsListPresenter'
 import CompletionDeadlinePresenter from './completionDeadlinePresenter'
@@ -85,15 +86,7 @@ export default class ReferralsController {
       try {
         await this.interventionsService.patchDraftReferral(res.locals.user.token, req.params.id, form.paramsForUpdate)
       } catch (e) {
-        error = {
-          errors: [
-            {
-              formFields: ['complexity-level-id'],
-              errorSummaryLinkedField: 'complexity-level-id',
-              message: e.message,
-            },
-          ],
-        }
+        error = createFormValidationErrorOrRethrow(e)
       }
     } else {
       error = form.error
@@ -149,16 +142,7 @@ export default class ReferralsController {
       try {
         await this.interventionsService.patchDraftReferral(res.locals.user.token, req.params.id, form.paramsForUpdate)
       } catch (e) {
-        error = {
-          errors: [
-            {
-              formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
-              errorSummaryLinkedField: 'completion-deadline-day',
-              // TODO (IC-615) there’s probably a more appropriate message to use from the response
-              message: e.message,
-            },
-          ],
-        }
+        error = createFormValidationErrorOrRethrow(e)
       }
     } else {
       error = form.error
@@ -215,15 +199,7 @@ export default class ReferralsController {
     try {
       await this.interventionsService.patchDraftReferral(res.locals.user.token, req.params.id, paramsForUpdate)
     } catch (e) {
-      error = {
-        errors: [
-          {
-            formFields: ['further-information'],
-            errorSummaryLinkedField: 'further-information',
-            message: e.message,
-          },
-        ],
-      }
+      error = createFormValidationErrorOrRethrow(e)
     }
 
     if (!error) {
@@ -275,15 +251,7 @@ export default class ReferralsController {
       try {
         await this.interventionsService.patchDraftReferral(res.locals.user.token, req.params.id, form.paramsForUpdate)
       } catch (e) {
-        error = {
-          errors: [
-            {
-              formFields: ['desired-outcomes-ids'],
-              errorSummaryLinkedField: 'desired-outcomes-ids',
-              message: e.message,
-            },
-          ],
-        }
+        error = createFormValidationErrorOrRethrow(e)
       }
     } else {
       error = form.error
@@ -330,16 +298,7 @@ export default class ReferralsController {
       try {
         await this.interventionsService.patchDraftReferral(res.locals.user.token, req.params.id, form.paramsForUpdate)
       } catch (e) {
-        // TODO IC-615 use proper error information
-        error = {
-          errors: [
-            {
-              formFields: ['additional-needs-information'],
-              errorSummaryLinkedField: 'additional-needs-information',
-              message: e.message,
-            },
-          ],
-        }
+        error = createFormValidationErrorOrRethrow(e)
       }
     } else {
       error = form.error
@@ -374,16 +333,7 @@ export default class ReferralsController {
     try {
       await this.interventionsService.patchDraftReferral(res.locals.user.token, req.params.id, paramsForUpdate)
     } catch (e) {
-      error = {
-        errors: [
-          {
-            formFields: ['additional-risk-information'],
-            errorSummaryLinkedField: 'additional-risk-information',
-            // TODO (IC-615) there’s probably a more appropriate message to use from the response
-            message: e.message,
-          },
-        ],
-      }
+      error = createFormValidationErrorOrRethrow(e)
     }
 
     if (error === null) {
@@ -437,10 +387,7 @@ export default class ReferralsController {
       try {
         await this.interventionsService.patchDraftReferral(res.locals.user.token, req.params.id, form.paramsForUpdate)
       } catch (e) {
-        // TODO IC-615 use proper error information
-        error = {
-          errors: [{ formFields: ['using-rar-days'], errorSummaryLinkedField: 'using-rar-days', message: e.message }],
-        }
+        error = createFormValidationErrorOrRethrow(e)
       }
     } else {
       error = form.error

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -25,9 +25,15 @@ describe('RiskInformationPresenter', () => {
           .serviceCategorySelected()
           .serviceUserSelected()
           .build({ serviceUser: { firstName: 'Geoffrey' } })
-        const presenter = new RiskInformationPresenter(referral, [
-          { field: 'additional-risk-information', message: 'additionalRiskInformation msg' },
-        ])
+        const presenter = new RiskInformationPresenter(referral, {
+          errors: [
+            {
+              formFields: ['additional-risk-information'],
+              errorSummaryLinkedField: 'additional-risk-information',
+              message: 'additionalRiskInformation msg',
+            },
+          ],
+        })
 
         expect(presenter.text).toMatchObject({
           additionalRiskInformation: {
@@ -92,9 +98,15 @@ describe('RiskInformationPresenter', () => {
     describe('when errors is not null', () => {
       it('returns the errors', () => {
         const referral = draftReferralFactory.serviceUserSelected().build()
-        const presenter = new RiskInformationPresenter(referral, [
-          { field: 'additional-risk-information', message: 'msg' },
-        ])
+        const presenter = new RiskInformationPresenter(referral, {
+          errors: [
+            {
+              formFields: ['additional-risk-information'],
+              errorSummaryLinkedField: 'additional-risk-information',
+              message: 'msg',
+            },
+          ],
+        })
 
         expect(presenter.errorSummary).toEqual([{ field: 'additional-risk-information', message: 'msg' }])
       })

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -1,10 +1,11 @@
 import { DraftReferral } from '../../services/interventionsService'
+import { FormValidationError } from '../../utils/formValidationError'
 import ReferralDataPresenterUtils from './referralDataPresenterUtils'
 
 export default class RiskInformationPresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly errors: { field: string; message: string }[] | null = null,
+    private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
@@ -20,11 +21,11 @@ export default class RiskInformationPresenter {
     title: `${this.referral.serviceUser?.firstName}’s risk information`,
     additionalRiskInformation: {
       label: `Additional information for the provider about ${this.referral.serviceUser?.firstName}’s risks (optional)`,
-      errorMessage: ReferralDataPresenterUtils.errorMessage(this.errors, 'additional-risk-information'),
+      errorMessage: ReferralDataPresenterUtils.errorMessage(this.error, 'additional-risk-information'),
     },
   }
 
-  readonly errorSummary = this.errors
+  readonly errorSummary = ReferralDataPresenterUtils.errorSummary(this.error)
 
   private readonly utils = new ReferralDataPresenterUtils(this.referral, this.userInputData)
 

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -4,16 +4,7 @@ import ViewUtils from '../../utils/viewUtils'
 export default class RiskInformationView {
   constructor(private readonly presenter: RiskInformationPresenter) {}
 
-  private get errorSummaryArgs() {
-    if (!this.presenter.errorSummary) {
-      return null
-    }
-
-    return {
-      titleText: 'There is a problem',
-      errorList: this.presenter.errorSummary.map(error => ({ text: error.message, href: `#${error.field}` })),
-    }
-  }
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   private get summaryListArgs() {
     return {

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -1,6 +1,6 @@
 import type { ResponseError } from 'superagent'
 
-interface SanitisedError {
+export interface SanitisedError {
   text?: string
   status?: number
   headers?: unknown

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -8,6 +8,7 @@ export default {
     monthEmpty: 'The date by which the service needs to be completed must include a month',
     yearEmpty: 'The date by which the service needs to be completed must include a year',
     invalidDate: 'The date by which the service needs to be completed must be a real date',
+    mustBeInFuture: 'The date by which the service needs to be completed must be in the future',
   },
   complexityLevel: {
     empty: 'Select a complexity level',

--- a/server/utils/formValidationError.ts
+++ b/server/utils/formValidationError.ts
@@ -1,0 +1,3 @@
+export interface FormValidationError {
+  errors: { formFields: string[]; errorSummaryLinkedField: string; message: string }[]
+}

--- a/server/utils/interventionsFormError.test.ts
+++ b/server/utils/interventionsFormError.test.ts
@@ -1,0 +1,87 @@
+import createFormValidationErrorOrRethrow from './interventionsFormError'
+
+describe(createFormValidationErrorOrRethrow, () => {
+  describe('with an error with no validationErrors key', () => {
+    it('re-throws the error', () => {
+      const error = { status: 400, message: 'Bad thing happened' }
+
+      try {
+        createFormValidationErrorOrRethrow(error)
+      } catch (e) {
+        // Jest’s toThrow matcher only lets you check the message
+        expect(e).toEqual(error)
+        return
+      }
+
+      fail('Expected an error to be thrown')
+    })
+  })
+
+  describe('with an error with validationErrors key', () => {
+    it('returns a validation error', () => {
+      const error = {
+        status: 400,
+        message: 'Validation error',
+        validationErrors: [
+          { field: 'myFirstField', error: 'SOME_ERROR_CODE_1' },
+          { field: 'mySecondField', error: 'SOME_ERROR_CODE_2' },
+        ],
+      }
+
+      expect(createFormValidationErrorOrRethrow(error)).toEqual({
+        errors: [
+          {
+            formFields: ['my-first-field'],
+            errorSummaryLinkedField: 'my-first-field',
+            message: 'SOME_ERROR_CODE_1',
+          },
+          {
+            formFields: ['my-second-field'],
+            errorSummaryLinkedField: 'my-second-field',
+            message: 'SOME_ERROR_CODE_2',
+          },
+        ],
+      })
+    })
+
+    describe('when the error is for a date field', () => {
+      it('returns an error for the day, month and year fields', () => {
+        const error = {
+          status: 400,
+          message: 'Validation error',
+          validationErrors: [{ field: 'completionDeadline', error: 'SOME_ERROR_CODE' }],
+        }
+
+        expect(createFormValidationErrorOrRethrow(error)).toEqual({
+          errors: [
+            {
+              formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
+              errorSummaryLinkedField: 'completion-deadline-day',
+              message: 'SOME_ERROR_CODE',
+            },
+          ],
+        })
+      })
+    })
+
+    describe('when the field and error correspond to a known message', () => {
+      it('inserts that error message', () => {
+        const error = {
+          status: 400,
+          message: 'Validation error',
+          validationErrors: [{ field: 'completionDeadline', error: 'DATE_MUST_BE_IN_THE_FUTURE' }],
+        }
+
+        expect(createFormValidationErrorOrRethrow(error)).toEqual({
+          errors: [
+            {
+              formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
+              errorSummaryLinkedField: 'completion-deadline-day',
+              message: 'The date by which the service needs to be completed must be in the future',
+            },
+          ],
+        })
+      })
+    })
+  })
+})

--- a/server/utils/interventionsFormError.ts
+++ b/server/utils/interventionsFormError.ts
@@ -1,0 +1,62 @@
+import { InterventionsServiceError, InterventionsServiceValidationError } from '../services/interventionsService'
+import interventionsServiceErrorMessages from './interventionsServiceErrorMessages'
+import { FormValidationError } from './formValidationError'
+
+const dateFormFields = ['completion-deadline']
+
+// This re-throws the error if `interventionsServiceError` is not a validation error.
+export default function createFormValidationErrorOrRethrow(
+  interventionsServiceError: InterventionsServiceError
+): FormValidationError {
+  if (interventionsServiceError.validationErrors === undefined) {
+    throw interventionsServiceError
+  }
+
+  const errors = interventionsServiceError.validationErrors.map(validationError => {
+    return {
+      formFields: formFieldsForServiceField(validationError.field),
+      errorSummaryLinkedField: errorSummaryLinkedFieldForServiceField(validationError.field),
+      message: messageForServiceValidationError(validationError),
+    }
+  })
+  return { errors }
+}
+
+function kebabCaseFromLowerCamelCase(val: string): string {
+  return val.replace(/[A-Z]/g, substring => `-${substring.toLowerCase()}`)
+}
+
+function formFieldsForServiceField(serviceField: string): string[] {
+  const formField = kebabCaseFromLowerCamelCase(serviceField)
+
+  if (isDateField(formField)) {
+    return [`${formField}-day`, `${formField}-month`, `${formField}-year`]
+  }
+
+  return [formField]
+}
+
+function errorSummaryLinkedFieldForServiceField(serviceField: string) {
+  const formField = kebabCaseFromLowerCamelCase(serviceField)
+
+  if (isDateField(formField)) {
+    return `${formField}-day`
+  }
+
+  return formField
+}
+
+function isDateField(formField: string): boolean {
+  return dateFormFields.includes(formField)
+}
+
+function messageForServiceValidationError(error: InterventionsServiceValidationError): string {
+  if (
+    error.field in interventionsServiceErrorMessages &&
+    error.error in interventionsServiceErrorMessages[error.field]
+  ) {
+    return interventionsServiceErrorMessages[error.field][error.error]
+  }
+
+  return error.error
+}

--- a/server/utils/interventionsServiceErrorMessages.ts
+++ b/server/utils/interventionsServiceErrorMessages.ts
@@ -1,0 +1,7 @@
+import errorMessages from './errorMessages'
+
+export default {
+  completionDeadline: {
+    DATE_MUST_BE_IN_THE_FUTURE: errorMessages.completionDeadline.mustBeInFuture,
+  },
+}

--- a/server/utils/viewUtils.test.ts
+++ b/server/utils/viewUtils.test.ts
@@ -13,7 +13,7 @@ describe('ViewUtils', () => {
 
   describe('govukErrorMessage', () => {
     describe('with a non-empty string', () => {
-      it('returns an error message object', () => {
+      it('returns an error message object, suitable to pass as the errorMessage property in the arguments of a GOV.UK Frontend macro', () => {
         expect(ViewUtils.govukErrorMessage('foo must be in the future')).toEqual({ text: 'foo must be in the future' })
       })
     })
@@ -33,6 +33,31 @@ describe('ViewUtils', () => {
     describe('with undefined', () => {
       it('returns null', () => {
         expect(ViewUtils.govukErrorMessage(undefined)).toBeNull()
+      })
+    })
+  })
+
+  describe('govukErrorSummaryArgs', () => {
+    describe('with null', () => {
+      it('returns null', () => {
+        expect(ViewUtils.govukErrorSummaryArgs(null)).toBeNull()
+      })
+    })
+
+    describe('with an error', () => {
+      it('returns an error summary object, suitable to pass to the govukErrorSummary macro', () => {
+        expect(
+          ViewUtils.govukErrorSummaryArgs([
+            { field: 'field-1', message: 'Message 1' },
+            { field: 'field-2', message: 'Message 2' },
+          ])
+        ).toEqual({
+          errorList: [
+            { href: '#field-1', text: 'Message 1' },
+            { href: '#field-2', text: 'Message 2' },
+          ],
+          titleText: 'There is a problem',
+        })
       })
     })
   })

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -9,4 +9,22 @@ export default class ViewUtils {
   static govukErrorMessage(message: string | null | undefined): { text: string } | null {
     return message === null || message === undefined ? null : { text: message }
   }
+
+  static govukErrorSummaryArgs(
+    errorSummary: { field: string; message: string }[] | null
+  ): Record<string, unknown> | null {
+    if (errorSummary === null) {
+      return null
+    }
+
+    return {
+      titleText: 'There is a problem',
+      errorList: errorSummary.map(error => {
+        return {
+          text: error.message,
+          href: `#${error.field}`,
+        }
+      }),
+    }
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

This updates the frontend to handle the field-level validation errors returned by the backend as of https://github.com/ministryofjustice/hmpps-interventions-service/pull/53.

## What is the intent behind these changes?

To be able to display granular error information to the user.
