### PR TITLE
Add contract tests for service provider entity

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -72,6 +72,36 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
     })
 
+    describe('for a referral that has had a service provider selected', () => {
+      beforeEach(async () => {
+        await provider.addInteraction({
+          state:
+            'There is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962, and it has had a service provider selected',
+          uponReceiving: 'a request for that referral',
+          withRequest: {
+            method: 'GET',
+            path: '/draft-referral/d496e4a7-7cc1-44ea-ba67-c295084f1962',
+            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like({
+              id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
+              serviceProviderId: '674b47a0-39bf-4514-82ae-61885b9c0cb4',
+            }),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+      })
+
+      it('returns a referral for the given ID, with the serviceProviderId field populated', async () => {
+        const referral = await interventionsService.getDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962')
+
+        expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
+        expect(referral.serviceProviderId).toEqual('674b47a0-39bf-4514-82ae-61885b9c0cb4')
+      })
+    })
+
     describe('for a referral that has had desired outcomes selected', () => {
       beforeEach(async () => {
         await provider.addInteraction({

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -821,4 +821,41 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(referrals.length).toBe(0)
     })
   })
+
+  describe('getServiceProvider', () => {
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: 'a service provider with ID 674b47a0-39bf-4514-82ae-61885b9c0cb4 exists',
+        uponReceiving: 'a GET request to fetch the service provider',
+        withRequest: {
+          method: 'GET',
+          path: '/service-provider/674b47a0-39bf-4514-82ae-61885b9c0cb4',
+          headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            id: '674b47a0-39bf-4514-82ae-61885b9c0cb4',
+            name: 'Harmony Living',
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns a service provider', async () => {
+      const serviceProvider = await interventionsService.getServiceProvider(
+        token,
+        '674b47a0-39bf-4514-82ae-61885b9c0cb4'
+      )
+
+      expect(serviceProvider.id).toEqual('674b47a0-39bf-4514-82ae-61885b9c0cb4')
+      expect(serviceProvider.name).toEqual('Harmony Living')
+    })
+  })
 })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -6,6 +6,7 @@ export interface DraftReferral {
   id: string
   createdAt: string
   completionDeadline: string | null
+  serviceProviderId: string | null
   serviceCategoryId: string | null
   complexityLevelId: string | null
   furtherInformation: string | null

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -45,6 +45,11 @@ export interface ServiceUser {
   firstName: string | null
 }
 
+export interface ServiceProvider {
+  id: string
+  name: string
+}
+
 export default class InterventionsService {
   constructor(private readonly config: ApiConfig) {}
 
@@ -82,11 +87,11 @@ export default class InterventionsService {
     })) as DraftReferral
   }
 
-  async getServiceCategory(token: string, serviceCategoryId: string): Promise<ServiceCategory> {
+  async getServiceCategory(token: string, id: string): Promise<ServiceCategory> {
     const restClient = this.createRestClient(token)
 
     return (await restClient.get({
-      path: `/service-category/${serviceCategoryId}`,
+      path: `/service-category/${id}`,
       headers: { Accept: 'application/json' },
     })) as ServiceCategory
   }
@@ -99,5 +104,14 @@ export default class InterventionsService {
       query: `userID=${userId}`,
       headers: { Accept: 'application/json' },
     })) as DraftReferral[]
+  }
+
+  async getServiceProvider(token: string, id: string): Promise<ServiceProvider> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/service-provider/${id}`,
+      headers: { Accept: 'application/json' },
+    })) as ServiceProvider
   }
 }

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -29,6 +29,7 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   id: sequence.toString(),
   createdAt: new Date(Date.now()).toISOString(),
   completionDeadline: null,
+  serviceProviderId: null,
   serviceCategoryId: null,
   complexityLevelId: null,
   furtherInformation: null,


### PR DESCRIPTION
## What does this pull request do?

Adds an endpoint allowing us to fetch a new `ServiceProvider` entity, and adds a `serviceProviderId` property linking a draft referral to a service provider.

## What is the intent behind these changes?

To allow us to display the name of the service provider on the referral submission confirmation page.