### PR TITLE
IC-1074: Add intervention details page

### DIFF
--- a/integration_tests/integration/findInterventions.spec.js
+++ b/integration_tests/integration/findInterventions.spec.js
@@ -30,6 +30,7 @@ context('Find an intervention', () => {
         title: params.title,
         serviceCategory: { name: params.categoryName },
         id: params.id,
+        serviceProvider: { name: 'Harmony Living' },
       })
     })
 
@@ -56,5 +57,7 @@ context('Find an intervention', () => {
 
     cy.get('h1').contains('Better solutions (anger management)')
     cy.contains('Thinking and behaviour')
+
+    cy.get('#service-provider-tab').contains('Harmony Living')
   })
 })

--- a/integration_tests/integration/findInterventions.spec.js
+++ b/integration_tests/integration/findInterventions.spec.js
@@ -12,12 +12,27 @@ context('Find an intervention', () => {
     cy.stubGetDraftReferralsForUser([])
     cy.login()
 
+    const thinkingAndBehaviourInterventionId = '6bf9d895-0d61-4b99-af91-f343befbc9a3'
+
     const interventions = [
-      { title: 'Better solutions (anger management)', categoryName: 'thinking and behaviour' },
-      { title: 'HELP (domestic violence for males)', categoryName: 'relationships' },
+      {
+        title: 'Better solutions (anger management)',
+        categoryName: 'thinking and behaviour',
+        id: thinkingAndBehaviourInterventionId,
+      },
+      {
+        title: 'HELP (domestic violence for males)',
+        categoryName: 'relationships',
+        id: 'bf3eb0df-2ef4-4aa9-9d98-bb0078be5042',
+      },
     ].map(params => {
-      return interventionFactory.build({ title: params.title, serviceCategory: { name: params.categoryName } })
+      return interventionFactory.build({
+        title: params.title,
+        serviceCategory: { name: params.categoryName },
+        id: params.id,
+      })
     })
+
     cy.stubGetInterventions(interventions)
 
     cy.visit('/find-interventions')
@@ -29,5 +44,17 @@ context('Find an intervention', () => {
     cy.contains('Thinking and behaviour')
     cy.get('h2').contains('HELP (domestic violence for males)')
     cy.contains('Relationships')
+
+    const selectedIntervention = interventions.find(
+      intervention => intervention.id === thinkingAndBehaviourInterventionId
+    )
+    cy.stubGetIntervention(thinkingAndBehaviourInterventionId, selectedIntervention)
+
+    cy.contains('Better solutions (anger management)').click()
+
+    cy.location('pathname').should('equal', `/find-interventions/intervention/${thinkingAndBehaviourInterventionId}`)
+
+    cy.get('h1').contains('Better solutions (anger management)')
+    cy.contains('Thinking and behaviour')
   })
 })

--- a/mocks.ts
+++ b/mocks.ts
@@ -49,8 +49,13 @@ export default async function setUpMocks(): Promise<void> {
   ]
 
   const interventions = [
-    { title: 'Better solutions (anger management)', categoryName: 'thinking and behaviour' },
     {
+      id: '1032df06-812a-42b9-b271-5ab3168f7989',
+      title: 'Better solutions (anger management)',
+      categoryName: 'thinking and behaviour',
+    },
+    {
+      id: 'd57a2c90-e8cd-489a-b62d-e8f01474f7b0',
       title: 'HELP (domestic violence for males)',
       categoryName: 'relationships',
       description:
@@ -60,6 +65,7 @@ export default async function setUpMocks(): Promise<void> {
     },
   ].map(params => {
     return interventionFactory.build({
+      id: params.id,
       title: params.title,
       serviceCategory: { name: params.categoryName },
       description: params.description,

--- a/server/routes/findInterventions/findInterventionsController.test.ts
+++ b/server/routes/findInterventions/findInterventionsController.test.ts
@@ -49,4 +49,23 @@ describe(FindInterventionsController, () => {
         })
     })
   })
+
+  describe('GET /find-interventions/intervention/:id', () => {
+    it('responds with a 200', async () => {
+      const intervention = interventionFactory.build({
+        title: 'Better solutions (anger management)',
+        serviceCategory: { name: 'thinking and behaviour' },
+      })
+
+      interventionsService.getIntervention.mockResolvedValue(intervention)
+
+      await request(app)
+        .get(`/find-interventions/intervention/${intervention.id}`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('Better solutions (anger management)')
+          expect(res.text).toContain('Thinking and behaviour')
+        })
+    })
+  })
 })

--- a/server/routes/findInterventions/findInterventionsController.ts
+++ b/server/routes/findInterventions/findInterventionsController.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from 'express'
 import InterventionsService from '../../services/interventionsService'
+import InterventionDetailsPresenter from './interventionDetailsPresenter'
+import InterventionDetailsView from './interventionDetailsView'
 import SearchResultsPresenter from './searchResultsPresenter'
 import SearchResultsView from './searchResultsView'
 
@@ -11,6 +13,15 @@ export default class FindInterventionsController {
 
     const presenter = new SearchResultsPresenter(interventions)
     const view = new SearchResultsView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async viewInterventionDetails(req: Request, res: Response): Promise<void> {
+    const intervention = await this.interventionsService.getIntervention(res.locals.user.token, req.params.id)
+
+    const presenter = new InterventionDetailsPresenter(intervention)
+    const view = new InterventionDetailsView(presenter)
 
     res.render(...view.renderArgs)
   }

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -134,11 +134,11 @@ describe(InterventionDetailsPresenter, () => {
       })
     })
 
-    describe('Sex', () => {
+    describe('Gender', () => {
       describe('with an intervention that’s for any adult male', () => {
         it('is “Male”', () => {
           expect(
-            linesForKey('Sex', {
+            linesForKey('Gender', {
               eligibility: eligibilityFactory.anyAdultMale().build(),
             })
           ).toEqual(['Male'])
@@ -148,7 +148,7 @@ describe(InterventionDetailsPresenter, () => {
       describe('with an intervention that’s for any adult female', () => {
         it('is “Female”', () => {
           expect(
-            linesForKey('Sex', {
+            linesForKey('Gender', {
               eligibility: eligibilityFactory.anyAdultFemale().build(),
             })
           ).toEqual(['Female'])
@@ -158,7 +158,7 @@ describe(InterventionDetailsPresenter, () => {
       describe('with an intervention that’s for all adults', () => {
         it('is “Male and female”', () => {
           expect(
-            linesForKey('Sex', {
+            linesForKey('Gender', {
               eligibility: eligibilityFactory.allAdults().build(),
             })
           ).toEqual(['Male and female'])

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -1,0 +1,144 @@
+import { DeepPartial } from 'fishery'
+import interventionFactory from '../../../testutils/factories/intervention'
+import eligibilityFactory from '../../../testutils/factories/eligibility'
+import { Intervention } from '../../services/interventionsService'
+import InterventionDetailsPresenter from './interventionDetailsPresenter'
+
+describe(InterventionDetailsPresenter, () => {
+  describe('title', () => {
+    const presenter = new InterventionDetailsPresenter(
+      interventionFactory.build({
+        title: 'Accommodation',
+      })
+    )
+    it('returns the intervention title', () => {
+      expect(presenter.title).toEqual('Accommodation')
+    })
+  })
+
+  describe('href', () => {
+    const presenter = new InterventionDetailsPresenter(
+      interventionFactory.build({
+        id: '65b5cc27-0b87-4f44-8a35-bb08fc64e90e',
+      })
+    )
+    it('returns the link to the intervention', () => {
+      expect(presenter.href).toEqual('/find-interventions/intervention/65b5cc27-0b87-4f44-8a35-bb08fc64e90e')
+    })
+  })
+
+  describe('body', () => {
+    const presenter = new InterventionDetailsPresenter(
+      interventionFactory.build({
+        description: 'Some information about the intervention',
+      })
+    )
+    it('returns the intervention description', () => {
+      expect(presenter.body).toEqual('Some information about the intervention')
+    })
+  })
+
+  describe('summary', () => {
+    function linesForKey(key: string, params: DeepPartial<Intervention>): string[] {
+      const presenter = new InterventionDetailsPresenter(interventionFactory.build(params))
+      const item = presenter.summary.find(anItem => anItem.key === key)
+      if (item === undefined) {
+        fail(`Didn't find item for key ${key}`)
+      }
+      return item.lines
+    }
+
+    describe('Type', () => {
+      it('is “Dynamic Framework”', () => {
+        expect(linesForKey('Type', {})).toEqual(['Dynamic Framework'])
+      })
+    })
+
+    describe('Location', () => {
+      it('is a comma-separated list of PCC regions', () => {
+        expect(
+          linesForKey('Location', {
+            pccRegions: [
+              { id: '1', name: 'Region 1' },
+              { id: '2', name: 'Region 2' },
+            ],
+          })
+        ).toEqual(['Region 1, Region 2'])
+      })
+    })
+
+    describe('Criminogenic needs', () => {
+      it('is the service category name', () => {
+        expect(
+          linesForKey('Criminogenic needs', {
+            serviceCategory: { name: 'accommodation' },
+          })
+        ).toEqual(['Accommodation'])
+      })
+    })
+
+    describe('Provider', () => {
+      it('is the service provider’s name', () => {
+        expect(
+          linesForKey('Criminogenic needs', {
+            serviceCategory: { name: 'accommodation' },
+          })
+        ).toEqual(['Accommodation'])
+      })
+    })
+
+    describe('Age group', () => {
+      describe('with an intervention that’s for all adults', () => {
+        it('is “18+”', () => {
+          expect(
+            linesForKey('Age group', {
+              eligibility: eligibilityFactory.allAdults().build(),
+            })
+          ).toEqual(['18+'])
+        })
+      })
+
+      describe('with an intervention that’s only for young people', () => {
+        it('is “18–25”', () => {
+          expect(
+            linesForKey('Age group', {
+              eligibility: eligibilityFactory.youngAdultMales().build(),
+            })
+          ).toEqual(['18–25'])
+        })
+      })
+    })
+
+    describe('Sex', () => {
+      describe('with an intervention that’s for any adult male', () => {
+        it('is “Male”', () => {
+          expect(
+            linesForKey('Sex', {
+              eligibility: eligibilityFactory.anyAdultMale().build(),
+            })
+          ).toEqual(['Male'])
+        })
+      })
+
+      describe('with an intervention that’s for any adult female', () => {
+        it('is “Female”', () => {
+          expect(
+            linesForKey('Sex', {
+              eligibility: eligibilityFactory.anyAdultFemale().build(),
+            })
+          ).toEqual(['Female'])
+        })
+      })
+
+      describe('with an intervention that’s for all adults', () => {
+        it('is “Male and female”', () => {
+          expect(
+            linesForKey('Sex', {
+              eligibility: eligibilityFactory.allAdults().build(),
+            })
+          ).toEqual(['Male and female'])
+        })
+      })
+    })
+  })
+})

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -1,6 +1,7 @@
 import { DeepPartial } from 'fishery'
 import interventionFactory from '../../../testutils/factories/intervention'
 import eligibilityFactory from '../../../testutils/factories/eligibility'
+import serviceProviderFactory from '../../../testutils/factories/serviceProvider'
 import { Intervention } from '../../services/interventionsService'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
 
@@ -35,6 +36,30 @@ describe(InterventionDetailsPresenter, () => {
     )
     it('returns the intervention description', () => {
       expect(presenter.body).toEqual('Some information about the intervention')
+    })
+  })
+
+  describe('tabs', () => {
+    const presenter = new InterventionDetailsPresenter(
+      interventionFactory.build({
+        serviceProvider: serviceProviderFactory.build({ name: 'Harmony Living' }),
+      })
+    )
+
+    it('returns an array of summary lists, each with an id and title', () => {
+      expect(presenter.tabs).toEqual([
+        {
+          id: 'service-provider-tab',
+          title: 'Service Provider',
+          items: [
+            {
+              key: 'Name',
+              lines: ['Harmony Living'],
+              isList: false,
+            },
+          ],
+        },
+      ])
     })
   })
 

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -17,6 +17,16 @@ export default class InterventionDetailsPresenter {
     return this.intervention.description
   }
 
+  get tabs(): { id: string; title: string; items: SummaryListItem[] }[] {
+    return [
+      {
+        id: 'service-provider-tab',
+        title: 'Service Provider',
+        items: this.serviceProviderSummary,
+      },
+    ]
+  }
+
   get summary(): SummaryListItem[] {
     return [
       {
@@ -71,5 +81,15 @@ export default class InterventionDetailsPresenter {
     }
 
     return ''
+  }
+
+  private get serviceProviderSummary(): SummaryListItem[] {
+    return [
+      {
+        key: 'Name',
+        lines: [this.intervention.serviceProvider.name],
+        isList: false,
+      },
+    ]
   }
 }

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -55,8 +55,8 @@ export default class InterventionDetailsPresenter {
         isList: false,
       },
       {
-        key: 'Sex',
-        lines: [InterventionDetailsPresenter.sexDescription(this.intervention.eligibility)],
+        key: 'Gender',
+        lines: [InterventionDetailsPresenter.genderDescription(this.intervention.eligibility)],
         isList: false,
       },
     ]
@@ -69,7 +69,7 @@ export default class InterventionDetailsPresenter {
     return `${eligibility.minimumAge}–${eligibility.maximumAge}`
   }
 
-  static sexDescription(eligibility: Eligibility): string {
+  static genderDescription(eligibility: Eligibility): string {
     if (eligibility.allowsMale && eligibility.allowsFemale) {
       return 'Male and female'
     }

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -1,0 +1,75 @@
+import { Eligibility, Intervention } from '../../services/interventionsService'
+import { SummaryListItem } from '../../utils/summaryList'
+import utils from '../../utils/utils'
+
+export default class InterventionDetailsPresenter {
+  constructor(private readonly intervention: Intervention) {}
+
+  get title(): string {
+    return this.intervention.title
+  }
+
+  get href(): string {
+    return `/find-interventions/intervention/${this.intervention.id}`
+  }
+
+  get body(): string {
+    return this.intervention.description
+  }
+
+  get summary(): SummaryListItem[] {
+    return [
+      {
+        key: 'Type',
+        lines: ['Dynamic Framework'],
+        isList: false,
+      },
+      {
+        key: 'Location',
+        lines: [this.intervention.pccRegions.map(region => region.name).join(', ')],
+        isList: false,
+      },
+      {
+        key: 'Criminogenic needs',
+        lines: [utils.convertToProperCase(this.intervention.serviceCategory.name)],
+        isList: false,
+      },
+      {
+        key: 'Provider',
+        lines: [this.intervention.serviceProvider.name],
+        isList: false,
+      },
+      {
+        key: 'Age group',
+        lines: [InterventionDetailsPresenter.ageGroupDescription(this.intervention.eligibility)],
+        isList: false,
+      },
+      {
+        key: 'Sex',
+        lines: [InterventionDetailsPresenter.sexDescription(this.intervention.eligibility)],
+        isList: false,
+      },
+    ]
+  }
+
+  static ageGroupDescription(eligibility: Eligibility): string {
+    if (eligibility.maximumAge === null) {
+      return `${eligibility.minimumAge}+`
+    }
+    return `${eligibility.minimumAge}–${eligibility.maximumAge}`
+  }
+
+  static sexDescription(eligibility: Eligibility): string {
+    if (eligibility.allowsMale && eligibility.allowsFemale) {
+      return 'Male and female'
+    }
+    if (eligibility.allowsMale) {
+      return 'Male'
+    }
+    if (eligibility.allowsFemale) {
+      return 'Female'
+    }
+
+    return ''
+  }
+}

--- a/server/routes/findInterventions/interventionDetailsView.ts
+++ b/server/routes/findInterventions/interventionDetailsView.ts
@@ -1,6 +1,7 @@
 import ViewUtils from '../../utils/viewUtils'
 import { SummaryListArgs, SummaryListItem } from '../../utils/summaryList'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
+import { TabsArgs } from '../../utils/govukFrontendTypes'
 
 export default class InterventionDetailsView {
   constructor(private readonly presenter: InterventionDetailsPresenter) {}
@@ -9,10 +10,28 @@ export default class InterventionDetailsView {
     return { ...ViewUtils.summaryListArgs(items), classes: 'govuk-summary-list--no-border' }
   }
 
+  private tabsArgs(summaryListMacro: (args: unknown) => string): TabsArgs {
+    return {
+      items: this.presenter.tabs.map(tab => {
+        return {
+          label: tab.title,
+          id: tab.id,
+          panel: {
+            html: summaryListMacro(InterventionDetailsView.summaryListArgs(tab.items)),
+          },
+        }
+      }),
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'findInterventions/interventionDetails',
-      { presenter: this.presenter, summaryListArgs: InterventionDetailsView.summaryListArgs },
+      {
+        presenter: this.presenter,
+        summaryListArgs: InterventionDetailsView.summaryListArgs,
+        tabsArgs: this.tabsArgs.bind(this),
+      },
     ]
   }
 }

--- a/server/routes/findInterventions/interventionDetailsView.ts
+++ b/server/routes/findInterventions/interventionDetailsView.ts
@@ -1,0 +1,18 @@
+import ViewUtils from '../../utils/viewUtils'
+import { SummaryListArgs, SummaryListItem } from '../../utils/summaryList'
+import InterventionDetailsPresenter from './interventionDetailsPresenter'
+
+export default class InterventionDetailsView {
+  constructor(private readonly presenter: InterventionDetailsPresenter) {}
+
+  static summaryListArgs(items: SummaryListItem[]): SummaryListArgs & { classes: string } {
+    return { ...ViewUtils.summaryListArgs(items), classes: 'govuk-summary-list--no-border' }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'findInterventions/interventionDetails',
+      { presenter: this.presenter, summaryListArgs: InterventionDetailsView.summaryListArgs },
+    ]
+  }
+}

--- a/server/routes/findInterventions/searchResultsPresenter.test.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.test.ts
@@ -1,8 +1,5 @@
-import { DeepPartial } from 'fishery'
 import SearchResultsPresenter from './searchResultsPresenter'
 import interventionFactory from '../../../testutils/factories/intervention'
-import eligibilityFactory from '../../../testutils/factories/eligibility'
-import { Intervention } from '../../services/interventionsService'
 
 describe(SearchResultsPresenter, () => {
   describe('results', () => {
@@ -10,108 +7,6 @@ describe(SearchResultsPresenter, () => {
       const presenter = new SearchResultsPresenter(interventionFactory.buildList(3))
 
       expect(presenter.results.length).toBe(3)
-    })
-
-    function linesForKey(key: string, params: DeepPartial<Intervention>): string[] {
-      const presenter = new SearchResultsPresenter([interventionFactory.build(params)])
-      const item = presenter.results[0].summary.find(anItem => anItem.key === key)
-      if (item === undefined) {
-        fail(`Didn't find item for key ${key}`)
-      }
-      return item.lines
-    }
-
-    describe('Type', () => {
-      it('is “Dynamic Framework”', () => {
-        expect(linesForKey('Type', {})).toEqual(['Dynamic Framework'])
-      })
-    })
-
-    describe('Location', () => {
-      it('is a comma-separated list of PCC regions', () => {
-        expect(
-          linesForKey('Location', {
-            pccRegions: [
-              { id: '1', name: 'Region 1' },
-              { id: '2', name: 'Region 2' },
-            ],
-          })
-        ).toEqual(['Region 1, Region 2'])
-      })
-    })
-
-    describe('Criminogenic needs', () => {
-      it('is the service category name', () => {
-        expect(
-          linesForKey('Criminogenic needs', {
-            serviceCategory: { name: 'accommodation' },
-          })
-        ).toEqual(['Accommodation'])
-      })
-    })
-
-    describe('Provider', () => {
-      it('is the service provider’s name', () => {
-        expect(
-          linesForKey('Criminogenic needs', {
-            serviceCategory: { name: 'accommodation' },
-          })
-        ).toEqual(['Accommodation'])
-      })
-    })
-
-    describe('Age group', () => {
-      describe('with an intervention that’s for all adults', () => {
-        it('is “18+”', () => {
-          expect(
-            linesForKey('Age group', {
-              eligibility: eligibilityFactory.allAdults().build(),
-            })
-          ).toEqual(['18+'])
-        })
-      })
-
-      describe('with an intervention that’s only for young people', () => {
-        it('is “18–25”', () => {
-          expect(
-            linesForKey('Age group', {
-              eligibility: eligibilityFactory.youngAdultMales().build(),
-            })
-          ).toEqual(['18–25'])
-        })
-      })
-    })
-
-    describe('Sex', () => {
-      describe('with an intervention that’s for any adult male', () => {
-        it('is “Male”', () => {
-          expect(
-            linesForKey('Sex', {
-              eligibility: eligibilityFactory.anyAdultMale().build(),
-            })
-          ).toEqual(['Male'])
-        })
-      })
-
-      describe('with an intervention that’s for any adult female', () => {
-        it('is “Female”', () => {
-          expect(
-            linesForKey('Sex', {
-              eligibility: eligibilityFactory.anyAdultFemale().build(),
-            })
-          ).toEqual(['Female'])
-        })
-      })
-
-      describe('with an intervention that’s for all adults', () => {
-        it('is “Male and female”', () => {
-          expect(
-            linesForKey('Sex', {
-              eligibility: eligibilityFactory.allAdults().build(),
-            })
-          ).toEqual(['Male and female'])
-        })
-      })
     })
   })
 

--- a/server/routes/findInterventions/searchResultsPresenter.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.ts
@@ -1,75 +1,12 @@
-import { Eligibility, Intervention } from '../../services/interventionsService'
-import { SummaryListItem } from '../../utils/summaryList'
-import utils from '../../utils/utils'
-
-export interface SearchResultPresenter {
-  title: string
-  href: string
-  body: string
-  summary: SummaryListItem[]
-}
+import { Intervention } from '../../services/interventionsService'
+import InterventionDetailsPresenter from './interventionDetailsPresenter'
 
 export default class SearchResultsPresenter {
   constructor(private readonly interventions: Intervention[]) {}
 
-  readonly results: SearchResultPresenter[] = this.interventions.map(intervention => ({
-    title: intervention.title,
-    href: '#',
-    body: intervention.description,
-    summary: [
-      {
-        key: 'Type',
-        lines: ['Dynamic Framework'],
-        isList: false,
-      },
-      {
-        key: 'Location',
-        lines: [intervention.pccRegions.map(region => region.name).join(', ')],
-        isList: false,
-      },
-      {
-        key: 'Criminogenic needs',
-        lines: [utils.convertToProperCase(intervention.serviceCategory.name)],
-        isList: false,
-      },
-      {
-        key: 'Provider',
-        lines: [intervention.serviceProvider.name],
-        isList: false,
-      },
-      {
-        key: 'Age group',
-        lines: [SearchResultsPresenter.ageGroupDescription(intervention.eligibility)],
-        isList: false,
-      },
-      {
-        key: 'Sex',
-        lines: [SearchResultsPresenter.sexDescription(intervention.eligibility)],
-        isList: false,
-      },
-    ],
-  }))
-
-  private static ageGroupDescription(eligibility: Eligibility): string {
-    if (eligibility.maximumAge === null) {
-      return `${eligibility.minimumAge}+`
-    }
-    return `${eligibility.minimumAge}–${eligibility.maximumAge}`
-  }
-
-  private static sexDescription(eligibility: Eligibility): string {
-    if (eligibility.allowsMale && eligibility.allowsFemale) {
-      return 'Male and female'
-    }
-    if (eligibility.allowsMale) {
-      return 'Male'
-    }
-    if (eligibility.allowsFemale) {
-      return 'Female'
-    }
-
-    return ''
-  }
+  readonly results: InterventionDetailsPresenter[] = this.interventions.map(
+    intervention => new InterventionDetailsPresenter(intervention)
+  )
 
   readonly text = {
     results: {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -88,6 +88,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/:id/confirmation', (req, res) => referralsController.viewConfirmation(req, res))
 
   get('/find-interventions', (req, res) => findInterventionsController.search(req, res))
+  get('/find-interventions/intervention/:id', (req, res) =>
+    findInterventionsController.viewInterventionDetails(req, res)
+  )
 
   return router
 }

--- a/server/utils/govukFrontendTypes.ts
+++ b/server/utils/govukFrontendTypes.ts
@@ -1,0 +1,12 @@
+export interface TabsArgs {
+  items: TabItem[]
+}
+
+interface TabItem {
+  id: string
+  label: string
+  panel: {
+    text?: string
+    html?: string
+  }
+}

--- a/server/views/findInterventions/interventionDetails.njk
+++ b/server/views/findInterventions/interventionDetails.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -21,6 +22,8 @@
       <form method="#">
         {{ govukButton({ text: "Make a referral" }) }}
       </form>
+
+      {{ govukTabs(tabsArgs(govukSummaryList)) }}
     </div>
   </div>
 {% endblock %}

--- a/server/views/findInterventions/interventionDetails.njk
+++ b/server/views/findInterventions/interventionDetails.njk
@@ -1,0 +1,26 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row govuk-!-margin-bottom-7">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
+
+      <p class="govuk-body">{{ presenter.body }}</p>
+
+      {{ govukSummaryList(summaryListArgs(presenter.summary)) }}
+
+      <form method="#">
+        {{ govukButton({ text: "Make a referral" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds intervention details page, accessible from Find search results.

Currently doesn't include the miscellaneous bullet points present in the design, as we're unsure exactly where they're from.

In doing this, extracts `interventionDetails` into own presenter

Also renames "Sex" to "Gender" in the Find journey.


## Screenshot
![image](https://user-images.githubusercontent.com/19826940/107788228-14dc8000-6d48-11eb-96fb-a1353d55e831.png)
