### PR TITLE
IC-1036 Move service provider to top level field on referral

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -1,7 +1,6 @@
 import draftReferralFactory from '../../testutils/factories/draftReferral'
 import sentReferralFactory from '../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
-import serviceProviderFactory from '../../testutils/factories/serviceProvider'
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
 
 describe('Referral form', () => {
@@ -41,11 +40,11 @@ describe('Referral form', () => {
       ],
     })
 
-    const serviceProvider = serviceProviderFactory.build({ name: 'Harmony Living' })
-
     const draftReferral = draftReferralFactory.build({
       serviceCategoryId: serviceCategory.id,
-      serviceProviderId: serviceProvider.id,
+      serviceProvider: {
+        name: 'Harmony Living',
+      },
       serviceUser: {
         crn: 'X320741',
         title: 'Mr',
@@ -82,7 +81,6 @@ describe('Referral form', () => {
     cy.stubGetServiceUserByCRN('X320741', deliusServiceUser)
     cy.stubCreateDraftReferral(draftReferral)
     cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
-    cy.stubGetServiceProvider(serviceProvider.id, serviceProvider)
     cy.stubGetDraftReferralsForUser([])
     cy.stubGetDraftReferral(draftReferral.id, draftReferral)
     cy.stubPatchDraftReferral(draftReferral.id, draftReferral)

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -51,10 +51,6 @@ module.exports = on => {
       return interventionsService.stubGetDraftReferralsForUser(arg.responseJson)
     },
 
-    stubGetServiceProvider: arg => {
-      return interventionsService.stubGetServiceProvider(arg.id, arg.responseJson)
-    },
-
     stubSendDraftReferral: arg => {
       return interventionsService.stubSendDraftReferral(arg.id, arg.responseJson)
     },

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -18,10 +18,6 @@ Cypress.Commands.add('stubGetDraftReferralsForUser', responseJson => {
   cy.task('stubGetDraftReferralsForUser', { responseJson })
 })
 
-Cypress.Commands.add('stubGetServiceProvider', (id, responseJson) => {
-  cy.task('stubGetServiceProvider', { id, responseJson })
-})
-
 Cypress.Commands.add('stubSendDraftReferral', (id, responseJson) => {
   cy.task('stubSendDraftReferral', { id, responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -84,22 +84,6 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubGetServiceProvider = async (id: string, responseJson: unknown): Promise<unknown> => {
-    return this.wiremock.stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: `${this.mockPrefix}/service-provider/${id}`,
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        jsonBody: responseJson,
-      },
-    })
-  }
-
   stubSendDraftReferral = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/routes/referrals/confirmationPresenter.test.ts
+++ b/server/routes/referrals/confirmationPresenter.test.ts
@@ -1,13 +1,11 @@
 import ConfirmationPresenter from './confirmationPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
-import serviceProviderFactory from '../../../testutils/factories/serviceProvider'
 
 describe(ConfirmationPresenter, () => {
   describe('text', () => {
     it('returns text to be displayed', () => {
       const referral = sentReferralFactory.build()
-      const serviceProvider = serviceProviderFactory.build({ name: 'Harmony Living' })
-      const presenter = new ConfirmationPresenter(referral, serviceProvider)
+      const presenter = new ConfirmationPresenter(referral)
 
       expect(presenter.text).toEqual({
         title: `We’ve sent your referral to Harmony Living`,

--- a/server/routes/referrals/confirmationPresenter.ts
+++ b/server/routes/referrals/confirmationPresenter.ts
@@ -1,12 +1,12 @@
-import { SentReferral, ServiceProvider } from '../../services/interventionsService'
+import { SentReferral } from '../../services/interventionsService'
 
 export default class ConfirmationPresenter {
-  constructor(private readonly referral: SentReferral, private readonly serviceProvider: ServiceProvider) {}
+  constructor(private readonly referral: SentReferral) {}
 
   readonly text = {
-    title: `We’ve sent your referral to ${this.serviceProvider.name}`,
+    title: `We’ve sent your referral to ${this.referral.referral.serviceProvider.name}`,
     referenceNumberIntro: `Your reference number`,
     referenceNumber: this.referral.referenceNumber,
-    whatHappensNext: `${this.serviceProvider.name} will be in contact within 10 days to schedule the assessment.`,
+    whatHappensNext: `${this.referral.referral.serviceProvider.name} will be in contact within 10 days to schedule the assessment.`,
   }
 }

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -87,7 +87,9 @@ describe('ReferralFormPresenter', () => {
         const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build({
           createdAt: '2021-01-11T10:32:12.382884Z',
           completionDeadline: '2021-04-01',
-          serviceProviderId: '674b47a0-39bf-4514-82ae-61885b9c0cb4',
+          serviceProvider: {
+            name: 'Harmony Living',
+          },
           serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
           complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
           furtherInformation: 'Some information about the service user',

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -6,7 +6,6 @@ import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
-import serviceProviderFactory from '../../../testutils/factories/serviceProvider'
 import apiConfig from '../../config'
 import MockedHmppsAuthClient from '../../data/testutils/hmppsAuthClientSetup'
 import deliusServiceUser from '../../../testutils/factories/deliusServiceUser'
@@ -994,9 +993,6 @@ describe('GET /referrals/:id/confirmation', () => {
   it('displays a submission confirmation page', async () => {
     const referral = sentReferralFactory.build()
     interventionsService.getSentReferral.mockResolvedValue(referral)
-
-    const serviceProvider = serviceProviderFactory.build({ name: 'Harmony Living' })
-    interventionsService.getServiceProvider.mockResolvedValue(serviceProvider)
 
     await request(app)
       .get('/referrals/1/confirmation')

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -519,12 +519,8 @@ export default class ReferralsController {
 
   async viewConfirmation(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getSentReferral(res.locals.user.token, req.params.id)
-    const serviceProvider = await this.interventionsService.getServiceProvider(
-      res.locals.user.token,
-      referral.referral.serviceProviderId
-    )
 
-    const presenter = new ConfirmationPresenter(referral, serviceProvider)
+    const presenter = new ConfirmationPresenter(referral)
     const view = new ConfirmationView(presenter)
 
     res.render(...view.renderArgs)

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -954,41 +954,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('getServiceProvider', () => {
-    beforeEach(async () => {
-      await provider.addInteraction({
-        state: 'a service provider with ID 674b47a0-39bf-4514-82ae-61885b9c0cb4 exists',
-        uponReceiving: 'a GET request to fetch the service provider',
-        withRequest: {
-          method: 'GET',
-          path: '/service-provider/674b47a0-39bf-4514-82ae-61885b9c0cb4',
-          headers: {
-            Accept: 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
-        },
-        willRespondWith: {
-          status: 200,
-          body: Matchers.like({
-            name: 'Harmony Living',
-          }),
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        },
-      })
-    })
-
-    it('returns a service provider', async () => {
-      const serviceProvider = await interventionsService.getServiceProvider(
-        token,
-        '674b47a0-39bf-4514-82ae-61885b9c0cb4'
-      )
-
-      expect(serviceProvider.name).toEqual('Harmony Living')
-    })
-  })
-
   const serviceUser = {
     crn: 'X862134',
     title: 'Mr',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -89,7 +89,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             status: 200,
             body: Matchers.like({
               id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
-              serviceProviderId: '674b47a0-39bf-4514-82ae-61885b9c0cb4',
+              serviceProvider: {
+                name: 'Harmony Living',
+              },
             }),
             headers: { 'Content-Type': 'application/json' },
           },
@@ -100,7 +102,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         const referral = await interventionsService.getDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962')
 
         expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
-        expect(referral.serviceProviderId).toEqual('674b47a0-39bf-4514-82ae-61885b9c0cb4')
+        expect(referral.serviceProvider!.name).toEqual('Harmony Living')
       })
     })
 
@@ -968,7 +970,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         willRespondWith: {
           status: 200,
           body: Matchers.like({
-            id: '674b47a0-39bf-4514-82ae-61885b9c0cb4',
             name: 'Harmony Living',
           }),
           headers: {
@@ -984,7 +985,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         '674b47a0-39bf-4514-82ae-61885b9c0cb4'
       )
 
-      expect(serviceProvider.id).toEqual('674b47a0-39bf-4514-82ae-61885b9c0cb4')
       expect(serviceProvider.name).toEqual('Harmony Living')
     })
   })
@@ -1009,7 +1009,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     referral: {
       createdAt: '2021-01-11T10:32:12.382884Z',
       completionDeadline: '2021-04-01',
-      serviceProviderId: '674b47a0-39bf-4514-82ae-61885b9c0cb4',
+      serviceProvider: {
+        name: 'Harmony Living',
+      },
       serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
       complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
       furtherInformation: 'Some information about the service user',

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -202,15 +202,6 @@ export default class InterventionsService {
     })) as DraftReferral[]
   }
 
-  async getServiceProvider(token: string, id: string): Promise<ServiceProvider> {
-    const restClient = this.createRestClient(token)
-
-    return (await restClient.get({
-      path: `/service-provider/${id}`,
-      headers: { Accept: 'application/json' },
-    })) as ServiceProvider
-  }
-
   async sendDraftReferral(token: string, id: string): Promise<SentReferral> {
     const restClient = this.createRestClient(token)
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -17,7 +17,7 @@ type WithNullableValues<T> = { [K in keyof T]: T[K] | null }
 export interface ReferralFields {
   createdAt: string
   completionDeadline: string
-  serviceProviderId: string
+  serviceProvider: ServiceProvider
   serviceCategoryId: string
   complexityLevelId: string
   furtherInformation: string
@@ -79,7 +79,6 @@ export interface ServiceUser {
 }
 
 export interface ServiceProvider {
-  id: string
   name: string
 }
 

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -54,7 +54,7 @@ export default DraftReferralFactory.define(({ sequence }) => ({
     disabilities: null,
   },
   completionDeadline: null,
-  serviceProviderId: null,
+  serviceProvider: null,
   serviceCategoryId: null,
   complexityLevelId: null,
   furtherInformation: null,

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -1,13 +1,14 @@
 import { Factory } from 'fishery'
 import { ReferralFields, SentReferral } from '../../server/services/interventionsService'
-import serviceProviderFactory from './serviceProvider'
 import serviceCategoryFactory from './serviceCategory'
 
 const exampleReferralFields = () => {
   return {
     createdAt: '2020-12-07T20:45:21.986389Z',
     completionDeadline: '2021-04-01',
-    serviceProviderId: serviceProviderFactory.build().id,
+    serviceProvider: {
+      name: 'Harmony Living',
+    },
     serviceCategoryId: serviceCategoryFactory.build().id,
     complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
     furtherInformation: 'Some information about the service user',

--- a/testutils/factories/serviceProvider.ts
+++ b/testutils/factories/serviceProvider.ts
@@ -1,7 +1,0 @@
-import { Factory } from 'fishery'
-import { ServiceProvider } from '../../server/services/interventionsService'
-
-export default Factory.define<ServiceProvider>(({ sequence }) => ({
-  id: sequence.toString(),
-  name: 'Harmony Living',
-}))


### PR DESCRIPTION
## What does this pull request do?

- Moves the `ServiceProvider` to the top level field on a referral.
- Removes `getServiceProvider` function, as we no longer need a Service Provider on its own.
- (Possibly controversial) removes `ServiceProviderFactory` for now, as we weren't using it anywhere and I don't feel it added much value, although we may want to add it back when we add more fields, but this won't be a large piece of work...

## What is the intent behind these changes?

To reduce the number of requests to the InterventionsService - we no longer need to request a `ServiceProvider` by its `id`, as we can access it on the referral itself.
