### PR TITLE
IC-1158 - Add service provider template and layout

### DIFF
--- a/server/routes/staticContent/staticContentController.ts
+++ b/server/routes/staticContent/staticContentController.ts
@@ -69,6 +69,11 @@ export default class StaticContentController {
       template: 'serviceProviderReferrals/sessions/amend',
       description: 'IC-1087 (session details: amend)',
     },
+    {
+      path: '/service-provider/session/layout-example',
+      template: 'serviceProviderReferrals/sessions/layoutExample',
+      description: 'IC-1129 layout example with all components',
+    },
   ]
 
   static get allPaths(): string[] {

--- a/server/views/serviceProviderReferrals/partials/backLink.njk
+++ b/server/views/serviceProviderReferrals/partials/backLink.njk
@@ -1,0 +1,4 @@
+<div>
+  < BACK
+  {# Add backlink here#}
+</div>

--- a/server/views/serviceProviderReferrals/partials/breadcrumbs.njk
+++ b/server/views/serviceProviderReferrals/partials/breadcrumbs.njk
@@ -1,0 +1,1 @@
+<div>BREADCRUMBS</div>

--- a/server/views/serviceProviderReferrals/partials/layoutAllComponents.njk
+++ b/server/views/serviceProviderReferrals/partials/layoutAllComponents.njk
@@ -1,0 +1,47 @@
+{% extends "../templates/serviceProviderSessionsTemplate.njk" %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{% block head %}
+  <!--[if !IE 8]><!-->
+  <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>
+  <!--<![endif]-->
+
+  <!--[if lt IE 9]> <link href="/assets/stylesheets/application-ie8.css?{{ version }}" rel="stylesheet"/> <script src="/assets/js/html5shiv-3.7.3.min.js"></script> <![endif]-->
+
+  <script src="/assets/js/jquery.min.js"></script>
+  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js" integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU=" crossorigin="anonymous"></script>
+  <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet">
+
+{% endblock %}
+
+{% block pageTitle %}HMPPS Interventions{% endblock %}
+
+{% block header %}
+  {% include "../../partials/header.njk" %}
+  {% include "./primaryNav.njk" %}
+  {% include "./serviceUserDetailsBanner.njk" %}
+{% endblock %}
+
+{% block breadcrumbs %}
+  {% include "./breadcrumbs.njk" %}
+{% endblock %}
+
+{% block subNav %}
+  {% include "./subNav.njk" %}
+{% endblock %}
+
+{% block backLink %}
+  {% include "./backLink.njk" %}
+{% endblock %}
+
+{% block sidebar %}
+  {% include "./sidebar.njk" %}
+{% endblock %}
+
+{% block bodyEnd %}
+  {# Run JavaScript at end of the
+  <body>, to avoid blocking the initial render. #}
+  <script src="/assets/govuk/all.js"></script>
+  <script src="/assets/govukFrontendInit.js"></script>
+  <script src="/assets/moj/all.js"></script>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/partials/primaryNav.njk
+++ b/server/views/serviceProviderReferrals/partials/primaryNav.njk
@@ -1,0 +1,1 @@
+<div>Primary Nav {# add SP Header here #}</div>

--- a/server/views/serviceProviderReferrals/partials/serviceUserDetailsBanner.njk
+++ b/server/views/serviceProviderReferrals/partials/serviceUserDetailsBanner.njk
@@ -1,0 +1,4 @@
+<div>
+  BANNER
+{# Add SU Details banner #}
+</div>

--- a/server/views/serviceProviderReferrals/partials/sidebar.njk
+++ b/server/views/serviceProviderReferrals/partials/sidebar.njk
@@ -1,0 +1,4 @@
+<div class="govuk-grid-column-one-third">
+  <h3 class="govuk-heading-m">sidebar</h3>
+  <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
+</div>

--- a/server/views/serviceProviderReferrals/partials/subNav.njk
+++ b/server/views/serviceProviderReferrals/partials/subNav.njk
@@ -1,0 +1,4 @@
+<div>
+  Sub nav
+{# Add primary nav #}
+</div>

--- a/server/views/serviceProviderReferrals/sessions/layoutExample.njk
+++ b/server/views/serviceProviderReferrals/sessions/layoutExample.njk
@@ -1,0 +1,289 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% extends "../partials/layoutAllComponents.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block primaryTitle %}
+    <h1 class="govuk-heading-l">This is a primary title example</h2>
+{% endblock %}
+
+
+{% block pageHeading %}
+  <h2 class="govuk-heading-l">Track progress of each intervention</h2>
+{% endblock %}
+
+{% block mainContent %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {%  set completedTagHtml %}
+        {{govukTag({
+          text: "COMPLETED"
+        })}}
+        {% endset -%}
+        {%  set draftTagHtml %}
+        {{govukTag({
+          text: "IN DRAFT",
+          classes: "govuk-tag--yellow"
+        })}}
+        {% endset -%}
+        {%  set awaitingfeedbackTagHtml %}
+        {{govukTag({
+          text: "AWAITING FEEDBACK",
+          classes: "govuk-tag--red"
+        })}}
+        {% endset -%}
+        {%  set noshowTagHtml %}
+        {{govukTag({
+          text: "NO SHOW",
+          classes: "govuk-tag--purple"
+        })}}
+        {% endset -%}
+        {%  set inactiveTagHtml %}
+        {{govukTag({
+          text: "NOT SCHEDULED",
+          classes: "govuk-tag--grey"
+        })}}
+        {% endset -%}
+        {%  set scheduledTagHtml %}
+        {{govukTag({
+          text: "SCHEDULED",
+          classes: "govuk-tag--blue"
+        })}}
+        {% endset -%}
+        {%  set activeTagHtml %}
+        {{govukTag({
+          text: "TODAY",
+          classes: "govuk-tag--green"
+        })}}
+        {% endset -%}
+
+            {{ govukTable({
+              firstCellIsHeader: true,
+              head: [
+                {
+                  text: "Session"
+                },
+                {
+                  text: "Date"
+                },
+                {
+                  text: "Time"
+                },
+                {
+                  text: "Facilitator"
+                },
+                {
+                  text: "Status"
+                },
+                {
+                  text: "Action"
+                }
+              ],
+              rows: [
+                [
+                  {
+                    html: '<a class="govuk-link" href="#">Session 1</a>'
+                  },
+                  {
+                    text: "14 Dec 2021"
+                  },
+                  {
+                    text: "5pm to 6pm"
+                  },
+                  {
+                    text: "Jenny Thompson"
+                  },
+                  {
+                    html: completedTagHtml
+                  },
+                  {
+                    html: '<a class="govuk-link" href="#">View feedback</a>'
+                  }
+                ],
+                [
+                  {
+                    html: '<a class="govuk-link" href="#">Session 2</a>'
+                  },
+                  {
+                    text: "15 Dec 2021"
+                  },
+                  {
+                    text: "5pm to 6pm"
+                  },
+                  {
+                    text: "Jenny Thompson"
+                  },
+                  {
+                    html: draftTagHtml
+                  },
+                  {
+                    html: '<a class="govuk-link" href="#">Continue feedback</a>'
+                  }
+                ],
+                [
+                  {
+                    html: '<a class="govuk-link" href="#">Session 3</a>'
+                  },
+                  {
+                    text: "16 Dec 2021"
+                  },
+                  {
+                    text: "5pm to 6pm"
+                  },
+                  {
+                    text: "Jenny Thompson"
+                  },
+                  {
+                    html: draftTagHtml
+                  },
+                  {
+                    html: '<a class="govuk-link" href="#">Continue feedback</a>'
+                  }
+                ],
+                [
+                  {
+                    html: '<a class="govuk-link" href="#">Session 4</a>'
+                  },
+                  {
+                    text: "17 Dec 2021"
+                  },
+                  {
+                    text: "5pm to 6pm"
+                  },
+                  {
+                    text: "Jenny Thompson"
+                  },
+                  {
+                    html: awaitingfeedbackTagHtml
+                  },
+                  {
+                    html: '<a class="govuk-link" href="#">Give feedback</a>'
+                  }
+                ],
+                [
+                  {
+                    html: '<a class="govuk-link" href="#">Session 5</a>'
+                  },
+                  {
+                    text: "18 Dec 2021"
+                  },
+                  {
+                    text: "5pm to 6pm"
+                  },
+                  {
+                    text: "Jenny Thompson"
+                  },
+                  {
+                    html: awaitingfeedbackTagHtml
+                  },
+                  {
+                    html: '<a class="govuk-link" href="#">Give feedback</a>'
+                  }
+                ],
+                [
+                  {
+                    html: '<a class="govuk-link" href="#">Session 6</a>'
+                  },
+                  {
+                    text: "19 Dec 2021"
+                  },
+                  {
+                    text: "5pm to 6pm"
+                  },
+                  {
+                    text: "Jenny Thompson"
+                  },
+                  {
+                    html: noshowTagHtml
+                  },
+                  {
+                    html: '<a class="govuk-link" href="#">View feedback</a>'
+                  }
+                ],
+                [
+                  {
+                    html: '<a class="govuk-link" href="#">Session 7</a>'
+                  },
+                  {
+                    text: "20 Dec 2021"
+                  },
+                  {
+                    text: "5pm to 6pm"
+                  },
+                  {
+                    text: "Jenny Thompson"
+                  },
+                  {
+                    html: activeTagHtml
+                  },
+                  {
+                    text: ""
+                  }
+                ],
+                [
+                  {
+                    html: '<a class="govuk-link" href="#">Session 8</a>'
+                  },
+                  {
+                    text: "14 Dec 2021"
+                  },
+                  {
+                    text: "5pm to 6pm"
+                  },
+                  {
+                    text: "Jenny Thompson"
+                  },
+                  {
+                    html: scheduledTagHtml
+                  },
+                  {
+                    text: ""
+                  }
+                ],
+                [
+                  {
+                    html: '<a class="govuk-link" href="#">Session 9</a>'
+                  },
+                  {
+                    text: "14 Dec 2021"
+                  },
+                  {
+                    text: "5pm to 6pm"
+                  },
+                  {
+                    text: "Jenny Thompson"
+                  },
+                  {
+                    html: inactiveTagHtml
+                  },
+                  {
+                    text: ""
+                  }
+                ],
+                [
+                  {
+                    html: '<a class="govuk-link" href="#">Session 10</a>'
+                  },
+                  {
+                    text: "14 Dec 2021"
+                  },
+                  {
+                    text: "5pm to 6pm"
+                  },
+                  {
+                    text: "Jenny Thompson"
+                  },
+                  {
+                    html: inactiveTagHtml
+                  },
+                  {
+                    text:""
+                  }
+                ]
+              ]
+            }) }}
+      </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/templates/serviceProviderSessionsTemplate.njk
+++ b/server/views/serviceProviderReferrals/templates/serviceProviderSessionsTemplate.njk
@@ -1,0 +1,68 @@
+{% from "govuk/components/skip-link/macro.njk" import govukSkipLink -%}
+{% from "govuk/components/header/macro.njk" import govukHeader -%}
+{% from "govuk/components/footer/macro.njk" import govukFooter -%}
+{# specify absolute url for the static assets folder e.g. http://wwww.domain.com/assets #}
+{%- set assetUrl = assetUrl | default(assetPath) -%}
+<!DOCTYPE html>
+<html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
+  <head>
+    <meta charset="utf-8">
+    <title{% if pageTitleLang %} lang="{{ pageTitleLang }}"{% endif %}>{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="{{ themeColor | default('#0b0c0c') }}"> {# Hardcoded value of $govuk-black #}
+    {# Ensure that older IE versions always render with the correct rendering engine #}
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    {% block headIcons %}
+      <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ assetPath | default('/assets') }}/images/favicon.ico" type="image/x-icon">
+      <link rel="mask-icon" href="{{ assetPath | default('/assets') }}/images/govuk-mask-icon.svg" color="{{ themeColor | default('#0b0c0c') }}"> {# Hardcoded value of $govuk-black #}
+      <link rel="apple-touch-icon" sizes="180x180" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-180x180.png">
+      <link rel="apple-touch-icon" sizes="167x167" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-167x167.png">
+      <link rel="apple-touch-icon" sizes="152x152" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-152x152.png">
+      <link rel="apple-touch-icon" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon.png">
+    {% endblock %}
+
+    {% block head %}{% endblock %}
+    {# The default og:image is added below head so that scrapers see any custom metatags first, and this is just a fallback #}
+    {# image url needs to be absolute e.g. http://wwww.domain.com/.../govuk-opengraph-image.png #}
+    <meta property="og:image" content="{{ assetUrl | default('/assets') }}/images/govuk-opengraph-image.png">
+  </head>
+  <body class="govuk-template__body {{ bodyClasses }}" {%- for attribute, value in bodyAttributes %} {{attribute}}="{{value}}"{% endfor %}>
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    {% block bodyStart %}{% endblock %}
+
+    {% block skipLink %}
+      {{ govukSkipLink({
+        href: '#main-content',
+        text: 'Skip to main content'
+      }) }}
+    {% endblock %}
+
+    {% block header %}
+      {{ govukHeader({}) }}
+    {% endblock %}
+
+    {% block main %}
+      <div class="govuk-width-container {{ containerClasses }}">
+        {% block beforeContent %}{% endblock %}
+        {% block breadcrumbs %}{% endblock %}
+        {% block primaryTitle %}{% endblock %}
+        {% block subNav %}{% endblock %}
+        {% block backLink %}{% endblock %}
+        <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+          {% block content %}
+          {% block pageHeading %}{% endblock %}
+          {% block mainContent %}{% endblock %}
+          {% block sidebar %}{% endblock %}
+          {% endblock %}
+        </main>
+      </div>
+    {% endblock %}
+
+    {% block footer %}
+      {{ govukFooter({}) }}
+    {% endblock %}
+
+    {% block bodyEnd %}{% endblock %}
+  </body>
+</html>


### PR DESCRIPTION
## What does this pull request do?

Adds a new template, replacing the standard GOV UK template as our Service Provider sessions pages have a different layout. This will allow us to extend the layout on those pages, and override the various blocks with the components that Israt will be adding content for.

An example template has been added to the `static-pages` index to demonstrate how you'd use these templates.

## Screenshot of example page (ugly text where partials will be added)

![image](https://user-images.githubusercontent.com/19826940/107630217-2431cf80-6c5b-11eb-96e9-626d484b5cd7.png)

