### PR TITLE
IC-1096 Add SU contact details to referral

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -50,6 +50,10 @@ describe('Referral form', () => {
         title: 'Mr',
         firstName: 'Geoffrey',
         lastName: 'River',
+        contactDetails: {
+          email: 'geoffrey.river@example.com',
+          mobile: '0123456789',
+        },
         dateOfBirth: '1980-01-01',
         gender: 'Male',
         preferredLanguage: 'English',

--- a/server/routes/referrals/deliusServiceUserSerializer.test.ts
+++ b/server/routes/referrals/deliusServiceUserSerializer.test.ts
@@ -1,0 +1,112 @@
+import DeliusServiceUserSerializer from './deliusServiceUserSerializer'
+
+describe(DeliusServiceUserSerializer, () => {
+  describe('call', () => {
+    it('transforms a DeliusServiceUser into a format expected by the Interventions Service, removing "expired" disabilities', () => {
+      const currentDisabilityEndDate = new Date()
+      currentDisabilityEndDate.setDate(currentDisabilityEndDate.getDate() + 1)
+
+      const deliusServiceUser = {
+        otherIds: {
+          crn: 'X123456',
+        },
+        offenderProfile: {
+          ethnicity: 'British',
+          religion: 'Agnostic',
+          offenderLanguages: {
+            primaryLanguage: 'English',
+          },
+          disabilities: [
+            {
+              disabilityType: {
+                description: 'Autism',
+              },
+              endDate: '',
+              notes: 'Some notes',
+              startDate: '2019-01-22',
+            },
+            {
+              disabilityType: {
+                description: 'Sciatica',
+              },
+              endDate: currentDisabilityEndDate.toString(),
+              notes: 'Some notes',
+              startDate: '2020-01-01',
+            },
+            {
+              disabilityType: {
+                description: 'An old disability',
+              },
+              endDate: '2020-01-22',
+              notes: 'Some notes',
+              startDate: '2020-01-22',
+            },
+          ],
+        },
+        title: 'Mr',
+        firstName: 'Alex',
+        surname: 'River',
+        contactDetails: {
+          emailAddresses: ['alex.river@example.com'],
+          phoneNumbers: [
+            {
+              number: '07123456789',
+              type: 'MOBILE',
+            },
+          ],
+        },
+        dateOfBirth: '1980-01-01',
+        gender: 'Male',
+      }
+
+      const serviceUser = new DeliusServiceUserSerializer(deliusServiceUser).call()
+
+      expect(serviceUser.crn).toEqual('X123456')
+      expect(serviceUser.title).toEqual('Mr')
+      expect(serviceUser.firstName).toEqual('Alex')
+      expect(serviceUser.lastName).toEqual('River')
+      expect(serviceUser.contactDetails.email).toEqual('alex.river@example.com')
+      expect(serviceUser.contactDetails.mobile).toEqual('07123456789')
+      expect(serviceUser.dateOfBirth).toEqual('1980-01-01')
+      expect(serviceUser.gender).toEqual('Male')
+      expect(serviceUser.ethnicity).toEqual('British')
+      expect(serviceUser.religionOrBelief).toEqual('Agnostic')
+      expect(serviceUser.preferredLanguage).toEqual('English')
+      expect(serviceUser.disabilities).toEqual(['Autism', 'Sciatica'])
+    })
+
+    describe('when there are fields missing in the response', () => {
+      // this is the current response when running the Community API locally
+      const incompleteDeliusServiceUser = {
+        firstName: 'Aadland',
+        surname: 'Bertrand',
+        dateOfBirth: '2065-07-19',
+        gender: 'Male',
+        otherIds: {
+          crn: 'X320741',
+        },
+        contactDetails: {},
+        offenderProfile: {
+          offenderLanguages: {},
+        },
+      }
+
+      it('sets null values on the serialized user for the missing values', () => {
+        const serviceUser = new DeliusServiceUserSerializer(incompleteDeliusServiceUser).call()
+
+        expect(serviceUser.crn).toEqual('X320741')
+        expect(serviceUser.title).toEqual(null)
+        expect(serviceUser.firstName).toEqual('Aadland')
+        expect(serviceUser.lastName).toEqual('Bertrand')
+        expect(serviceUser.contactDetails.email).toEqual(null)
+        expect(serviceUser.contactDetails.mobile).toEqual(null)
+        expect(serviceUser.dateOfBirth).toEqual('2065-07-19')
+        expect(serviceUser.gender).toEqual('Male')
+        expect(serviceUser.ethnicity).toEqual(null)
+        expect(serviceUser.religionOrBelief).toEqual(null)
+        expect(serviceUser.preferredLanguage).toEqual(null)
+        expect(serviceUser.disabilities).toEqual(null)
+      })
+    })
+  })
+})

--- a/server/routes/referrals/deliusServiceUserSerializer.ts
+++ b/server/routes/referrals/deliusServiceUserSerializer.ts
@@ -1,0 +1,65 @@
+import { DeliusServiceUser } from '../../services/communityApiService'
+import { ServiceUser } from '../../services/interventionsService'
+import CalendarDay from '../../utils/calendarDay'
+
+export default class DeliusServiceUserSerializer {
+  constructor(private readonly deliusServiceUser: DeliusServiceUser) {}
+
+  call(): ServiceUser {
+    return {
+      crn: this.deliusServiceUser.otherIds.crn,
+      title: this.deliusServiceUser.title || null,
+      firstName: this.deliusServiceUser.firstName || null,
+      lastName: this.deliusServiceUser.surname || null,
+      contactDetails: {
+        email: this.email,
+        mobile: this.mobile,
+      },
+      dateOfBirth: this.iso8601DateOfBirth || null,
+      gender: this.deliusServiceUser.gender || null,
+      ethnicity: this.deliusServiceUser.offenderProfile?.ethnicity || null,
+      preferredLanguage: this.deliusServiceUser.offenderProfile?.offenderLanguages?.primaryLanguage || null,
+      religionOrBelief: this.deliusServiceUser.offenderProfile?.religion || null,
+      disabilities: this.currentDisabilities,
+    }
+  }
+
+  private get currentDisabilities(): string[] | null {
+    return this.deliusServiceUser.offenderProfile?.disabilities
+      ? this.deliusServiceUser.offenderProfile.disabilities
+          .filter(disability => {
+            const today = new Date().toString()
+            return disability.endDate === '' || Date.parse(disability.endDate) >= Date.parse(today)
+          })
+          .map(disability => disability.disabilityType.description)
+      : null
+  }
+
+  private get iso8601DateOfBirth(): string | null {
+    return this.deliusServiceUser.dateOfBirth
+      ? CalendarDay.parseIso8601(this.deliusServiceUser.dateOfBirth)?.iso8601 || null
+      : null
+  }
+
+  private get email(): string | null {
+    const { emailAddresses } = this.deliusServiceUser.contactDetails
+
+    if (emailAddresses && emailAddresses.length > 0) {
+      return emailAddresses[0]
+    }
+
+    return null
+  }
+
+  private get mobile(): string | null {
+    const { phoneNumbers } = this.deliusServiceUser.contactDetails
+
+    if (phoneNumbers) {
+      const mobileNumber = phoneNumbers.find(phoneNumber => phoneNumber.type === 'MOBILE')
+
+      return mobileNumber ? mobileNumber.number : null
+    }
+
+    return null
+  }
+}

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -46,7 +46,6 @@ beforeEach(() => {
   const referral = draftReferralFactory.justCreated().build({ id: '1' })
   interventionsService.createDraftReferral.mockResolvedValue(referral)
   interventionsService.getDraftReferralsForUser.mockResolvedValue([])
-  interventionsService.serializeDeliusServiceUser.mockReturnValue(serviceUser)
 })
 
 afterEach(() => {

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -23,6 +23,10 @@ const serviceUser = {
   title: 'Mr',
   firstName: 'Alex',
   lastName: 'River',
+  contactDetails: {
+    email: 'alex.river@example.com',
+    mobile: '07123456789',
+  },
   dateOfBirth: '1980-01-01',
   gender: 'Male',
   preferredLanguage: 'English',

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -35,6 +35,7 @@ import logger from '../../../log'
 import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
 import ServiceUserDetailsView from './serviceUserDetailsView'
 import ReferralStartForm from './referralStartForm'
+import DeliusServiceUserSerializer from './deliusServiceUserSerializer'
 
 export default class ReferralsController {
   constructor(
@@ -92,17 +93,18 @@ export default class ReferralsController {
       error = form.error
     }
 
-    if (error === null) {
+    if (error === null && serviceUser !== null) {
       const referral = await this.interventionsService.createDraftReferral(
         res.locals.user.token,
         crn,
         hardcodedInterventionId
       )
+
       // fixme: this sets some static data for the new referral which will need to be
       //  changed to allow these fields to be set properly
       await this.interventionsService.patchDraftReferral(res.locals.user.token, referral.id, {
         serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
-        serviceUser: this.interventionsService.serializeDeliusServiceUser(serviceUser),
+        serviceUser: new DeliusServiceUserSerializer(serviceUser).call(),
       })
 
       res.redirect(303, `/referrals/${referral.id}/form`)

--- a/server/routes/referrals/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.test.ts
@@ -6,6 +6,10 @@ describe(ServiceUserDetailsPresenter, () => {
     title: 'Mr',
     firstName: 'Alex',
     lastName: 'River',
+    contactDetails: {
+      email: 'alex.river@example.com',
+      mobile: '07123456789',
+    },
     dateOfBirth: '1980-01-01',
     gender: 'Male',
     ethnicity: 'British',
@@ -19,6 +23,10 @@ describe(ServiceUserDetailsPresenter, () => {
     title: null,
     firstName: null,
     lastName: null,
+    contactDetails: {
+      mobile: null,
+      email: null,
+    },
     dateOfBirth: null,
     gender: null,
     ethnicity: null,

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -22,10 +22,21 @@ export interface DeliusServiceUser {
   surname: string | null
   dateOfBirth: string | null
   gender: string | null
+  contactDetails: ContactDetails
 }
 
 interface DeliusRole {
   name: string
+}
+
+interface ContactDetails {
+  emailAddresses?: string[] | null
+  phoneNumbers?: PhoneNumber[] | null
+}
+
+interface PhoneNumber {
+  number: string | null
+  type: string | null
 }
 
 interface Disability {

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -17,7 +17,7 @@ export interface DeliusServiceUser {
   // TODO IC-620 validate this data properly
   otherIds: OtherIds
   offenderProfile: OffenderProfile
-  title: string | null
+  title?: string | null
   firstName: string | null
   surname: string | null
   dateOfBirth: string | null
@@ -53,13 +53,13 @@ interface OtherIds {
 
 interface OffenderProfile {
   offenderLanguages: OffenderLanguages
-  ethnicity: string
-  religion: string
-  disabilities: Disability[] | null
+  ethnicity?: string | null
+  religion?: string | null
+  disabilities?: Disability[] | null
 }
 
 interface OffenderLanguages {
-  primaryLanguage: string
+  primaryLanguage?: string
 }
 
 export default class CommunityApiService {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -5,7 +5,6 @@ import { term } from '@pact-foundation/pact/dsl/matchers'
 import InterventionsService, { SentReferral, ServiceUser } from './interventionsService'
 import config from '../config'
 import oauth2TokenFactory from '../../testutils/factories/oauth2Token'
-import { DeliusServiceUser } from './communityApiService'
 
 jest.mock('../data/hmppsAuthClient')
 
@@ -1073,117 +1072,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       expect(await interventionsService.getSentReferrals(token)).toEqual([sentReferral, sentReferral])
-    })
-  })
-})
-
-describe('serializeDeliusServiceUser', () => {
-  const interventionsService = new InterventionsService(config.apis.interventionsService)
-
-  it('transforms a DeliusServiceUser into a format expected by the Interventions Service, removing "expired" disabilities', () => {
-    const currentDisabilityEndDate = new Date()
-    currentDisabilityEndDate.setDate(currentDisabilityEndDate.getDate() + 1)
-
-    const deliusServiceUser = {
-      otherIds: {
-        crn: 'X123456',
-      },
-      offenderProfile: {
-        ethnicity: 'British',
-        religion: 'Agnostic',
-        offenderLanguages: {
-          primaryLanguage: 'English',
-        },
-        disabilities: [
-          {
-            disabilityType: {
-              description: 'Autism',
-            },
-            endDate: '',
-            notes: 'Some notes',
-            startDate: '2019-01-22',
-          },
-          {
-            disabilityType: {
-              description: 'Sciatica',
-            },
-            endDate: currentDisabilityEndDate.toString(),
-            notes: 'Some notes',
-            startDate: '2020-01-01',
-          },
-          {
-            disabilityType: {
-              description: 'An old disability',
-            },
-            endDate: '2020-01-22',
-            notes: 'Some notes',
-            startDate: '2020-01-22',
-          },
-        ],
-      },
-      title: 'Mr',
-      firstName: 'Alex',
-      surname: 'River',
-      contactDetails: {
-        emailAddresses: ['alex.river@example.com'],
-        phoneNumbers: [
-          {
-            number: '07123456789',
-            type: 'MOBILE',
-          },
-        ],
-      },
-      dateOfBirth: '1980-01-01',
-      gender: 'Male',
-    } as DeliusServiceUser
-
-    const serviceUser = interventionsService.serializeDeliusServiceUser(deliusServiceUser)
-
-    expect(serviceUser.crn).toEqual('X123456')
-    expect(serviceUser.title).toEqual('Mr')
-    expect(serviceUser.firstName).toEqual('Alex')
-    expect(serviceUser.lastName).toEqual('River')
-    expect(serviceUser.contactDetails.email).toEqual('alex.river@example.com')
-    expect(serviceUser.contactDetails.mobile).toEqual('07123456789')
-    expect(serviceUser.dateOfBirth).toEqual('1980-01-01')
-    expect(serviceUser.gender).toEqual('Male')
-    expect(serviceUser.ethnicity).toEqual('British')
-    expect(serviceUser.religionOrBelief).toEqual('Agnostic')
-    expect(serviceUser.preferredLanguage).toEqual('English')
-    expect(serviceUser.disabilities).toEqual(['Autism', 'Sciatica'])
-  })
-
-  describe('when there are fields missing in the response', () => {
-    // this is the current response when running the Community API locally
-    const incompleteDeliusServiceUser = {
-      firstName: 'Aadland',
-      surname: 'Bertrand',
-      dateOfBirth: '2065-07-19',
-      gender: 'Male',
-      otherIds: {
-        crn: 'X320741',
-      },
-      contactDetails: {},
-      offenderProfile: {
-        offenderLanguages: {},
-      },
-    } as DeliusServiceUser
-
-    it('sets null values on the serialized user for the missing values', () => {
-      const serviceUser = interventionsService.serializeDeliusServiceUser(incompleteDeliusServiceUser)
-
-      expect(serviceUser.crn).toEqual('X320741')
-      expect(serviceUser.title).toEqual(null)
-      expect(serviceUser.firstName).toEqual('Aadland')
-      expect(serviceUser.lastName).toEqual('Bertrand')
-      expect(serviceUser.contactDetails.email).toEqual(null)
-      expect(serviceUser.contactDetails.mobile).toEqual(null)
-      expect(serviceUser.dateOfBirth).toEqual('2065-07-19')
-      expect(serviceUser.gender).toEqual('Male')
-      expect(serviceUser.ethnicity).toEqual(null)
-      expect(serviceUser.religionOrBelief).toEqual(null)
-      expect(serviceUser.preferredLanguage).toEqual(null)
-      expect(serviceUser.disabilities).toEqual(null)
     })
   })
 })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -161,6 +161,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
                 title: 'Mr',
                 firstName: 'Alex',
                 lastName: 'River',
+                contactDetails: {
+                  email: 'alex.river@example.com',
+                  mobile: '07123456789',
+                },
                 dateOfBirth: '1980-01-01',
                 gender: 'Male',
                 preferredLanguage: 'English',
@@ -182,6 +186,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         expect(referral.serviceUser.title).toEqual('Mr')
         expect(referral.serviceUser.firstName).toEqual('Alex')
         expect(referral.serviceUser.lastName).toEqual('River')
+        expect(referral.serviceUser.contactDetails.email).toEqual('alex.river@example.com')
+        expect(referral.serviceUser.contactDetails.mobile).toEqual('07123456789')
         expect(referral.serviceUser.dateOfBirth).toEqual('1980-01-01')
         expect(referral.serviceUser.gender).toEqual('Male')
         expect(referral.serviceUser.ethnicity).toEqual('British')
@@ -286,6 +292,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         title: 'Mr',
         firstName: 'Alex',
         lastName: 'River',
+        contactDetails: {
+          email: 'alex.river@example.com',
+          mobile: '07123456789',
+        },
         dateOfBirth: '1980-01-01',
         gender: 'Male',
         ethnicity: 'British',
@@ -1114,6 +1124,15 @@ describe('serializeDeliusServiceUser', () => {
       title: 'Mr',
       firstName: 'Alex',
       surname: 'River',
+      contactDetails: {
+        emailAddresses: ['alex.river@example.com'],
+        phoneNumbers: [
+          {
+            number: '07123456789',
+            type: 'MOBILE',
+          },
+        ],
+      },
       dateOfBirth: '1980-01-01',
       gender: 'Male',
     } as DeliusServiceUser
@@ -1124,6 +1143,8 @@ describe('serializeDeliusServiceUser', () => {
     expect(serviceUser.title).toEqual('Mr')
     expect(serviceUser.firstName).toEqual('Alex')
     expect(serviceUser.lastName).toEqual('River')
+    expect(serviceUser.contactDetails.email).toEqual('alex.river@example.com')
+    expect(serviceUser.contactDetails.mobile).toEqual('07123456789')
     expect(serviceUser.dateOfBirth).toEqual('1980-01-01')
     expect(serviceUser.gender).toEqual('Male')
     expect(serviceUser.ethnicity).toEqual('British')
@@ -1142,6 +1163,7 @@ describe('serializeDeliusServiceUser', () => {
       otherIds: {
         crn: 'X320741',
       },
+      contactDetails: {},
       offenderProfile: {
         offenderLanguages: {},
       },
@@ -1154,6 +1176,8 @@ describe('serializeDeliusServiceUser', () => {
       expect(serviceUser.title).toEqual(null)
       expect(serviceUser.firstName).toEqual('Aadland')
       expect(serviceUser.lastName).toEqual('Bertrand')
+      expect(serviceUser.contactDetails.email).toEqual(null)
+      expect(serviceUser.contactDetails.mobile).toEqual(null)
       expect(serviceUser.dateOfBirth).toEqual('2065-07-19')
       expect(serviceUser.gender).toEqual('Male')
       expect(serviceUser.ethnicity).toEqual(null)

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -70,6 +70,7 @@ export interface ServiceUser {
   title: string | null
   firstName: string | null
   lastName: string | null
+  contactDetails: ContactDetails
   dateOfBirth: string | null
   gender: string | null
   ethnicity: string | null
@@ -80,6 +81,11 @@ export interface ServiceUser {
 
 export interface ServiceProvider {
   name: string
+}
+
+interface ContactDetails {
+  mobile: string | null
+  email: string | null
 }
 
 export default class InterventionsService {
@@ -122,11 +128,23 @@ export default class InterventionsService {
       ? CalendarDay.parseIso8601(deliusServiceUser.dateOfBirth)?.iso8601 || null
       : null
 
+    const mobile = deliusServiceUser.contactDetails.phoneNumbers
+      ? deliusServiceUser.contactDetails.phoneNumbers.find(phoneNumber => phoneNumber.type === 'MOBILE')?.number || null
+      : null
+
+    const email = deliusServiceUser.contactDetails.emailAddresses
+      ? deliusServiceUser.contactDetails.emailAddresses[0] || null
+      : null
+
     return {
       crn: deliusServiceUser.otherIds.crn,
       title: deliusServiceUser.title || null,
       firstName: deliusServiceUser.firstName || null,
       lastName: deliusServiceUser.surname || null,
+      contactDetails: {
+        email,
+        mobile,
+      },
       dateOfBirth: iso8601DateOfBirth || null,
       gender: deliusServiceUser.gender || null,
       ethnicity: deliusServiceUser.offenderProfile?.ethnicity || null,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -2,8 +2,6 @@ import RestClient from '../data/restClient'
 import logger from '../../log'
 import { ApiConfig } from '../config'
 import { SanitisedError } from '../sanitisedError'
-import { DeliusServiceUser } from './communityApiService'
-import CalendarDay from '../utils/calendarDay'
 
 export type InterventionsServiceError = SanitisedError & { validationErrors?: InterventionsServiceValidationError[] }
 
@@ -108,50 +106,6 @@ export default class InterventionsService {
     }
 
     return sanitisedError
-  }
-
-  serializeDeliusServiceUser(deliusServiceUser: DeliusServiceUser | null): ServiceUser {
-    if (!deliusServiceUser) {
-      return {} as ServiceUser
-    }
-
-    const currentDisabilities = deliusServiceUser.offenderProfile?.disabilities
-      ? deliusServiceUser.offenderProfile.disabilities
-          .filter(disability => {
-            const today = new Date().toString()
-            return disability.endDate === '' || Date.parse(disability.endDate) >= Date.parse(today)
-          })
-          .map(disability => disability.disabilityType.description)
-      : null
-
-    const iso8601DateOfBirth = deliusServiceUser.dateOfBirth
-      ? CalendarDay.parseIso8601(deliusServiceUser.dateOfBirth)?.iso8601 || null
-      : null
-
-    const mobile = deliusServiceUser.contactDetails.phoneNumbers
-      ? deliusServiceUser.contactDetails.phoneNumbers.find(phoneNumber => phoneNumber.type === 'MOBILE')?.number || null
-      : null
-
-    const email = deliusServiceUser.contactDetails.emailAddresses
-      ? deliusServiceUser.contactDetails.emailAddresses[0] || null
-      : null
-
-    return {
-      crn: deliusServiceUser.otherIds.crn,
-      title: deliusServiceUser.title || null,
-      firstName: deliusServiceUser.firstName || null,
-      lastName: deliusServiceUser.surname || null,
-      contactDetails: {
-        email,
-        mobile,
-      },
-      dateOfBirth: iso8601DateOfBirth || null,
-      gender: deliusServiceUser.gender || null,
-      ethnicity: deliusServiceUser.offenderProfile?.ethnicity || null,
-      preferredLanguage: deliusServiceUser.offenderProfile?.offenderLanguages?.primaryLanguage || null,
-      religionOrBelief: deliusServiceUser.offenderProfile?.religion || null,
-      disabilities: currentDisabilities,
-    }
   }
 
   async getDraftReferral(token: string, id: string): Promise<DraftReferral> {

--- a/testutils/factories/deliusServiceUser.ts
+++ b/testutils/factories/deliusServiceUser.ts
@@ -25,6 +25,15 @@ export default Factory.define<DeliusServiceUser>(() => ({
   title: 'Mr',
   firstName: 'Alex',
   surname: 'River',
+  contactDetails: {
+    emailAddresses: ['alex.river@example.com'],
+    phoneNumbers: [
+      {
+        number: '07123456789',
+        type: 'MOBILE',
+      },
+    ],
+  },
   dateOfBirth: '1980-01-01',
   gender: 'Male',
 }))

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -27,6 +27,10 @@ class DraftReferralFactory extends Factory<DraftReferral> {
         title: 'Mr',
         firstName: 'Alex',
         lastName: 'River',
+        contactDetails: {
+          email: 'alex.river@example.com',
+          mobile: '0123456789',
+        },
         dateOfBirth: '1980-01-01',
         gender: 'Male',
         ethnicity: 'British',
@@ -46,6 +50,10 @@ export default DraftReferralFactory.define(({ sequence }) => ({
     title: null,
     firstName: null,
     lastName: null,
+    contactDetails: {
+      email: null,
+      mobile: null,
+    },
     dateOfBirth: null,
     gender: null,
     ethnicity: null,

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -24,6 +24,10 @@ const exampleReferralFields = () => {
       title: 'Mr',
       firstName: 'Alex',
       lastName: 'River',
+      contactDetails: {
+        email: 'alex.river@example.com',
+        mobile: '0123456789',
+      },
       dateOfBirth: '1980-01-01',
       gender: 'Male',
       ethnicity: 'British',


### PR DESCRIPTION
## What does this pull request do?

Adds service user's mobile and email to the referral when fetching the service user from the Community API. It currently doesn't display it anywhere.

Extracts Delius Service User serialization function into own class, as it was getting quite complicated in there.

## What is the intent behind these changes?

So we can store the SU details on a referral and play it back to the Service Provider.
