### PR TITLE
add username claim to token used for testing

### DIFF
--- a/testutils/factories/oauth2Token.ts
+++ b/testutils/factories/oauth2Token.ts
@@ -4,6 +4,7 @@ import { Factory } from 'fishery'
 interface TokenParams {
   authSource: string
   userID: string
+  username: string
   roles: string[]
   clientID: string
 }
@@ -13,16 +14,18 @@ class Oauth2TokenFactory extends Factory<string, TokenParams> {
     return this.transient({
       authSource: 'delius',
       userID: '2500128586',
+      username: 'joe.smith',
       roles: ['ROLE_PROBATION'],
     })
   }
 }
 
 export default Oauth2TokenFactory.define(({ transientParams }) => {
-  const { authSource, userID, roles, clientID = 'interventions' } = transientParams
+  const { authSource, userID, username, roles, clientID = 'interventions' } = transientParams
   const payload = {
     user_id: userID,
     auth_source: authSource,
+    user_name: username,
     authorities: roles,
     client_id: clientID,
     exp: 3758875200, // warning - tests may start to fail in 2089...


### PR DESCRIPTION
## What does this pull request do?

add username claim to token used for testing

## What is the intent behind these changes?
ensures that the username claim is available to the backend when running pact tests.
