### PR TITLE
IC-972 Add Service User Details Page

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -46,7 +46,18 @@ describe('Referral form', () => {
     const draftReferral = draftReferralFactory.build({
       serviceCategoryId: serviceCategory.id,
       serviceProviderId: serviceProvider.id,
-      serviceUser: { firstName: 'Geoffrey' },
+      serviceUser: {
+        crn: 'X320741',
+        title: 'Mr',
+        firstName: 'Geoffrey',
+        lastName: 'River',
+        dateOfBirth: '1980-01-01',
+        gender: 'Male',
+        preferredLanguage: 'English',
+        ethnicity: 'British',
+        religionOrBelief: 'Agnostic',
+        disabilities: ['Autism'],
+      },
     })
 
     const sentReferral = sentReferralFactory.fromFields(draftReferral).build()
@@ -68,6 +79,22 @@ describe('Referral form', () => {
     cy.contains('Start now').click()
 
     cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
+
+    cy.contains('Confirm service user details').click()
+
+    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/service-user-details`)
+    cy.get('h1').contains("Geoffrey's information")
+    cy.contains('X320741')
+    cy.contains('Mr')
+    cy.contains('River')
+    cy.contains('1980-01-01')
+    cy.contains('Male')
+    cy.contains('British')
+    cy.contains('English')
+    cy.contains('Agnostic')
+    cy.contains('Autism')
+
+    cy.contains('Save and continue').click()
 
     cy.contains('Service user’s needs and requirements').click()
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -45,6 +45,8 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/start', (req, res) => referralsController.startReferral(req, res))
   post('/referrals/start', (req, res) => referralsController.createReferral(req, res))
   get('/referrals/:id/form', (req, res) => referralsController.viewReferralForm(req, res))
+  get('/referrals/:id/service-user-details', (req, res) => referralsController.viewServiceUserDetails(req, res))
+  post('/referrals/:id/service-user-details', (req, res) => referralsController.confirmServiceUserDetails(req, res))
   get('/referrals/:id/complexity-level', (req, res) => referralsController.viewComplexityLevel(req, res))
   post('/referrals/:id/complexity-level', (req, res) => referralsController.updateComplexityLevel(req, res))
   get('/referrals/:id/completion-deadline', (req, res) => referralsController.viewCompletionDeadline(req, res))

--- a/server/routes/referrals/needsAndRequirementsPresenter.ts
+++ b/server/routes/referrals/needsAndRequirementsPresenter.ts
@@ -1,5 +1,6 @@
 import { DraftReferral } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
+import { SummaryListItem } from '../../utils/summaryList'
 import ReferralDataPresenterUtils from './referralDataPresenterUtils'
 
 export default class NeedsAndRequirementsPresenter {
@@ -9,7 +10,7 @@ export default class NeedsAndRequirementsPresenter {
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
-  readonly summary: { key: string; lines: string[]; isList: boolean }[] = [
+  readonly summary: SummaryListItem[] = [
     { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], isList: true },
     { key: 'Gender', lines: ['Male'], isList: false },
     // TODO IC-746 populate with service user data once we have it

--- a/server/routes/referrals/needsAndRequirementsView.ts
+++ b/server/routes/referrals/needsAndRequirementsView.ts
@@ -7,28 +7,7 @@ export default class NeedsAndRequirementsView {
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   private get summaryListArgs() {
-    return {
-      rows: this.presenter.summary.map(item => {
-        return {
-          key: {
-            text: item.key,
-          },
-          value: (() => {
-            if (item.isList) {
-              const html = `<ul class="govuk-list">${item.lines
-                .map(line => `<li>${ViewUtils.escape(line)}</li>`)
-                .join('\n')}</ul>`
-              return { html }
-            }
-            if (item.lines.length > 1) {
-              const html = item.lines.map(line => `<p class="govuk-body">${ViewUtils.escape(line)}</p>`).join('\n')
-              return { html }
-            }
-            return { text: item.lines[0] || '' }
-          })(),
-        }
-      }),
-    }
+    return ViewUtils.summaryListArgs(this.presenter.summary)
   }
 
   private get additionalNeedsInformationTextareaArgs() {

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -20,7 +20,7 @@ describe('ReferralFormPresenter', () => {
           status: ReferralFormStatus.Completed,
           tasks: [
             { title: 'Enter service user case identifier', url: null },
-            { title: 'Confirm service user details', url: null },
+            { title: 'Confirm service user details', url: 'service-user-details' },
           ],
         },
         {

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -22,7 +22,7 @@ export default class ReferralFormPresenter {
           },
           {
             title: 'Confirm service user details',
-            url: null,
+            url: 'service-user-details',
           },
         ],
       },

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -176,6 +176,43 @@ describe('GET /referrals/:id/form', () => {
   })
 })
 
+describe('GET /referrals/:id/service-user-details', () => {
+  beforeEach(() => {
+    const serviceCategory = serviceCategoryFactory.build()
+    const referral = draftReferralFactory.serviceUserSelected().build({ id: '1' })
+
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+  })
+
+  it('renders a service user details page', async () => {
+    await request(app)
+      .get('/referrals/1/service-user-details')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain(`Alex&#39;s information`)
+      })
+  })
+})
+
+describe('POST /referrals/:id/confirm-service-user-details', () => {
+  beforeEach(() => {
+    const serviceCategory = serviceCategoryFactory.build()
+    const referral = draftReferralFactory.serviceUserSelected().build({ id: '1' })
+
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+  })
+
+  it('redirects to the form page', async () => {
+    await request(app)
+      .post('/referrals/1/service-user-details')
+      .type('form')
+      .expect(303)
+      .expect('Location', '/referrals/1/form')
+  })
+})
+
 describe('GET /referrals/:id/completion-deadline', () => {
   beforeEach(() => {
     const serviceCategory = serviceCategoryFactory.build()

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -32,6 +32,8 @@ import ConfirmationPresenter from './confirmationPresenter'
 import CommunityApiService, { DeliusServiceUser } from '../../services/communityApiService'
 import errorMessages from '../../utils/errorMessages'
 import logger from '../../../log'
+import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
+import ServiceUserDetailsView from './serviceUserDetailsView'
 import ReferralStartForm from './referralStartForm'
 
 export default class ReferralsController {
@@ -108,6 +110,21 @@ export default class ReferralsController {
       res.status(400)
       res.render(...view.renderArgs)
     }
+  }
+
+  async viewServiceUserDetails(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+    const presenter = new ServiceUserDetailsPresenter(referral.serviceUser)
+    const view = new ServiceUserDetailsView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async confirmServiceUserDetails(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+    res.redirect(303, `/referrals/${referral.id}/form`)
   }
 
   async viewReferralForm(req: Request, res: Response): Promise<void> {

--- a/server/routes/referrals/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.test.ts
@@ -1,0 +1,79 @@
+import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
+
+describe(ServiceUserDetailsPresenter, () => {
+  const serviceUser = {
+    crn: 'X862134',
+    title: 'Mr',
+    firstName: 'Alex',
+    lastName: 'River',
+    dateOfBirth: '1980-01-01',
+    gender: 'Male',
+    ethnicity: 'British',
+    preferredLanguage: 'English',
+    religionOrBelief: 'Agnostic',
+    disabilities: ['Autism spectrum condition', 'sciatica'],
+  }
+
+  const nullFieldsServiceUser = {
+    crn: 'X862134',
+    title: null,
+    firstName: null,
+    lastName: null,
+    dateOfBirth: null,
+    gender: null,
+    ethnicity: null,
+    preferredLanguage: null,
+    religionOrBelief: null,
+    disabilities: null,
+  }
+
+  describe('title', () => {
+    it("returns a title for the page with the service user's name", () => {
+      const presenter = new ServiceUserDetailsPresenter(serviceUser)
+
+      expect(presenter.title).toEqual("Alex's information")
+    })
+
+    it("falls back to an empty string if the service user's name is null", () => {
+      const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser)
+
+      expect(presenter.title).toEqual("Service user's information")
+    })
+  })
+
+  describe('summary', () => {
+    it('returns an array of summary list items for each field on the Service User', () => {
+      const presenter = new ServiceUserDetailsPresenter(serviceUser)
+
+      expect(presenter.summary).toEqual([
+        { key: 'CRN', lines: [serviceUser.crn], isList: false },
+        { key: 'Title', lines: [serviceUser.title], isList: false },
+        { key: 'First name', lines: [serviceUser.firstName], isList: false },
+        { key: 'Last name', lines: [serviceUser.lastName], isList: false },
+        { key: 'Date of birth', lines: [serviceUser.dateOfBirth], isList: false },
+        { key: 'Gender', lines: [serviceUser.gender], isList: false },
+        { key: 'Ethnicity', lines: [serviceUser.ethnicity], isList: false },
+        { key: 'Preferred language', lines: [serviceUser.preferredLanguage], isList: false },
+        { key: 'Religion or belief', lines: [serviceUser.religionOrBelief], isList: false },
+        { key: 'Disabilities', lines: serviceUser.disabilities || [], isList: true },
+      ])
+    })
+
+    it('returns an empty values in lines for nullable fields on the Service User', () => {
+      const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser)
+
+      expect(presenter.summary).toEqual([
+        { key: 'CRN', lines: ['X862134'], isList: false },
+        { key: 'Title', lines: [''], isList: false },
+        { key: 'First name', lines: [''], isList: false },
+        { key: 'Last name', lines: [''], isList: false },
+        { key: 'Date of birth', lines: [''], isList: false },
+        { key: 'Gender', lines: [''], isList: false },
+        { key: 'Ethnicity', lines: [''], isList: false },
+        { key: 'Preferred language', lines: [''], isList: false },
+        { key: 'Religion or belief', lines: [''], isList: false },
+        { key: 'Disabilities', lines: [], isList: true },
+      ])
+    })
+  })
+})

--- a/server/routes/referrals/serviceUserDetailsPresenter.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.ts
@@ -1,0 +1,21 @@
+import { ServiceUser } from '../../services/interventionsService'
+import { SummaryListItem } from '../../utils/summaryList'
+
+export default class ServiceUserDetailsPresenter {
+  constructor(private readonly serviceUser: ServiceUser) {}
+
+  readonly title = `${this.serviceUser.firstName || 'Service user'}'s information`
+
+  readonly summary: SummaryListItem[] = [
+    { key: 'CRN', lines: [this.serviceUser.crn], isList: false },
+    { key: 'Title', lines: [this.serviceUser.title ?? ''], isList: false },
+    { key: 'First name', lines: [this.serviceUser.firstName ?? ''], isList: false },
+    { key: 'Last name', lines: [this.serviceUser.lastName ?? ''], isList: false },
+    { key: 'Date of birth', lines: [this.serviceUser.dateOfBirth ?? ''], isList: false },
+    { key: 'Gender', lines: [this.serviceUser.gender ?? ''], isList: false },
+    { key: 'Ethnicity', lines: [this.serviceUser.ethnicity ?? ''], isList: false },
+    { key: 'Preferred language', lines: [this.serviceUser.preferredLanguage ?? ''], isList: false },
+    { key: 'Religion or belief', lines: [this.serviceUser.religionOrBelief ?? ''], isList: false },
+    { key: 'Disabilities', lines: this.serviceUser.disabilities ?? [], isList: true },
+  ]
+}

--- a/server/routes/referrals/serviceUserDetailsView.ts
+++ b/server/routes/referrals/serviceUserDetailsView.ts
@@ -1,0 +1,20 @@
+import ViewUtils from '../../utils/viewUtils'
+import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
+
+export default class ServiceUserDetailsView {
+  constructor(private readonly presenter: ServiceUserDetailsPresenter) {}
+
+  private get summaryListArgs() {
+    return ViewUtils.summaryListArgs(this.presenter.summary)
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/serviceUserDetails',
+      {
+        presenter: this.presenter,
+        summaryListArgs: this.summaryListArgs,
+      },
+    ]
+  }
+}

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -154,7 +154,16 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             body: Matchers.like({
               id: '1219a064-709b-4b6c-a11e-10b8cb3966f6',
               serviceUser: {
+                crn: 'X862134',
+                title: 'Mr',
                 firstName: 'Alex',
+                lastName: 'River',
+                dateOfBirth: '1980-01-01',
+                gender: 'Male',
+                preferredLanguage: 'English',
+                ethnicity: 'British',
+                religionOrBelief: 'Agnostic',
+                disabilities: ['Autism spectrum condition'],
               },
             }),
             headers: { 'Content-Type': 'application/json' },
@@ -162,11 +171,20 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         })
       })
 
-      it('returns a referral for the given ID, with the service category id field populated', async () => {
+      it('returns a referral for the given ID, with the service user details', async () => {
         const referral = await interventionsService.getDraftReferral(token, '1219a064-709b-4b6c-a11e-10b8cb3966f6')
 
         expect(referral.id).toBe('1219a064-709b-4b6c-a11e-10b8cb3966f6')
-        expect(referral.serviceUser!.firstName).toEqual('Alex')
+        expect(referral.serviceUser.crn).toEqual('X862134')
+        expect(referral.serviceUser.title).toEqual('Mr')
+        expect(referral.serviceUser.firstName).toEqual('Alex')
+        expect(referral.serviceUser.lastName).toEqual('River')
+        expect(referral.serviceUser.dateOfBirth).toEqual('1980-01-01')
+        expect(referral.serviceUser.gender).toEqual('Male')
+        expect(referral.serviceUser.ethnicity).toEqual('British')
+        expect(referral.serviceUser.preferredLanguage).toEqual('English')
+        expect(referral.serviceUser.religionOrBelief).toEqual('Agnostic')
+        expect(referral.serviceUser.disabilities).toEqual(['Autism spectrum condition'])
       })
     })
   })

--- a/server/utils/summaryList.ts
+++ b/server/utils/summaryList.ts
@@ -1,0 +1,13 @@
+export interface SummaryListItem {
+  key: string
+  lines: string[]
+  isList: boolean
+}
+export interface SummaryListArgs {
+  rows: SummaryListRow[]
+}
+
+interface SummaryListRow {
+  key: { text: string }
+  value: { html?: string; text?: string }
+}

--- a/server/utils/viewUtils.test.ts
+++ b/server/utils/viewUtils.test.ts
@@ -61,4 +61,73 @@ describe('ViewUtils', () => {
       })
     })
   })
+
+  describe('summaryListArgs', () => {
+    it('returns a summary list args object for passing to the govukSummaryList macro', () => {
+      expect(
+        ViewUtils.summaryListArgs([
+          { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], isList: true },
+          { key: 'Gender', lines: ['Male'], isList: false },
+          { key: 'Address', lines: ['Flat 2', '27 Test Walk', 'SY16 1AQ'], isList: false },
+        ])
+      ).toEqual({
+        rows: [
+          {
+            key: {
+              text: 'Needs',
+            },
+            value: {
+              html: `<ul class="govuk-list"><li>Accommodation</li>\n<li>Social inclusion</li></ul>`,
+            },
+          },
+          {
+            key: {
+              text: 'Gender',
+            },
+            value: {
+              text: 'Male',
+            },
+          },
+          {
+            key: {
+              text: 'Address',
+            },
+            value: {
+              html:
+                '<p class="govuk-body">Flat 2</p>\n<p class="govuk-body">27 Test Walk</p>\n<p class="govuk-body">SY16 1AQ</p>',
+            },
+          },
+        ],
+      })
+    })
+  })
+
+  it('escapes special characters passed iin', () => {
+    expect(
+      ViewUtils.summaryListArgs([
+        { key: 'Needs', lines: ['Accommodation&', 'Social inclusion'], isList: true },
+        { key: 'Address', lines: ['Flat 2', "27 St James's Road", 'SY16 1AQ'], isList: false },
+      ])
+    ).toEqual({
+      rows: [
+        {
+          key: {
+            text: 'Needs',
+          },
+          value: {
+            html: `<ul class="govuk-list"><li>Accommodation&amp;</li>\n<li>Social inclusion</li></ul>`,
+          },
+        },
+        {
+          key: {
+            text: 'Address',
+          },
+          value: {
+            html:
+              '<p class="govuk-body">Flat 2</p>\n<p class="govuk-body">27 St James&#39;s Road</p>\n<p class="govuk-body">SY16 1AQ</p>',
+          },
+        },
+      ],
+    })
+  })
 })

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -1,4 +1,5 @@
 import * as nunjucks from 'nunjucks'
+import { SummaryListArgs, SummaryListItem } from './summaryList'
 
 export default class ViewUtils {
   static escape(val: string): string {
@@ -23,6 +24,31 @@ export default class ViewUtils {
         return {
           text: error.message,
           href: `#${error.field}`,
+        }
+      }),
+    }
+  }
+
+  static summaryListArgs(summaryListItems: SummaryListItem[]): SummaryListArgs {
+    return {
+      rows: summaryListItems.map(item => {
+        return {
+          key: {
+            text: item.key,
+          },
+          value: (() => {
+            if (item.isList) {
+              const html = `<ul class="govuk-list">${item.lines
+                .map(line => `<li>${ViewUtils.escape(line)}</li>`)
+                .join('\n')}</ul>`
+              return { html }
+            }
+            if (item.lines.length > 1) {
+              const html = item.lines.map(line => `<p class="govuk-body">${ViewUtils.escape(line)}</p>`).join('\n')
+              return { html }
+            }
+            return { text: item.lines[0] || '' }
+          })(),
         }
       }),
     }

--- a/server/views/referrals/serviceUserDetails.njk
+++ b/server/views/referrals/serviceUserDetails.njk
@@ -1,0 +1,24 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
+
+      {{ govukSummaryList(summaryListArgs) }}
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+        {{ govukButton({ text: "Save and continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds service user details page to the form. Clicking "save and continue" takes you back to the form. 

Local data is currently very limited, so I'd like to check it out on Dev too. It'd be good to add some data to the local community API image.

## What is the intent behind these changes?

To demonstrate that we can display user details in the referral form and integrate with the community API.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/105736066-4e318500-5f2c-11eb-9599-6b80579870b7.png)

