### PR TITLE
Add sample endpoint to display assessment data from Offender Assessments API (data from OASys)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,24 @@
 - npm >= 6
 - Docker
 
-### Build & Run 
+### Initial setup
 
 ```
 docker-compose pull
-docker-compose up -d 
 (nvm use)
-npm install 
+npm install
+```
+
+You'll also need to add the following line to your `/etc/hosts` file:
+
+```
+127.0.0.1 hmpps-auth
+```
+
+### Running the app
+
+```
+docker-compose up -d
 npm run start:dev
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ services:
       - hmpps
     container_name: hmpps-auth
     ports:
-      - "8090:8090"
+      - '8090:8090'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8090/auth/health"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:8090/auth/health']
     environment:
       - SERVER_PORT=8090
       - SPRING_PROFILES_ACTIVE=dev
@@ -30,9 +30,9 @@ services:
       - hmpps
     container_name: community-api
     ports:
-      - "8091:8080"
+      - '8091:8080'
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,11 @@ services:
       - hmpps
     container_name: hmpps-auth
     ports:
-      - "8090:8080"
+      - "8090:8090"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8090/auth/health"]
     environment:
-      - SERVER_PORT=8080
+      - SERVER_PORT=8090
       - SPRING_PROFILES_ACTIVE=dev
       - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
 
@@ -36,6 +36,23 @@ services:
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
+
+  offender-assessments-api:
+    image: mojdigitalstudio/offender-assessments-api:latest
+    restart: always
+    networks:
+      - hmpps
+    container_name: offender-assessments-api
+    depends_on:
+      - hmpps-auth
+    ports:
+      - '8092:8080'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=dev
+      - OAUTH_ENDPOINT_URL=http://hmpps-auth:8090/auth
 
 networks:
   hmpps:

--- a/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
@@ -58,6 +58,9 @@ env:
   - name: COMMUNITY_API_URL
     value: {{ .Values.env.COMMUNITY_API_URL | quote }}
 
+  - name: OFFENDER_ASSESSMENTS_API_URL
+    value: {{ .Values.env.OFFENDER_ASSESSMENTS_API_URL | quote }}
+
   - name: INTERVENTIONS_SERVICE_URL
     value: {{ .Values.env.INTERVENTIONS_SERVICE_URL | quote }}
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,6 +17,7 @@ ingress:
 env:
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
+  OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/
   INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true

--- a/server/app.ts
+++ b/server/app.ts
@@ -25,12 +25,14 @@ import authorisationMiddleware from './middleware/authorisationMiddleware'
 import type UserService from './services/userService'
 import CommunityApiService from './services/communityApiService'
 import InterventionsService from './services/interventionsService'
+import OffenderAssessmentsApiService from './services/offenderAssessmentsApiService'
 
 const RedisStore = connectRedis(session)
 
 export default function createApp(
   userService: UserService,
   communityApiService: CommunityApiService,
+  offenderAssessmentsApiService: OffenderAssessmentsApiService,
   interventionsService: InterventionsService
 ): express.Application {
   const app = express()
@@ -192,7 +194,14 @@ export default function createApp(
   })
 
   app.use(authorisationMiddleware())
-  app.use('/', indexRoutes(standardRouter(userService), { communityApiService, interventionsService }))
+  app.use(
+    '/',
+    indexRoutes(standardRouter(userService), {
+      communityApiService,
+      offenderAssessmentsApiService,
+      interventionsService,
+    })
+  )
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(config.production))
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -59,8 +59,16 @@ export default {
       },
       agent: new AgentConfig(),
     },
+    offenderAssessmentsApi: {
+      url: get('OFFENDER_ASSESSMENTS_API', 'http://localhost:8092', requiredInProduction),
+      timeout: {
+        response: Number(get('OFFENDER_ASSESSMENTS_API_RESPONSE', 10000)),
+        deadline: Number(get('OFFENDER_ASSESSMENTS_API_DEADLINE', 10000)),
+      },
+      agent: new AgentConfig(),
+    },
     hmppsAuth: {
-      url: get('HMPPS_AUTH_URL', 'http://localhost:8090/auth', requiredInProduction),
+      url: get('HMPPS_AUTH_URL', 'http://hmpps-auth:8090/auth', requiredInProduction),
       timeout: {
         response: Number(get('HMPPS_AUTH_TIMEOUT_RESPONSE', 10000)),
         deadline: Number(get('HMPPS_AUTH_TIMEOUT_DEADLINE', 10000)),

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,12 +4,14 @@ import UserService from './services/userService'
 import CommunityApiService from './services/communityApiService'
 import config from './config'
 import InterventionsService from './services/interventionsService'
+import OffenderAssessmentsApiService from './services/offenderAssessmentsApiService'
 
 const hmppsAuthClient = new HmppsAuthClient()
 const userService = new UserService(hmppsAuthClient)
 const communityApiService = new CommunityApiService(hmppsAuthClient)
+const offenderAssessmentsApiService = new OffenderAssessmentsApiService(hmppsAuthClient)
 const interventionsService = new InterventionsService(config.apis.interventionsService)
 
-const app = createApp(userService, communityApiService, interventionsService)
+const app = createApp(userService, communityApiService, offenderAssessmentsApiService, interventionsService)
 
 export default app

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -3,6 +3,7 @@ import type { RequestHandler, Router } from 'express'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import CommunityApiService from '../services/communityApiService'
 import InterventionsService from '../services/interventionsService'
+import OffenderAssessmentsApiService from '../services/offenderAssessmentsApiService'
 import IntegrationSamplesRoutes from './integrationSamples'
 import ReferralsController from './referrals/referralsController'
 
@@ -12,6 +13,7 @@ interface RouteProvider {
 
 export interface Services {
   communityApiService: CommunityApiService
+  offenderAssessmentsApiService: OffenderAssessmentsApiService
   interventionsService: InterventionsService
 }
 
@@ -19,7 +21,10 @@ export default function routes(router: Router, services: Services): Router {
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
   const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
 
-  const integrationSamples: RouteProvider = IntegrationSamplesRoutes(services.communityApiService)
+  const integrationSamples: RouteProvider = IntegrationSamplesRoutes(
+    services.communityApiService,
+    services.offenderAssessmentsApiService
+  )
   const referralsController = new ReferralsController(services.interventionsService)
 
   get('/', (req, res, next) => {
@@ -27,6 +32,7 @@ export default function routes(router: Router, services: Services): Router {
   })
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
+  get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)
 
   get('/referrals/start', (req, res) => referralsController.startReferral(req, res))
   post('/referrals', (req, res) => referralsController.createReferral(req, res))

--- a/server/routes/integrationSamples.ts
+++ b/server/routes/integrationSamples.ts
@@ -1,15 +1,26 @@
 import { Request, Response } from 'express'
 import CommunityApiService from '../services/communityApiService'
+import OffenderAssessmentsApiService from '../services/offenderAssessmentsApiService'
 
 // fixme: this is just sample code to validate secure API access
 export default function IntegrationSamplesRoutes(
-  communityApiService: CommunityApiService
-): { viewDeliusUserSample: (req: Request, res: Response) => Promise<void> } {
+  communityApiService: CommunityApiService,
+  offenderAssessmentsApiService: OffenderAssessmentsApiService
+): {
+  viewDeliusUserSample: (req: Request, res: Response) => Promise<void>
+  viewOasysAssessmentSample: (req: Request, res: Response) => Promise<void>
+} {
   return {
     viewDeliusUserSample: async (req: Request, res: Response) => {
       const deliusUser = await communityApiService.getUserByUsername(req.query.username as string)
       res.setHeader('Content-Type', 'application/json')
       res.end(JSON.stringify(deliusUser))
+    },
+    viewOasysAssessmentSample: async (req: Request, res: Response) => {
+      const hardcodedCRN = 'X320741'
+      const assessmentSummary = await offenderAssessmentsApiService.getAssessmentByCRN(hardcodedCRN)
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify(assessmentSummary))
     },
   }
 }

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -12,6 +12,7 @@ import * as auth from '../../authentication/auth'
 import { user, MockUserService } from './mocks/mockUserService'
 import MockCommunityApiService from './mocks/mockCommunityApiService'
 import InterventionsService from '../../services/interventionsService'
+import MockOffenderAssessmentsApiService from './mocks/mockOffenderAssessmentsApiService'
 
 function appSetup(route: Router, production: boolean): Express {
   const app = express()
@@ -48,6 +49,7 @@ export default function appWithAllRoutes({
   return appSetup(
     allRoutes(standardRouter(new MockUserService()), {
       communityApiService: new MockCommunityApiService(),
+      offenderAssessmentsApiService: new MockOffenderAssessmentsApiService(),
       interventionsService: {} as InterventionsService,
       ...overrides,
     }),

--- a/server/routes/testutils/mocks/mockOffenderAssessmentsApiService.ts
+++ b/server/routes/testutils/mocks/mockOffenderAssessmentsApiService.ts
@@ -1,0 +1,102 @@
+import MockedHmppsAuthClient from '../../../data/testutils/hmppsAuthClientSetup'
+import OffenderAssessmentsApiService, { OasysAssessment } from '../../../services/offenderAssessmentsApiService'
+
+export = class MockOffenderAssessmentsApiService extends OffenderAssessmentsApiService {
+  constructor() {
+    super(new MockedHmppsAuthClient())
+  }
+
+  async getAssessmentSummaryByCRN(_crn: string): Promise<OasysAssessment> {
+    return {
+      assessmentId: 1234,
+      assessmentStatus: 'OPEN',
+      assessmentType: 'LAYER_£',
+      assessorName: 'Layer 3',
+      childSafeguardingIndicated: true,
+      completed: '2020-01-02T16:00:00',
+      created: '2020-01-02T16:00:00',
+      historicStatus: 'CURRENT',
+      layer3SentencePlanNeeds: [
+        {
+          flaggedAsNeed: true,
+          name: 'Accommodation',
+          overThreshold: false,
+          riskOfHarm: true,
+          riskOfReoffending: true,
+          section: 'ACCOMMODATION',
+          severity: true,
+        },
+      ],
+      refAssessmentId: 1,
+      refAssessmentOasysScoringAlgorithmVersion: 1,
+      refAssessmentVersionCode: 'LAYER3',
+      refAssessmentVersionNumber: 1,
+      sections: [
+        {
+          assessmentId: 0,
+          lowScoreAttentionNeeded: 'Y',
+          questions: [
+            {
+              answers: [
+                {
+                  displayOrder: 1,
+                  freeFormText: 'Some answer',
+                  oasysAnswerId: 123456,
+                  ogpScore: 1,
+                  ovpScore: 1,
+                  qaRawScore: 2,
+                  refAnswerCode: 'NO',
+                  refAnswerId: 123456,
+                  staticText: 123456,
+                },
+              ],
+              displayOrder: 123456,
+              displayScore: 123456,
+              oasysQuestionId: 123456,
+              questionText: 123456,
+              refQuestionCode: 10.98,
+              refQuestionId: 123456,
+            },
+          ],
+          refAssessmentVersionCode: 'string',
+          refSectionCode: 'string',
+          refSectionCrimNeedScoreThreshold: 0,
+          refSectionVersionNumber: 'string',
+          sectionId: 0,
+          sectionOgpRawScore: 0,
+          sectionOgpWeightedScore: 0,
+          sectionOtherRawScore: 0,
+          sectionOtherWeightedScore: 0,
+          sectionOvpRawScore: 0,
+          sectionOvpWeightedScore: 0,
+          status: 'string',
+        },
+      ],
+      sentence: [
+        {
+          activity: 'string',
+          cja: true,
+          cjaSupervisionMonths: 0,
+          cjaUnpaidHours: 0,
+          custodial: true,
+          offenceBlockType: {
+            code: 'LAYER_3',
+            description: 'Full (Layer 3)',
+            shortDescription: 'Layer 3',
+          },
+          offenceDate: 'string',
+          orderType: {
+            code: 'LAYER_3',
+            description: 'Full (Layer 3)',
+            shortDescription: 'Layer 3',
+          },
+          sentenceCode: 'string',
+          sentenceDate: 'string',
+          sentenceDescription: 'string',
+          sentenceLengthCustodyDays: 0,
+        },
+      ],
+      voided: '2020-01-02T16:00:00',
+    } as OasysAssessment
+  }
+}

--- a/server/services/offenderAssessmentsApiService.ts
+++ b/server/services/offenderAssessmentsApiService.ts
@@ -1,0 +1,92 @@
+import type HmppsAuthClient from '../data/hmppsAuthClient'
+import RestClient from '../data/restClient'
+import config from '../config'
+import logger from '../../log'
+
+export interface OasysAssessment {
+  assessmentId: number
+  assessmentStatus: string
+  childSafeguardingIndicated: boolean
+  completed: string
+  created: string
+  historicStatus: string
+  layer3SentencePlanNeeds: SentencePlanNeed[]
+  refAssessmentId: number
+  refAssessmentOasysScoringAlgorithmVersion: number
+  refAssessmentVersionCode: string
+  refAssessmentVersionNumber: number
+  sections: Section[]
+  sentence: Sentence[]
+  voided: string
+}
+
+interface SentencePlanNeed {
+  flaggedAsNeed: boolean
+  name: string
+  overThreshold: boolean
+  riskOfHarm: boolean
+  riskOfReoffending: boolean
+  section: string
+  severity: boolean
+}
+
+interface Section {
+  assessmentId: number
+  lowScoreAttentionNeeded: string
+  questions: Record<string, unknown>[]
+  refAssessmentVersionCode: string
+  refSectionCode: string
+  refSectionCrimNeedScoreThreshold: number
+  refSectionVersionNumber: string
+  sectionId: number
+  sectionOgpRawScore: number
+  sectionOgpWeightedScore: number
+  sectionOtherRawScore: number
+  sectionOtherWeightedScore: number
+  sectionOvpRawScore: number
+  sectionOvpWeightedScore: number
+  status: string
+}
+
+interface Sentence {
+  activity: string
+  cja: boolean
+  cjaSupervisionMonths: number
+  cjaUnpaidHours: number
+  custodial: true
+  offenceBlockType: OffenceBlockType
+  offenceDate: string
+  orderType: OrderType
+  sentenceCode: string
+  sentenceDate: string
+  sentenceDescription: string
+  sentenceLengthCustodyDays: number
+}
+
+interface OffenceBlockType {
+  code: string
+  description: string
+  shortDescription: string
+}
+interface OrderType {
+  code: string
+  description: string
+  shortDescription: string
+}
+
+export default class OffenderAssessmentsApiService {
+  constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
+
+  private restClient(token: string): RestClient {
+    return new RestClient('Offender Assessments Api Client', config.apis.offenderAssessmentsApi, token)
+  }
+
+  async getAssessmentByCRN(crn: string): Promise<OasysAssessment> {
+    const token = await this.hmppsAuthClient.getApiClientToken()
+
+    logger.info(`getting user details for CRN ${crn}`)
+    return (await this.restClient(token).get({
+      path: `/offenders/crn/${crn}/assessments/latest`,
+    })) as OasysAssessment
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

- Configures & runs Offender Assessments API locally via docker image, authenticating with HMPPS Auth.
- Adds an Offender Assessments API Service to make requests to offender assessments API, with sample endpoint (`/integrations/oasys/assessment`) for viewing `/offenders/crn/{crn}/assessments/latest` with hardcoded CRN.

### NOTE: You'll need to update your `etc/hosts` file to point `hmpps-auth` to `localhost` to get this working due to the way auth is handled - see README for more setup instructions.

## What is the intent behind these changes?

To allow us to display risks and needs for a service user in our service.

## Screenshot of endpoint

![image](https://user-images.githubusercontent.com/19826940/104611430-02095980-567d-11eb-8efc-437c519e064d.png)



