### PR TITLE
IC-1012: Link intervention to draftReferral when creating

### DIFF
--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -67,19 +67,26 @@ describe('GET /referrals/start', () => {
 })
 
 describe('POST /referrals/start', () => {
-  describe('when searching for a CRN found in Delius', () => {
+  describe('when searching for a CRN found in Delius and an intervention has been selected', () => {
     beforeEach(() => {
       communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser.build())
     })
 
     it('creates a referral on the interventions service and redirects to the referral form', async () => {
+      const currentlyHardcodedInterventionId = '98a42c61-c30f-4beb-8062-04033c376e2d'
+      const serviceUserCRN = 'X123456'
+
       await request(app)
         .post('/referrals/start')
-        .send({ 'service-user-crn': 'X123456' })
+        .send({ 'service-user-crn': serviceUserCRN })
         .expect(303)
         .expect('Location', '/referrals/1/form')
 
-      expect(interventionsService.createDraftReferral).toHaveBeenCalledTimes(1)
+      expect(interventionsService.createDraftReferral).toHaveBeenCalledWith(
+        'token',
+        serviceUserCRN,
+        currentlyHardcodedInterventionId
+      )
     })
 
     it('updates the newly-created referral on the interventions service with the found service user', async () => {

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -59,6 +59,7 @@ export default class ReferralsController {
     let serviceUser: DeliusServiceUser | null = null
 
     const crn = req.body['service-user-crn']
+    const hardcodedInterventionId = '98a42c61-c30f-4beb-8062-04033c376e2d'
 
     if (form.isValid) {
       try {
@@ -92,7 +93,11 @@ export default class ReferralsController {
     }
 
     if (error === null) {
-      const referral = await this.interventionsService.createDraftReferral(res.locals.user.token, crn)
+      const referral = await this.interventionsService.createDraftReferral(
+        res.locals.user.token,
+        crn,
+        hardcodedInterventionId
+      )
       // fixme: this sets some static data for the new referral which will need to be
       //  changed to allow these fields to be set properly
       await this.interventionsService.patchDraftReferral(res.locals.user.token, referral.id, {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -191,22 +191,27 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
   describe('createDraftReferral', () => {
     it('returns a newly created draft referral', async () => {
+      const interventionId = '98a42c61-c30f-4beb-8062-04033c376e2d'
+      const serviceUserCrn = 'X862134'
+
       await provider.addInteraction({
-        // We're not sure what is an appropriate state here
-        state: 'a draft referral can be created',
+        state: 'an intervention has been selected and a draft referral can be created',
         uponReceiving: 'a POST request to create a draft referral',
         withRequest: {
           method: 'POST',
           path: '/draft-referral',
           headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
-          body: { serviceUserCrn: 'X862134' },
+          body: {
+            serviceUserCrn,
+            interventionId,
+          },
         },
         willRespondWith: {
           status: 201,
           body: Matchers.like({
             id: 'dfb64747-f658-40e0-a827-87b4b0bdcfed',
             createdAt: '2020-12-07T20:45:21.986389Z',
-            serviceUser: { crn: 'X862134' },
+            serviceUser: { crn: serviceUserCrn },
           }),
           headers: {
             'Content-Type': 'application/json',
@@ -217,9 +222,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.createDraftReferral(token, 'X862134')
+      const referral = await interventionsService.createDraftReferral(token, serviceUserCrn, interventionId)
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
-      expect(referral.serviceUser.crn).toBe('X862134')
+      expect(referral.serviceUser.crn).toBe(serviceUserCrn)
     })
   })
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -152,14 +152,14 @@ export default class InterventionsService {
     }
   }
 
-  async createDraftReferral(token: string, crn: string): Promise<DraftReferral> {
+  async createDraftReferral(token: string, crn: string, interventionId: string): Promise<DraftReferral> {
     const restClient = this.createRestClient(token)
 
     try {
       return (await restClient.post({
         path: `/draft-referral`,
         headers: { Accept: 'application/json' },
-        data: { serviceUserCrn: crn },
+        data: { serviceUserCrn: crn, interventionId },
       })) as DraftReferral
     } catch (e) {
       throw this.createServiceError(e)


### PR DESCRIPTION
## What does this pull request do?

Links an intervention to a draft referral on creation.

The `interventionId` will be hardcoded until we start work on the 'Find' journey, which
will pass the selected `interventionId` to the `#createDraftReferral`
method.

At the moment, we don't actually need to update the response, as the
'Refer' journey doesn't need anything from the intervention. We're
currently getting all the information we need from the service category.

## What is the intent behind these changes?

This will allow us to store things like a `location` or its ID on the
intervention when we need to display it in future.
