### PR TITLE
Watch files when running test server

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "watch": "concurrently -k -p \"[{name}]\" -n \"Views,TypeScript,Node,Sass\" -c \"yellow.bold,cyan.bold,green.bold,blue.bold\" \"npm run watch:views\" \"npm run watch:ts\" \"npm run watch:node\" \"npm run watch:sass\"",
     "start": "node $NODE_OPTIONS dist/server.js | bunyan -o short",
     "start:dev": "npm run build && npm run watch",
-    "start:test": "export $(cat test.env) && npm run start",
+    "start:test": "export $(cat test.env) && npm run start:dev",
     "test": "jest --runInBand",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open",


### PR DESCRIPTION
## What does this pull request do?

Runs the test server using `npm run start:dev`, so that it restarts automatically when the code changes.

## What is the intent behind these changes?

It’s nice to not need to restart the server in order for changes to be picked up in Cypress tests.
