### PR TITLE
IC-940: Add placeholder copy to check answers page

### DIFF
--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -870,13 +870,13 @@ describe('GET /referrals/:id/check-answers', () => {
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
-  it('displays a summary of the draft referral', async () => {
+  it('displays placeholder text in place of a summary of the referral', async () => {
     await request(app)
       .get('/referrals/1/check-answers')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Johnny')
-        expect(res.text).toContain('Information for the accommodation referral')
+        expect(res.text).toContain('Submit your referral')
+        expect(res.text).toContain('Make sure you have checked your answers before submitting your referral')
       })
   })
 

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -11,13 +11,9 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Check your answers</h1>
+      <h1 class="govuk-heading-xl">Submit your referral</h1>
 
-      <h2 class="govuk-heading-l">Service user’s information</h2>
-      
-      <p>{{ presenter.serviceUserName }}</p>
-
-      <h2 class="govuk-heading-l">{{ presenter.referralSectionHeading }}</h2>
+      <p class="govuk-body-m">Make sure you have checked your answers before submitting your referral.</p>
 
       <form method="post" action="send">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">


### PR DESCRIPTION
## What does this pull request do?

Adds placeholder check answers page allowing users to submit a referral.

## What is the intent behind these changes?

As part of the walking skeleton design, as we're keeping this to a bare minimum for now to focus on integrations etc.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/105860173-35d17100-5fe5-11eb-9ac6-d53b175c6c39.png)

