### PR TITLE
IC-1067: Show a list of all interventions

### DIFF
--- a/integration_tests/integration/findInterventions.spec.js
+++ b/integration_tests/integration/findInterventions.spec.js
@@ -1,0 +1,33 @@
+import interventionFactory from '../../testutils/factories/intervention'
+
+context('Find an intervention', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubLogin')
+    cy.task('stubProbationPractitionerToken')
+    cy.task('stubProbationPractitionerAuthUser')
+  })
+
+  it('Probation practitioner views a list of search results', () => {
+    cy.stubGetDraftReferralsForUser([])
+    cy.login()
+
+    const interventions = [
+      { title: 'Better solutions (anger management)', categoryName: 'thinking and behaviour' },
+      { title: 'HELP (domestic violence for males)', categoryName: 'relationships' },
+    ].map(params => {
+      return interventionFactory.build({ title: params.title, serviceCategory: { name: params.categoryName } })
+    })
+    cy.stubGetInterventions(interventions)
+
+    cy.visit('/find-interventions')
+
+    cy.get('h1').contains('Find interventions')
+    cy.contains('2 results found')
+
+    cy.get('h2').contains('Better solutions (anger management)')
+    cy.contains('Thinking and behaviour')
+    cy.get('h2').contains('HELP (domestic violence for males)')
+    cy.contains('Relationships')
+  })
+})

--- a/mocks.ts
+++ b/mocks.ts
@@ -48,8 +48,23 @@ export default async function setUpMocks(): Promise<void> {
     }),
   ]
 
-  const intervention = interventionFactory.build()
-  const interventions = [intervention, intervention, intervention]
+  const interventions = [
+    { title: 'Better solutions (anger management)', categoryName: 'thinking and behaviour' },
+    {
+      title: 'HELP (domestic violence for males)',
+      categoryName: 'relationships',
+      description:
+        'HELP - the Healthy Relationships programme, is a new, preventative approach to domestic abuse.' +
+        'The course aims to help create successful relationships. Those who complete the group will have' +
+        'skills and strategies to manage situations differently and avoid problems escalating into violence.',
+    },
+  ].map(params => {
+    return interventionFactory.build({
+      title: params.title,
+      serviceCategory: { name: params.categoryName },
+      description: params.description,
+    })
+  })
 
   await Promise.all([
     interventionsMocks.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory),

--- a/server/routes/findInterventions/findInterventionsController.test.ts
+++ b/server/routes/findInterventions/findInterventionsController.test.ts
@@ -1,0 +1,52 @@
+import { Express } from 'express'
+import request from 'supertest'
+import FindInterventionsController from './findInterventionsController'
+import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
+import InterventionsService from '../../services/interventionsService'
+import apiConfig from '../../config'
+import interventionFactory from '../../../testutils/factories/intervention'
+
+jest.mock('../../services/interventionsService')
+const interventionsService = new InterventionsService(apiConfig.apis.interventionsService) as jest.Mocked<
+  InterventionsService
+>
+
+let app: Express
+
+beforeEach(() => {
+  app = appWithAllRoutes({
+    userType: AppSetupUserType.serviceProvider,
+    overrides: { interventionsService },
+  })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe(FindInterventionsController, () => {
+  describe('GET /find-interventions', () => {
+    it('responds with a 200', async () => {
+      const interventions = [
+        { title: 'Better solutions (anger management)', categoryName: 'thinking and behaviour' },
+        { title: 'HELP (domestic violence for males)', categoryName: 'relationships' },
+      ].map(params => {
+        return interventionFactory.build({ title: params.title, serviceCategory: { name: params.categoryName } })
+      })
+      interventionsService.getInterventions.mockResolvedValue(interventions)
+
+      await request(app)
+        .get('/find-interventions')
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('Find interventions')
+
+          expect(res.text).toContain('Better solutions (anger management)')
+          expect(res.text).toContain('Thinking and behaviour')
+
+          expect(res.text).toContain('HELP (domestic violence for males)')
+          expect(res.text).toContain('Relationships')
+        })
+    })
+  })
+})

--- a/server/routes/findInterventions/findInterventionsController.ts
+++ b/server/routes/findInterventions/findInterventionsController.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from 'express'
+import InterventionsService from '../../services/interventionsService'
+import SearchResultsPresenter from './searchResultsPresenter'
+import SearchResultsView from './searchResultsView'
+
+export default class FindInterventionsController {
+  constructor(private readonly interventionsService: InterventionsService) {}
+
+  async search(req: Request, res: Response): Promise<void> {
+    const interventions = await this.interventionsService.getInterventions(res.locals.user.token)
+
+    const presenter = new SearchResultsPresenter(interventions)
+    const view = new SearchResultsView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+}

--- a/server/routes/findInterventions/searchResultsPresenter.test.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.test.ts
@@ -1,0 +1,145 @@
+import { DeepPartial } from 'fishery'
+import SearchResultsPresenter from './searchResultsPresenter'
+import interventionFactory from '../../../testutils/factories/intervention'
+import eligibilityFactory from '../../../testutils/factories/eligibility'
+import { Intervention } from '../../services/interventionsService'
+
+describe(SearchResultsPresenter, () => {
+  describe('results', () => {
+    it('contains as many items as there are interventions', () => {
+      const presenter = new SearchResultsPresenter(interventionFactory.buildList(3))
+
+      expect(presenter.results.length).toBe(3)
+    })
+
+    function linesForKey(key: string, params: DeepPartial<Intervention>): string[] {
+      const presenter = new SearchResultsPresenter([interventionFactory.build(params)])
+      const item = presenter.results[0].summary.find(anItem => anItem.key === key)
+      if (item === undefined) {
+        fail(`Didn't find item for key ${key}`)
+      }
+      return item.lines
+    }
+
+    describe('Type', () => {
+      it('is “Dynamic Framework”', () => {
+        expect(linesForKey('Type', {})).toEqual(['Dynamic Framework'])
+      })
+    })
+
+    describe('Location', () => {
+      it('is a comma-separated list of PCC regions', () => {
+        expect(
+          linesForKey('Location', {
+            pccRegions: [
+              { id: '1', name: 'Region 1' },
+              { id: '2', name: 'Region 2' },
+            ],
+          })
+        ).toEqual(['Region 1, Region 2'])
+      })
+    })
+
+    describe('Criminogenic needs', () => {
+      it('is the service category name', () => {
+        expect(
+          linesForKey('Criminogenic needs', {
+            serviceCategory: { name: 'accommodation' },
+          })
+        ).toEqual(['Accommodation'])
+      })
+    })
+
+    describe('Provider', () => {
+      it('is the service provider’s name', () => {
+        expect(
+          linesForKey('Criminogenic needs', {
+            serviceCategory: { name: 'accommodation' },
+          })
+        ).toEqual(['Accommodation'])
+      })
+    })
+
+    describe('Age group', () => {
+      describe('with an intervention that’s for all adults', () => {
+        it('is “18+”', () => {
+          expect(
+            linesForKey('Age group', {
+              eligibility: eligibilityFactory.allAdults().build(),
+            })
+          ).toEqual(['18+'])
+        })
+      })
+
+      describe('with an intervention that’s only for young people', () => {
+        it('is “18–25”', () => {
+          expect(
+            linesForKey('Age group', {
+              eligibility: eligibilityFactory.youngAdultMales().build(),
+            })
+          ).toEqual(['18–25'])
+        })
+      })
+    })
+
+    describe('Sex', () => {
+      describe('with an intervention that’s for any adult male', () => {
+        it('is “Male”', () => {
+          expect(
+            linesForKey('Sex', {
+              eligibility: eligibilityFactory.anyAdultMale().build(),
+            })
+          ).toEqual(['Male'])
+        })
+      })
+
+      describe('with an intervention that’s for any adult female', () => {
+        it('is “Female”', () => {
+          expect(
+            linesForKey('Sex', {
+              eligibility: eligibilityFactory.anyAdultFemale().build(),
+            })
+          ).toEqual(['Female'])
+        })
+      })
+
+      describe('with an intervention that’s for all adults', () => {
+        it('is “Male and female”', () => {
+          expect(
+            linesForKey('Sex', {
+              eligibility: eligibilityFactory.allAdults().build(),
+            })
+          ).toEqual(['Male and female'])
+        })
+      })
+    })
+  })
+
+  describe('text', () => {
+    describe('results', () => {
+      describe('with no results', () => {
+        it('is correctly pluralised', () => {
+          const presenter = new SearchResultsPresenter([])
+
+          expect(presenter.text.results).toEqual({ count: '0', countSuffix: 'results found.' })
+        })
+      })
+
+      describe('with 1 result', () => {
+        it('is correctly pluralised', () => {
+          const presenter = new SearchResultsPresenter(interventionFactory.buildList(1))
+
+          expect(presenter.text.results).toEqual({ count: '1', countSuffix: 'result found.' })
+        })
+      })
+
+      describe('with > 1 result', () => {
+        it('is correctly pluralised', () => {
+          const presenter = new SearchResultsPresenter(interventionFactory.buildList(2))
+
+          expect(presenter.text.results).toEqual({ count: '2', countSuffix: 'results found.' })
+        })
+      })
+    })
+  })
+})

--- a/server/routes/findInterventions/searchResultsPresenter.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.ts
@@ -1,0 +1,80 @@
+import { Eligibility, Intervention } from '../../services/interventionsService'
+import { SummaryListItem } from '../../utils/summaryList'
+import utils from '../../utils/utils'
+
+export interface SearchResultPresenter {
+  title: string
+  href: string
+  body: string
+  summary: SummaryListItem[]
+}
+
+export default class SearchResultsPresenter {
+  constructor(private readonly interventions: Intervention[]) {}
+
+  readonly results: SearchResultPresenter[] = this.interventions.map(intervention => ({
+    title: intervention.title,
+    href: '#',
+    body: intervention.description,
+    summary: [
+      {
+        key: 'Type',
+        lines: ['Dynamic Framework'],
+        isList: false,
+      },
+      {
+        key: 'Location',
+        lines: [intervention.pccRegions.map(region => region.name).join(', ')],
+        isList: false,
+      },
+      {
+        key: 'Criminogenic needs',
+        lines: [utils.convertToProperCase(intervention.serviceCategory.name)],
+        isList: false,
+      },
+      {
+        key: 'Provider',
+        lines: [intervention.serviceProvider.name],
+        isList: false,
+      },
+      {
+        key: 'Age group',
+        lines: [SearchResultsPresenter.ageGroupDescription(intervention.eligibility)],
+        isList: false,
+      },
+      {
+        key: 'Sex',
+        lines: [SearchResultsPresenter.sexDescription(intervention.eligibility)],
+        isList: false,
+      },
+    ],
+  }))
+
+  private static ageGroupDescription(eligibility: Eligibility): string {
+    if (eligibility.maximumAge === null) {
+      return `${eligibility.minimumAge}+`
+    }
+    return `${eligibility.minimumAge}–${eligibility.maximumAge}`
+  }
+
+  private static sexDescription(eligibility: Eligibility): string {
+    if (eligibility.allowsMale && eligibility.allowsFemale) {
+      return 'Male and female'
+    }
+    if (eligibility.allowsMale) {
+      return 'Male'
+    }
+    if (eligibility.allowsFemale) {
+      return 'Female'
+    }
+
+    return ''
+  }
+
+  readonly text = {
+    results: {
+      count: this.results.length.toString(),
+      countSuffix: `${this.results.length === 1 ? 'result' : 'results'} found.`,
+    },
+  }
+}

--- a/server/routes/findInterventions/searchResultsView.ts
+++ b/server/routes/findInterventions/searchResultsView.ts
@@ -1,0 +1,18 @@
+import SearchResultsPresenter from './searchResultsPresenter'
+import ViewUtils from '../../utils/viewUtils'
+import { SummaryListArgs, SummaryListItem } from '../../utils/summaryList'
+
+export default class SearchResultsView {
+  constructor(private readonly presenter: SearchResultsPresenter) {}
+
+  static summaryListArgs(items: SummaryListItem[]): SummaryListArgs & { classes: string } {
+    return { ...ViewUtils.summaryListArgs(items), classes: 'govuk-summary-list--no-border' }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'findInterventions/searchResults',
+      { presenter: this.presenter, summaryListArgs: SearchResultsView.summaryListArgs },
+    ]
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -8,6 +8,7 @@ import IntegrationSamplesRoutes from './integrationSamples'
 import ServiceProviderReferralsController from './serviceProviderReferrals/serviceProviderReferralsController'
 import ReferralsController from './referrals/referralsController'
 import StaticContentController from './staticContent/staticContentController'
+import FindInterventionsController from './findInterventions/findInterventionsController'
 
 interface RouteProvider {
   [key: string]: RequestHandler
@@ -34,6 +35,7 @@ export default function routes(router: Router, services: Services): Router {
     services.interventionsService,
     services.communityApiService
   )
+  const findInterventionsController = new FindInterventionsController(services.interventionsService)
 
   get('/', (req, res, next) => {
     const { authSource } = res.locals.user
@@ -84,6 +86,8 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/:id/check-answers', (req, res) => referralsController.checkAnswers(req, res))
   post('/referrals/:id/send', (req, res) => referralsController.sendDraftReferral(req, res))
   get('/referrals/:id/confirmation', (req, res) => referralsController.viewConfirmation(req, res))
+
+  get('/find-interventions', (req, res) => findInterventionsController.search(req, res))
 
   return router
 }

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -1,0 +1,47 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row govuk-!-margin-bottom-7">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Find interventions</h1>
+
+      <p class="govuk-body">
+      Welcome to this new repository, where you can find the most appropriate interventions for your service users, according to their region and criminogenic needs. At the moment, you can use this to find:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><strong>Dynamic Framework</strong> interventions – individual rehabilitation and resettlement services that help to stabilise a service user’s life</li>
+        <li><strong>Structured Interventions</strong> – classroom-style group courses aimed at changing behaviours</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <p class="govuk-body">Filters to go here</p>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body"><span class="govuk-!-font-size-36 govuk-!-margin-right-1"><strong>{{presenter.text.results.count}}</strong></span> {{ presenter.text.results.countSuffix }}</p>
+
+      {% for result in presenter.results %}
+        <h2 class="govuk-heading-l">
+          <a class="govuk-link" href="{{ result.href }}">{{ result.title }}</a>
+        </h2>
+
+        <p class="govuk-body">{{ result.body }}</p>
+
+        {{ govukSummaryList(summaryListArgs(result.summary)) }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {% endfor %}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a page for displaying a list of all of the interventions.

## What is the intent behind these changes?

To allow a probation practitioner to see all of the available interventions, and to provide a starting point for us to build the search functionality.

## Why is this a draft?

1. It's based on top of #107, so that needs to be merged first.
2. I have an outstanding question about where the "Region" should come from (see inline comment).

## Screenshot

![Screenshot_2021-02-08 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/107257513-a8553e80-6a32-11eb-9d77-28292d934887.png)


