### PR TITLE
IC-1067: Add contract for `GET /interventions`

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -66,5 +66,9 @@ module.exports = on => {
     stubGetSentReferrals: arg => {
       return interventionsService.stubGetSentReferrals(arg.responseJson)
     },
+
+    stubGetInterventions: arg => {
+      return interventionsService.stubGetInterventions(arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -29,3 +29,7 @@ Cypress.Commands.add('stubGetSentReferral', (id, responseJson) => {
 Cypress.Commands.add('stubGetSentReferrals', responseJson => {
   cy.task('stubGetSentReferrals', { responseJson })
 })
+
+Cypress.Commands.add('stubGetInterventions', responseJson => {
+  cy.task('stubGetInterventions', { responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -131,4 +131,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubGetInterventions = async (responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/interventions`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/mocks.ts
+++ b/mocks.ts
@@ -2,6 +2,7 @@ import Wiremock from './mockApis/wiremock'
 import InterventionsServiceMocks from './mockApis/interventionsService'
 import sentReferralFactory from './testutils/factories/sentReferral'
 import serviceCategoryFactory from './testutils/factories/serviceCategory'
+import interventionFactory from './testutils/factories/intervention'
 
 const wiremock = new Wiremock('http://localhost:9092/__admin')
 const interventionsMocks = new InterventionsServiceMocks(wiremock, '')
@@ -47,10 +48,14 @@ export default async function setUpMocks(): Promise<void> {
     }),
   ]
 
+  const intervention = interventionFactory.build()
+  const interventions = [intervention, intervention, intervention]
+
   await Promise.all([
     interventionsMocks.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory),
     interventionsMocks.stubGetServiceCategory(socialInclusionServiceCategory.id, socialInclusionServiceCategory),
     Promise.all(sentReferrals.map(referral => interventionsMocks.stubGetSentReferral(referral.id, referral))),
     interventionsMocks.stubGetSentReferrals(sentReferrals),
+    interventionsMocks.stubGetInterventions(interventions),
   ])
 }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -5,6 +5,9 @@ import { term } from '@pact-foundation/pact/dsl/matchers'
 import InterventionsService, { SentReferral, ServiceUser } from './interventionsService'
 import config from '../config'
 import oauth2TokenFactory from '../../testutils/factories/oauth2Token'
+import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
+import serviceProviderFactory from '../../testutils/factories/serviceProvider'
+import eligibilityFactory from '../../testutils/factories/eligibility'
 import { DeliusServiceUser } from './communityApiService'
 
 jest.mock('../data/hmppsAuthClient')
@@ -1067,6 +1070,43 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       expect(await interventionsService.getSentReferrals(token)).toEqual([sentReferral, sentReferral])
+    })
+  })
+
+  describe('getInterventions', () => {
+    it('returns a list of all interventions', async () => {
+      const intervention = {
+        id: '15237ae5-a017-4de6-a033-abf350f14d99',
+        title: 'Better solutions (anger management)',
+        description:
+          'To provide service users with key tools and strategies to address issues of anger management and temper control and explore the link between thoughts, emotions and behaviour. It provides the opportunity for service users to practice these strategies in a safe and closed environment.',
+        pccRegions: [
+          { id: 'cheshire', name: 'Cheshire' },
+          { id: 'cumbria', name: 'Cumbria' },
+          { id: 'lancashire', name: 'Lancashire' },
+          { id: 'merseyside', name: 'Merseyside' },
+        ],
+        serviceCategory: serviceCategoryFactory.build(),
+        serviceProvider: serviceProviderFactory.build(),
+        eligibility: eligibilityFactory.allAdults().build(),
+      }
+
+      await provider.addInteraction({
+        state: 'There are some interventions',
+        uponReceiving: 'a request for all interventions',
+        withRequest: {
+          method: 'GET',
+          path: '/interventions',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like([intervention, intervention]),
+          headers: { 'Content-Type': 'application/json' },
+        },
+      })
+
+      expect(await interventionsService.getInterventions(token)).toEqual([intervention, intervention])
     })
   })
 })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -88,6 +88,28 @@ export interface AuthUser {
   authSource: string
 }
 
+export interface Intervention {
+  id: string
+  title: string
+  description: string
+  pccRegions: PCCRegion[]
+  serviceCategory: ServiceCategory
+  serviceProvider: ServiceProvider
+  eligibility: Eligibility
+}
+
+export interface PCCRegion {
+  id: string
+  name: string
+}
+
+export interface Eligibility {
+  minimumAge: number
+  maximumAge: number | null
+  allowsFemale: boolean
+  allowsMale: boolean
+}
+
 export default class InterventionsService {
   constructor(private readonly config: ApiConfig) {}
 
@@ -233,5 +255,14 @@ export default class InterventionsService {
       path: `/sent-referrals`,
       headers: { Accept: 'application/json' },
     })) as SentReferral[]
+  }
+
+  async getInterventions(token: string): Promise<Intervention[]> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: '/interventions',
+      headers: { Accept: 'application/json' },
+    })) as Intervention[]
   }
 }

--- a/testutils/factories/eligibility.ts
+++ b/testutils/factories/eligibility.ts
@@ -1,0 +1,47 @@
+import { Factory } from 'fishery'
+import { Eligibility } from '../../server/services/interventionsService'
+
+class EligibilityFactory extends Factory<Eligibility> {
+  allAdults() {
+    return this.params({
+      minimumAge: 18,
+      maximumAge: null,
+      allowsMale: true,
+      allowsFemale: true,
+    })
+  }
+
+  anyAdultMale() {
+    return this.params({
+      minimumAge: 18,
+      maximumAge: null,
+      allowsMale: true,
+      allowsFemale: false,
+    })
+  }
+
+  anyAdultFemale() {
+    return this.params({
+      minimumAge: 18,
+      maximumAge: null,
+      allowsMale: false,
+      allowsFemale: true,
+    })
+  }
+
+  youngAdultMales() {
+    return this.params({
+      minimumAge: 18,
+      maximumAge: 25,
+      allowsMale: true,
+      allowsFemale: false,
+    })
+  }
+}
+
+export default EligibilityFactory.define(() => ({
+  minimumAge: 18,
+  maximumAge: 24,
+  allowsMale: true,
+  allowsFemale: true,
+}))

--- a/testutils/factories/intervention.ts
+++ b/testutils/factories/intervention.ts
@@ -1,0 +1,21 @@
+import { Factory } from 'fishery'
+import { Intervention } from '../../server/services/interventionsService'
+import serviceCategoryFactory from './serviceCategory'
+import serviceProviderFactory from './serviceProvider'
+import eligibilityFactory from './eligibility'
+
+export default Factory.define<Intervention>(sequence => ({
+  id: sequence.toString(),
+  title: 'Better solutions (anger management)',
+  description:
+    'To provide service users with key tools and strategies to address issues of anger management and temper control and explore the link between thoughts, emotions and behaviour. It provides the opportunity for service users to practice these strategies in a safe and closed environment.',
+  pccRegions: [
+    { id: 'cheshire', name: 'Cheshire' },
+    { id: 'cumbria', name: 'Cumbria' },
+    { id: 'lancashire', name: 'Lancashire' },
+    { id: 'merseyside', name: 'Merseyside' },
+  ],
+  serviceCategory: serviceCategoryFactory.build(),
+  serviceProvider: serviceProviderFactory.build(),
+  eligibility: eligibilityFactory.allAdults().build(),
+}))

--- a/testutils/factories/serviceProvider.ts
+++ b/testutils/factories/serviceProvider.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import { ServiceProvider } from '../../server/services/interventionsService'
+
+export default Factory.define<ServiceProvider>(({ sequence }) => ({
+  id: sequence.toString(),
+  name: 'Harmony Living',
+}))


### PR DESCRIPTION
## What does this pull request do?

Adds the `Intervention` type and a contract for the `GET /interventions` endpoint proposed in ministryofjustice/hmpps-interventions-service#87.

## What is the intent behind these changes?

To allow us to display a list of interventions.
