### PR TITLE
Change code owners to interventions-ui team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/hmpps-interventions
+* @ministryofjustice/interventions-ui


### PR DESCRIPTION
## What does this pull request do?

Changes the code owners to the interventions-ui team, which only contains frontend developers.

## What is the intent behind these changes?

To stop backend-only developers from being bothered by automatic review requests for this repo.