### PR TITLE
IC-1113 filter sent referrals by SP organization

### DIFF
--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -120,7 +120,7 @@ export default class InterventionsServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `${this.mockPrefix}/sent-referrals`,
+        urlPathPattern: `${this.mockPrefix}/sent-referrals(\\?serviceProviderID\\=(a-zA-Z\\d\\_\\-)+)?`,
       },
       response: {
         status: 200,

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -13,7 +13,10 @@ export default class ServiceProviderReferralsController {
   ) {}
 
   async showDashboard(req: Request, res: Response): Promise<void> {
-    const referrals = await this.interventionsService.getSentReferrals(res.locals.user.token)
+    const referrals = await this.interventionsService.getSentReferrals(
+      res.locals.user.token,
+      res.locals.user.organizations[0].code
+    )
 
     const dedupedServiceCategoryIds = Array.from(
       new Set(referrals.map(referral => referral.referral.serviceCategoryId))

--- a/server/routes/testutils/mocks/mockUserService.ts
+++ b/server/routes/testutils/mocks/mockUserService.ts
@@ -10,6 +10,7 @@ export const user = {
   token: 'token',
   authSource: 'nomis',
   userId: '123',
+  organizations: [{ code: 'HARMONY_LIVING', name: 'Harmony Living' }],
 }
 
 export class MockUserService extends UserService {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1021,7 +1021,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   describe('getSentReferrals', () => {
     it('returns a list of all sent referrals', async () => {
       await provider.addInteraction({
-        state: 'There are some existing sent referrals',
+        state: 'There are some existing sent referrals for service provider HARMONY_LIVING',
         uponReceiving: 'a request for all sent referrals',
         withRequest: {
           method: 'GET',
@@ -1035,7 +1035,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      expect(await interventionsService.getSentReferrals(token)).toEqual([sentReferral, sentReferral])
+      expect(await interventionsService.getSentReferrals(token, 'HARMONY_LIVING')).toEqual([sentReferral, sentReferral])
     })
   })
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -255,12 +255,13 @@ export default class InterventionsService {
     })) as SentReferral
   }
 
-  async getSentReferrals(token: string): Promise<SentReferral[]> {
+  async getSentReferrals(token: string, organizationId: string): Promise<SentReferral[]> {
     const restClient = this.createRestClient(token)
 
     return (await restClient.get({
       path: `/sent-referrals`,
       headers: { Accept: 'application/json' },
+      query: `serviceProviderID=${organizationId}`,
     })) as SentReferral[]
   }
 

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -31,7 +31,7 @@ describe('User service', () => {
           groupName: 'NPS West Yorks Staff',
         },
         {
-          groupCode: 'INT_SP_HARMONY',
+          groupCode: 'INT_SP_HARMONY_LIVING',
           groupName: 'Harmony Living',
         },
       ])
@@ -45,7 +45,7 @@ describe('User service', () => {
     it('filters auth user groups', async () => {
       hmppsAuthClient.getUser.mockResolvedValue(authUser)
       const result = await userService.getUser(token)
-      expect(result.organizations).toEqual([{ code: 'INT_SP_HARMONY', name: 'Harmony Living' }])
+      expect(result.organizations).toEqual([{ code: 'HARMONY_LIVING', name: 'Harmony Living' }])
     })
     it('does not include auth user groups for delius users', async () => {
       hmppsAuthClient.getUser.mockResolvedValue(deliusUser)

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -25,7 +25,10 @@ export default class UserService {
     if (user.authSource === 'auth') {
       userDetails.organizations = (await this.hmppsAuthClient.getAuthUserGroups(token, user.username))
         .filter(group => group.groupCode.startsWith(this.serviceProviderGroupPrefix))
-        .map(group => ({ code: group.groupCode, name: group.groupName }))
+        .map(group => ({
+          code: group.groupCode.substring(this.serviceProviderGroupPrefix.length),
+          name: group.groupName,
+        }))
     }
 
     return userDetails


### PR DESCRIPTION
## What does this pull request do?

passes service provider organization query param to 'get sent referrals' endpoint

## What is the intent behind these changes?

only show the cases relevent to the SP staff member in their dashboard.
