### PR TITLE
Add contract tests for sending a draft referral and fetching a sent referral

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -862,6 +862,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   const sentReferral: SentReferral = {
     id: '81d754aa-d868-4347-9c0f-50690773014e',
     createdAt: '2021-01-11T10:32:12.382884Z',
+    referenceNumber: 'HDJ2123F',
     referral: {
       completionDeadline: '2021-04-01',
       serviceProviderId: '674b47a0-39bf-4514-82ae-61885b9c0cb4',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -914,4 +914,27 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       )
     })
   })
+
+  describe('getSentReferral', () => {
+    it('returns a referral for the given ID', async () => {
+      await provider.addInteraction({
+        state: 'There is an existing sent referral with ID of 81d754aa-d868-4347-9c0f-50690773014e',
+        uponReceiving: 'a request for the sent referral with ID of 81d754aa-d868-4347-9c0f-50690773014e',
+        withRequest: {
+          method: 'GET',
+          path: '/sent-referral/81d754aa-d868-4347-9c0f-50690773014e',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(sentReferral),
+          headers: { 'Content-Type': 'application/json' },
+        },
+      })
+
+      expect(await interventionsService.getSentReferral(token, '81d754aa-d868-4347-9c0f-50690773014e')).toEqual(
+        sentReferral
+      )
+    })
+  })
 })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1,7 +1,7 @@
 import { pactWith } from 'jest-pact'
 import { Matchers } from '@pact-foundation/pact'
 
-import InterventionsService from './interventionsService'
+import InterventionsService, { SentReferral } from './interventionsService'
 import config from '../config'
 import oauth2TokenFactory from '../../testutils/factories/oauth2Token'
 
@@ -856,6 +856,61 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
       expect(serviceProvider.id).toEqual('674b47a0-39bf-4514-82ae-61885b9c0cb4')
       expect(serviceProvider.name).toEqual('Harmony Living')
+    })
+  })
+
+  const sentReferral: SentReferral = {
+    id: '81d754aa-d868-4347-9c0f-50690773014e',
+    createdAt: '2021-01-11T10:32:12.382884Z',
+    referral: {
+      completionDeadline: '2021-04-01',
+      serviceProviderId: '674b47a0-39bf-4514-82ae-61885b9c0cb4',
+      serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+      complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+      furtherInformation: 'Some information about the service user',
+      desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+      additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
+      accessibilityNeeds: 'She uses a wheelchair',
+      needsInterpreter: true,
+      interpreterLanguage: 'Spanish',
+      hasAdditionalResponsibilities: true,
+      whenUnavailable: 'She works Mondays 9am - midday',
+      serviceUser: {
+        firstName: 'Alex',
+      },
+      additionalRiskInformation: 'A danger to the elderly',
+      usingRarDays: true,
+      maximumRarDays: 10,
+    },
+  }
+
+  describe('sendDraftReferral', () => {
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: 'a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists and is ready to be sent',
+        uponReceiving: 'a POST request to send the draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        withRequest: {
+          method: 'POST',
+          path: '/draft-referral/dfb64747-f658-40e0-a827-87b4b0bdcfed/send',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 201,
+          body: Matchers.like(sentReferral),
+          headers: {
+            'Content-Type': 'application/json',
+            Location: Matchers.like(
+              'https://hmpps-interventions-service.com/referral/81d754aa-d868-4347-9c0f-50690773014e'
+            ),
+          },
+        },
+      })
+    })
+
+    it('returns a sent referral', async () => {
+      expect(await interventionsService.sendDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed')).toEqual(
+        sentReferral
+      )
     })
   })
 })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -135,4 +135,13 @@ export default class InterventionsService {
       headers: { Accept: 'application/json' },
     })) as SentReferral
   }
+
+  async getSentReferral(token: string, id: string): Promise<SentReferral> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/sent-referral/${id}`,
+      headers: { Accept: 'application/json' },
+    })) as SentReferral
+  }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -2,25 +2,36 @@ import RestClient from '../data/restClient'
 import logger from '../../log'
 import { ApiConfig } from '../config'
 
-export interface DraftReferral {
+type WithNullableValues<T> = { [K in keyof T]: T[K] | null }
+
+export interface ReferralFields {
+  completionDeadline: string
+  serviceProviderId: string
+  serviceCategoryId: string
+  complexityLevelId: string
+  furtherInformation: string
+  desiredOutcomesIds: string[]
+  additionalNeedsInformation: string
+  accessibilityNeeds: string
+  needsInterpreter: boolean
+  interpreterLanguage: string | null
+  hasAdditionalResponsibilities: boolean
+  whenUnavailable: string | null
+  serviceUser: ServiceUser
+  additionalRiskInformation: string
+  usingRarDays: boolean
+  maximumRarDays: number | null
+}
+
+export interface DraftReferral extends WithNullableValues<ReferralFields> {
   id: string
   createdAt: string
-  completionDeadline: string | null
-  serviceProviderId: string | null
-  serviceCategoryId: string | null
-  complexityLevelId: string | null
-  furtherInformation: string | null
-  desiredOutcomesIds: string[] | null
-  additionalNeedsInformation: string | null
-  accessibilityNeeds: string | null
-  needsInterpreter: boolean | null
-  interpreterLanguage: string | null
-  hasAdditionalResponsibilities: boolean | null
-  whenUnavailable: string | null
-  serviceUser: ServiceUser | null
-  additionalRiskInformation: string | null
-  usingRarDays: boolean | null
-  maximumRarDays: number | null
+}
+
+export interface SentReferral {
+  id: string
+  createdAt: string
+  referral: ReferralFields
 }
 
 export interface ServiceCategory {
@@ -113,5 +124,14 @@ export default class InterventionsService {
       path: `/service-provider/${id}`,
       headers: { Accept: 'application/json' },
     })) as ServiceProvider
+  }
+
+  async sendDraftReferral(token: string, id: string): Promise<SentReferral> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/draft-referral/${id}/send`,
+      headers: { Accept: 'application/json' },
+    })) as SentReferral
   }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -31,6 +31,7 @@ export interface DraftReferral extends WithNullableValues<ReferralFields> {
 export interface SentReferral {
   id: string
   createdAt: string
+  referenceNumber: string
   referral: ReferralFields
 }
 


### PR DESCRIPTION
## What does this pull request do?

This adds an endpoint `POST /referral`, which takes the ID of a draft
referral and uses it to create a referral. This is just my idea of how
this would work; putting it up for review to get some other thoughts.

## What is the intent behind these changes?

To allow us to build a UI for submitting a draft referral.