### PR TITLE
Use correct fields from Community API response

### DIFF
--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -22,9 +22,6 @@ export interface DeliusServiceUser {
   surname: string | null
   dateOfBirth: string | null
   gender: string | null
-  ethnicity: string | null
-  religionOrBelief: string | null
-  disabilities: Disability[] | null
 }
 
 interface DeliusRole {
@@ -45,6 +42,9 @@ interface OtherIds {
 
 interface OffenderProfile {
   offenderLanguages: OffenderLanguages
+  ethnicity: string
+  religion: string
+  disabilities: Disability[] | null
 }
 
 interface OffenderLanguages {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1064,43 +1064,43 @@ describe('serializeDeliusServiceUser', () => {
         crn: 'X123456',
       },
       offenderProfile: {
+        ethnicity: 'British',
+        religion: 'Agnostic',
         offenderLanguages: {
           primaryLanguage: 'English',
         },
+        disabilities: [
+          {
+            disabilityType: {
+              description: 'Autism',
+            },
+            endDate: '',
+            notes: 'Some notes',
+            startDate: '2019-01-22',
+          },
+          {
+            disabilityType: {
+              description: 'Sciatica',
+            },
+            endDate: currentDisabilityEndDate.toString(),
+            notes: 'Some notes',
+            startDate: '2020-01-01',
+          },
+          {
+            disabilityType: {
+              description: 'An old disability',
+            },
+            endDate: '2020-01-22',
+            notes: 'Some notes',
+            startDate: '2020-01-22',
+          },
+        ],
       },
       title: 'Mr',
       firstName: 'Alex',
       surname: 'River',
       dateOfBirth: '1980-01-01',
       gender: 'Male',
-      ethnicity: 'British',
-      religionOrBelief: 'Agnostic',
-      disabilities: [
-        {
-          disabilityType: {
-            description: 'Autism',
-          },
-          endDate: '',
-          notes: 'Some notes',
-          startDate: '2019-01-22',
-        },
-        {
-          disabilityType: {
-            description: 'Sciatica',
-          },
-          endDate: currentDisabilityEndDate.toString(),
-          notes: 'Some notes',
-          startDate: '2020-01-01',
-        },
-        {
-          disabilityType: {
-            description: 'An old disability',
-          },
-          endDate: '2020-01-22',
-          notes: 'Some notes',
-          startDate: '2020-01-22',
-        },
-      ],
     } as DeliusServiceUser
 
     const serviceUser = interventionsService.serializeDeliusServiceUser(deliusServiceUser)

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -110,8 +110,8 @@ export default class InterventionsService {
       return {} as ServiceUser
     }
 
-    const currentDisabilities = deliusServiceUser.disabilities
-      ? deliusServiceUser.disabilities
+    const currentDisabilities = deliusServiceUser.offenderProfile?.disabilities
+      ? deliusServiceUser.offenderProfile.disabilities
           .filter(disability => {
             const today = new Date().toString()
             return disability.endDate === '' || Date.parse(disability.endDate) >= Date.parse(today)
@@ -130,9 +130,9 @@ export default class InterventionsService {
       lastName: deliusServiceUser.surname || null,
       dateOfBirth: iso8601DateOfBirth || null,
       gender: deliusServiceUser.gender || null,
-      ethnicity: deliusServiceUser.ethnicity || null,
+      ethnicity: deliusServiceUser.offenderProfile?.ethnicity || null,
       preferredLanguage: deliusServiceUser.offenderProfile?.offenderLanguages?.primaryLanguage || null,
-      religionOrBelief: deliusServiceUser.religionOrBelief || null,
+      religionOrBelief: deliusServiceUser.offenderProfile?.religion || null,
       disabilities: currentDisabilities,
     }
   }

--- a/testutils/factories/deliusServiceUser.ts
+++ b/testutils/factories/deliusServiceUser.ts
@@ -6,6 +6,18 @@ export default Factory.define<DeliusServiceUser>(() => ({
     crn: 'X123456',
   },
   offenderProfile: {
+    ethnicity: 'British',
+    religion: 'Agnostic',
+    disabilities: [
+      {
+        disabilityType: {
+          description: 'Autism',
+        },
+        endDate: '',
+        notes: 'Some notes',
+        startDate: '2019-01-22',
+      },
+    ],
     offenderLanguages: {
       primaryLanguage: 'English',
     },
@@ -15,16 +27,4 @@ export default Factory.define<DeliusServiceUser>(() => ({
   surname: 'River',
   dateOfBirth: '1980-01-01',
   gender: 'Male',
-  ethnicity: 'British',
-  religionOrBelief: 'Agnostic',
-  disabilities: [
-    {
-      disabilityType: {
-        description: 'Autism',
-      },
-      endDate: '',
-      notes: 'Some notes',
-      startDate: '2019-01-22',
-    },
-  ],
 }))


### PR DESCRIPTION
## What does this pull request do?

Uses the correct fields from the Communtiy API response to populate the `serviceUser` object that we send to the Interventions Service, as it turns out ethnicity, religion and disabilities are stored on the `offenderProfile` sub-object, rather than on the main object itself.

## What is the intent behind these changes?

To display the correct fields on the service user details page.