### PR TITLE
IC-1078: Link find and refer journey

### DIFF
--- a/integration_tests/integration/login.spec.js
+++ b/integration_tests/integration/login.spec.js
@@ -20,7 +20,7 @@ context('Login', () => {
     })
 
     it('the user is redirected to the referral start page', () => {
-      cy.location('pathname').should('equal', '/referrals/start')
+      cy.location('pathname').should('equal', '/probation-practitioner/dashboard')
     })
 
     it('the user name is visible in the header', () => {

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -89,6 +89,10 @@ describe('Referral form', () => {
 
     cy.login()
 
+    const randomInterventionId = '99ee16d3-130a-4d8f-97c5-f1a42119a382'
+
+    cy.visit(`/intervention/${randomInterventionId}/refer`)
+
     cy.contains('Service User CRN').type('X320741')
 
     cy.contains('Start now').click()

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -95,7 +95,7 @@ describe('Referral form', () => {
 
     cy.contains('Service User CRN').type('X320741')
 
-    cy.contains('Start now').click()
+    cy.contains('Continue').click()
 
     cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
 

--- a/mocks.ts
+++ b/mocks.ts
@@ -50,7 +50,7 @@ export default async function setUpMocks(): Promise<void> {
 
   const interventions = [
     {
-      id: '1032df06-812a-42b9-b271-5ab3168f7989',
+      id: '98a42c61-c30f-4beb-8062-04033c376e2d',
       title: 'Better solutions (anger management)',
       categoryName: 'thinking and behaviour',
     },

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -17,14 +17,16 @@ describe(InterventionDetailsPresenter, () => {
     })
   })
 
-  describe('href', () => {
+  describe('hrefInterventionDetails', () => {
     const presenter = new InterventionDetailsPresenter(
       interventionFactory.build({
         id: '65b5cc27-0b87-4f44-8a35-bb08fc64e90e',
       })
     )
     it('returns the link to the intervention', () => {
-      expect(presenter.href).toEqual('/find-interventions/intervention/65b5cc27-0b87-4f44-8a35-bb08fc64e90e')
+      expect(presenter.hrefInterventionDetails).toEqual(
+        '/find-interventions/intervention/65b5cc27-0b87-4f44-8a35-bb08fc64e90e'
+      )
     })
   })
 

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -17,6 +17,17 @@ describe(InterventionDetailsPresenter, () => {
     })
   })
 
+  describe('hrefReferralStart', () => {
+    const presenter = new InterventionDetailsPresenter(
+      interventionFactory.build({
+        id: '65b5cc27-0b87-4f44-8a35-bb08fc64e90e',
+      })
+    )
+    it('returns the link to make a referral', () => {
+      expect(presenter.hrefReferralStart).toEqual('/intervention/65b5cc27-0b87-4f44-8a35-bb08fc64e90e/refer')
+    })
+  })
+
   describe('hrefInterventionDetails', () => {
     const presenter = new InterventionDetailsPresenter(
       interventionFactory.build({

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -9,7 +9,7 @@ export default class InterventionDetailsPresenter {
     return this.intervention.title
   }
 
-  get href(): string {
+  get hrefInterventionDetails(): string {
     return `/find-interventions/intervention/${this.intervention.id}`
   }
 

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -9,6 +9,10 @@ export default class InterventionDetailsPresenter {
     return this.intervention.title
   }
 
+  get hrefReferralStart(): string {
+    return `/intervention/${this.intervention.id}/refer`
+  }
+
   get hrefInterventionDetails(): string {
     return `/find-interventions/intervention/${this.intervention.id}`
   }

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -9,7 +9,7 @@ describe('GET /', () => {
   describe('when logged in as a probation practitioner', () => {
     it('redirects to the referral start page', () => {
       const app = appWithAllRoutes({ userType: AppSetupUserType.probationPractitioner })
-      return request(app).get('/').expect(302).expect('Location', '/referrals/start')
+      return request(app).get('/').expect(302).expect('Location', '/probation-practitioner/dashboard')
     })
   })
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -9,6 +9,7 @@ import ServiceProviderReferralsController from './serviceProviderReferrals/servi
 import ReferralsController from './referrals/referralsController'
 import StaticContentController from './staticContent/staticContentController'
 import FindInterventionsController from './findInterventions/findInterventionsController'
+import ProbationPractitionerReferralsController from './probationPractitionerReferrals/probationPractitionerReferralsController'
 
 interface RouteProvider {
   [key: string]: RequestHandler
@@ -29,6 +30,7 @@ export default function routes(router: Router, services: Services): Router {
     services.offenderAssessmentsApiService
   )
 
+  const probationPractitionerReferralsController = new ProbationPractitionerReferralsController()
   const referralsController = new ReferralsController(services.interventionsService, services.communityApiService)
   const staticContentController = new StaticContentController()
   const serviceProviderReferralsController = new ServiceProviderReferralsController(
@@ -40,7 +42,7 @@ export default function routes(router: Router, services: Services): Router {
   get('/', (req, res, next) => {
     const { authSource } = res.locals.user
     if (authSource === 'delius') {
-      res.redirect('/referrals/start')
+      res.redirect('/probation-practitioner/dashboard')
     } else {
       res.redirect('/service-provider/dashboard')
     }
@@ -60,6 +62,10 @@ export default function routes(router: Router, services: Services): Router {
       })
     })
   }
+
+  get('/probation-practitioner/dashboard', (req, res) =>
+    probationPractitionerReferralsController.showDashboard(req, res)
+  )
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
   get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -64,8 +64,8 @@ export default function routes(router: Router, services: Services): Router {
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
   get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)
 
-  get('/referrals/start', (req, res) => referralsController.startReferral(req, res))
-  post('/referrals/start', (req, res) => referralsController.createReferral(req, res))
+  get('/intervention/:interventionId/refer', (req, res) => referralsController.startReferral(req, res))
+  post('/intervention/:interventionId/refer', (req, res) => referralsController.createReferral(req, res))
   get('/referrals/:id/form', (req, res) => referralsController.viewReferralForm(req, res))
   get('/referrals/:id/service-user-details', (req, res) => referralsController.viewServiceUserDetails(req, res))
   post('/referrals/:id/service-user-details', (req, res) => referralsController.confirmServiceUserDetails(req, res))

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -30,7 +30,9 @@ export default function routes(router: Router, services: Services): Router {
     services.offenderAssessmentsApiService
   )
 
-  const probationPractitionerReferralsController = new ProbationPractitionerReferralsController()
+  const probationPractitionerReferralsController = new ProbationPractitionerReferralsController(
+    services.interventionsService
+  )
   const referralsController = new ReferralsController(services.interventionsService, services.communityApiService)
   const staticContentController = new StaticContentController()
   const serviceProviderReferralsController = new ServiceProviderReferralsController(

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.test.ts
@@ -1,0 +1,37 @@
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import DashboardPresenter from './dashboardPresenter'
+
+describe('DashboardPresenter', () => {
+  const referrals = [
+    draftReferralFactory.createdAt(new Date('2021-01-02T12:00:00Z')).build({
+      serviceUser: {
+        firstName: 'rob',
+        lastName: 'shah-brookes',
+      },
+    }),
+    draftReferralFactory.createdAt(new Date('2021-01-03T12:00:00Z')).build({
+      serviceUser: {
+        firstName: 'HARDIP',
+        lastName: 'fraiser',
+      },
+    }),
+    draftReferralFactory.createdAt(new Date('2021-01-01T12:00:00Z')).build({
+      serviceUser: {
+        firstName: 'Jenny',
+        lastName: 'Catherine',
+      },
+    }),
+  ]
+
+  describe('orderedReferrals', () => {
+    it('returns an ordered list of draft referrals with formatted dates and names', () => {
+      const presenter = new DashboardPresenter(referrals)
+
+      expect(presenter.orderedReferrals).toEqual([
+        expect.objectContaining({ createdAt: '1 Jan 2021', serviceUserFullName: 'Jenny Catherine' }),
+        expect.objectContaining({ createdAt: '2 Jan 2021', serviceUserFullName: 'Rob Shah-Brookes' }),
+        expect.objectContaining({ createdAt: '3 Jan 2021', serviceUserFullName: 'Hardip Fraiser' }),
+      ])
+    })
+  })
+})

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
@@ -1,0 +1,29 @@
+import { DraftReferral } from '../../services/interventionsService'
+import CalendarDay from '../../utils/calendarDay'
+import ReferralDataPresenterUtils from '../referrals/referralDataPresenterUtils'
+
+export default class DashboardPresenter {
+  constructor(private readonly draftReferrals: DraftReferral[]) {}
+
+  get orderedReferrals(): DraftReferralSummaryPresenter[] {
+    return this.draftReferrals
+      .sort((a, b) => (new Date(a.createdAt) < new Date(b.createdAt) ? -1 : 1))
+      .map(referral => ({
+        serviceUserFullName: ReferralDataPresenterUtils.fullName(referral.serviceUser),
+        createdAt: ReferralDataPresenterUtils.govukShortFormattedDate(
+          CalendarDay.britishDayForDate(new Date(referral.createdAt))
+        ),
+        url: `/referrals/${referral.id}/form`,
+      }))
+  }
+
+  readonly text = {
+    noDraftReferrals: 'You do not have any draft referrals at this moment.',
+  }
+}
+
+interface DraftReferralSummaryPresenter {
+  serviceUserFullName: string
+  createdAt: string
+  url: string
+}

--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -1,0 +1,25 @@
+import DashboardPresenter from './dashboardPresenter'
+
+export default class DashboardView {
+  constructor(private readonly presenter: DashboardPresenter) {}
+
+  private get tableArgs(): Record<string, unknown> {
+    return {
+      firstCellIsHeader: true,
+      head: [{ text: 'Service User' }, { text: 'Started on' }],
+      rows: this.presenter.orderedReferrals.map(referral => {
+        return [{ html: `<a href="${referral.url}">${referral.serviceUserFullName}</a>` }, { text: referral.createdAt }]
+      }),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'probationPractitionerReferrals/dashboard',
+      {
+        presenter: this.presenter,
+        tableArgs: this.tableArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -1,0 +1,41 @@
+import request from 'supertest'
+import { Express } from 'express'
+import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
+import InterventionsService from '../../services/interventionsService'
+import apiConfig from '../../config'
+
+import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
+import CommunityApiService from '../../services/communityApiService'
+
+jest.mock('../../services/interventionsService')
+jest.mock('../../services/communityApiService')
+
+const interventionsService = new InterventionsService(apiConfig.apis.interventionsService) as jest.Mocked<
+  InterventionsService
+>
+const communityApiService = new MockCommunityApiService() as jest.Mocked<CommunityApiService>
+
+let app: Express
+
+beforeEach(() => {
+  app = appWithAllRoutes({
+    overrides: { interventionsService, communityApiService },
+    userType: AppSetupUserType.serviceProvider,
+  })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET /probation-practitioner/dashboard', () => {
+  it('displays a dashboard page', async () => {
+    await request(app)
+      .get('/probation-practitioner/dashboard')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Refer and monitor an intervention')
+        expect(res.text).toContain('Find interventions')
+      })
+  })
+})

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest'
 import { Express } from 'express'
 import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import InterventionsService from '../../services/interventionsService'
 import apiConfig from '../../config'
 
@@ -29,6 +30,8 @@ afterEach(() => {
 })
 
 describe('GET /probation-practitioner/dashboard', () => {
+  interventionsService.getDraftReferralsForUser.mockResolvedValue([])
+
   it('displays a dashboard page', async () => {
     await request(app)
       .get('/probation-practitioner/dashboard')
@@ -36,6 +39,19 @@ describe('GET /probation-practitioner/dashboard', () => {
       .expect(res => {
         expect(res.text).toContain('Refer and monitor an intervention')
         expect(res.text).toContain('Find interventions')
+      })
+  })
+
+  it('displays a list in-progress referrals', async () => {
+    const referral = draftReferralFactory.serviceUserSelected().build()
+
+    interventionsService.getDraftReferralsForUser.mockResolvedValue([referral])
+
+    await request(app)
+      .get('/probation-practitioner/dashboard')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Alex River')
       })
   })
 })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from 'express'
+
+export default class ProbationPractitionerReferralsController {
+  async showDashboard(req: Request, res: Response): Promise<void> {
+    res.render('probationPractitionerReferrals/dashboard')
+  }
+}

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -1,7 +1,18 @@
 import { Request, Response } from 'express'
+import InterventionsService from '../../services/interventionsService'
+import DashboardPresenter from './dashboardPresenter'
+import DashboardView from './dashboardView'
 
 export default class ProbationPractitionerReferralsController {
+  constructor(private readonly interventionsService: InterventionsService) {}
+
   async showDashboard(req: Request, res: Response): Promise<void> {
-    res.render('probationPractitionerReferrals/dashboard')
+    const { token, userId } = res.locals.user
+
+    const existingDraftReferrals = await this.interventionsService.getDraftReferralsForUser(token, userId)
+    const presenter = new DashboardPresenter(existingDraftReferrals)
+    const view = new DashboardView(presenter)
+
+    res.render(...view.renderArgs)
   }
 }

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -3,11 +3,6 @@ import { DraftReferral } from '../../services/interventionsService'
 export default class ReferralFormPresenter {
   constructor(private readonly referral: DraftReferral, private readonly serviceCategoryName: string) {}
 
-  // This is just temporary, will remove it once we get rid of the referral ID output in the template
-  get referralID(): string {
-    return this.referral.id
-  }
-
   get sections(): ReferralFormSectionPresenter[] {
     return [
       {

--- a/server/routes/referrals/referralStartPresenter.test.ts
+++ b/server/routes/referrals/referralStartPresenter.test.ts
@@ -2,30 +2,32 @@ import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import ReferralStartPresenter from './referralStartPresenter'
 
 describe('ReferralStartPresenter', () => {
+  const referrals = [
+    draftReferralFactory.createdAt(new Date('2021-01-02T12:00:00Z')).build({
+      serviceUser: {
+        firstName: 'rob',
+        lastName: 'shah-brookes',
+      },
+    }),
+    draftReferralFactory.createdAt(new Date('2021-01-03T12:00:00Z')).build({
+      serviceUser: {
+        firstName: 'HARDIP',
+        lastName: 'fraiser',
+      },
+    }),
+    draftReferralFactory.createdAt(new Date('2021-01-01T12:00:00Z')).build({
+      serviceUser: {
+        firstName: 'Jenny',
+        lastName: 'Catherine',
+      },
+    }),
+  ]
+
+  const interventionId = '6a5735c6-3a2c-4896-9565-461417aa1c77'
+
   describe('orderedReferrals', () => {
     it('returns an ordered list of draft referrals with formatted dates and names', () => {
-      const referrals = [
-        draftReferralFactory.createdAt(new Date('2021-01-02T12:00:00Z')).build({
-          serviceUser: {
-            firstName: 'rob',
-            lastName: 'shah-brookes',
-          },
-        }),
-        draftReferralFactory.createdAt(new Date('2021-01-03T12:00:00Z')).build({
-          serviceUser: {
-            firstName: 'HARDIP',
-            lastName: 'fraiser',
-          },
-        }),
-        draftReferralFactory.createdAt(new Date('2021-01-01T12:00:00Z')).build({
-          serviceUser: {
-            firstName: 'Jenny',
-            lastName: 'Catherine',
-          },
-        }),
-      ]
-
-      const presenter = new ReferralStartPresenter(referrals)
+      const presenter = new ReferralStartPresenter(referrals, interventionId)
 
       // referrals are ordered oldest first
       expect(presenter.orderedReferrals).toEqual([
@@ -33,6 +35,14 @@ describe('ReferralStartPresenter', () => {
         expect.objectContaining({ createdAt: '2 Jan 2021', serviceUserFullName: 'Rob Shah-Brookes' }),
         expect.objectContaining({ createdAt: '3 Jan 2021', serviceUserFullName: 'Hardip Fraiser' }),
       ])
+    })
+  })
+
+  describe('hrefStartReferral', () => {
+    it('returns a link including the intervention ID to start the referral', () => {
+      const presenter = new ReferralStartPresenter(referrals, interventionId)
+
+      expect(presenter.hrefStartReferral).toEqual(`/intervention/${interventionId}/refer`)
     })
   })
 })

--- a/server/routes/referrals/referralStartPresenter.test.ts
+++ b/server/routes/referrals/referralStartPresenter.test.ts
@@ -1,48 +1,11 @@
-import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import ReferralStartPresenter from './referralStartPresenter'
 
 describe('ReferralStartPresenter', () => {
-  const referrals = [
-    draftReferralFactory.createdAt(new Date('2021-01-02T12:00:00Z')).build({
-      serviceUser: {
-        firstName: 'rob',
-        lastName: 'shah-brookes',
-      },
-    }),
-    draftReferralFactory.createdAt(new Date('2021-01-03T12:00:00Z')).build({
-      serviceUser: {
-        firstName: 'HARDIP',
-        lastName: 'fraiser',
-      },
-    }),
-    draftReferralFactory.createdAt(new Date('2021-01-01T12:00:00Z')).build({
-      serviceUser: {
-        firstName: 'Jenny',
-        lastName: 'Catherine',
-      },
-    }),
-  ]
-
-  const interventionId = '6a5735c6-3a2c-4896-9565-461417aa1c77'
-
-  describe('orderedReferrals', () => {
-    it('returns an ordered list of draft referrals with formatted dates and names', () => {
-      const presenter = new ReferralStartPresenter(referrals, interventionId)
-
-      // referrals are ordered oldest first
-      expect(presenter.orderedReferrals).toEqual([
-        expect.objectContaining({ createdAt: '1 Jan 2021', serviceUserFullName: 'Jenny Catherine' }),
-        expect.objectContaining({ createdAt: '2 Jan 2021', serviceUserFullName: 'Rob Shah-Brookes' }),
-        expect.objectContaining({ createdAt: '3 Jan 2021', serviceUserFullName: 'Hardip Fraiser' }),
-      ])
-    })
-  })
-
   describe('hrefStartReferral', () => {
     it('returns a link including the intervention ID to start the referral', () => {
-      const presenter = new ReferralStartPresenter(referrals, interventionId)
+      const presenter = new ReferralStartPresenter('6a5735c6-3a2c-4896-9565-461417aa1c77')
 
-      expect(presenter.hrefStartReferral).toEqual(`/intervention/${interventionId}/refer`)
+      expect(presenter.hrefStartReferral).toEqual(`/intervention/6a5735c6-3a2c-4896-9565-461417aa1c77/refer`)
     })
   })
 })

--- a/server/routes/referrals/referralStartPresenter.ts
+++ b/server/routes/referrals/referralStartPresenter.ts
@@ -1,37 +1,12 @@
-import { DraftReferral } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import ReferralDataPresenterUtils from './referralDataPresenterUtils'
-import CalendarDay from '../../utils/calendarDay'
 
 export default class ReferralStartPresenter {
-  constructor(
-    private readonly draftReferrals: DraftReferral[],
-    private readonly interventionId: string,
-    private readonly error: FormValidationError | null = null
-  ) {}
-
-  get orderedReferrals(): DraftReferralSummaryPresenter[] {
-    return this.draftReferrals
-      .sort((a, b) => (new Date(a.createdAt) < new Date(b.createdAt) ? -1 : 1))
-      .map(referral => ({
-        serviceUserFullName: ReferralDataPresenterUtils.fullName(referral.serviceUser),
-        createdAt: ReferralDataPresenterUtils.govukShortFormattedDate(
-          CalendarDay.britishDayForDate(new Date(referral.createdAt))
-        ),
-        url: `/referrals/${referral.id}/form`,
-      }))
-  }
+  constructor(private readonly interventionId: string, private readonly error: FormValidationError | null = null) {}
 
   readonly text = {
-    noDraftReferrals: 'You do not have any draft referrals at this moment.',
     errorMessage: ReferralDataPresenterUtils.errorMessage(this.error, 'service-user-crn'),
   }
 
   readonly hrefStartReferral = `/intervention/${this.interventionId}/refer`
-}
-
-interface DraftReferralSummaryPresenter {
-  serviceUserFullName: string
-  createdAt: string
-  url: string
 }

--- a/server/routes/referrals/referralStartPresenter.ts
+++ b/server/routes/referrals/referralStartPresenter.ts
@@ -6,6 +6,7 @@ import CalendarDay from '../../utils/calendarDay'
 export default class ReferralStartPresenter {
   constructor(
     private readonly draftReferrals: DraftReferral[],
+    private readonly interventionId: string,
     private readonly error: FormValidationError | null = null
   ) {}
 
@@ -25,6 +26,8 @@ export default class ReferralStartPresenter {
     noDraftReferrals: 'You do not have any draft referrals at this moment.',
     errorMessage: ReferralDataPresenterUtils.errorMessage(this.error, 'service-user-crn'),
   }
+
+  readonly hrefStartReferral = `/intervention/${this.interventionId}/refer`
 }
 
 interface DraftReferralSummaryPresenter {

--- a/server/routes/referrals/referralStartView.ts
+++ b/server/routes/referrals/referralStartView.ts
@@ -4,16 +4,6 @@ import viewUtils from '../../utils/viewUtils'
 export default class ReferralStartView {
   constructor(private readonly presenter: ReferralStartPresenter) {}
 
-  private get tableArgs(): Record<string, unknown> {
-    return {
-      firstCellIsHeader: true,
-      head: [{ text: 'Service User' }, { text: 'Started on' }],
-      rows: this.presenter.orderedReferrals.map(referral => {
-        return [{ html: `<a href="${referral.url}">${referral.serviceUserFullName}</a>` }, { text: referral.createdAt }]
-      }),
-    }
-  }
-
   private crnInputArgs(): Record<string, unknown> {
     return {
       id: 'service-user-crn',
@@ -33,7 +23,6 @@ export default class ReferralStartView {
       'referrals/start',
       {
         presenter: this.presenter,
-        tableArgs: this.tableArgs,
         crnInputArgs: this.crnInputArgs(),
       },
     ]

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -60,7 +60,7 @@ describe('GET /intervention/:id/refer', () => {
       .expect('Content-Type', /html/)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('You can make a new referral here')
+        expect(res.text).toContain("Enter the service user's case identifier")
       })
   })
 })

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -49,14 +49,14 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('GET /referrals/start', () => {
+describe('GET /intervention/:id/refer', () => {
   beforeEach(() => {
     interventionsService.getDraftReferralsForUser.mockResolvedValue([])
   })
 
-  it('renders a start page', () => {
+  it('renders the page to start a referral', () => {
     return request(app)
-      .get('/referrals/start')
+      .get('/intervention/98a42c61-c30f-4beb-8062-04033c376e2d/refer')
       .expect('Content-Type', /html/)
       .expect(200)
       .expect(res => {
@@ -65,31 +65,29 @@ describe('GET /referrals/start', () => {
   })
 })
 
-describe('POST /referrals/start', () => {
+describe('POST /intervention/:id/refer', () => {
   describe('when searching for a CRN found in Delius and an intervention has been selected', () => {
     beforeEach(() => {
       communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser.build())
     })
 
     it('creates a referral on the interventions service and redirects to the referral form', async () => {
-      const currentlyHardcodedInterventionId = '98a42c61-c30f-4beb-8062-04033c376e2d'
+      const interventionId = '98a42c61-c30f-4beb-8062-04033c376e2d'
       const serviceUserCRN = 'X123456'
 
       await request(app)
-        .post('/referrals/start')
+        .post(`/intervention/${interventionId}/refer`)
         .send({ 'service-user-crn': serviceUserCRN })
         .expect(303)
         .expect('Location', '/referrals/1/form')
 
-      expect(interventionsService.createDraftReferral).toHaveBeenCalledWith(
-        'token',
-        serviceUserCRN,
-        currentlyHardcodedInterventionId
-      )
+      expect(interventionsService.createDraftReferral).toHaveBeenCalledWith('token', serviceUserCRN, interventionId)
     })
 
     it('updates the newly-created referral on the interventions service with the found service user', async () => {
-      await request(app).post('/referrals/start').send({ 'service-user-crn': 'X123456' })
+      await request(app)
+        .post('/intervention/98a42c61-c30f-4beb-8062-04033c376e2d/refer')
+        .send({ 'service-user-crn': 'X123456' })
 
       expect(interventionsService.patchDraftReferral).toHaveBeenCalledWith('token', '1', {
         serviceUser,
@@ -104,7 +102,7 @@ describe('POST /referrals/start', () => {
 
     it('displays an error page', async () => {
       await request(app)
-        .post('/referrals/start')
+        .post('/intervention/98a42c61-c30f-4beb-8062-04033c376e2d/refer')
         .send({ 'service-user-crn': 'X123456' })
         .expect(500)
         .expect(res => {
@@ -118,7 +116,7 @@ describe('POST /referrals/start', () => {
   describe('when a crn is not entered', () => {
     it('renders a validation error', async () => {
       await request(app)
-        .post('/referrals/start')
+        .post('/intervention/98a42c61-c30f-4beb-8062-04033c376e2d/refer')
         .type('form')
         .send({ 'service-user-crn': '' })
         .expect(400)
@@ -137,7 +135,7 @@ describe('POST /referrals/start', () => {
 
     it('renders a validation error', async () => {
       await request(app)
-        .post('/referrals/start')
+        .post('/intervention/98a42c61-c30f-4beb-8062-04033c376e2d/refer')
         .type('form')
         .send({ 'service-user-crn': 'X123456' })
         .expect(400)

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -150,19 +150,19 @@ describe('POST /intervention/:id/refer', () => {
 
 describe('GET /referrals/:id/form', () => {
   beforeEach(() => {
-    const serviceCategory = serviceCategoryFactory.build()
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build({ id: '1' })
 
     interventionsService.getDraftReferral.mockResolvedValue(referral)
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
   })
 
-  it('fetches the referral from the interventions service and renders a page with information about the referral', async () => {
+  it('fetches the referral from the interventions service displays its service category in the form', async () => {
     await request(app)
       .get('/referrals/1/form')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Viewing referral with ID 1')
+        expect(res.text).toContain('Add accommodation referral details')
       })
 
     expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['token', '1'])

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -43,11 +43,9 @@ export default class ReferralsController {
   ) {}
 
   async startReferral(req: Request, res: Response): Promise<void> {
-    const { token, userId } = res.locals.user
     const { interventionId } = req.params
 
-    const existingDraftReferrals = await this.interventionsService.getDraftReferralsForUser(token, userId)
-    const presenter = new ReferralStartPresenter(existingDraftReferrals, interventionId)
+    const presenter = new ReferralStartPresenter(interventionId)
     const view = new ReferralStartView(presenter)
 
     res.render(...view.renderArgs)
@@ -103,9 +101,7 @@ export default class ReferralsController {
 
       res.redirect(303, `/referrals/${referral.id}/form`)
     } else {
-      const { token, userId } = res.locals.user
-      const existingDraftReferrals = await this.interventionsService.getDraftReferralsForUser(token, userId)
-      const presenter = new ReferralStartPresenter(existingDraftReferrals, interventionId, error)
+      const presenter = new ReferralStartPresenter(interventionId, error)
       const view = new ReferralStartView(presenter)
 
       res.status(400)

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -44,8 +44,10 @@ export default class ReferralsController {
 
   async startReferral(req: Request, res: Response): Promise<void> {
     const { token, userId } = res.locals.user
+    const { interventionId } = req.params
+
     const existingDraftReferrals = await this.interventionsService.getDraftReferralsForUser(token, userId)
-    const presenter = new ReferralStartPresenter(existingDraftReferrals)
+    const presenter = new ReferralStartPresenter(existingDraftReferrals, interventionId)
     const view = new ReferralStartView(presenter)
 
     res.render(...view.renderArgs)
@@ -59,7 +61,7 @@ export default class ReferralsController {
     let serviceUser: DeliusServiceUser | null = null
 
     const crn = req.body['service-user-crn']
-    const hardcodedInterventionId = '98a42c61-c30f-4beb-8062-04033c376e2d'
+    const { interventionId } = req.params
 
     if (form.isValid) {
       try {
@@ -93,11 +95,7 @@ export default class ReferralsController {
     }
 
     if (error === null) {
-      const referral = await this.interventionsService.createDraftReferral(
-        res.locals.user.token,
-        crn,
-        hardcodedInterventionId
-      )
+      const referral = await this.interventionsService.createDraftReferral(res.locals.user.token, crn, interventionId)
 
       await this.interventionsService.patchDraftReferral(res.locals.user.token, referral.id, {
         serviceUser: this.interventionsService.serializeDeliusServiceUser(serviceUser),
@@ -107,7 +105,7 @@ export default class ReferralsController {
     } else {
       const { token, userId } = res.locals.user
       const existingDraftReferrals = await this.interventionsService.getDraftReferralsForUser(token, userId)
-      const presenter = new ReferralStartPresenter(existingDraftReferrals, error)
+      const presenter = new ReferralStartPresenter(existingDraftReferrals, interventionId, error)
       const view = new ReferralStartView(presenter)
 
       res.status(400)

--- a/server/views/findInterventions/interventionDetails.njk
+++ b/server/views/findInterventions/interventionDetails.njk
@@ -19,7 +19,7 @@
 
       {{ govukSummaryList(summaryListArgs(presenter.summary)) }}
 
-      <form method="#">
+      <form action="{{ presenter.hrefReferralStart }}" method="GET">
         {{ govukButton({ text: "Make a referral" }) }}
       </form>
 

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -33,7 +33,7 @@
 
       {% for result in presenter.results %}
         <h2 class="govuk-heading-l">
-          <a class="govuk-link" href="{{ result.href }}">{{ result.title }}</a>
+          <a class="govuk-link" href="{{ result.hrefInterventionDetails }}">{{ result.title }}</a>
         </h2>
 
         <p class="govuk-body">{{ result.body }}</p>

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -19,6 +19,15 @@
           </svg>
         </button>
       </form>
+
+      <h2 class="govuk-heading-l">
+        Draft referrals
+      </h2>
+      {% if presenter.orderedReferrals | length %}
+        {{ govukTable(tableArgs) }}
+      {% else %}
+        <p class="govuk-body-m">{{ presenter.text.noDraftReferrals }}</p>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -1,0 +1,24 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      <h1 class="govuk-heading-xl">Refer and monitor an intervention</h1>
+
+      <p class="govuk-body govuk-!-margin-bottom-7">Use this service to find interventions for your service users</p>
+      <form action="/find-interventions">
+        <button role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+          Find interventions
+          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
+          </svg>
+        </button>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/referrals/form.njk
+++ b/server/views/referrals/form.njk
@@ -13,8 +13,6 @@
         Make a referral
       </h1>
 
-      <p class="govuk-body-m">Viewing referral with ID {{ presenter.referralID }}</p>
-
       <ol class="moj-task-list">
         {% for section in presenter.sections %}
           {% if section.type === 'multi' %}

--- a/server/views/referrals/start.njk
+++ b/server/views/referrals/start.njk
@@ -30,16 +30,6 @@
           </svg>
         </button>
       </form>
-
-      <h2 class="govuk-heading-l">
-        Draft referrals
-      </h2>
-      {% if presenter.orderedReferrals | length %}
-        {{ govukTable(tableArgs) }}
-      {% else %}
-        <p class="govuk-body-m">{{ presenter.text.noDraftReferrals }}</p>
-      {% endif %}
-    </div>
   </div>
 
 {% endblock %}

--- a/server/views/referrals/start.njk
+++ b/server/views/referrals/start.njk
@@ -18,7 +18,7 @@
 
       <p class="govuk-body-m">You can make a new referral here:</p>
 
-      <form action="/referrals/start" method="POST">
+      <form action="{{presenter.hrefStartReferral}}" method="POST">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
         {{govukInput(crnInputArgs)}}

--- a/server/views/referrals/start.njk
+++ b/server/views/referrals/start.njk
@@ -13,18 +13,20 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Make a referral
+        Enter the service user's case identifier
       </h1>
 
-      <p class="govuk-body-m">You can make a new referral here:</p>
+      <p class="govuk-body-l">Retrieve service user's record</p>
 
       <form action="{{presenter.hrefStartReferral}}" method="POST">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
         {{govukInput(crnInputArgs)}}
 
+        <p>The service user's details will be imported</p>
+
         <button role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
-          Start now
+          Continue
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
           </svg>


### PR DESCRIPTION
## What does this pull request do?

- Adds new PP dashboard placeholder page to start PP referral journey, with a button taking them to the Find interventions search results page.
- Passes selected intervention ID to Refer journey, replacing hardcoded one.
- Updates referral start page routes to take Intervention ID in params - `/interventions/:id/refer`
- Updates copy on User CRN entry page
- Removes referral id from Refer form

## What is the intent behind these changes?

To link up the Find and Refer user journeys.

## Screenshot

### Placeholder PP start journey
![image](https://user-images.githubusercontent.com/19826940/108057376-76536600-704a-11eb-9e97-01236ec47507.png)


### User CRN lookup
![image](https://user-images.githubusercontent.com/19826940/108057461-92ef9e00-704a-11eb-8bd4-82e1c441f816.png)


