### PR TITLE
IC-946, IC-947: Redirect users to different start pages depending on whether they're a probation practitioner or a service provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ docker-compose up -d
 npm run start:dev
 ```
 
-Navigate to `http://localhost:3000` and login to the application using HMPPS Auth dev credentials e.g. `AUTH_ADM/password123456`
+Navigate to `http://localhost:3000` and log in:
+
+- To log in as a service provider user, use HMPPS Auth dev credentials e.g. `AUTH_ADM/password123456`
+- To log in as a probation practitioner user, use [Community API dev credentials](https://github.com/ministryofjustice/community-api/blob/main/src/main/resources/schema.ldif) e.g. `bernard.beaks/secret`.
 
 ### Running the app without the interventions service
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,10 @@ services:
       test: ['CMD', 'curl', '-f', 'http://localhost:8090/auth/health']
     environment:
       - SERVER_PORT=8090
-      - SPRING_PROFILES_ACTIVE=dev
+      - SPRING_PROFILES_ACTIVE=dev,delius
       - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
       - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
+      - DELIUS_ENDPOINT_URL=http://community-api:8080
 
   community-api:
     image: quay.io/hmpps/community-api:latest

--- a/integration_tests/integration/login.spec.js
+++ b/integration_tests/integration/login.spec.js
@@ -1,26 +1,57 @@
-const IndexPage = require('../pages/index')
 const AuthLoginPage = require('../pages/authLogin')
 
 context('Login', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubLogin')
-    cy.task('stubAuthUser')
   })
 
   it('Unauthenticated user directed to auth', () => {
     cy.visit('/')
     AuthLoginPage.verifyOnPage()
   })
-  it('User name visible in header', () => {
-    cy.login()
-    const landingPage = IndexPage.verifyOnPage()
-    landingPage.headerUserName().should('contain.text', 'J. Smith')
+
+  describe('after logging in as a probation practitioner', () => {
+    beforeEach(() => {
+      cy.task('stubProbationPractitionerToken')
+      cy.task('stubProbationPractitionerAuthUser')
+      cy.stubGetDraftReferralsForUser([])
+      cy.login()
+    })
+
+    it('the user is redirected to the referral start page', () => {
+      cy.location('pathname').should('equal', '/referrals/start')
+    })
+
+    it('the user name is visible in the header', () => {
+      cy.get('[data-qa=header-user-name]').should('contain.text', 'J. Smith')
+    })
+
+    it('the user can log out', () => {
+      cy.get('[data-qa=logout]').click()
+      AuthLoginPage.verifyOnPage()
+    })
   })
-  it('User can log out', () => {
-    cy.login()
-    const landingPage = IndexPage.verifyOnPage()
-    landingPage.logout().click()
-    AuthLoginPage.verifyOnPage()
+
+  describe('after logging in as a service provider', () => {
+    beforeEach(() => {
+      cy.task('stubServiceProviderToken')
+      cy.task('stubServiceProviderAuthUser')
+      cy.login()
+    })
+
+    it('the user is redirected to the receive dashboard', () => {
+      cy.visit('/')
+      cy.location('pathname').should('equal', '/receive/dashboard')
+    })
+
+    it('the user name is visible in the header', () => {
+      cy.get('[data-qa=header-user-name]').should('contain.text', 'J. Smith')
+    })
+
+    it('the user can log out', () => {
+      cy.get('[data-qa=logout]').click()
+      AuthLoginPage.verifyOnPage()
+    })
   })
 })

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -8,12 +8,11 @@ describe('Referral form', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubLogin')
-    cy.task('stubAuthUser')
+    cy.task('stubProbationPractitionerToken')
+    cy.task('stubProbationPractitionerAuthUser')
   })
 
   it('User starts a referral, fills in the form, and submits it', () => {
-    cy.login()
-
     const deliusServiceUser = deliusServiceUserFactory.build({ firstName: 'Geoffrey' })
 
     const serviceCategory = serviceCategoryFactory.build({
@@ -62,7 +61,7 @@ describe('Referral form', () => {
     cy.stubSendDraftReferral(draftReferral.id, sentReferral)
     cy.stubGetSentReferral(sentReferral.id, sentReferral)
 
-    cy.visit('/referrals/start')
+    cy.login()
 
     cy.contains('Service User CRN').type('X320741')
 

--- a/integration_tests/pages/index.js
+++ b/integration_tests/pages/index.js
@@ -1,8 +1,0 @@
-const page = require('./page')
-
-const indexPage = () =>
-  page('This site is under construction...', {
-    headerUserName: () => cy.get('[data-qa=header-user-name]'),
-  })
-
-module.exports = { verifyOnPage: indexPage }

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -9,8 +9,11 @@ module.exports = on => {
 
     getLoginUrl: auth.getLoginUrl,
     stubLogin: auth.stubLogin,
+    stubServiceProviderToken: auth.stubServiceProviderToken,
+    stubProbationPractitionerToken: auth.stubProbationPractitionerToken,
 
-    stubAuthUser: auth.stubUser,
+    stubServiceProviderAuthUser: auth.stubServiceProviderUser,
+    stubProbationPractitionerAuthUser: auth.stubProbationPractitionerUser,
     stubAuthPing: auth.stubPing,
 
     stubTokenVerificationPing: tokenVerification.stubPing,

--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -1,11 +1,11 @@
 import request from 'supertest'
 import { Express } from 'express'
-import appWithAllRoutes from './routes/testutils/appSetup'
+import appWithAllRoutes, { AppSetupUserType } from './routes/testutils/appSetup'
 
 let app: Express
 
 beforeEach(() => {
-  app = appWithAllRoutes({})
+  app = appWithAllRoutes({ userType: AppSetupUserType.probationPractitioner })
 })
 
 afterEach(() => {
@@ -25,7 +25,7 @@ describe('GET 404', () => {
   })
 
   it('should render content without stack in production mode', () => {
-    return request(appWithAllRoutes({ production: true }))
+    return request(appWithAllRoutes({ userType: AppSetupUserType.probationPractitioner, production: true }))
       .get('/unknown')
       .expect(404)
       .expect('Content-Type', /html/)

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -1,24 +1,22 @@
 import request from 'supertest'
-import { Express } from 'express'
-import appWithAllRoutes from './testutils/appSetup'
-
-let app: Express
-
-beforeEach(() => {
-  app = appWithAllRoutes({})
-})
+import appWithAllRoutes, { AppSetupUserType } from './testutils/appSetup'
 
 afterEach(() => {
   jest.resetAllMocks()
 })
 
 describe('GET /', () => {
-  it('should render index page', () => {
-    return request(app)
-      .get('/')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('This site is under construction...')
-      })
+  describe('when logged in as a probation practitioner', () => {
+    it('redirects to the referral start page', () => {
+      const app = appWithAllRoutes({ userType: AppSetupUserType.probationPractitioner })
+      return request(app).get('/').expect(302).expect('Location', '/referrals/start')
+    })
+  })
+
+  describe('when logged in as a service provider', () => {
+    it('redirects to the receive dashboard', () => {
+      const app = appWithAllRoutes({ userType: AppSetupUserType.serviceProvider })
+      return request(app).get('/').expect(302).expect('Location', '/receive/dashboard')
+    })
   })
 })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -29,8 +29,15 @@ export default function routes(router: Router, services: Services): Router {
   const referralsController = new ReferralsController(services.interventionsService, services.communityApiService)
 
   get('/', (req, res, next) => {
-    res.render('pages/index')
+    const { authSource } = res.locals.user
+    if (authSource === 'delius') {
+      res.redirect('/referrals/start')
+    } else {
+      res.redirect('/receive/dashboard')
+    }
   })
+
+  get('/receive/dashboard', (req, res) => res.render('receive/dashboard'))
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
   get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest'
 import { Express } from 'express'
 import InterventionsService from '../../services/interventionsService'
 import CommunityApiService from '../../services/communityApiService'
-import appWithAllRoutes from '../testutils/appSetup'
+import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
@@ -19,7 +19,10 @@ const communityApiService = new CommunityApiService(new MockedHmppsAuthClient())
 let app: Express
 
 beforeEach(() => {
-  app = appWithAllRoutes({ overrides: { interventionsService, communityApiService } })
+  app = appWithAllRoutes({
+    overrides: { interventionsService, communityApiService },
+    userType: AppSetupUserType.probationPractitioner,
+  })
 
   const referral = draftReferralFactory.justCreated().build({ id: '1' })
   interventionsService.createDraftReferral.mockResolvedValue(referral)

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -14,12 +14,19 @@ import MockCommunityApiService from './mocks/mockCommunityApiService'
 import InterventionsService from '../../services/interventionsService'
 import MockOffenderAssessmentsApiService from './mocks/mockOffenderAssessmentsApiService'
 
-function appSetup(route: Router, production: boolean): Express {
+export enum AppSetupUserType {
+  probationPractitioner = 'delius',
+  serviceProvider = 'auth',
+}
+
+function appSetup(route: Router, production: boolean, userType: AppSetupUserType): Express {
   const app = express()
 
   app.set('view engine', 'njk')
 
   nunjucksSetup(app, path)
+
+  user.authSource = userType
 
   app.use((req, res, next) => {
     req.user = user
@@ -41,9 +48,11 @@ function appSetup(route: Router, production: boolean): Express {
 export default function appWithAllRoutes({
   production = false,
   overrides = {},
+  userType,
 }: {
   production?: boolean
   overrides?: Partial<Services>
+  userType: AppSetupUserType
 }): Express {
   auth.default.authenticationMiddleware = () => (req, res, next) => next()
   return appSetup(
@@ -53,6 +62,7 @@ export default function appWithAllRoutes({
       interventionsService: {} as InterventionsService,
       ...overrides,
     }),
-    production
+    production,
+    userType
   )
 }

--- a/server/views/receive/dashboard.njk
+++ b/server/views/receive/dashboard.njk
@@ -1,0 +1,13 @@
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+
+  <main class="app-container">
+    <h1 class="govuk-heading-xl">Service provider - receive interventions</h1>
+    <p>This is a placeholder for the service provider dashboard page.</p>
+  </main>
+
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

- Adds a new placeholder "receive referrals dashboard" page for service providers
- Makes the `/` route redirect to either the referral start page or the receive dashboard depending on whether the logged-in user is a probation practitioner or a service provider

## What is the intent behind these changes?

To prove that we can distinguish between different types of user.
