### PR TITLE
Add contract tests for filtering intervention search results

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -74,5 +74,9 @@ module.exports = on => {
     stubGetIntervention: arg => {
       return interventionsService.stubGetIntervention(arg.id, arg.responseJson)
     },
+
+    stubGetPccRegions: arg => {
+      return interventionsService.stubGetPccRegions(arg.id, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -37,3 +37,7 @@ Cypress.Commands.add('stubGetInterventions', responseJson => {
 Cypress.Commands.add('stubGetIntervention', (id, responseJson) => {
   cy.task('stubGetIntervention', { id, responseJson })
 })
+
+Cypress.Commands.add('stubGetPccRegions', (id, responseJson) => {
+  cy.task('stubGetPccRegions', { id, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -163,4 +163,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubGetPccRegions = async (id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/pcc-regions`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -9,7 +9,7 @@ import type { UnsanitisedError } from '../sanitisedError'
 
 interface GetRequest {
   path?: string
-  query?: string
+  query?: string | Record<string, unknown>
   headers?: Record<string, string>
   responseType?: string
   raw?: boolean

--- a/server/routes/findInterventions/findInterventionsController.ts
+++ b/server/routes/findInterventions/findInterventionsController.ts
@@ -9,7 +9,7 @@ export default class FindInterventionsController {
   constructor(private readonly interventionsService: InterventionsService) {}
 
   async search(req: Request, res: Response): Promise<void> {
-    const interventions = await this.interventionsService.getInterventions(res.locals.user.token)
+    const interventions = await this.interventionsService.getInterventions(res.locals.user.token, {})
 
     const presenter = new SearchResultsPresenter(interventions)
     const view = new SearchResultsView(presenter)

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1211,6 +1211,34 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(await interventionsService.getIntervention(token, interventionId)).toEqual(intervention)
     })
   })
+
+  describe('getPccRegions', () => {
+    it('returns a list of PCC regions', async () => {
+      const pccRegions = [
+        { id: 'cheshire', name: 'Cheshire' },
+        { id: 'cumbria', name: 'Cumbria' },
+        { id: 'lancashire', name: 'Lancashire' },
+        { id: 'merseyside', name: 'Merseyside' },
+      ]
+
+      await provider.addInteraction({
+        state: 'There are some PCC regions',
+        uponReceiving: 'a request for all the PCC regions',
+        withRequest: {
+          method: 'GET',
+          path: `/pcc-regions`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(pccRegions),
+          headers: { 'Content-Type': 'application/json' },
+        },
+      })
+
+      expect(await interventionsService.getPccRegions(token)).toEqual(pccRegions)
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1122,6 +1122,32 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         expect(await interventionsService.getInterventions(token, { allowsFemale: value })).toEqual(interventions)
       })
     })
+
+    describe('pccRegionIds filter', () => {
+      it('accepts a list of PCC region IDs', async () => {
+        const intervention = interventionFactory.build()
+
+        await provider.addInteraction({
+          state: 'There are some interventions',
+          uponReceiving: `a request to get all interventions, filtered by a non-empty list of pccRegions`,
+          withRequest: {
+            method: 'GET',
+            path: '/interventions',
+            query: { pccRegionIds: 'cheshire,cumbria,merseyside' },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like([intervention, intervention]),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        expect(
+          await interventionsService.getInterventions(token, { pccRegionIds: ['cheshire', 'cumbria', 'merseyside'] })
+        ).toEqual([intervention, intervention])
+      })
+    })
   })
 
   describe('getIntervention', () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -8,6 +8,7 @@ import oauth2TokenFactory from '../../testutils/factories/oauth2Token'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
 import serviceProviderFactory from '../../testutils/factories/serviceProvider'
 import eligibilityFactory from '../../testutils/factories/eligibility'
+import interventionFactory from '../../testutils/factories/intervention'
 import { DeliusServiceUser } from './communityApiService'
 
 jest.mock('../data/hmppsAuthClient')
@@ -1071,7 +1072,55 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      expect(await interventionsService.getInterventions(token)).toEqual([intervention, intervention])
+      expect(await interventionsService.getInterventions(token, {})).toEqual([intervention, intervention])
+    })
+
+    describe('allowsMale filter', () => {
+      it.each([[true], [false]])('accepts a value of %s', async value => {
+        const interventions = interventionFactory.buildList(2)
+
+        await provider.addInteraction({
+          state: 'There are some interventions',
+          uponReceiving: `a request to get all interventions, filtered by allowsMale == ${value}`,
+          withRequest: {
+            method: 'GET',
+            path: '/interventions',
+            query: { allowsMale: value ? 'true' : 'false' },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like(interventions),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        expect(await interventionsService.getInterventions(token, { allowsMale: value })).toEqual(interventions)
+      })
+    })
+
+    describe('allowsFemale filter', () => {
+      it.each([[true], [false]])('accepts a value of %s', async value => {
+        const interventions = interventionFactory.buildList(2)
+
+        await provider.addInteraction({
+          state: 'There are some interventions',
+          uponReceiving: `a request to get all interventions, filtered by allowsFemale == ${value}`,
+          withRequest: {
+            method: 'GET',
+            path: '/interventions',
+            query: { allowsFemale: value ? 'true' : 'false' },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like(interventions),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        expect(await interventionsService.getInterventions(token, { allowsFemale: value })).toEqual(interventions)
+      })
     })
   })
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1148,6 +1148,30 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         ).toEqual([intervention, intervention])
       })
     })
+
+    describe('maximumAge filter', () => {
+      it('accepts a positive integer', async () => {
+        const interventions = interventionFactory.buildList(2)
+
+        await provider.addInteraction({
+          state: 'There are some interventions',
+          uponReceiving: `a request to get all interventions, filtered by maximumAge`,
+          withRequest: {
+            method: 'GET',
+            path: '/interventions',
+            query: { maximumAge: '25' },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like(interventions),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        expect(await interventionsService.getInterventions(token, { maximumAge: 25 })).toEqual(interventions)
+      })
+    })
   })
 
   describe('getIntervention', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -114,6 +114,7 @@ export interface InterventionsFilterParams {
   allowsMale?: boolean
   allowsFemale?: boolean
   pccRegionIds?: string[]
+  maximumAge?: number
 }
 
 export default class InterventionsService {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -110,6 +110,11 @@ export interface Eligibility {
   allowsMale: boolean
 }
 
+export interface InterventionsFilterParams {
+  allowsMale?: boolean
+  allowsFemale?: boolean
+}
+
 export default class InterventionsService {
   constructor(private readonly config: ApiConfig) {}
 
@@ -257,12 +262,13 @@ export default class InterventionsService {
     })) as SentReferral[]
   }
 
-  async getInterventions(token: string): Promise<Intervention[]> {
+  async getInterventions(token: string, filter: InterventionsFilterParams): Promise<Intervention[]> {
     const restClient = this.createRestClient(token)
 
     return (await restClient.get({
       path: '/interventions',
       headers: { Accept: 'application/json' },
+      query: filter as Record<string, unknown>,
     })) as Intervention[]
   }
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -288,4 +288,13 @@ export default class InterventionsService {
       headers: { Accept: 'application/json' },
     })) as Intervention
   }
+
+  async getPccRegions(token: string): Promise<PCCRegion[]> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/pcc-regions`,
+      headers: { Accept: 'application/json' },
+    })) as PCCRegion[]
+  }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -113,6 +113,7 @@ export interface Eligibility {
 export interface InterventionsFilterParams {
   allowsMale?: boolean
   allowsFemale?: boolean
+  pccRegionIds?: string[]
 }
 
 export default class InterventionsService {
@@ -265,10 +266,16 @@ export default class InterventionsService {
   async getInterventions(token: string, filter: InterventionsFilterParams): Promise<Intervention[]> {
     const restClient = this.createRestClient(token)
 
+    const filterQuery: Record<string, unknown> = { ...filter }
+
+    if (filter.pccRegionIds !== undefined) {
+      filterQuery.pccRegionIds = filter.pccRegionIds.join(',')
+    }
+
     return (await restClient.get({
       path: '/interventions',
       headers: { Accept: 'application/json' },
-      query: filter as Record<string, unknown>,
+      query: filterQuery,
     })) as Intervention[]
   }
 


### PR DESCRIPTION
## What does this pull request do?

Adds contract tests for filtering the `GET /interventions` results by:

- maximum age
- PCC region
- gender restrictions

It also adds a contract test for an endpoint that already exists in the interventions service.

I have an open question about whether the UI's understanding of _how_ the API interprets these filtering parameters should be considered part of the contract they share, and if so how to test this interpretation without it turning into some sort of functional test of the API.

## What is the intent behind these changes?

To allow API developers to see the functionality we'll need for building the interventions filters, and to review the proposed contract.
