### PR TITLE
IC-909: Make intervention details section required before being able to view check answers page

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -60,7 +60,24 @@ describe('Referral form', () => {
       },
     })
 
-    const sentReferral = sentReferralFactory.fromFields(draftReferral).build()
+    const completedDraftReferral = {
+      ...draftReferral,
+      completionDeadline: '2021-04-01',
+      complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+      furtherInformation: 'Some information about the service user',
+      desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+      additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
+      accessibilityNeeds: 'She uses a wheelchair',
+      needsInterpreter: true,
+      interpreterLanguage: 'Spanish',
+      hasAdditionalResponsibilities: true,
+      whenUnavailable: 'She works Mondays 9am - midday',
+      additionalRiskInformation: 'A danger to the elderly',
+      usingRarDays: true,
+      maximumRarDays: 10,
+    }
+
+    const sentReferral = sentReferralFactory.fromFields(completedDraftReferral).build()
 
     cy.stubGetServiceUserByCRN('X320741', deliusServiceUser)
     cy.stubCreateDraftReferral(draftReferral)
@@ -155,6 +172,9 @@ describe('Referral form', () => {
     cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/further-information`)
     cy.get('h1').contains('Do you have further information for the accommodation service provider? (optional)')
     cy.get('textarea').type('Some information about Geoffrey')
+
+    // stub completed draft referral to mark section as completed
+    cy.stubGetDraftReferral(draftReferral.id, completedDraftReferral)
 
     cy.contains('Save and continue').click()
 

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -11,7 +11,7 @@ describe('ReferralFormPresenter', () => {
           .serviceCategorySelected(serviceCategory.id)
           .completionDeadlineSet()
           .build()
-        const presenter = new ReferralFormPresenter(referral)
+        const presenter = new ReferralFormPresenter(referral, 'social inclusion')
 
         const expected = [
           {
@@ -50,15 +50,15 @@ describe('ReferralFormPresenter', () => {
             number: '4',
             taskListSections: [
               {
-                title: 'Accommodation referral',
+                title: 'Social inclusion referral',
                 number: '4.1',
                 status: ReferralFormStatus.NotStarted,
                 tasks: [
-                  { title: 'Select the relevant sentence for the accommodation referral', url: null },
+                  { title: 'Select the relevant sentence for the social inclusion referral', url: null },
                   { title: 'Select desired outcomes', url: 'desired-outcomes' },
                   { title: 'Select required complexity level', url: 'complexity-level' },
                   {
-                    title: 'What date does the accommodation service need to be completed by?',
+                    title: 'What date does the social inclusion service need to be completed by?',
                     url: 'completion-deadline',
                   },
                   { title: 'Enter RAR days used', url: 'rar-days' },
@@ -108,7 +108,7 @@ describe('ReferralFormPresenter', () => {
           usingRarDays: false,
           maximumRarDays: null,
         })
-        const presenter = new ReferralFormPresenter(referral)
+        const presenter = new ReferralFormPresenter(referral, 'accommodation')
 
         const expected = [
           {

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -45,26 +45,20 @@ describe('ReferralFormPresenter', () => {
             ],
           },
           {
-            type: 'multi',
+            type: 'single',
             title: 'Add intervention referrals detail',
             number: '4',
-            taskListSections: [
+            status: ReferralFormStatus.NotStarted,
+            tasks: [
+              { title: 'Select the relevant sentence for the social inclusion referral', url: null },
+              { title: 'Select desired outcomes', url: 'desired-outcomes' },
+              { title: 'Select required complexity level', url: 'complexity-level' },
               {
-                title: 'Social inclusion referral',
-                number: '4.1',
-                status: ReferralFormStatus.NotStarted,
-                tasks: [
-                  { title: 'Select the relevant sentence for the social inclusion referral', url: null },
-                  { title: 'Select desired outcomes', url: 'desired-outcomes' },
-                  { title: 'Select required complexity level', url: 'complexity-level' },
-                  {
-                    title: 'What date does the social inclusion service need to be completed by?',
-                    url: 'completion-deadline',
-                  },
-                  { title: 'Enter RAR days used', url: 'rar-days' },
-                  { title: 'Further information for service provider', url: 'further-information' },
-                ],
+                title: 'What date does the social inclusion service need to be completed by?',
+                url: 'completion-deadline',
               },
+              { title: 'Enter RAR days used', url: 'rar-days' },
+              { title: 'Further information for service provider', url: 'further-information' },
             ],
           },
           {
@@ -142,26 +136,20 @@ describe('ReferralFormPresenter', () => {
             ],
           },
           {
-            type: 'multi',
+            type: 'single',
             title: 'Add intervention referrals detail',
             number: '4',
-            taskListSections: [
+            status: ReferralFormStatus.Completed,
+            tasks: [
+              { title: 'Select the relevant sentence for the accommodation referral', url: null },
+              { title: 'Select desired outcomes', url: 'desired-outcomes' },
+              { title: 'Select required complexity level', url: 'complexity-level' },
               {
-                title: 'Accommodation referral',
-                number: '4.1',
-                status: ReferralFormStatus.Completed,
-                tasks: [
-                  { title: 'Select the relevant sentence for the accommodation referral', url: null },
-                  { title: 'Select desired outcomes', url: 'desired-outcomes' },
-                  { title: 'Select required complexity level', url: 'complexity-level' },
-                  {
-                    title: 'What date does the accommodation service need to be completed by?',
-                    url: 'completion-deadline',
-                  },
-                  { title: 'Enter RAR days used', url: 'rar-days' },
-                  { title: 'Further information for service provider', url: 'further-information' },
-                ],
+                title: 'What date does the accommodation service need to be completed by?',
+                url: 'completion-deadline',
               },
+              { title: 'Enter RAR days used', url: 'rar-days' },
+              { title: 'Further information for service provider', url: 'further-information' },
             ],
           },
           {

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -46,7 +46,7 @@ describe('ReferralFormPresenter', () => {
           },
           {
             type: 'single',
-            title: 'Add intervention referrals detail',
+            title: `Add social inclusion referral details`,
             number: '4',
             status: ReferralFormStatus.NotStarted,
             tasks: [
@@ -137,7 +137,7 @@ describe('ReferralFormPresenter', () => {
           },
           {
             type: 'single',
-            title: 'Add intervention referrals detail',
+            title: 'Add accommodation referral details',
             number: '4',
             status: ReferralFormStatus.Completed,
             tasks: [

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -79,7 +79,7 @@ describe('ReferralFormPresenter', () => {
             title: 'Check your answers',
             number: '6',
             status: ReferralFormStatus.CannotStartYet,
-            tasks: [{ title: 'Check your answers', url: 'check-answers' }],
+            tasks: [{ title: 'Check your answers', url: null }],
           },
         ]
 
@@ -88,7 +88,7 @@ describe('ReferralFormPresenter', () => {
     })
 
     describe('when the intervention details section has all required fields filled in', () => {
-      it('returns an array of section presenters, with a "completed" label for the intervention details', () => {
+      it('returns an array of section presenters, with a "completed" label for the intervention details, and allows the user to submit the referral', () => {
         const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build({
           createdAt: '2021-01-11T10:32:12.382884Z',
@@ -175,7 +175,7 @@ describe('ReferralFormPresenter', () => {
             type: 'single',
             title: 'Check your answers',
             number: '6',
-            status: ReferralFormStatus.CannotStartYet,
+            status: ReferralFormStatus.NotStarted,
             tasks: [{ title: 'Check your answers', url: 'check-answers' }],
           },
         ]

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -4,85 +4,184 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 
 describe('ReferralFormPresenter', () => {
   describe('sections', () => {
-    // This is not a very exciting test at the moment but will become more useful
-    // as the task list starts to handle different referral states.
+    describe('when the intervention details section has not been completed', () => {
+      it('returns an array of section presenters, with a "not started" label for the intervention details', () => {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory
+          .serviceCategorySelected(serviceCategory.id)
+          .completionDeadlineSet()
+          .build()
+        const presenter = new ReferralFormPresenter(referral)
 
-    it('returns an array of section presenters', () => {
-      const serviceCategory = serviceCategoryFactory.build()
-      const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).completionDeadlineSet().build()
-      const presenter = new ReferralFormPresenter(referral)
+        const expected = [
+          {
+            type: 'single',
+            title: 'Retrieve service user record',
+            number: '1',
+            status: ReferralFormStatus.Completed,
+            tasks: [
+              { title: 'Enter service user case identifier', url: null },
+              { title: 'Confirm service user details', url: 'service-user-details' },
+            ],
+          },
+          {
+            type: 'single',
+            title: 'Find and select service user interventions',
+            number: '2',
+            status: ReferralFormStatus.Completed,
+            tasks: [
+              { title: 'Find and select service user interventions', url: null },
+              { title: 'Confirm interventions', url: null },
+            ],
+          },
+          {
+            type: 'single',
+            title: 'Review service user’s information',
+            number: '3',
+            status: ReferralFormStatus.Completed,
+            tasks: [
+              { title: 'Service user’s risk information', url: 'risk-information' },
+              { title: 'Service user’s needs and requirements', url: 'needs-and-requirements' },
+            ],
+          },
+          {
+            type: 'multi',
+            title: 'Add intervention referrals detail',
+            number: '4',
+            taskListSections: [
+              {
+                title: 'Accommodation referral',
+                number: '4.1',
+                status: ReferralFormStatus.NotStarted,
+                tasks: [
+                  { title: 'Select the relevant sentence for the accommodation referral', url: null },
+                  { title: 'Select desired outcomes', url: 'desired-outcomes' },
+                  { title: 'Select required complexity level', url: 'complexity-level' },
+                  {
+                    title: 'What date does the accommodation service need to be completed by?',
+                    url: 'completion-deadline',
+                  },
+                  { title: 'Enter RAR days used', url: 'rar-days' },
+                  { title: 'Further information for service provider', url: 'further-information' },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'single',
+            title: 'Review responsible officer’s information',
+            number: '5',
+            status: ReferralFormStatus.NotStarted,
+            tasks: [{ title: 'Responsible officer information', url: null }],
+          },
+          {
+            type: 'single',
+            title: 'Check your answers',
+            number: '6',
+            status: ReferralFormStatus.CannotStartYet,
+            tasks: [{ title: 'Check your answers', url: 'check-answers' }],
+          },
+        ]
 
-      const expected = [
-        {
-          type: 'single',
-          title: 'Retrieve service user record',
-          number: '1',
-          status: ReferralFormStatus.Completed,
-          tasks: [
-            { title: 'Enter service user case identifier', url: null },
-            { title: 'Confirm service user details', url: 'service-user-details' },
-          ],
-        },
-        {
-          type: 'single',
-          title: 'Find and select service user interventions',
-          number: '2',
-          status: ReferralFormStatus.Completed,
-          tasks: [
-            { title: 'Find and select service user interventions', url: null },
-            { title: 'Confirm interventions', url: null },
-          ],
-        },
-        {
-          type: 'single',
-          title: 'Review service user’s information',
-          number: '3',
-          status: ReferralFormStatus.Completed,
-          tasks: [
-            { title: 'Service user’s risk information', url: 'risk-information' },
-            { title: 'Service user’s needs and requirements', url: 'needs-and-requirements' },
-          ],
-        },
-        {
-          type: 'multi',
-          title: 'Add intervention referrals detail',
-          number: '4',
-          taskListSections: [
-            {
-              title: 'Accommodation referral',
-              number: '4.1',
-              status: ReferralFormStatus.InProgress,
-              tasks: [
-                { title: 'Select the relevant sentence for the accommodation referral', url: null },
-                { title: 'Select desired outcomes', url: 'desired-outcomes' },
-                { title: 'Select required complexity level', url: 'complexity-level' },
-                {
-                  title: 'What date does the accommodation service need to be completed by?',
-                  url: 'completion-deadline',
-                },
-                { title: 'Enter RAR days used', url: 'rar-days' },
-                { title: 'Further information for service provider', url: 'further-information' },
-              ],
-            },
-          ],
-        },
-        {
-          type: 'single',
-          title: 'Review responsible officer’s information',
-          number: '5',
-          status: ReferralFormStatus.NotStarted,
-          tasks: [{ title: 'Responsible officer information', url: null }],
-        },
-        {
-          type: 'single',
-          title: 'Check your answers',
-          number: '6',
-          status: ReferralFormStatus.CannotStartYet,
-          tasks: [{ title: 'Check your answers', url: 'check-answers' }],
-        },
-      ]
+        expect(presenter.sections).toEqual(expected)
+      })
+    })
 
-      expect(presenter.sections).toEqual(expected)
+    describe('when the intervention details section has all required fields filled in', () => {
+      it('returns an array of section presenters, with a "completed" label for the intervention details', () => {
+        const serviceCategory = serviceCategoryFactory.build()
+        const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build({
+          createdAt: '2021-01-11T10:32:12.382884Z',
+          completionDeadline: '2021-04-01',
+          serviceProviderId: '674b47a0-39bf-4514-82ae-61885b9c0cb4',
+          serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+          complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+          furtherInformation: 'Some information about the service user',
+          desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+          additionalNeedsInformation: null,
+          accessibilityNeeds: null,
+          needsInterpreter: null,
+          interpreterLanguage: null,
+          hasAdditionalResponsibilities: null,
+          whenUnavailable: null,
+          additionalRiskInformation: null,
+          usingRarDays: false,
+          maximumRarDays: null,
+        })
+        const presenter = new ReferralFormPresenter(referral)
+
+        const expected = [
+          {
+            type: 'single',
+            title: 'Retrieve service user record',
+            number: '1',
+            status: ReferralFormStatus.Completed,
+            tasks: [
+              { title: 'Enter service user case identifier', url: null },
+              { title: 'Confirm service user details', url: 'service-user-details' },
+            ],
+          },
+          {
+            type: 'single',
+            title: 'Find and select service user interventions',
+            number: '2',
+            status: ReferralFormStatus.Completed,
+            tasks: [
+              { title: 'Find and select service user interventions', url: null },
+              { title: 'Confirm interventions', url: null },
+            ],
+          },
+          {
+            type: 'single',
+            title: 'Review service user’s information',
+            number: '3',
+            status: ReferralFormStatus.Completed,
+            tasks: [
+              { title: 'Service user’s risk information', url: 'risk-information' },
+              { title: 'Service user’s needs and requirements', url: 'needs-and-requirements' },
+            ],
+          },
+          {
+            type: 'multi',
+            title: 'Add intervention referrals detail',
+            number: '4',
+            taskListSections: [
+              {
+                title: 'Accommodation referral',
+                number: '4.1',
+                status: ReferralFormStatus.Completed,
+                tasks: [
+                  { title: 'Select the relevant sentence for the accommodation referral', url: null },
+                  { title: 'Select desired outcomes', url: 'desired-outcomes' },
+                  { title: 'Select required complexity level', url: 'complexity-level' },
+                  {
+                    title: 'What date does the accommodation service need to be completed by?',
+                    url: 'completion-deadline',
+                  },
+                  { title: 'Enter RAR days used', url: 'rar-days' },
+                  { title: 'Further information for service provider', url: 'further-information' },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'single',
+            title: 'Review responsible officer’s information',
+            number: '5',
+            status: ReferralFormStatus.NotStarted,
+            tasks: [{ title: 'Responsible officer information', url: null }],
+          },
+          {
+            type: 'single',
+            title: 'Check your answers',
+            number: '6',
+            status: ReferralFormStatus.CannotStartYet,
+            tasks: [{ title: 'Check your answers', url: 'check-answers' }],
+          },
+        ]
+
+        expect(presenter.sections).toEqual(expected)
+      })
     })
   })
 })

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -112,11 +112,11 @@ export default class ReferralFormPresenter {
         type: 'single',
         title: 'Check your answers',
         number: '6',
-        status: ReferralFormStatus.CannotStartYet,
+        status: this.canSubmitReferral ? ReferralFormStatus.NotStarted : ReferralFormStatus.CannotStartYet,
         tasks: [
           {
             title: 'Check your answers',
-            url: 'check-answers',
+            url: this.canSubmitReferral ? 'check-answers' : null,
           },
         ],
       },
@@ -132,6 +132,10 @@ export default class ReferralFormPresenter {
     ].every(field => field !== null)
 
     return hasCompletedSection ? ReferralFormStatus.Completed : ReferralFormStatus.NotStarted
+  }
+
+  private get canSubmitReferral(): boolean {
+    return this.determineInterventionDetailsSectionStatus() === ReferralFormStatus.Completed
   }
 }
 

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -1,7 +1,8 @@
 import { DraftReferral } from '../../services/interventionsService'
+import utils from '../../utils/utils'
 
 export default class ReferralFormPresenter {
-  constructor(private readonly referral: DraftReferral) {}
+  constructor(private readonly referral: DraftReferral, private readonly serviceCategoryName: string) {}
 
   // This is just temporary, will remove it once we get rid of the referral ID output in the template
   get referralID(): string {
@@ -64,12 +65,12 @@ export default class ReferralFormPresenter {
         number: '4',
         taskListSections: [
           {
-            title: 'Accommodation referral',
+            title: `${utils.convertToProperCase(this.serviceCategoryName)} referral`,
             number: '4.1',
             status: this.determineInterventionDetailsSectionStatus(),
             tasks: [
               {
-                title: 'Select the relevant sentence for the accommodation referral',
+                title: `Select the relevant sentence for the ${this.serviceCategoryName} referral`,
                 url: null,
               },
               {
@@ -81,7 +82,7 @@ export default class ReferralFormPresenter {
                 url: 'complexity-level',
               },
               {
-                title: 'What date does the accommodation service need to be completed by?',
+                title: `What date does the ${this.serviceCategoryName} service need to be completed by?`,
                 url: 'completion-deadline',
               },
               {

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -66,7 +66,7 @@ export default class ReferralFormPresenter {
           {
             title: 'Accommodation referral',
             number: '4.1',
-            status: ReferralFormStatus.InProgress,
+            status: this.determineInterventionDetailsSectionStatus(),
             tasks: [
               {
                 title: 'Select the relevant sentence for the accommodation referral',
@@ -121,6 +121,17 @@ export default class ReferralFormPresenter {
         ],
       },
     ]
+  }
+
+  private determineInterventionDetailsSectionStatus(): ReferralFormStatus {
+    const hasCompletedSection = [
+      this.referral.desiredOutcomesIds,
+      this.referral.complexityLevelId,
+      this.referral.completionDeadline,
+      this.referral.usingRarDays,
+    ].every(field => field !== null)
+
+    return hasCompletedSection ? ReferralFormStatus.Completed : ReferralFormStatus.NotStarted
   }
 }
 

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -60,40 +60,34 @@ export default class ReferralFormPresenter {
         ],
       },
       {
-        type: 'multi',
+        type: 'single',
         title: 'Add intervention referrals detail',
         number: '4',
-        taskListSections: [
+        status: this.determineInterventionDetailsSectionStatus(),
+        tasks: [
           {
-            title: `${utils.convertToProperCase(this.serviceCategoryName)} referral`,
-            number: '4.1',
-            status: this.determineInterventionDetailsSectionStatus(),
-            tasks: [
-              {
-                title: `Select the relevant sentence for the ${this.serviceCategoryName} referral`,
-                url: null,
-              },
-              {
-                title: 'Select desired outcomes',
-                url: 'desired-outcomes',
-              },
-              {
-                title: 'Select required complexity level',
-                url: 'complexity-level',
-              },
-              {
-                title: `What date does the ${this.serviceCategoryName} service need to be completed by?`,
-                url: 'completion-deadline',
-              },
-              {
-                title: 'Enter RAR days used',
-                url: 'rar-days',
-              },
-              {
-                title: 'Further information for service provider',
-                url: 'further-information',
-              },
-            ],
+            title: `Select the relevant sentence for the ${this.serviceCategoryName} referral`,
+            url: null,
+          },
+          {
+            title: 'Select desired outcomes',
+            url: 'desired-outcomes',
+          },
+          {
+            title: 'Select required complexity level',
+            url: 'complexity-level',
+          },
+          {
+            title: `What date does the ${this.serviceCategoryName} service need to be completed by?`,
+            url: 'completion-deadline',
+          },
+          {
+            title: 'Enter RAR days used',
+            url: 'rar-days',
+          },
+          {
+            title: 'Further information for service provider',
+            url: 'further-information',
           },
         ],
       },

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -1,5 +1,4 @@
 import { DraftReferral } from '../../services/interventionsService'
-import utils from '../../utils/utils'
 
 export default class ReferralFormPresenter {
   constructor(private readonly referral: DraftReferral, private readonly serviceCategoryName: string) {}
@@ -61,7 +60,7 @@ export default class ReferralFormPresenter {
       },
       {
         type: 'single',
-        title: 'Add intervention referrals detail',
+        title: `Add ${this.serviceCategoryName} referral details`,
         number: '4',
         status: this.determineInterventionDetailsSectionStatus(),
         tasks: [

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -147,8 +147,11 @@ describe('POST /referrals/start', () => {
 
 describe('GET /referrals/:id/form', () => {
   beforeEach(() => {
-    const referral = draftReferralFactory.justCreated().build({ id: '1' })
+    const serviceCategory = serviceCategoryFactory.build()
+    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build({ id: '1' })
+
     interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
   })
 
   it('fetches the referral from the interventions service and renders a page with information about the referral', async () => {
@@ -173,6 +176,22 @@ describe('GET /referrals/:id/form', () => {
         .expect(500)
         .expect(res => {
           expect(res.text).toContain('Failed to get intervention')
+        })
+    })
+  })
+
+  describe('if a service category has not been selected', () => {
+    beforeEach(() => {
+      const referral = draftReferralFactory.build({ id: '1' })
+      interventionsService.getDraftReferral.mockResolvedValue(referral)
+    })
+
+    it('displays an error page', async () => {
+      await request(app)
+        .get('/referrals/1/form')
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain('No service category selected')
         })
     })
   })

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -130,7 +130,16 @@ export default class ReferralsController {
   async viewReferralForm(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
 
-    const presenter = new ReferralFormPresenter(referral)
+    if (referral.serviceCategoryId === null) {
+      throw new Error('No service category selected')
+    }
+
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      res.locals.user.token,
+      referral.serviceCategoryId
+    )
+
+    const presenter = new ReferralFormPresenter(referral, serviceCategory.name)
     const view = new ReferralFormView(presenter)
 
     res.render(...view.renderArgs)

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1,5 +1,6 @@
 import { pactWith } from 'jest-pact'
 import { Matchers } from '@pact-foundation/pact'
+import { term } from '@pact-foundation/pact/dsl/matchers'
 
 import InterventionsService, { SentReferral, ServiceUser } from './interventionsService'
 import config from '../config'
@@ -856,7 +857,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           status: 200,
           body: Matchers.like({
             id: '428ee70f-3001-4399-95a6-ad25eaaede16',
-            name: 'accommodation',
+            name: term({
+              generate: 'accommodation',
+              matcher: '[^A-Z]',
+            }),
             complexityLevels,
             desiredOutcomes,
           }),


### PR DESCRIPTION
## What does this pull request do?

- Requires PP to fill in the minimum intervention details before being able to submit their referral to a service provider.
- Displays "Not started" or "Completed" badge by these sections, removing "in progress" for now.
- Removes 'multi' form section for referrals, as we're only showing one, so we don't need a sub-heading for each referral type selected.

## What is the intent behind these changes?

To ensure we have the minimum intervention details before submitting a referral to the back-end, so a user doesn't submit their referral too early in the process and get stuck with an unfriendly error message.

## Screenshots

### Before completing intervention details section

![image](https://user-images.githubusercontent.com/19826940/106027128-7fdc5480-60c2-11eb-9102-4be963b04b6f.png)

### Intervention details section completed

![image](https://user-images.githubusercontent.com/19826940/106027017-63401c80-60c2-11eb-9338-b7827dc84b0f.png)


