### PR TITLE
IC-1074: Add GET /intervention contract tests

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -70,5 +70,9 @@ module.exports = on => {
     stubGetInterventions: arg => {
       return interventionsService.stubGetInterventions(arg.responseJson)
     },
+
+    stubGetIntervention: arg => {
+      return interventionsService.stubGetIntervention(arg.id, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -33,3 +33,7 @@ Cypress.Commands.add('stubGetSentReferrals', responseJson => {
 Cypress.Commands.add('stubGetInterventions', responseJson => {
   cy.task('stubGetInterventions', { responseJson })
 })
+
+Cypress.Commands.add('stubGetIntervention', (id, responseJson) => {
+  cy.task('stubGetIntervention', { id, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -147,4 +147,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubGetIntervention = async (id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/intervention/${id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/mocks.ts
+++ b/mocks.ts
@@ -72,5 +72,6 @@ export default async function setUpMocks(): Promise<void> {
     Promise.all(sentReferrals.map(referral => interventionsMocks.stubGetSentReferral(referral.id, referral))),
     interventionsMocks.stubGetSentReferrals(sentReferrals),
     interventionsMocks.stubGetInterventions(interventions),
+    interventionsMocks.stubGetIntervention(interventions[0].id, interventions[0]),
   ])
 }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1109,6 +1109,44 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(await interventionsService.getInterventions(token)).toEqual([intervention, intervention])
     })
   })
+
+  describe('getIntervention', () => {
+    it('returns a single intervention', async () => {
+      const interventionId = '15237ae5-a017-4de6-a033-abf350f14d99'
+      const intervention = {
+        id: interventionId,
+        title: 'Better solutions (anger management)',
+        description:
+          'To provide service users with key tools and strategies to address issues of anger management and temper control and explore the link between thoughts, emotions and behaviour. It provides the opportunity for service users to practice these strategies in a safe and closed environment.',
+        pccRegions: [
+          { id: 'cheshire', name: 'Cheshire' },
+          { id: 'cumbria', name: 'Cumbria' },
+          { id: 'lancashire', name: 'Lancashire' },
+          { id: 'merseyside', name: 'Merseyside' },
+        ],
+        serviceCategory: serviceCategoryFactory.build(),
+        serviceProvider: serviceProviderFactory.build(),
+        eligibility: eligibilityFactory.allAdults().build(),
+      }
+
+      await provider.addInteraction({
+        state: 'There is an existing intervention with ID 15237ae5-a017-4de6-a033-abf350f14d99',
+        uponReceiving: 'a request for that intervention',
+        withRequest: {
+          method: 'GET',
+          path: `/intervention/${interventionId}`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(intervention),
+          headers: { 'Content-Type': 'application/json' },
+        },
+      })
+
+      expect(await interventionsService.getIntervention(token, interventionId)).toEqual(intervention)
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -265,4 +265,13 @@ export default class InterventionsService {
       headers: { Accept: 'application/json' },
     })) as Intervention[]
   }
+
+  async getIntervention(token: string, id: string): Promise<Intervention> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/intervention/${id}`,
+      headers: { Accept: 'application/json' },
+    })) as Intervention
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds pact test for `/intervention/:id` endpoint which will be queried when viewing the Intervention Details page.

## What is the intent behind these changes?

To allow us to display a single intervention on the intervention details page.
