### PR TITLE
IC-1089: Ensure `desired-outcomes-ids` is always an array

### DIFF
--- a/server/routes/referrals/desiredOutcomesView.ts
+++ b/server/routes/referrals/desiredOutcomesView.ts
@@ -7,7 +7,7 @@ export default class DesiredOutcomesView {
   get checkboxArgs(): Record<string, unknown> {
     return {
       idPrefix: 'desired-outcomes-ids',
-      name: 'desired-outcomes-ids',
+      name: 'desired-outcomes-ids[]',
       fieldset: {
         legend: {
           text: this.presenter.title,

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -573,7 +573,7 @@ describe('POST /referrals/:id/desired-outcomes', () => {
     await request(app)
       .post('/referrals/1/desired-outcomes')
       .type('form')
-      .send({ 'desired-outcomes-ids': [desiredOutcomes[0].id, desiredOutcomes[1].id] })
+      .send({ 'desired-outcomes-ids[]': [desiredOutcomes[0].id, desiredOutcomes[1].id] })
       .expect(302)
       .expect('Location', '/referrals/1/complexity-level')
 
@@ -592,7 +592,7 @@ describe('POST /referrals/:id/desired-outcomes', () => {
     await request(app)
       .post('/referrals/1/desired-outcomes')
       .type('form')
-      .send({ 'desired-outcomes-ids': [desiredOutcomes[0].id, desiredOutcomes[1].id] })
+      .send({ 'desired-outcomes-ids[]': [desiredOutcomes[0].id, desiredOutcomes[1].id] })
       .expect(500)
       .expect(res => {
         expect(res.text).toContain('Some backend error message')


### PR DESCRIPTION
## What does this pull request do?

Ensures `desired-outcomes-ids` are an array, as the backend was being sent a string (rather than an array, which it expected) when a single Desired Outcome checkbox was selected, and didn't know how to handle it.

## What is the intent behind these changes?

To allow users to be able to select a single desired outcome without breaking the user journey :trollface: 
