### PR TITLE
start the referral journey with a SU CRN

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ npm run start:dev
 
 Navigate to `http://localhost:3000` and login to the application using HMPPS Auth dev credentials e.g. `AUTH_ADM/password123456`
 
+### Running the app without the interventions service
+
+You may want to run the UI without the overhead of the whole
+interventions service and its database, e.g. using the Pact Mock
+Server or WireMock.
+
+```
+docker-compose -f docker-compose-ui.yml up
+npm run start:dev
+```
+
 ### Unit Test
 
 `npm run test`

--- a/docker-compose-ui.yml
+++ b/docker-compose-ui.yml
@@ -1,0 +1,58 @@
+version: '3.1'
+services:
+  redis:
+    image: 'bitnami/redis:6.0'
+    networks:
+      - hmpps
+    container_name: redis
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - '6379:6379'
+
+  hmpps-auth:
+    image: quay.io/hmpps/hmpps-auth:latest
+    networks:
+      - hmpps
+    container_name: hmpps-auth
+    ports:
+      - '8090:8090'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8090/auth/health']
+    environment:
+      - SERVER_PORT=8090
+      - SPRING_PROFILES_ACTIVE=dev
+      - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
+
+  community-api:
+    image: quay.io/hmpps/community-api:latest
+    networks:
+      - hmpps
+    container_name: community-api
+    ports:
+      - '8091:8080'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=dev
+
+  offender-assessments-api:
+    image: mojdigitalstudio/offender-assessments-api:latest
+    restart: always
+    networks:
+      - hmpps
+    container_name: offender-assessments-api
+    depends_on:
+      - hmpps-auth
+    ports:
+      - '8093:8080'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=dev
+      - OAUTH_ENDPOINT_URL=http://hmpps-auth:8090/auth
+
+networks:
+  hmpps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     depends_on:
       - hmpps-auth
     ports:
-      - '8092:8080'
+      - '8093:8080'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,5 +54,33 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - OAUTH_ENDPOINT_URL=http://hmpps-auth:8090/auth
 
+  interventions-service:
+    image: quay.io/hmpps/hmpps-interventions-service
+    restart: always
+    networks:
+      - hmpps
+    container_name: interventions-service
+    depends_on:
+      - postgres
+    ports:
+      - '8092:8080'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - POSTGRES_URI=postgres:5432
+
+  postgres:
+    image: postgres:10-alpine
+    container_name: postgres
+    networks:
+      - hmpps
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=password
+    volumes:
+      - ./testutils/docker/postgres:/docker-entrypoint-initdb.d:ro
+
 networks:
   hmpps:

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -2,6 +2,7 @@ import draftReferralFactory from '../../testutils/factories/draftReferral'
 import sentReferralFactory from '../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
 import serviceProviderFactory from '../../testutils/factories/serviceProvider'
+import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
 
 describe('Referral form', () => {
   beforeEach(() => {
@@ -12,6 +13,8 @@ describe('Referral form', () => {
 
   it('User starts a referral, fills in the form, and submits it', () => {
     cy.login()
+
+    const deliusServiceUser = deliusServiceUserFactory.build({ firstName: 'Geoffrey' })
 
     const serviceCategory = serviceCategoryFactory.build({
       name: 'accommodation',
@@ -49,6 +52,7 @@ describe('Referral form', () => {
 
     const sentReferral = sentReferralFactory.fromFields(draftReferral).build()
 
+    cy.stubGetServiceUserByCRN('X320741', deliusServiceUser)
     cy.stubCreateDraftReferral(draftReferral)
     cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
     cy.stubGetServiceProvider(serviceProvider.id, serviceProvider)
@@ -59,6 +63,8 @@ describe('Referral form', () => {
     cy.stubGetSentReferral(sentReferral.id, sentReferral)
 
     cy.visit('/referrals/start')
+
+    cy.contains('Service User CRN').type('X320741')
 
     cy.contains('Start now').click()
 

--- a/integration_tests/support/communityApiStubs.js
+++ b/integration_tests/support/communityApiStubs.js
@@ -1,0 +1,15 @@
+Cypress.Commands.add('stubGetServiceUserByCRN', (crn, responseJson) => {
+  cy.task('stubFor', {
+    request: {
+      method: 'GET',
+      urlPattern: `/community-api/secure/offenders/crn/${crn}`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      jsonBody: responseJson,
+    },
+  })
+})

--- a/integration_tests/support/index.js
+++ b/integration_tests/support/index.js
@@ -1,2 +1,3 @@
 import './commands'
 import './interventionsServiceStubs'
+import './communityApiStubs'

--- a/server/config.ts
+++ b/server/config.ts
@@ -60,7 +60,7 @@ export default {
       agent: new AgentConfig(),
     },
     offenderAssessmentsApi: {
-      url: get('OFFENDER_ASSESSMENTS_API_URL', 'http://localhost:8092', requiredInProduction),
+      url: get('OFFENDER_ASSESSMENTS_API_URL', 'http://localhost:8093', requiredInProduction),
       timeout: {
         response: Number(get('OFFENDER_ASSESSMENTS_API_RESPONSE', 10000)),
         deadline: Number(get('OFFENDER_ASSESSMENTS_API_DEADLINE', 10000)),

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -25,7 +25,8 @@ export default function routes(router: Router, services: Services): Router {
     services.communityApiService,
     services.offenderAssessmentsApiService
   )
-  const referralsController = new ReferralsController(services.interventionsService)
+
+  const referralsController = new ReferralsController(services.interventionsService, services.communityApiService)
 
   get('/', (req, res, next) => {
     res.render('pages/index')
@@ -35,7 +36,7 @@ export default function routes(router: Router, services: Services): Router {
   get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)
 
   get('/referrals/start', (req, res) => referralsController.startReferral(req, res))
-  post('/referrals', (req, res) => referralsController.createReferral(req, res))
+  post('/referrals/start', (req, res) => referralsController.createReferral(req, res))
   get('/referrals/:id/form', (req, res) => referralsController.viewReferralForm(req, res))
   get('/referrals/:id/complexity-level', (req, res) => referralsController.viewComplexityLevel(req, res))
   post('/referrals/:id/complexity-level', (req, res) => referralsController.updateComplexityLevel(req, res))

--- a/server/routes/referrals/draftReferralsListPresenter.ts
+++ b/server/routes/referrals/draftReferralsListPresenter.ts
@@ -1,7 +1,12 @@
 import { DraftReferral } from '../../services/interventionsService'
+import { FormValidationError } from '../../utils/formValidationError'
+import ReferralDataPresenterUtils from './referralDataPresenterUtils'
 
 export default class DraftReferralsListPresenter {
-  constructor(private readonly draftReferrals: DraftReferral[]) {}
+  constructor(
+    private readonly draftReferrals: DraftReferral[],
+    private readonly error: FormValidationError | null = null
+  ) {}
 
   get orderedReferrals(): DraftReferralSummaryPresenter[] {
     return this.draftReferrals
@@ -13,7 +18,10 @@ export default class DraftReferralsListPresenter {
       }))
   }
 
-  readonly emptyText = 'You do not have any draft referrals at this moment.'
+  readonly text = {
+    noDraftReferrals: 'You do not have any draft referrals at this moment.',
+    errorMessage: ReferralDataPresenterUtils.errorMessage(this.error, 'service-user-crn'),
+  }
 }
 
 interface DraftReferralSummaryPresenter {

--- a/server/routes/referrals/referralStartForm.test.ts
+++ b/server/routes/referrals/referralStartForm.test.ts
@@ -1,0 +1,92 @@
+import { Request } from 'express'
+import ReferralStartForm from './referralStartForm'
+
+describe(ReferralStartForm, () => {
+  describe('isValid', () => {
+    it('returns true when the service-user-crn property is present and not empty in the body', async () => {
+      const form = await ReferralStartForm.createForm({
+        body: {
+          'service-user-crn': 'X320741',
+        },
+      } as Request)
+
+      expect(form.isValid).toBe(true)
+    })
+
+    it('returns false when the service-user-crn property is absent in the body', async () => {
+      const form = await ReferralStartForm.createForm({
+        body: {},
+      } as Request)
+
+      expect(form.isValid).toBe(false)
+    })
+
+    it('returns false when the service-user-crn property is null in the body', async () => {
+      const form = await ReferralStartForm.createForm({
+        body: { 'service-user-crn': null },
+      } as Request)
+
+      expect(form.isValid).toBe(false)
+    })
+  })
+
+  describe('error', () => {
+    it('returns null when the service-user-crn property is present and not empty in the body', async () => {
+      const form = await ReferralStartForm.createForm({
+        body: {
+          'service-user-crn': 'X320741',
+        },
+      } as Request)
+
+      expect(form.error).toBeNull()
+    })
+
+    it('returns an error when the service-user-crn property is absent in the body', async () => {
+      const form = await ReferralStartForm.createForm({
+        body: {},
+      } as Request)
+
+      expect(form.error).toEqual({
+        errors: [
+          {
+            formFields: ['service-user-crn'],
+            errorSummaryLinkedField: 'service-user-crn',
+            message: 'A CRN is required',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when the service-user-crn property is blank in the body', async () => {
+      const form = await ReferralStartForm.createForm({
+        body: { 'service-user-crn': '' },
+      } as Request)
+
+      expect(form.error).toEqual({
+        errors: [
+          {
+            formFields: ['service-user-crn'],
+            errorSummaryLinkedField: 'service-user-crn',
+            message: 'A CRN is required',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when the service-user-crn property is null in the body', async () => {
+      const form = await ReferralStartForm.createForm({
+        body: { 'service-user-crn': null },
+      } as Request)
+
+      expect(form.error).toEqual({
+        errors: [
+          {
+            formFields: ['service-user-crn'],
+            errorSummaryLinkedField: 'service-user-crn',
+            message: 'A CRN is required',
+          },
+        ],
+      })
+    })
+  })
+})

--- a/server/routes/referrals/referralStartForm.ts
+++ b/server/routes/referrals/referralStartForm.ts
@@ -1,0 +1,35 @@
+import { Request } from 'express'
+import errorMessages from '../../utils/errorMessages'
+import { FormValidationError } from '../../utils/formValidationError'
+
+export default class ReferralStartForm {
+  private constructor(private readonly request: Request) {}
+
+  static async createForm(request: Request): Promise<ReferralStartForm> {
+    return new ReferralStartForm(request)
+  }
+
+  get isValid(): boolean {
+    return this.error === null
+  }
+
+  get error(): FormValidationError | null {
+    const crn = this.request.body['service-user-crn']
+
+    let error: FormValidationError | null = null
+
+    if (crn === null || crn === '' || crn === undefined) {
+      error = {
+        errors: [
+          {
+            formFields: ['service-user-crn'],
+            errorSummaryLinkedField: 'service-user-crn',
+            message: errorMessages.startReferral.crnEmpty,
+          },
+        ],
+      }
+    }
+
+    return error
+  }
+}

--- a/server/routes/referrals/referralStartPresenter.test.ts
+++ b/server/routes/referrals/referralStartPresenter.test.ts
@@ -1,7 +1,7 @@
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
-import DraftReferralsListPresenter from './draftReferralsListPresenter'
+import ReferralStartPresenter from './referralStartPresenter'
 
-describe('DraftReferralsListPresenter', () => {
+describe('ReferralStartPresenter', () => {
   describe('orderedReferrals', () => {
     it('returns an ordered list of draft referrals with formatted dates', () => {
       const referrals = [
@@ -10,7 +10,7 @@ describe('DraftReferralsListPresenter', () => {
         draftReferralFactory.createdAt(new Date('2021-01-01T12:00:00Z')).build(),
       ]
 
-      const presenter = new DraftReferralsListPresenter(referrals)
+      const presenter = new ReferralStartPresenter(referrals)
 
       // referrals are ordered oldest first
       expect(presenter.orderedReferrals).toEqual([

--- a/server/routes/referrals/referralStartPresenter.ts
+++ b/server/routes/referrals/referralStartPresenter.ts
@@ -2,7 +2,7 @@ import { DraftReferral } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import ReferralDataPresenterUtils from './referralDataPresenterUtils'
 
-export default class DraftReferralsListPresenter {
+export default class ReferralStartPresenter {
   constructor(
     private readonly draftReferrals: DraftReferral[],
     private readonly error: FormValidationError | null = null

--- a/server/routes/referrals/referralStartView.ts
+++ b/server/routes/referrals/referralStartView.ts
@@ -1,8 +1,8 @@
-import DraftReferralsListPresenter from './draftReferralsListPresenter'
+import ReferralStartPresenter from './referralStartPresenter'
 import viewUtils from '../../utils/viewUtils'
 
 export default class ReferralStartView {
-  constructor(private readonly presenter: DraftReferralsListPresenter) {}
+  constructor(private readonly presenter: ReferralStartPresenter) {}
 
   private get tableArgs(): Record<string, unknown> {
     return {

--- a/server/routes/referrals/referralStartView.ts
+++ b/server/routes/referrals/referralStartView.ts
@@ -1,4 +1,5 @@
 import DraftReferralsListPresenter from './draftReferralsListPresenter'
+import viewUtils from '../../utils/viewUtils'
 
 export default class ReferralStartView {
   constructor(private readonly presenter: DraftReferralsListPresenter) {}
@@ -13,12 +14,27 @@ export default class ReferralStartView {
     }
   }
 
+  private crnInputArgs(): Record<string, unknown> {
+    return {
+      id: 'service-user-crn',
+      name: 'service-user-crn',
+      label: {
+        text: 'Service User CRN',
+        classes: 'govuk-label--m',
+        isPageHeading: false,
+      },
+      autocomplete: 'off',
+      errorMessage: viewUtils.govukErrorMessage(this.presenter.text.errorMessage),
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/start',
       {
         presenter: this.presenter,
         tableArgs: this.tableArgs,
+        crnInputArgs: this.crnInputArgs(),
       },
     ]
   }

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -3,7 +3,7 @@ import InterventionsService from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import createFormValidationErrorOrRethrow from '../../utils/interventionsFormError'
 import ReferralFormPresenter from './referralFormPresenter'
-import DraftReferralsListPresenter from './draftReferralsListPresenter'
+import ReferralStartPresenter from './referralStartPresenter'
 import CompletionDeadlinePresenter from './completionDeadlinePresenter'
 import ReferralFormView from './referralFormView'
 import CompletionDeadlineView from './completionDeadlineView'
@@ -43,7 +43,7 @@ export default class ReferralsController {
   async startReferral(req: Request, res: Response): Promise<void> {
     const { token, userId } = res.locals.user
     const existingDraftReferrals = await this.interventionsService.getDraftReferralsForUser(token, userId)
-    const presenter = new DraftReferralsListPresenter(existingDraftReferrals)
+    const presenter = new ReferralStartPresenter(existingDraftReferrals)
     const view = new ReferralStartView(presenter)
 
     res.render(...view.renderArgs)
@@ -99,7 +99,7 @@ export default class ReferralsController {
     } else {
       const { token, userId } = res.locals.user
       const existingDraftReferrals = await this.interventionsService.getDraftReferralsForUser(token, userId)
-      const presenter = new DraftReferralsListPresenter(existingDraftReferrals, error)
+      const presenter = new ReferralStartPresenter(existingDraftReferrals, error)
       const view = new ReferralStartView(presenter)
 
       res.status(400)

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -29,9 +29,16 @@ import CheckAnswersView from './checkAnswersView'
 import CheckAnswersPresenter from './checkAnswersPresenter'
 import ConfirmationView from './confirmationView'
 import ConfirmationPresenter from './confirmationPresenter'
+import CommunityApiService from '../../services/communityApiService'
+import errorMessages from '../../utils/errorMessages'
+import logger from '../../../log'
+import ReferralStartForm from './referralStartForm'
 
 export default class ReferralsController {
-  constructor(private readonly interventionsService: InterventionsService) {}
+  constructor(
+    private readonly interventionsService: InterventionsService,
+    private readonly communityApiService: CommunityApiService
+  ) {}
 
   async startReferral(req: Request, res: Response): Promise<void> {
     const { token, userId } = res.locals.user
@@ -43,15 +50,61 @@ export default class ReferralsController {
   }
 
   async createReferral(req: Request, res: Response): Promise<void> {
-    const referral = await this.interventionsService.createDraftReferral(res.locals.user.token)
+    const form = await ReferralStartForm.createForm(req)
 
-    // fixme: this sets some static data for the new referral which will need to be
-    //  changed to allow these fields to be set properly
-    await this.interventionsService.patchDraftReferral(res.locals.user.token, referral.id, {
-      serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
-    })
+    let error: FormValidationError | null = null
 
-    res.redirect(303, `/referrals/${referral.id}/form`)
+    const crn = req.body['service-user-crn']
+
+    if (form.isValid) {
+      try {
+        await this.communityApiService.getServiceUserByCRN(crn)
+      } catch (e) {
+        if (e.status === 404) {
+          error = {
+            errors: [
+              {
+                formFields: ['service-user-crn'],
+                errorSummaryLinkedField: 'service-user-crn',
+                message: errorMessages.startReferral.crnNotFound,
+              },
+            ],
+          }
+        } else {
+          logger.error('crn lookup failed', e)
+          error = {
+            errors: [
+              {
+                formFields: ['service-user-crn'],
+                errorSummaryLinkedField: 'service-user-crn',
+                message: errorMessages.startReferral.unknownError,
+              },
+            ],
+          }
+        }
+      }
+    } else {
+      error = form.error
+    }
+
+    if (error === null) {
+      const referral = await this.interventionsService.createDraftReferral(res.locals.user.token, crn)
+      // fixme: this sets some static data for the new referral which will need to be
+      //  changed to allow these fields to be set properly
+      await this.interventionsService.patchDraftReferral(res.locals.user.token, referral.id, {
+        serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+      })
+
+      res.redirect(303, `/referrals/${referral.id}/form`)
+    } else {
+      const { token, userId } = res.locals.user
+      const existingDraftReferrals = await this.interventionsService.getDraftReferralsForUser(token, userId)
+      const presenter = new DraftReferralsListPresenter(existingDraftReferrals, error)
+      const view = new ReferralStartView(presenter)
+
+      res.status(400)
+      res.render(...view.renderArgs)
+    }
   }
 
   async viewReferralForm(req: Request, res: Response): Promise<void> {

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -13,6 +13,13 @@ export interface DeliusUser {
   roles: Array<DeliusRole>
 }
 
+export interface DeliusServiceUser {
+  offenderId: string
+  firstName: string
+  surname: string
+  dateOfBirth: string
+}
+
 interface DeliusRole {
   name: string
 }
@@ -29,5 +36,11 @@ export default class CommunityApiService {
 
     logger.info(`getting user details for username ${username}`)
     return (await this.restClient(token).get({ path: `/secure/users/${username}/details` })) as DeliusUser
+  }
+
+  async getServiceUserByCRN(crn: string): Promise<DeliusServiceUser> {
+    const token = await this.hmppsAuthClient.getApiClientToken()
+    logger.info(`getting details for offender with crn ${crn}`)
+    return (await this.restClient(token).get({ path: `/secure/offenders/crn/${crn}` })) as DeliusServiceUser
   }
 }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -180,12 +180,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           method: 'POST',
           path: '/draft-referral',
           headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          body: { serviceUserCrn: 'X862134' },
         },
         willRespondWith: {
           status: 201,
           body: Matchers.like({
             id: 'dfb64747-f658-40e0-a827-87b4b0bdcfed',
             createdAt: '2020-12-07T20:45:21.986389Z',
+            serviceUser: { crn: 'X862134' },
           }),
           headers: {
             'Content-Type': 'application/json',
@@ -196,8 +198,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.createDraftReferral(token)
+      const referral = await interventionsService.createDraftReferral(token, 'X862134')
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(referral.serviceUser.crn).toBe('X862134')
     })
   })
 
@@ -926,6 +929,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       hasAdditionalResponsibilities: true,
       whenUnavailable: 'She works Mondays 9am - midday',
       serviceUser: {
+        crn: 'X862134',
         firstName: 'Alex',
       },
       additionalRiskInformation: 'A danger to the elderly',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -909,9 +909,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
   const sentReferral: SentReferral = {
     id: '81d754aa-d868-4347-9c0f-50690773014e',
-    createdAt: '2021-01-11T10:32:12.382884Z',
+    sentAt: '2021-01-14T15:56:45.382884Z',
     referenceNumber: 'HDJ2123F',
     referral: {
+      createdAt: '2021-01-11T10:32:12.382884Z',
       completionDeadline: '2021-04-01',
       serviceProviderId: '674b47a0-39bf-4514-82ae-61885b9c0cb4',
       serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -13,6 +13,7 @@ export interface InterventionsServiceValidationError {
 type WithNullableValues<T> = { [K in keyof T]: T[K] | null }
 
 export interface ReferralFields {
+  createdAt: string
   completionDeadline: string
   serviceProviderId: string
   serviceCategoryId: string
@@ -38,7 +39,7 @@ export interface DraftReferral extends WithNullableValues<ReferralFields> {
 
 export interface SentReferral {
   id: string
-  createdAt: string
+  sentAt: string
   referenceNumber: string
   referral: ReferralFields
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -35,6 +35,7 @@ export interface ReferralFields {
 export interface DraftReferral extends WithNullableValues<ReferralFields> {
   id: string
   createdAt: string
+  serviceUser: ServiceUser
 }
 
 export interface SentReferral {
@@ -63,6 +64,7 @@ export interface DesiredOutcome {
 }
 
 export interface ServiceUser {
+  crn: string
   firstName: string | null
 }
 
@@ -108,13 +110,14 @@ export default class InterventionsService {
     }
   }
 
-  async createDraftReferral(token: string): Promise<DraftReferral> {
+  async createDraftReferral(token: string, crn: string): Promise<DraftReferral> {
     const restClient = this.createRestClient(token)
 
     try {
       return (await restClient.post({
         path: `/draft-referral`,
         headers: { Accept: 'application/json' },
+        data: { serviceUserCrn: crn },
       })) as DraftReferral
     } catch (e) {
       throw this.createServiceError(e)

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -3,6 +3,11 @@
 // informational — everything returned is a string, since they’re messages!
 
 export default {
+  startReferral: {
+    crnEmpty: 'A CRN is required',
+    crnNotFound: 'CRN not found in nDelius',
+    unknownError: 'Could not start referral due to service interruption; please try again later',
+  },
   completionDeadline: {
     dayEmpty: 'The date by which the service needs to be completed must include a day',
     monthEmpty: 'The date by which the service needs to be completed must include a month',

--- a/server/views/referrals/start.njk
+++ b/server/views/referrals/start.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% extends "../partials/layout.njk" %}
@@ -17,8 +18,10 @@
 
       <p class="govuk-body-m">You can make a new referral here:</p>
 
-      <form action="/referrals" method="POST">
+      <form action="/referrals/start" method="POST">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {{govukInput(crnInputArgs)}}
 
         <button role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           Start now

--- a/test.env
+++ b/test.env
@@ -2,4 +2,5 @@ PORT=3007
 HMPPS_AUTH_URL=http://localhost:9091/auth
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 INTERVENTIONS_SERVICE_URL=http://localhost:9091/interventions
+COMMUNITY_API_URL=http://localhost:9091/community-api
 NODE_ENV=test

--- a/testutils/docker/postgres/init-db.sql
+++ b/testutils/docker/postgres/init-db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE interventions;

--- a/testutils/factories/deliusServiceUser.ts
+++ b/testutils/factories/deliusServiceUser.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery'
+import { DeliusServiceUser } from '../../server/services/communityApiService'
+
+export default Factory.define<DeliusServiceUser>(({ sequence }) => ({
+  offenderId: String(sequence),
+  firstName: 'Alex',
+  surname: 'River',
+  dateOfBirth: '1982-10-24',
+}))

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -21,13 +21,14 @@ class DraftReferralFactory extends Factory<DraftReferral> {
   }
 
   serviceUserSelected() {
-    return this.params({ serviceUser: { firstName: 'Marsha' } })
+    return this.params({ serviceUser: { crn: 'X78910', firstName: 'Marsha' } })
   }
 }
 
 export default DraftReferralFactory.define(({ sequence }) => ({
   id: sequence.toString(),
   createdAt: new Date(Date.now()).toISOString(),
+  serviceUser: { crn: 'X123456', firstName: null },
   completionDeadline: null,
   serviceProviderId: null,
   serviceCategoryId: null,
@@ -40,7 +41,6 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   interpreterLanguage: null,
   hasAdditionalResponsibilities: null,
   whenUnavailable: null,
-  serviceUser: null,
   additionalRiskInformation: null,
   usingRarDays: null,
   maximumRarDays: null,

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -4,6 +4,7 @@ import serviceProviderFactory from './serviceProvider'
 import serviceCategoryFactory from './serviceCategory'
 
 const exampleReferralFields = {
+  createdAt: '2020-12-07T20:45:21.986389Z',
   completionDeadline: '2021-04-01',
   serviceProviderId: serviceProviderFactory.build().id,
   serviceCategoryId: serviceCategoryFactory.build().id,
@@ -38,7 +39,7 @@ class SentReferralFactory extends Factory<SentReferral> {
 
 export default SentReferralFactory.define(({ sequence }) => ({
   id: sequence.toString(),
-  createdAt: new Date().toISOString(),
+  sentAt: new Date().toISOString(),
   referenceNumber: sequence.toString().padStart(8, 'ABC'),
   referral: exampleReferralFields,
 }))

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -19,6 +19,7 @@ const exampleReferralFields = {
   whenUnavailable: 'She works Mondays 9am - midday',
   serviceUser: {
     firstName: 'Alex',
+    crn: 'X012345',
   },
   additionalRiskInformation: 'A danger to the elderly',
   usingRarDays: true,


### PR DESCRIPTION
## What does this pull request do?

Adds a simple text input to the start referral page to specificy SU CRN before referral creation.

This requires a running instance of the Interventions Service, which has been added to the project's `docker-compose` to make this easier.

This PR also adds a new UI docker compose file that allows us to run the project without the interventions service's overhead.

## What is the intent behind these changes?

this is a temporary change to allow specifying a SU for the referral until we build the discover part of the product
