### PR TITLE
IC-877 - Allow user to send a draft referral

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -45,6 +45,7 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals/:id/risk-information', (req, res) => referralsController.updateRiskInformation(req, res))
   get('/referrals/:id/rar-days', (req, res) => referralsController.viewRarDays(req, res))
   post('/referrals/:id/rar-days', (req, res) => referralsController.updateRarDays(req, res))
+  get('/referrals/:id/check-answers', (req, res) => referralsController.checkAnswers(req, res))
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -47,6 +47,7 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals/:id/rar-days', (req, res) => referralsController.updateRarDays(req, res))
   get('/referrals/:id/check-answers', (req, res) => referralsController.checkAnswers(req, res))
   post('/referrals/:id/send', (req, res) => referralsController.sendDraftReferral(req, res))
+  get('/referrals/:id/confirmation', (req, res) => referralsController.viewConfirmation(req, res))
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -46,6 +46,7 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/:id/rar-days', (req, res) => referralsController.viewRarDays(req, res))
   post('/referrals/:id/rar-days', (req, res) => referralsController.updateRarDays(req, res))
   get('/referrals/:id/check-answers', (req, res) => referralsController.checkAnswers(req, res))
+  post('/referrals/:id/send', (req, res) => referralsController.sendDraftReferral(req, res))
 
   return router
 }

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -1,0 +1,11 @@
+import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+
+export default class CheckAnswersPresenter {
+  constructor(private readonly referral: DraftReferral, private readonly serviceCategory: ServiceCategory) {}
+
+  // TODO IC-679 build this page properly - this
+  // is just a placeholder to show the data’s coming in
+  readonly serviceUserName = this.referral.serviceUser?.firstName ?? ''
+
+  readonly referralSectionHeading = `Information for the ${this.serviceCategory.name} referral`
+}

--- a/server/routes/referrals/checkAnswersView.ts
+++ b/server/routes/referrals/checkAnswersView.ts
@@ -1,0 +1,9 @@
+import CheckAnswersPresenter from './checkAnswersPresenter'
+
+export default class CheckAnswersView {
+  constructor(private readonly presenter: CheckAnswersPresenter) {}
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return ['referrals/checkAnswers', { presenter: this.presenter }]
+  }
+}

--- a/server/routes/referrals/confirmationPresenter.test.ts
+++ b/server/routes/referrals/confirmationPresenter.test.ts
@@ -1,0 +1,20 @@
+import ConfirmationPresenter from './confirmationPresenter'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceProviderFactory from '../../../testutils/factories/serviceProvider'
+
+describe(ConfirmationPresenter, () => {
+  describe('text', () => {
+    it('returns text to be displayed', () => {
+      const referral = sentReferralFactory.build()
+      const serviceProvider = serviceProviderFactory.build({ name: 'Harmony Living' })
+      const presenter = new ConfirmationPresenter(referral, serviceProvider)
+
+      expect(presenter.text).toEqual({
+        title: `We’ve sent your referral to Harmony Living`,
+        referenceNumberIntro: `Your reference number`,
+        referenceNumber: referral.referenceNumber,
+        whatHappensNext: 'Harmony Living will be in contact within 10 days to schedule the assessment.',
+      })
+    })
+  })
+})

--- a/server/routes/referrals/confirmationPresenter.ts
+++ b/server/routes/referrals/confirmationPresenter.ts
@@ -1,0 +1,12 @@
+import { SentReferral, ServiceProvider } from '../../services/interventionsService'
+
+export default class ConfirmationPresenter {
+  constructor(private readonly referral: SentReferral, private readonly serviceProvider: ServiceProvider) {}
+
+  readonly text = {
+    title: `We’ve sent your referral to ${this.serviceProvider.name}`,
+    referenceNumberIntro: `Your reference number`,
+    referenceNumber: this.referral.referenceNumber,
+    whatHappensNext: `${this.serviceProvider.name} will be in contact within 10 days to schedule the assessment.`,
+  }
+}

--- a/server/routes/referrals/confirmationView.ts
+++ b/server/routes/referrals/confirmationView.ts
@@ -1,0 +1,20 @@
+import ConfirmationPresenter from './confirmationPresenter'
+
+export default class ConfirmationView {
+  constructor(private readonly presenter: ConfirmationPresenter) {}
+
+  private readonly panelArgs = {
+    titleText: this.presenter.text.title,
+    html: `${this.presenter.text.referenceNumberIntro}<br><strong>${this.presenter.text.referenceNumber}`,
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/confirmation',
+      {
+        presenter: this.presenter,
+        panelArgs: this.panelArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -78,7 +78,7 @@ describe('ReferralFormPresenter', () => {
           title: 'Check your answers',
           number: '6',
           status: ReferralFormStatus.CannotStartYet,
-          tasks: [{ title: 'Check your answers', url: null }],
+          tasks: [{ title: 'Check your answers', url: 'check-answers' }],
         },
       ]
 

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -116,7 +116,7 @@ export default class ReferralFormPresenter {
         tasks: [
           {
             title: 'Check your answers',
-            url: null,
+            url: 'check-answers',
           },
         ],
       },

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -779,3 +779,38 @@ describe('POST /referrals/:id/rar-days', () => {
       })
   })
 })
+
+describe('GET /referrals/:id/check-answers', () => {
+  beforeEach(() => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const referral = draftReferralFactory
+      .serviceCategorySelected(serviceCategory.id)
+      .build({ serviceUser: { firstName: 'Johnny' } })
+
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
+  })
+
+  it('displays a summary of the draft referral', async () => {
+    await request(app)
+      .get('/referrals/1/check-answers')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Johnny')
+        expect(res.text).toContain('Information for the accommodation referral')
+      })
+  })
+
+  describe('when an API call returns an error', () => {
+    it('returns a 500 and displays an error message', async () => {
+      interventionsService.getDraftReferral.mockRejectedValue(new Error('Backend error message'))
+
+      await request(app)
+        .get('/referrals/1/check-answers')
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain('Backend error message')
+        })
+    })
+  })
+})

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -25,6 +25,8 @@ import RarDaysView from './rarDaysView'
 import RarDaysPresenter from './rarDaysPresenter'
 import RarDaysForm from './rarDaysForm'
 import ReferralStartView from './referralStartView'
+import CheckAnswersView from './checkAnswersView'
+import CheckAnswersPresenter from './checkAnswersPresenter'
 
 export default class ReferralsController {
   constructor(private readonly interventionsService: InterventionsService) {}
@@ -402,5 +404,21 @@ export default class ReferralsController {
       res.status(400)
       res.render(...view.renderArgs)
     }
+  }
+
+  async checkAnswers(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+    if (referral.serviceCategoryId === null) {
+      throw new Error('Attempting to check answers without service category selected')
+    }
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      res.locals.user.token,
+      referral.serviceCategoryId
+    )
+
+    const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+    const view = new CheckAnswersView(presenter)
+
+    res.render(...view.renderArgs)
   }
 }

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -421,4 +421,10 @@ export default class ReferralsController {
 
     res.render(...view.renderArgs)
   }
+
+  async sendDraftReferral(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.sendDraftReferral(res.locals.user.token, req.params.id)
+
+    res.redirect(303, `/referrals/${referral.id}/confirmation`)
+  }
 }

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -27,6 +27,8 @@ import RarDaysForm from './rarDaysForm'
 import ReferralStartView from './referralStartView'
 import CheckAnswersView from './checkAnswersView'
 import CheckAnswersPresenter from './checkAnswersPresenter'
+import ConfirmationView from './confirmationView'
+import ConfirmationPresenter from './confirmationPresenter'
 
 export default class ReferralsController {
   constructor(private readonly interventionsService: InterventionsService) {}
@@ -426,5 +428,18 @@ export default class ReferralsController {
     const referral = await this.interventionsService.sendDraftReferral(res.locals.user.token, req.params.id)
 
     res.redirect(303, `/referrals/${referral.id}/confirmation`)
+  }
+
+  async viewConfirmation(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.getSentReferral(res.locals.user.token, req.params.id)
+    const serviceProvider = await this.interventionsService.getServiceProvider(
+      res.locals.user.token,
+      referral.referral.serviceProviderId
+    )
+
+    const presenter = new ConfirmationPresenter(referral, serviceProvider)
+    const view = new ConfirmationView(presenter)
+
+    res.render(...view.renderArgs)
   }
 }

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -1,0 +1,28 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Check your answers</h1>
+
+      <h2 class="govuk-heading-l">Service user’s information</h2>
+      
+      <p>{{ presenter.serviceUserName }}</p>
+
+      <h2 class="govuk-heading-l">{{ presenter.referralSectionHeading }}</h2>
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+        {{ govukButton({ text: "Submit referral" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -19,7 +19,7 @@
 
       <h2 class="govuk-heading-l">{{ presenter.referralSectionHeading }}</h2>
 
-      <form method="post">
+      <form method="post" action="send">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukButton({ text: "Submit referral" }) }}
       </form>

--- a/server/views/referrals/confirmation.njk
+++ b/server/views/referrals/confirmation.njk
@@ -1,0 +1,31 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel(panelArgs) }}
+
+      <p class="govuk-body">We have sent you a confirmation email.</p>
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+
+      <p class="govuk-body">
+      {{ presenter.text.whatHappensNext }}
+      </p>
+
+      <p class="govuk-body">
+      {# TODO IC-885 feedback link #}
+      <a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -1,0 +1,30 @@
+import { Factory } from 'fishery'
+import { SentReferral } from '../../server/services/interventionsService'
+import serviceProviderFactory from './serviceProvider'
+import serviceCategoryFactory from './serviceCategory'
+
+export default Factory.define<SentReferral>(({ sequence }) => ({
+  id: sequence.toString(),
+  createdAt: new Date().toISOString(),
+  referenceNumber: sequence.toString().padStart(8, 'ABC'),
+  referral: {
+    completionDeadline: '2021-04-01',
+    serviceProviderId: serviceProviderFactory.build().id,
+    serviceCategoryId: serviceCategoryFactory.build().id,
+    complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+    furtherInformation: 'Some information about the service user',
+    desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+    additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
+    accessibilityNeeds: 'She uses a wheelchair',
+    needsInterpreter: true,
+    interpreterLanguage: 'Spanish',
+    hasAdditionalResponsibilities: true,
+    whenUnavailable: 'She works Mondays 9am - midday',
+    serviceUser: {
+      firstName: 'Alex',
+    },
+    additionalRiskInformation: 'A danger to the elderly',
+    usingRarDays: true,
+    maximumRarDays: 10,
+  },
+}))

--- a/testutils/factories/serviceProvider.ts
+++ b/testutils/factories/serviceProvider.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import { ServiceProvider } from '../../server/services/interventionsService'
+
+export default Factory.define<ServiceProvider>(({ sequence }) => ({
+  id: sequence.toString(),
+  name: 'Harmony Living',
+}))


### PR DESCRIPTION
## What does this pull request do?

This allows a probation practitioner to send a draft referral to the service provider. It contains:

- a placeholder "check your answers" screen with a submit button
- a confirmation page that displays the sent referral's reference number

## What is the intent behind these changes?

To allow a user to send a referral via the UI, building out our "walking skeleton".

## Screenshots

Check your answers:
![Screenshot_2021-01-13 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/104700698-75a67780-570c-11eb-9dd8-e8d2c0868ae4.png)

Confirmation page:
![Screenshot_2021-01-13 HMPPS Interventions - GOV UK(3)](https://user-images.githubusercontent.com/53756884/104450104-7ff33500-5597-11eb-8aeb-7f2b2d549f32.png)
