### PR TITLE
IC-1093 - Create empty static pages for Record, for designers to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ The integration tests require a different docker-compose stack and a different a
 `npm run start:test`
 
 `npm run int-test(-ui)`
- 
+
+### Building a static page (designers)
+
+To view the existing static pages, and for more instructions about how to edit them, go to `http://localhost:3000/static-pages`. If you get asked to log in when you try to go to this page, then you might need to re-enter this URL after logging in.
+
 ## Dependencies
 
 - hmpps-auth - for authentication

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,6 +7,7 @@ import OffenderAssessmentsApiService from '../services/offenderAssessmentsApiSer
 import IntegrationSamplesRoutes from './integrationSamples'
 import ServiceProviderReferralsController from './serviceProviderReferrals/serviceProviderReferralsController'
 import ReferralsController from './referrals/referralsController'
+import StaticContentController from './staticContent/staticContentController'
 
 interface RouteProvider {
   [key: string]: RequestHandler
@@ -29,6 +30,7 @@ export default function routes(router: Router, services: Services): Router {
 
   const referralsController = new ReferralsController(services.interventionsService, services.communityApiService)
   const serviceProviderReferralsController = new ServiceProviderReferralsController(services.interventionsService)
+  const staticContentController = new StaticContentController()
 
   get('/', (req, res, next) => {
     const { authSource } = res.locals.user
@@ -40,6 +42,18 @@ export default function routes(router: Router, services: Services): Router {
   })
 
   get('/service-provider/dashboard', (req, res) => serviceProviderReferralsController.showDashboard(req, res))
+
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
+    get('/static-pages', (req, res) => {
+      staticContentController.index(req, res)
+    })
+
+    StaticContentController.allPaths.forEach(path => {
+      get(path, (req, res) => {
+        staticContentController.renderStaticPage(req, res)
+      })
+    })
+  }
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
   get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)

--- a/server/routes/staticContent/indexPresenter.test.ts
+++ b/server/routes/staticContent/indexPresenter.test.ts
@@ -1,0 +1,15 @@
+import StaticContentIndexPresenter from './indexPresenter'
+
+describe(StaticContentIndexPresenter, () => {
+  describe('rows', () => {
+    it('returns rows to be displayed in the table', () => {
+      const presenter = new StaticContentIndexPresenter([
+        { path: '/foo/bar', template: 'someFolder/someFile', description: 'Some text' },
+      ])
+
+      expect(presenter.rows).toEqual([
+        { href: '/foo/bar', template: 'server/views/someFolder/someFile.njk', description: 'Some text' },
+      ])
+    })
+  })
+})

--- a/server/routes/staticContent/indexPresenter.ts
+++ b/server/routes/staticContent/indexPresenter.ts
@@ -1,0 +1,11 @@
+export default class StaticContentIndexPresenter {
+  constructor(private readonly pages: { path: string; template: string; description: string }[]) {}
+
+  get rows(): { href: string; template: string; description: string }[] {
+    return this.pages.map(page => ({
+      href: page.path,
+      template: `server/views/${page.template}.njk`,
+      description: page.description,
+    }))
+  }
+}

--- a/server/routes/staticContent/indexView.ts
+++ b/server/routes/staticContent/indexView.ts
@@ -1,0 +1,24 @@
+import StaticContentIndexPresenter from './indexPresenter'
+import ViewUtils from '../../utils/viewUtils'
+
+export default class StaticContentIndexView {
+  constructor(private readonly presenter: StaticContentIndexPresenter) {}
+
+  private get tableArgs() {
+    return {
+      firstCellIsHeader: true,
+      head: [{ text: 'Page' }, { text: 'URL' }, { text: 'Template file' }],
+      rows: this.presenter.rows.map(row => {
+        return [
+          { text: row.description },
+          { html: `<a href="${row.href}">${ViewUtils.escape(row.href)}</a>` },
+          { html: `<code>${ViewUtils.escape(row.template)}</code>` },
+        ]
+      }),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return ['staticContent/index', { tableArgs: this.tableArgs }]
+  }
+}

--- a/server/routes/staticContent/staticContentController.test.ts
+++ b/server/routes/staticContent/staticContentController.test.ts
@@ -1,0 +1,26 @@
+import request from 'supertest'
+import { Express } from 'express'
+import StaticContentController from './staticContentController'
+import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
+
+describe(StaticContentController, () => {
+  let app: Express
+
+  beforeEach(() => {
+    app = appWithAllRoutes({
+      userType: AppSetupUserType.probationPractitioner,
+    })
+  })
+
+  describe('GET /static-pages', () => {
+    it('responds with a 200', async () => {
+      await request(app).get('/static-pages').expect(200)
+    })
+  })
+
+  describe.each(StaticContentController.allPaths)('GET %s', path => {
+    it('responds with a 200', async () => {
+      await request(app).get(path).expect(200)
+    })
+  })
+})

--- a/server/routes/staticContent/staticContentController.ts
+++ b/server/routes/staticContent/staticContentController.ts
@@ -9,6 +9,66 @@ export default class StaticContentController {
       template: 'serviceProviderReferrals/sessionProgress',
       description: 'IC-1052 (session progress)',
     },
+    {
+      path: '/service-provider/session-feedback/attendance',
+      template: 'serviceProviderReferrals/sessions/feedback/attendance',
+      description: 'IC-1094 (session feedback: attendance)',
+    },
+    {
+      path: '/service-provider/session-feedback/safeguarding',
+      template: 'serviceProviderReferrals/sessions/feedback/safeguarding',
+      description: 'IC-1095 (session feedback: safeguarding)',
+    },
+    {
+      path: '/service-provider/session-feedback/any-changes',
+      template: 'serviceProviderReferrals/sessions/feedback/anyChanges',
+      description: 'IC-1053 (session feedback: any changes)',
+    },
+    {
+      path: '/service-provider/session-feedback/outcomes',
+      template: 'serviceProviderReferrals/sessions/feedback/outcomes',
+      description: 'IC-1054 (session feedback: outcomes)',
+    },
+    {
+      path: '/service-provider/session-feedback/behaviour',
+      template: 'serviceProviderReferrals/sessions/feedback/behaviour',
+      description: 'IC-1055 (session feedback: behaviour)',
+    },
+    {
+      path: '/service-provider/session-feedback/information',
+      template: 'serviceProviderReferrals/sessions/feedback/information',
+      description: 'IC-1056 (session feedback: information)',
+    },
+    {
+      path: '/service-provider/session-feedback/next-session',
+      template: 'serviceProviderReferrals/sessions/feedback/nextSession',
+      description: 'IC-1057 (session feedback: next session)',
+    },
+    {
+      path: '/service-provider/session-feedback/review',
+      template: 'serviceProviderReferrals/sessions/feedback/review',
+      description: 'IC-1058 (session feedback: review)',
+    },
+    {
+      path: '/service-provider/session-feedback/confirmation',
+      template: 'serviceProviderReferrals/sessions/feedback/confirmation',
+      description: 'IC-1085 (session feedback: confirmation)',
+    },
+    {
+      path: '/service-provider/session-feedback/show',
+      template: 'serviceProviderReferrals/sessions/feedback/show',
+      description: 'IC-1083 (session feedback: show)',
+    },
+    {
+      path: '/service-provider/session/show',
+      template: 'serviceProviderReferrals/sessions/show',
+      description: 'IC-1087 (session details: show)',
+    },
+    {
+      path: '/service-provider/session/amend',
+      template: 'serviceProviderReferrals/sessions/amend',
+      description: 'IC-1087 (session details: amend)',
+    },
   ]
 
   static get allPaths(): string[] {

--- a/server/routes/staticContent/staticContentController.ts
+++ b/server/routes/staticContent/staticContentController.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from 'express'
+import StaticContentIndexPresenter from './indexPresenter'
+import StaticContentIndexView from './indexView'
+
+export default class StaticContentController {
+  private static pages: { path: string; template: string; description: string }[] = [
+    {
+      path: '/service-provider/session-progress',
+      template: 'serviceProviderReferrals/sessionProgress',
+      description: 'IC-1052 (session progress)',
+    },
+  ]
+
+  static get allPaths(): string[] {
+    return this.pages.map(page => page.path)
+  }
+
+  async index(req: Request, res: Response): Promise<void> {
+    const presenter = new StaticContentIndexPresenter(StaticContentController.pages)
+    const view = new StaticContentIndexView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async renderStaticPage(req: Request, res: Response): Promise<void> {
+    const page = StaticContentController.pages.find(aPage => aPage.path === req.path)
+
+    if (page === undefined) {
+      throw new Error(`No static page found for path ${req.path}`)
+    }
+
+    res.render(page.template)
+  }
+}

--- a/server/views/serviceProviderReferrals/sessionProgress.njk
+++ b/server/views/serviceProviderReferrals/sessionProgress.njk
@@ -1,0 +1,14 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1052 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/amend.njk
+++ b/server/views/serviceProviderReferrals/sessions/amend.njk
@@ -1,0 +1,12 @@
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1087 Add content here (show session details) #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/anyChanges.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/anyChanges.njk
@@ -1,0 +1,12 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1053 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/attendance.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/attendance.njk
@@ -1,0 +1,12 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1094 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/behaviour.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/behaviour.njk
@@ -1,0 +1,12 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1055 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/confirmation.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/confirmation.njk
@@ -1,0 +1,12 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1085 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/information.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/information.njk
@@ -1,0 +1,12 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1056 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/nextSession.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/nextSession.njk
@@ -1,0 +1,12 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1057 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/outcomes.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/outcomes.njk
@@ -1,0 +1,12 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1054 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/review.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/review.njk
@@ -1,0 +1,12 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1058 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/safeguarding.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/safeguarding.njk
@@ -1,0 +1,12 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1095 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/show.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/show.njk
@@ -1,0 +1,12 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1083 Add content here #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/show.njk
+++ b/server/views/serviceProviderReferrals/sessions/show.njk
@@ -1,0 +1,12 @@
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {# TODO IC-1087 Add content here (amend session) #}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/staticContent/index.njk
+++ b/server/views/staticContent/index.njk
@@ -1,0 +1,28 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      <h1 class="govuk-heading-xl">Static pages</h1>
+
+      <p class="govuk-body">These are the static pages which are either:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>ready for designers to build</li>
+        <li>already built by designers</li>
+      </ul>
+
+      <p class="govuk-body">To change the application’s styling, change the SASS file <code>assets/sass/local.sass</code>.</p>
+
+      {{ govukTable(tableArgs) }}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a general mechanism for adding and listing static pages for designers to build, and adds empty pages for all of the Record tasks that @isratc will be working on in sprint 6.

## What is the intent behind these changes?

To make it easy for designers to contribute to the codebase.

## Screenshot

Listing of all static pages (`/static-pages`):

![Screenshot_2021-02-04 HMPPS Interventions - GOV UK(1)](https://user-images.githubusercontent.com/53756884/106883676-38645280-66d8-11eb-8a44-214255b52f39.png)
