### PR TITLE
IC-605: Re-enable container vulnerability scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,14 +97,14 @@ workflows:
                 - main
       - hmpps/build_docker:
           name: build_docker_publish
-          snyk-scan: false # fixme!
+          snyk-scan: true
           filters:
             branches:
               only:
                 - main
       - hmpps/build_docker:
           publish: false
-          snyk-scan: false # fixme!
+          snyk-scan: true
           filters:
             branches:
               ignore:


### PR DESCRIPTION
## What does this pull request do?

Re-enables container vulnerability scanning by

- switching to `node:14-alpine` base image
- and turning the settings back on again

It also reduced the image size:
```
$ docker images | grep 'ui-'
ui-after   latest               719d64e1cbf2   2 minutes ago    145MB
ui-before  latest               147851f179a4   11 minutes ago   239MB
```

<img width="1490" alt="Screenshot 2021-01-21 at 23 24 16" src="https://user-images.githubusercontent.com/1526295/105424725-cf90cb00-5c3f-11eb-888f-81dfa6f91430.png">

## What is the intent behind these changes?

Shift left security: get informed about vulnerable environments sooner  🎉 

Related to https://github.com/ministryofjustice/hmpps-interventions-service/pull/38