### PR TITLE
display SU name instead of referral ID in draft referrals list

### DIFF
--- a/server/routes/referrals/referralStartPresenter.test.ts
+++ b/server/routes/referrals/referralStartPresenter.test.ts
@@ -3,20 +3,35 @@ import ReferralStartPresenter from './referralStartPresenter'
 
 describe('ReferralStartPresenter', () => {
   describe('orderedReferrals', () => {
-    it('returns an ordered list of draft referrals with formatted dates', () => {
+    it('returns an ordered list of draft referrals with formatted dates and names', () => {
       const referrals = [
-        draftReferralFactory.createdAt(new Date('2021-01-02T12:00:00Z')).build(),
-        draftReferralFactory.createdAt(new Date('2021-01-03T12:00:00Z')).build(),
-        draftReferralFactory.createdAt(new Date('2021-01-01T12:00:00Z')).build(),
+        draftReferralFactory.createdAt(new Date('2021-01-02T12:00:00Z')).build({
+          serviceUser: {
+            firstName: 'rob',
+            lastName: 'shah-brookes',
+          },
+        }),
+        draftReferralFactory.createdAt(new Date('2021-01-03T12:00:00Z')).build({
+          serviceUser: {
+            firstName: 'HARDIP',
+            lastName: 'fraiser',
+          },
+        }),
+        draftReferralFactory.createdAt(new Date('2021-01-01T12:00:00Z')).build({
+          serviceUser: {
+            firstName: 'Jenny',
+            lastName: 'Catherine',
+          },
+        }),
       ]
 
       const presenter = new ReferralStartPresenter(referrals)
 
       // referrals are ordered oldest first
       expect(presenter.orderedReferrals).toEqual([
-        expect.objectContaining({ createdAt: '01/01/2021' }),
-        expect.objectContaining({ createdAt: '02/01/2021' }),
-        expect.objectContaining({ createdAt: '03/01/2021' }),
+        expect.objectContaining({ createdAt: '01/01/2021', serviceUserFullName: 'Jenny Catherine' }),
+        expect.objectContaining({ createdAt: '02/01/2021', serviceUserFullName: 'Rob Shah-Brookes' }),
+        expect.objectContaining({ createdAt: '03/01/2021', serviceUserFullName: 'Hardip Fraiser' }),
       ])
     })
   })

--- a/server/routes/referrals/referralStartPresenter.ts
+++ b/server/routes/referrals/referralStartPresenter.ts
@@ -1,6 +1,7 @@
 import { DraftReferral } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import ReferralDataPresenterUtils from './referralDataPresenterUtils'
+import convertToTitleCase from '../../utils/utils'
 
 export default class ReferralStartPresenter {
   constructor(
@@ -12,7 +13,7 @@ export default class ReferralStartPresenter {
     return this.draftReferrals
       .sort((a, b) => (new Date(a.createdAt) < new Date(b.createdAt) ? -1 : 1))
       .map(referral => ({
-        id: referral.id.slice(0, 8), // this is totally arbitrary, and probably meaningless to the user
+        serviceUserFullName: convertToTitleCase(`${referral.serviceUser.firstName} ${referral.serviceUser.lastName}`),
         createdAt: new Date(referral.createdAt).toLocaleDateString('en-GB'),
         url: `/referrals/${referral.id}/form`,
       }))
@@ -25,7 +26,7 @@ export default class ReferralStartPresenter {
 }
 
 interface DraftReferralSummaryPresenter {
-  id: string
+  serviceUserFullName: string
   createdAt: string
   url: string
 }

--- a/server/routes/referrals/referralStartView.ts
+++ b/server/routes/referrals/referralStartView.ts
@@ -7,9 +7,9 @@ export default class ReferralStartView {
   private get tableArgs(): Record<string, unknown> {
     return {
       firstCellIsHeader: true,
-      head: [{ text: 'ID' }, { text: 'Started on' }, { text: 'Link' }],
+      head: [{ text: 'Service User' }, { text: 'Started on' }],
       rows: this.presenter.orderedReferrals.map(referral => {
-        return [{ text: referral.id }, { text: referral.createdAt }, { html: `<a href="${referral.url}">Continue</a>` }]
+        return [{ html: `<a href="${referral.url}">${referral.serviceUserFullName}</a>` }, { text: referral.createdAt }]
       }),
     }
   }


### PR DESCRIPTION
## What does this pull request do?

display SU name instead of referral ID in draft referrals list. remove the 'link' column and just make the name clickable.

## What is the intent behind these changes?

make the start referral page more usable. 

![Screenshot 2021-01-26 at 10 33 13](https://user-images.githubusercontent.com/63233073/105834120-fc3b3e80-5fc1-11eb-890c-b2e3e4b12cd8.png)

