### PR TITLE
fix 'no draft referrals' text on start referrals page

### DIFF
--- a/server/views/referrals/start.njk
+++ b/server/views/referrals/start.njk
@@ -37,7 +37,7 @@
       {% if presenter.orderedReferrals | length %}
         {{ govukTable(tableArgs) }}
       {% else %}
-        <p class="govuk-body-m">{{ presenter.emptyText }}</p>
+        <p class="govuk-body-m">{{ presenter.text.noDraftReferrals }}</p>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## What does this pull request do?

updates the name of a presenter field in the start referral page which has been refactored

## What is the intent behind these changes?

show the message when there are no draft referrals to display
