### PR TITLE
IC-911: Show probation practitioner details to service provider

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1,5 +1,6 @@
 import sentReferralFactory from '../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
+import deliusUserFactory from '../../testutils/factories/deliusUser'
 
 describe('Service provider referrals dashboard', () => {
   beforeEach(() => {
@@ -9,7 +10,7 @@ describe('Service provider referrals dashboard', () => {
     cy.task('stubServiceProviderAuthUser')
   })
 
-  it('User views a list of sent referrals', () => {
+  it('User views a list of sent referrals and the referral details page', () => {
     const accommodationServiceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
 
@@ -32,10 +33,17 @@ describe('Service provider referrals dashboard', () => {
       }),
     ]
 
+    const deliusUser = deliusUserFactory.build({
+      firstName: 'Bernard',
+      surname: 'Beaks',
+      email: 'bernard.beaks@justice.gov.uk',
+    })
+
     cy.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory)
     cy.stubGetServiceCategory(socialInclusionServiceCategory.id, socialInclusionServiceCategory)
     sentReferrals.forEach(referral => cy.stubGetSentReferral(referral.id, referral))
     cy.stubGetSentReferrals(sentReferrals)
+    cy.stubGetUserByUsername(deliusUser.username, deliusUser)
 
     cy.login()
 
@@ -57,5 +65,11 @@ describe('Service provider referrals dashboard', () => {
           'Service user': 'Jenny Jones',
         },
       ])
+
+    cy.contains('ABCABCA2').click()
+    cy.location('pathname').should('equal', `/service-provider/referrals/${sentReferrals[1].id}`)
+    cy.get('h1').contains('Social inclusion referral for Jenny Jones')
+    cy.contains('Bernard Beaks')
+    cy.contains('bernard.beaks@justice.gov.uk')
   })
 })

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -31,6 +31,10 @@ module.exports = on => {
       return communityApi.stubGetServiceUserByCRN(arg.crn, arg.responseJson)
     },
 
+    stubGetUserByUsername: arg => {
+      return communityApi.stubGetUserByUsername(arg.username, arg.responseJson)
+    },
+
     stubGetDraftReferral: arg => {
       return interventionsService.stubGetDraftReferral(arg.id, arg.responseJson)
     },

--- a/integration_tests/support/communityApiStubs.js
+++ b/integration_tests/support/communityApiStubs.js
@@ -1,3 +1,7 @@
 Cypress.Commands.add('stubGetServiceUserByCRN', (crn, responseJson) => {
   cy.task('stubGetServiceUserByCRN', { crn, responseJson })
 })
+
+Cypress.Commands.add('stubGetUserByUsername', (username, responseJson) => {
+  cy.task('stubGetUserByUsername', { username, responseJson })
+})

--- a/mockApis/communityApi.ts
+++ b/mockApis/communityApi.ts
@@ -18,4 +18,20 @@ export default class CommunityApiMocks {
       },
     })
   }
+
+  stubGetUserByUsername = async (username: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/community-api/secure/users/${username}/details`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/mocks.ts
+++ b/mocks.ts
@@ -29,6 +29,14 @@ export default async function setUpMocks(): Promise<void> {
         serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
       },
     }),
+    sentReferralFactory.build({
+      sentAt: '2021-02-10:00:00.000000Z',
+      referenceNumber: 'ABCABCA3',
+      referral: {
+        serviceCategoryId: socialInclusionServiceCategory.id,
+        serviceUser: { firstName: 'Jenny', lastName: 'Yates' },
+      },
+    }),
   ]
 
   await Promise.all([

--- a/mocks.ts
+++ b/mocks.ts
@@ -12,6 +12,11 @@ export default async function setUpMocks(): Promise<void> {
   const accommodationServiceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
   const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
 
+  const sentBy = {
+    username: 'BERNARD.BEAKS',
+    authSource: 'delius',
+  }
+
   const sentReferrals = [
     sentReferralFactory.build({
       sentAt: '2021-01-26T13:00:00.000000Z',
@@ -20,6 +25,7 @@ export default async function setUpMocks(): Promise<void> {
         serviceCategoryId: accommodationServiceCategory.id,
         serviceUser: { firstName: 'George', lastName: 'Michael' },
       },
+      sentBy,
     }),
     sentReferralFactory.build({
       sentAt: '2020-09-13T13:00:00.000000Z',
@@ -28,6 +34,7 @@ export default async function setUpMocks(): Promise<void> {
         serviceCategoryId: socialInclusionServiceCategory.id,
         serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
       },
+      sentBy,
     }),
     sentReferralFactory.build({
       sentAt: '2021-02-10:00:00.000000Z',
@@ -36,6 +43,7 @@ export default async function setUpMocks(): Promise<void> {
         serviceCategoryId: socialInclusionServiceCategory.id,
         serviceUser: { firstName: 'Jenny', lastName: 'Yates' },
       },
+      sentBy,
     }),
   ]
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -29,8 +29,11 @@ export default function routes(router: Router, services: Services): Router {
   )
 
   const referralsController = new ReferralsController(services.interventionsService, services.communityApiService)
-  const serviceProviderReferralsController = new ServiceProviderReferralsController(services.interventionsService)
   const staticContentController = new StaticContentController()
+  const serviceProviderReferralsController = new ServiceProviderReferralsController(
+    services.interventionsService,
+    services.communityApiService
+  )
 
   get('/', (req, res, next) => {
     const { authSource } = res.locals.user
@@ -42,6 +45,7 @@ export default function routes(router: Router, services: Services): Router {
   })
 
   get('/service-provider/dashboard', (req, res) => serviceProviderReferralsController.showDashboard(req, res))
+  get('/service-provider/referrals/:id', (req, res) => serviceProviderReferralsController.showReferral(req, res))
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -41,16 +41,16 @@ describe(DashboardPresenter, () => {
 
       expect(presenter.tableRows).toEqual([
         [
-          { text: '26 Jan 2021', sortValue: '2021-01-26' },
-          { text: 'ABCABCA1', sortValue: null },
-          { text: 'George Michael', sortValue: 'michael, george' },
-          { text: 'Accommodation', sortValue: null },
+          { text: '26 Jan 2021', sortValue: '2021-01-26', href: null },
+          { text: 'ABCABCA1', sortValue: null, href: null },
+          { text: 'George Michael', sortValue: 'michael, george', href: null },
+          { text: 'Accommodation', sortValue: null, href: null },
         ],
         [
-          { text: '13 Sep 2020', sortValue: '2020-09-13' },
-          { text: 'ABCABCA2', sortValue: null },
-          { text: 'Jenny Jones', sortValue: 'jones, jenny' },
-          { text: 'Social inclusion', sortValue: null },
+          { text: '13 Sep 2020', sortValue: '2020-09-13', href: null },
+          { text: 'ABCABCA2', sortValue: null, href: null },
+          { text: 'Jenny Jones', sortValue: 'jones, jenny', href: null },
+          { text: 'Social inclusion', sortValue: null, href: null },
         ],
       ])
     })

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -42,13 +42,13 @@ describe(DashboardPresenter, () => {
       expect(presenter.tableRows).toEqual([
         [
           { text: '26 Jan 2021', sortValue: '2021-01-26', href: null },
-          { text: 'ABCABCA1', sortValue: null, href: null },
+          { text: 'ABCABCA1', sortValue: null, href: `/service-provider/referrals/${sentReferrals[0].id}` },
           { text: 'George Michael', sortValue: 'michael, george', href: null },
           { text: 'Accommodation', sortValue: null, href: null },
         ],
         [
           { text: '13 Sep 2020', sortValue: '2020-09-13', href: null },
-          { text: 'ABCABCA2', sortValue: null, href: null },
+          { text: 'ABCABCA2', sortValue: null, href: `/service-provider/referrals/${sentReferrals[1].id}` },
           { text: 'Jenny Jones', sortValue: 'jones, jenny', href: null },
           { text: 'Social inclusion', sortValue: null, href: null },
         ],

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -25,7 +25,7 @@ export default class DashboardPresenter {
           sortValue: sentAtDay.iso8601,
           href: null,
         },
-        { text: referral.referenceNumber, sortValue: null, href: null },
+        { text: referral.referenceNumber, sortValue: null, href: `/service-provider/referrals/${referral.id}` },
         {
           text: ReferralDataPresenterUtils.fullName(serviceUser),
           sortValue: ReferralDataPresenterUtils.fullNameSortValue(serviceUser),

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -8,24 +8,31 @@ export default class DashboardPresenter {
 
   readonly tableHeadings = ['Date received', 'Referral', 'Service user', 'Intervention type']
 
-  readonly tableRows: { text: string; sortValue: string | null }[][] = this.referrals.map(referral => {
-    const { serviceCategoryId } = referral.referral
-    const serviceCategory = this.serviceCategories.find(aServiceCategory => aServiceCategory.id === serviceCategoryId)
-    if (serviceCategory === undefined) {
-      throw new Error(`Expected serviceCategories to contain service category with ID ${serviceCategoryId}`)
+  readonly tableRows: { text: string; sortValue: string | null; href: string | null }[][] = this.referrals.map(
+    referral => {
+      const { serviceCategoryId } = referral.referral
+      const serviceCategory = this.serviceCategories.find(aServiceCategory => aServiceCategory.id === serviceCategoryId)
+      if (serviceCategory === undefined) {
+        throw new Error(`Expected serviceCategories to contain service category with ID ${serviceCategoryId}`)
+      }
+
+      const sentAtDay = CalendarDay.britishDayForDate(new Date(referral.sentAt))
+      const { serviceUser } = referral.referral
+
+      return [
+        {
+          text: ReferralDataPresenterUtils.govukShortFormattedDate(sentAtDay),
+          sortValue: sentAtDay.iso8601,
+          href: null,
+        },
+        { text: referral.referenceNumber, sortValue: null, href: null },
+        {
+          text: ReferralDataPresenterUtils.fullName(serviceUser),
+          sortValue: ReferralDataPresenterUtils.fullNameSortValue(serviceUser),
+          href: null,
+        },
+        { text: utils.convertToProperCase(serviceCategory.name), sortValue: null, href: null },
+      ]
     }
-
-    const sentAtDay = CalendarDay.britishDayForDate(new Date(referral.sentAt))
-    const { serviceUser } = referral.referral
-
-    return [
-      { text: ReferralDataPresenterUtils.govukShortFormattedDate(sentAtDay), sortValue: sentAtDay.iso8601 },
-      { text: referral.referenceNumber, sortValue: null },
-      {
-        text: ReferralDataPresenterUtils.fullName(serviceUser),
-        sortValue: ReferralDataPresenterUtils.fullNameSortValue(serviceUser),
-      },
-      { text: utils.convertToProperCase(serviceCategory.name), sortValue: null },
-    ]
-  })
+  )
 }

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -1,4 +1,5 @@
 import DashboardPresenter from './dashboardPresenter'
+import ViewUtils from '../../utils/viewUtils'
 
 export default class DashboardView {
   constructor(private readonly presenter: DashboardPresenter) {}
@@ -15,10 +16,18 @@ export default class DashboardView {
       }),
       rows: this.presenter.tableRows.map(row => {
         return row.map(cell => {
-          const result = { text: cell.text, attributes: {} }
+          const result: Record<string, unknown> = {}
+
           if (cell.sortValue !== null) {
             result.attributes = { 'data-sort-value': cell.sortValue }
           }
+
+          if (cell.href === null) {
+            result.text = cell.text
+          } else {
+            result.html = `<a href="${cell.href}" class="govuk-link">${ViewUtils.escape(cell.text)}</a>`
+          }
+
           return result
         })
       }),

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -1,10 +1,16 @@
 import { Request, Response } from 'express'
+import CommunityApiService from '../../services/communityApiService'
 import InterventionsService from '../../services/interventionsService'
 import DashboardPresenter from './dashboardPresenter'
 import DashboardView from './dashboardView'
+import ShowReferralPresenter from './showReferralPresenter'
+import ShowReferralView from './showReferralView'
 
 export default class ServiceProviderReferralsController {
-  constructor(private readonly interventionsService: InterventionsService) {}
+  constructor(
+    private readonly interventionsService: InterventionsService,
+    private readonly communityApiService: CommunityApiService
+  ) {}
 
   async showDashboard(req: Request, res: Response): Promise<void> {
     const referrals = await this.interventionsService.getSentReferrals(res.locals.user.token)
@@ -18,6 +24,19 @@ export default class ServiceProviderReferralsController {
 
     const presenter = new DashboardPresenter(referrals, serviceCategories)
     const view = new DashboardView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async showReferral(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.getSentReferral(res.locals.user.token, req.params.id)
+    const [serviceCategory, sentBy] = await Promise.all([
+      this.interventionsService.getServiceCategory(res.locals.user.token, referral.referral.serviceCategoryId),
+      this.communityApiService.getUserByUsername(referral.sentBy.username),
+    ])
+
+    const presenter = new ShowReferralPresenter(referral, serviceCategory, sentBy)
+    const view = new ShowReferralView(presenter)
 
     res.render(...view.renderArgs)
   }

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -1,0 +1,35 @@
+import ShowReferralPresenter from './showReferralPresenter'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import deliusUserFactory from '../../../testutils/factories/deliusUser'
+
+describe(ShowReferralPresenter, () => {
+  const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+  const referral = sentReferralFactory.build({
+    referral: { serviceCategoryId: serviceCategory.id, serviceUser: { firstName: 'Jenny', lastName: 'Jones' } },
+  })
+  const deliusUser = deliusUserFactory.build({
+    firstName: 'Bernard',
+    surname: 'Beaks',
+    email: 'bernard.beaks@justice.gov.uk',
+  })
+
+  describe('text', () => {
+    it('returns text to be displayed', () => {
+      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser)
+
+      expect(presenter.text).toEqual({ title: 'Accommodation referral for Jenny Jones' })
+    })
+  })
+
+  describe('probationPractitionerDetails', () => {
+    it('returns a summary list of probation practitioner details', () => {
+      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser)
+
+      expect(presenter.probationPractitionerDetails).toEqual([
+        { isList: false, key: 'Name', lines: ['Bernard Beaks'] },
+        { isList: false, key: 'Email address', lines: ['bernard.beaks@justice.gov.uk'] },
+      ])
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -1,0 +1,24 @@
+import { DeliusUser } from '../../services/communityApiService'
+import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { SummaryListItem } from '../../utils/summaryList'
+import utils from '../../utils/utils'
+import ReferralDataPresenterUtils from '../referrals/referralDataPresenterUtils'
+
+export default class ShowReferralPresenter {
+  constructor(
+    private readonly referral: SentReferral,
+    private readonly serviceCategory: ServiceCategory,
+    private readonly sentBy: DeliusUser
+  ) {}
+
+  readonly text = {
+    title: `${utils.convertToProperCase(this.serviceCategory.name)} referral for ${ReferralDataPresenterUtils.fullName(
+      this.referral.referral.serviceUser
+    )}`,
+  }
+
+  readonly probationPractitionerDetails: SummaryListItem[] = [
+    { key: 'Name', lines: [`${this.sentBy.firstName} ${this.sentBy.surname}`], isList: false },
+    { key: 'Email address', lines: [this.sentBy.email ?? ''], isList: false },
+  ]
+}

--- a/server/routes/serviceProviderReferrals/showReferralView.ts
+++ b/server/routes/serviceProviderReferrals/showReferralView.ts
@@ -1,0 +1,20 @@
+import ShowReferralPresenter from './showReferralPresenter'
+import ViewUtils from '../../utils/viewUtils'
+
+export default class ShowReferralView {
+  constructor(private readonly presenter: ShowReferralPresenter) {}
+
+  private readonly probationPractitionerSummaryListArgs = ViewUtils.summaryListArgs(
+    this.presenter.probationPractitionerDetails
+  )
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/showReferral',
+      {
+        presenter: this.presenter,
+        probationPractitionerSummaryListArgs: this.probationPractitionerSummaryListArgs,
+      },
+    ]
+  }
+}

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -970,6 +970,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   const sentReferral: SentReferral = {
     id: '81d754aa-d868-4347-9c0f-50690773014e',
     sentAt: '2021-01-14T15:56:45.382884Z',
+    sentBy: {
+      username: 'BERNARD.BEAKS',
+      authSource: 'delius',
+    },
     referenceNumber: 'HDJ2123F',
     referral: {
       createdAt: '2021-01-11T10:32:12.382884Z',

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -45,6 +45,7 @@ export interface SentReferral {
   sentAt: string
   referenceNumber: string
   referral: ReferralFields
+  sentBy: AuthUser
 }
 
 export interface ServiceCategory {
@@ -80,6 +81,11 @@ export interface ServiceUser {
 
 export interface ServiceProvider {
   name: string
+}
+
+export interface AuthUser {
+  username: string
+  authSource: string
 }
 
 export default class InterventionsService {

--- a/server/views/serviceProviderReferrals/showReferral.njk
+++ b/server/views/serviceProviderReferrals/showReferral.njk
@@ -1,0 +1,21 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      <h2 class="govuk-heading-m">Referring probation practitioner details</h2>
+
+      {{ govukSummaryList(probationPractitionerSummaryListArgs) }}
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/deliusUser.ts
+++ b/testutils/factories/deliusUser.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery'
+import { DeliusUser } from '../../server/services/communityApiService'
+
+export default Factory.define<DeliusUser>(sequence => ({
+  userId: sequence.toString(),
+  username: 'BERNARD.BEAKS',
+  firstName: 'Bernard',
+  surname: 'Beaks',
+  email: 'bernard.beaks@justice.gov.uk',
+  enabled: true,
+  roles: [],
+}))

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -52,6 +52,10 @@ class SentReferralFactory extends Factory<SentReferral> {
 export default SentReferralFactory.define(({ sequence }) => ({
   id: sequence.toString(),
   sentAt: new Date().toISOString(),
+  sentBy: {
+    username: 'BERNARD.BEAKS',
+    authSource: 'delius',
+  },
   referenceNumber: sequence.toString().padStart(8, 'ABC'),
   referral: exampleReferralFields(),
 }))


### PR DESCRIPTION
## What does this pull request do?

Adds a basic referral details page for service providers, which contains the name and email address of the service provider who sent the referral.

## What is the intent behind these changes?

To demonstrate that sufficient information about the referring PP is captured in the referral that we are able to display details of this PP in the future.

## Screenshot

![Screenshot_2021-02-03 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/106809286-652a5280-6663-11eb-8134-140852d87bce.png)
