### PR TITLE
IC-1097: Display Service User contact details on SP intervention view

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1,6 +1,7 @@
 import sentReferralFactory from '../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
 import deliusUserFactory from '../../testutils/factories/deliusUser'
+import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
 
 describe('Service provider referrals dashboard', () => {
   beforeEach(() => {
@@ -28,7 +29,7 @@ describe('Service provider referrals dashboard', () => {
         referenceNumber: 'ABCABCA2',
         referral: {
           serviceCategoryId: socialInclusionServiceCategory.id,
-          serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+          serviceUser: { firstName: 'Jenny', lastName: 'Jones', crn: 'X123456' },
         },
       }),
     ]
@@ -39,11 +40,29 @@ describe('Service provider referrals dashboard', () => {
       email: 'bernard.beaks@justice.gov.uk',
     })
 
+    const deliusServiceUser = deliusServiceUserFactory.build({
+      firstName: 'Jenny',
+      surname: 'Jones',
+      dateOfBirth: '1980-01-01',
+      contactDetails: {
+        emailAddresses: ['jenny.jones@example.com'],
+        phoneNumbers: [
+          {
+            number: '07123456789',
+            type: 'MOBILE',
+          },
+        ],
+      },
+    })
+
+    const referralToSelect = sentReferrals[1]
+
     cy.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory)
     cy.stubGetServiceCategory(socialInclusionServiceCategory.id, socialInclusionServiceCategory)
     sentReferrals.forEach(referral => cy.stubGetSentReferral(referral.id, referral))
     cy.stubGetSentReferrals(sentReferrals)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+    cy.stubGetServiceUserByCRN(referralToSelect.referral.serviceUser.crn, deliusServiceUser)
 
     cy.login()
 
@@ -67,8 +86,9 @@ describe('Service provider referrals dashboard', () => {
       ])
 
     cy.contains('ABCABCA2').click()
-    cy.location('pathname').should('equal', `/service-provider/referrals/${sentReferrals[1].id}`)
+    cy.location('pathname').should('equal', `/service-provider/referrals/${referralToSelect.id}`)
     cy.get('h1').contains('Social inclusion referral for Jenny Jones')
+    cy.contains('07123456789 | jenny.jones@example.com')
     cy.contains('Bernard Beaks')
     cy.contains('bernard.beaks@justice.gov.uk')
   })

--- a/mocks.ts
+++ b/mocks.ts
@@ -23,7 +23,7 @@ export default async function setUpMocks(): Promise<void> {
       referenceNumber: 'ABCABCA1',
       referral: {
         serviceCategoryId: accommodationServiceCategory.id,
-        serviceUser: { firstName: 'George', lastName: 'Michael' },
+        serviceUser: { firstName: 'Aadland', lastName: 'Bertrand', crn: 'X320741' },
       },
       sentBy,
     }),
@@ -32,7 +32,7 @@ export default async function setUpMocks(): Promise<void> {
       referenceNumber: 'ABCABCA2',
       referral: {
         serviceCategoryId: socialInclusionServiceCategory.id,
-        serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+        serviceUser: { firstName: 'George', lastName: 'Michael', crn: 'X320741' },
       },
       sentBy,
     }),
@@ -41,7 +41,7 @@ export default async function setUpMocks(): Promise<void> {
       referenceNumber: 'ABCABCA3',
       referral: {
         serviceCategoryId: socialInclusionServiceCategory.id,
-        serviceUser: { firstName: 'Jenny', lastName: 'Yates' },
+        serviceUser: { firstName: 'Jenny', lastName: 'Jones', crn: 'X320741' },
       },
       sentBy,
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -6052,9 +6052,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.9.1.tgz",
-      "integrity": "sha512-ouOoDUj0QwDA4uCHIBkGCFMpORuTRcSuDscOrz7V1PBcOecntLglxJAZAuNm+j2sPo7anoScHU0ZSeE2QIoeAg=="
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.2.tgz",
+      "integrity": "sha512-MpMymgLsKoMw40MggZ0XLCAj1FY5N2s8Pf3aQR+k0cZOsegjLsnejxNfEB9qEl9jcma2fiiVcvsEZ+Ipo+Oo2g=="
     },
     "govuk_frontend_toolkit": {
       "version": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "express-session": "^1.17.1",
     "express-validator": "^6.8.0",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^3.9.0",
+    "govuk-frontend": "^3.10.2",
     "helmet": "^4.1.1",
     "http-errors": "^1.8.0",
     "joi": "^17.2.1",

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -8,6 +8,7 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import deliusUserFactory from '../../../testutils/factories/deliusUser'
 import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
 import CommunityApiService from '../../services/communityApiService'
+import deliusServiceUser from '../../../testutils/factories/deliusServiceUser'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -69,7 +70,7 @@ describe('GET /service-provider/dashboard', () => {
 })
 
 describe('GET /service-provider/referrals/:id', () => {
-  it('displays information about the referral', async () => {
+  it('displays information about the referral and service user', async () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const sentReferral = sentReferralFactory.build({
       referral: { serviceCategoryId: serviceCategory.id, serviceUser: { firstName: 'Jenny', lastName: 'Jones' } },
@@ -79,10 +80,24 @@ describe('GET /service-provider/referrals/:id', () => {
       surname: 'Beaks',
       email: 'bernard.beaks@justice.gov.uk',
     })
+    const serviceUser = deliusServiceUser.build({
+      firstName: 'Alex',
+      surname: 'River',
+      contactDetails: {
+        emailAddresses: ['alex.river@example.com'],
+        phoneNumbers: [
+          {
+            number: '07123456789',
+            type: 'MOBILE',
+          },
+        ],
+      },
+    })
 
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
+    communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
 
     await request(app)
       .get(`/service-provider/referrals/${sentReferral.id}`)
@@ -91,6 +106,9 @@ describe('GET /service-provider/referrals/:id', () => {
         expect(res.text).toContain('Accommodation referral for Jenny Jones')
         expect(res.text).toContain('Bernard Beaks')
         expect(res.text).toContain('bernard.beaks@justice.gov.uk')
+        expect(res.text).toContain('alex.river@example.com')
+        expect(res.text).toContain('07123456789')
+        expect(res.text).toContain('Alex River')
       })
   })
 })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -30,12 +30,13 @@ export default class ServiceProviderReferralsController {
 
   async showReferral(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getSentReferral(res.locals.user.token, req.params.id)
-    const [serviceCategory, sentBy] = await Promise.all([
+    const [serviceCategory, sentBy, serviceUser] = await Promise.all([
       this.interventionsService.getServiceCategory(res.locals.user.token, referral.referral.serviceCategoryId),
       this.communityApiService.getUserByUsername(referral.sentBy.username),
+      this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn),
     ])
 
-    const presenter = new ShowReferralPresenter(referral, serviceCategory, sentBy)
+    const presenter = new ShowReferralPresenter(referral, serviceCategory, sentBy, serviceUser)
     const view = new ShowReferralView(presenter)
 
     res.render(...view.renderArgs)

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -2,6 +2,8 @@ import ShowReferralPresenter from './showReferralPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import deliusUserFactory from '../../../testutils/factories/deliusUser'
+import deliusServiceUser from '../../../testutils/factories/deliusServiceUser'
+import { DeliusServiceUser } from '../../services/communityApiService'
 
 describe(ShowReferralPresenter, () => {
   const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
@@ -13,10 +15,24 @@ describe(ShowReferralPresenter, () => {
     surname: 'Beaks',
     email: 'bernard.beaks@justice.gov.uk',
   })
+  const serviceUser = deliusServiceUser.build({
+    firstName: 'Alex',
+    surname: 'River',
+    dateOfBirth: '1980-01-01',
+    contactDetails: {
+      emailAddresses: ['alex.river@example.com'],
+      phoneNumbers: [
+        {
+          number: '07123456789',
+          type: 'MOBILE',
+        },
+      ],
+    },
+  })
 
   describe('text', () => {
     it('returns text to be displayed', () => {
-      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser)
+      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser)
 
       expect(presenter.text).toEqual({ title: 'Accommodation referral for Jenny Jones' })
     })
@@ -24,12 +40,54 @@ describe(ShowReferralPresenter, () => {
 
   describe('probationPractitionerDetails', () => {
     it('returns a summary list of probation practitioner details', () => {
-      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser)
+      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser)
 
       expect(presenter.probationPractitionerDetails).toEqual([
         { isList: false, key: 'Name', lines: ['Bernard Beaks'] },
         { isList: false, key: 'Email address', lines: ['bernard.beaks@justice.gov.uk'] },
       ])
+    })
+  })
+
+  describe('serviceUserNotificationBannerArgs', () => {
+    describe('when all contact details are present on the Delius Service User', () => {
+      it('returns a notification banner with service user details', () => {
+        const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser)
+
+        expect(presenter.serviceUserNotificationBannerArgs).toEqual({
+          titleText: 'Service user details',
+          html:
+            `<p class="govuk-notification-banner__heading">Alex River<p>` +
+            `<p>Date of birth: 1 January 1980</p>` +
+            `<p class="govuk-body">07123456789 | alex.river@example.com</p>`,
+        })
+      })
+    })
+
+    describe('if contact details are missing on the Delius Service User', () => {
+      it('displays a useful message to the user in the banner', () => {
+        const serviceUserWithoutContactDetails = {
+          firstName: 'Alex',
+          surname: 'River',
+          dateOfBirth: '1980-01-01',
+          contactDetails: {},
+        } as DeliusServiceUser
+
+        const presenter = new ShowReferralPresenter(
+          referral,
+          serviceCategory,
+          deliusUser,
+          serviceUserWithoutContactDetails
+        )
+
+        expect(presenter.serviceUserNotificationBannerArgs).toEqual({
+          titleText: 'Service user details',
+          html:
+            `<p class="govuk-notification-banner__heading">Alex River<p>` +
+            `<p>Date of birth: 1 January 1980</p>` +
+            `<p class="govuk-body">Mobile number not found | Email address not found</p>`,
+        })
+      })
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -1,5 +1,6 @@
-import { DeliusUser } from '../../services/communityApiService'
+import { DeliusServiceUser, DeliusUser } from '../../services/communityApiService'
 import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import CalendarDay from '../../utils/calendarDay'
 import { SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
 import ReferralDataPresenterUtils from '../referrals/referralDataPresenterUtils'
@@ -8,7 +9,8 @@ export default class ShowReferralPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly serviceCategory: ServiceCategory,
-    private readonly sentBy: DeliusUser
+    private readonly sentBy: DeliusUser,
+    private readonly serviceUser: DeliusServiceUser
   ) {}
 
   readonly text = {
@@ -21,4 +23,49 @@ export default class ShowReferralPresenter {
     { key: 'Name', lines: [`${this.sentBy.firstName} ${this.sentBy.surname}`], isList: false },
     { key: 'Email address', lines: [this.sentBy.email ?? ''], isList: false },
   ]
+
+  readonly serviceUserNotificationBannerArgs = {
+    titleText: 'Service user details',
+    html:
+      `<p class="govuk-notification-banner__heading">${this.serviceUser.firstName} ${this.serviceUser.surname}<p>` +
+      `<p>Date of birth: ${this.serviceUserDateOfBirth}</p>` +
+      `<p class="govuk-body">${this.serviceUserMobile} | ${this.serviceUserEmail}</p>`,
+  }
+
+  private get serviceUserDateOfBirth(): string {
+    const { dateOfBirth } = this.serviceUser
+
+    const notFoundMessage = 'Not found'
+
+    if (dateOfBirth) {
+      const iso8601DateOfBirth = CalendarDay.parseIso8601(dateOfBirth)
+
+      return iso8601DateOfBirth ? ReferralDataPresenterUtils.govukFormattedDate(iso8601DateOfBirth) : notFoundMessage
+    }
+
+    return notFoundMessage
+  }
+
+  private get serviceUserEmail(): string {
+    const { emailAddresses } = this.serviceUser.contactDetails
+
+    if (emailAddresses && emailAddresses.length > 0) {
+      return emailAddresses[0]
+    }
+
+    return 'Email address not found'
+  }
+
+  private get serviceUserMobile(): string {
+    const { phoneNumbers } = this.serviceUser.contactDetails
+    const notFoundMessage = 'Mobile number not found'
+
+    if (phoneNumbers) {
+      const mobileNumber = phoneNumbers.find(phoneNumber => phoneNumber.type === 'MOBILE')
+
+      return mobileNumber && mobileNumber.number ? mobileNumber.number : notFoundMessage
+    }
+
+    return notFoundMessage
+  }
 }

--- a/server/routes/serviceProviderReferrals/showReferralView.ts
+++ b/server/routes/serviceProviderReferrals/showReferralView.ts
@@ -14,6 +14,7 @@ export default class ShowReferralView {
       {
         presenter: this.presenter,
         probationPractitionerSummaryListArgs: this.probationPractitionerSummaryListArgs,
+        serviceUserNotificationBannerArgs: this.presenter.serviceUserNotificationBannerArgs,
       },
     ]
   }

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -22,6 +22,7 @@ export interface DeliusServiceUser {
   surname: string | null
   dateOfBirth: string | null
   gender: string | null
+  contactDetails: ContactDetails
 }
 
 interface DeliusRole {
@@ -49,6 +50,16 @@ interface OffenderProfile {
 
 interface OffenderLanguages {
   primaryLanguage: string
+}
+
+interface ContactDetails {
+  emailAddresses?: string[] | null
+  phoneNumbers?: PhoneNumber[] | null
+}
+
+interface PhoneNumber {
+  number: string | null
+  type: string | null
 }
 
 export default class CommunityApiService {

--- a/server/views/serviceProviderReferrals/showReferral.njk
+++ b/server/views/serviceProviderReferrals/showReferral.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -9,6 +10,7 @@
 {% endblock %}
 
 {% block content %}
+  {{ govukNotificationBanner(serviceUserNotificationBannerArgs) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>

--- a/testutils/factories/deliusServiceUser.ts
+++ b/testutils/factories/deliusServiceUser.ts
@@ -27,4 +27,13 @@ export default Factory.define<DeliusServiceUser>(() => ({
   surname: 'River',
   dateOfBirth: '1980-01-01',
   gender: 'Male',
+  contactDetails: {
+    emailAddresses: ['alex.river@example.com'],
+    phoneNumbers: [
+      {
+        number: '0123456789',
+        type: 'MOBILE',
+      },
+    ],
+  },
 }))


### PR DESCRIPTION
## What does this pull request do?

Adds a placeholder GOVUK Notification banner (needs futher design work) to the SP's interventions view, with data fetched from the Community API. This is currently hardcoded to Aadland Bertrand locally, which looks a bit weird on some pages, as the response from the community api doesn't match the mocked service user on our referral.

A couple of notes/questions:
- What happens if the community API is down and a Service Provider is trying to view this screen? Should we store a snapshot on the contact details on referral creation and fall back to this if that's the case, or would that confuse things?
- If we want to display this on another screen, it'd be good to move it into a partial, but I've gone for the simplest option for now as the Critical Outcomes approach.
- Again, the local instance of the community api has made testing this locally very difficult, as the data is a bit lacking (everything seems to come back empty, as you see in the screenshot below) - I'm going to have a chat with Matt R and see if he can help us update this.

## What is the intent behind these changes?

To ensure we can show an up-to-date record of the Service User's contact details to the Service Provider.

## Screenshot (shows data discrepancy between local community API and mocks, but there's an example with Aadland Bertrand as the service user too)

![image](https://user-images.githubusercontent.com/19826940/107048041-6624c680-67c0-11eb-9e3b-72f3dd34734c.png)

