### PR TITLE
IC-1063 to 1065, IC-1033: A probation practitioner can filter the list of intervention search results

### DIFF
--- a/integration_tests/integration/findInterventions.spec.js
+++ b/integration_tests/integration/findInterventions.spec.js
@@ -1,4 +1,5 @@
 import interventionFactory from '../../testutils/factories/intervention'
+import pccRegionFactory from '../../testutils/factories/pccRegion'
 
 context('Find an intervention', () => {
   beforeEach(() => {
@@ -36,6 +37,9 @@ context('Find an intervention', () => {
 
     cy.stubGetInterventions(interventions)
 
+    const pccRegions = [pccRegionFactory.build({ name: 'Cheshire' }), pccRegionFactory.build({ name: 'Lancashire' })]
+    cy.stubGetPccRegions(pccRegions)
+
     cy.visit('/find-interventions')
 
     cy.get('h1').contains('Find interventions')
@@ -45,6 +49,12 @@ context('Find an intervention', () => {
     cy.contains('Thinking and behaviour')
     cy.get('h2').contains('HELP (domestic violence for males)')
     cy.contains('Relationships')
+
+    cy.get('label[for*="gender"]').contains('Male').click()
+    cy.get('label[for*="age"]').contains('Only for ages 18 to 25').click()
+    cy.get('label[for*="pcc-region-ids"]').contains('Cheshire').click()
+
+    cy.contains('Filter results').click()
 
     const selectedIntervention = interventions.find(
       intervention => intervention.id === thinkingAndBehaviourInterventionId

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -76,7 +76,7 @@ module.exports = on => {
     },
 
     stubGetPccRegions: arg => {
-      return interventionsService.stubGetPccRegions(arg.id, arg.responseJson)
+      return interventionsService.stubGetPccRegions(arg.responseJson)
     },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -38,6 +38,6 @@ Cypress.Commands.add('stubGetIntervention', (id, responseJson) => {
   cy.task('stubGetIntervention', { id, responseJson })
 })
 
-Cypress.Commands.add('stubGetPccRegions', (id, responseJson) => {
-  cy.task('stubGetPccRegions', { id, responseJson })
+Cypress.Commands.add('stubGetPccRegions', responseJson => {
+  cy.task('stubGetPccRegions', { responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -136,7 +136,8 @@ export default class InterventionsServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `${this.mockPrefix}/interventions`,
+        // We don’t care about the query (filter)
+        urlPath: `${this.mockPrefix}/interventions`,
       },
       response: {
         status: 200,

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -164,7 +164,7 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubGetPccRegions = async (id: string, responseJson: unknown): Promise<unknown> => {
+  stubGetPccRegions = async (responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -49,7 +49,7 @@ export default class RestClient {
   }
 
   async get({ path, query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {
-    logger.info(`Get using user credentials: calling ${this.name}: ${path} ${query}`)
+    logger.info(`Get using user credentials: calling ${this.name}: ${path} ${JSON.stringify(query)}`)
     try {
       const result = await superagent
         .get(`${this.apiUrl()}${path}`)

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -4,6 +4,7 @@ import eligibilityFactory from '../../../testutils/factories/eligibility'
 import serviceProviderFactory from '../../../testutils/factories/serviceProvider'
 import { Intervention } from '../../services/interventionsService'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
+import TestUtils from '../../../testutils/testUtils'
 
 describe(InterventionDetailsPresenter, () => {
   describe('title', () => {
@@ -64,13 +65,11 @@ describe(InterventionDetailsPresenter, () => {
   })
 
   describe('summary', () => {
-    function linesForKey(key: string, params: DeepPartial<Intervention>): string[] {
-      const presenter = new InterventionDetailsPresenter(interventionFactory.build(params))
-      const item = presenter.summary.find(anItem => anItem.key === key)
-      if (item === undefined) {
-        fail(`Didn't find item for key ${key}`)
-      }
-      return item.lines
+    function linesForKey(key: string, params: DeepPartial<Intervention>): string[] | null {
+      return TestUtils.linesForKey(
+        key,
+        () => new InterventionDetailsPresenter(interventionFactory.build(params)).summary
+      )
     }
 
     describe('Type', () => {

--- a/server/routes/findInterventions/interventionsFilter.test.ts
+++ b/server/routes/findInterventions/interventionsFilter.test.ts
@@ -1,0 +1,66 @@
+import { Request } from 'express'
+import InterventionsFilter from './interventionsFilter'
+
+describe(InterventionsFilter, () => {
+  describe('.fromRequest', () => {
+    it('creates a filter from the request’s query params', () => {
+      const query = { 'pcc-region-ids': ['a', 'b', 'c'], gender: ['male'], age: ['18-to-25-only'] }
+
+      const filter = InterventionsFilter.fromRequest(({ query } as unknown) as Request)
+
+      expect(filter.pccRegionIds).toEqual(['a', 'b', 'c'])
+      expect(filter.gender).toEqual(['male'])
+      expect(filter.age).toEqual(['18-to-25-only'])
+    })
+  })
+
+  describe('params', () => {
+    it('correctly sets pccRegionIds', () => {
+      const filter = new InterventionsFilter()
+
+      expect(filter.params.pccRegionIds).toBeUndefined()
+
+      filter.pccRegionIds = ['a', 'b', 'c']
+      expect(filter.pccRegionIds).toEqual(['a', 'b', 'c'])
+    })
+
+    it('correctly sets allowsMale', () => {
+      const filter = new InterventionsFilter()
+
+      expect(filter.params.allowsMale).toBeUndefined()
+
+      filter.gender = ['female']
+      expect(filter.params.allowsMale).toBeUndefined()
+
+      filter.gender = ['male']
+      expect(filter.params.allowsMale).toBe(true)
+
+      filter.gender = ['male', 'female']
+      expect(filter.params.allowsMale).toBe(true)
+    })
+
+    it('correctly sets allowsFemale', () => {
+      const filter = new InterventionsFilter()
+
+      expect(filter.params.allowsFemale).toBeUndefined()
+
+      filter.gender = ['male']
+      expect(filter.params.allowsFemale).toBeUndefined()
+
+      filter.gender = ['female']
+      expect(filter.params.allowsFemale).toBe(true)
+
+      filter.gender = ['male', 'female']
+      expect(filter.params.allowsFemale).toBe(true)
+    })
+
+    it('correctly sets maximumAge', () => {
+      const filter = new InterventionsFilter()
+
+      expect(filter.params.maximumAge).toBeUndefined()
+
+      filter.age = ['18-to-25-only']
+      expect(filter.params.maximumAge).toBe(25)
+    })
+  })
+})

--- a/server/routes/findInterventions/interventionsFilter.ts
+++ b/server/routes/findInterventions/interventionsFilter.ts
@@ -1,0 +1,46 @@
+import { Request } from 'express'
+import { InterventionsFilterParams } from '../../services/interventionsService'
+
+export default class InterventionsFilter {
+  pccRegionIds: string[] | undefined
+
+  gender: ('male' | 'female')[] | undefined
+
+  age: '18-to-25-only'[] | undefined
+
+  static fromRequest(request: Request): InterventionsFilter {
+    const filter = new InterventionsFilter()
+
+    filter.pccRegionIds = request.query['pcc-region-ids'] as string[] | undefined
+    filter.gender = request.query.gender as ('male' | 'female')[] | undefined
+    filter.age = request.query.age as '18-to-25-only'[] | undefined
+
+    return filter
+  }
+
+  get params(): InterventionsFilterParams {
+    const params: InterventionsFilterParams = {}
+
+    if (this.pccRegionIds !== undefined) {
+      params.pccRegionIds = this.pccRegionIds
+    }
+
+    if (this.gender !== undefined) {
+      if (this.gender.includes('male')) {
+        params.allowsMale = true
+      }
+
+      if (this.gender.includes('female')) {
+        params.allowsFemale = true
+      }
+    }
+
+    if (this.age !== undefined) {
+      if (this.age.includes('18-to-25-only')) {
+        params.maximumAge = 25
+      }
+    }
+
+    return params
+  }
+}

--- a/server/routes/findInterventions/searchResultsPresenter.test.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.test.ts
@@ -1,10 +1,12 @@
 import SearchResultsPresenter from './searchResultsPresenter'
 import interventionFactory from '../../../testutils/factories/intervention'
+import InterventionsFilter from './interventionsFilter'
+import pccRegionFactory from '../../../testutils/factories/pccRegion'
 
 describe(SearchResultsPresenter, () => {
   describe('results', () => {
     it('contains as many items as there are interventions', () => {
-      const presenter = new SearchResultsPresenter(interventionFactory.buildList(3))
+      const presenter = new SearchResultsPresenter(interventionFactory.buildList(3), new InterventionsFilter(), [])
 
       expect(presenter.results.length).toBe(3)
     })
@@ -14,7 +16,7 @@ describe(SearchResultsPresenter, () => {
     describe('results', () => {
       describe('with no results', () => {
         it('is correctly pluralised', () => {
-          const presenter = new SearchResultsPresenter([])
+          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [])
 
           expect(presenter.text.results).toEqual({ count: '0', countSuffix: 'results found.' })
         })
@@ -22,7 +24,7 @@ describe(SearchResultsPresenter, () => {
 
       describe('with 1 result', () => {
         it('is correctly pluralised', () => {
-          const presenter = new SearchResultsPresenter(interventionFactory.buildList(1))
+          const presenter = new SearchResultsPresenter(interventionFactory.buildList(1), new InterventionsFilter(), [])
 
           expect(presenter.text.results).toEqual({ count: '1', countSuffix: 'result found.' })
         })
@@ -30,9 +32,111 @@ describe(SearchResultsPresenter, () => {
 
       describe('with > 1 result', () => {
         it('is correctly pluralised', () => {
-          const presenter = new SearchResultsPresenter(interventionFactory.buildList(2))
+          const presenter = new SearchResultsPresenter(interventionFactory.buildList(2), new InterventionsFilter(), [])
 
           expect(presenter.text.results).toEqual({ count: '2', countSuffix: 'results found.' })
+        })
+      })
+    })
+  })
+
+  describe('pccRegionFilters', () => {
+    const pccRegions = [pccRegionFactory.build({ name: 'Cheshire' }), pccRegionFactory.build({ name: 'Lancashire' })]
+
+    it('has the correct name and value', () => {
+      const presenter = new SearchResultsPresenter([], new InterventionsFilter(), pccRegions)
+
+      expect(presenter.pccRegionFilters).toMatchObject([
+        { value: pccRegions[0].id, text: 'Cheshire' },
+        { value: pccRegions[1].id, text: 'Lancashire' },
+      ])
+    })
+
+    describe('checked', () => {
+      describe('when filter doesn’t specify PCC region IDs', () => {
+        it('is false for all regions', () => {
+          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), pccRegions)
+
+          expect(presenter.pccRegionFilters).toMatchObject([{ checked: false }, { checked: false }])
+        })
+      })
+
+      describe('when filter specifies PCC region IDs', () => {
+        it('returns true for a region listed in the filter and false for a region not listed in the filter', () => {
+          const filter = new InterventionsFilter()
+          filter.pccRegionIds = [pccRegions[0].id]
+          const presenter = new SearchResultsPresenter([], filter, pccRegions)
+
+          expect(presenter.pccRegionFilters).toMatchObject([{ checked: true }, { checked: false }])
+        })
+      })
+    })
+  })
+
+  describe('genderFilters', () => {
+    it('has the correct name and value', () => {
+      const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [])
+
+      expect(presenter.genderFilters).toMatchObject([
+        { value: 'male', text: 'Male' },
+        { value: 'female', text: 'Female' },
+      ])
+    })
+
+    describe('checked', () => {
+      describe('when filter doesn’t specify gender', () => {
+        it('is false for all values', () => {
+          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [])
+
+          expect(presenter.genderFilters).toMatchObject([{ checked: false }, { checked: false }])
+        })
+      })
+
+      describe('when filter specifies male', () => {
+        it('is true for male', () => {
+          const filter = new InterventionsFilter()
+          filter.gender = ['male']
+          const presenter = new SearchResultsPresenter([], filter, [])
+
+          expect(presenter.genderFilters[0]).toMatchObject({ checked: true })
+        })
+      })
+
+      describe('when filter specifies female', () => {
+        it('is true for female', () => {
+          const filter = new InterventionsFilter()
+          filter.gender = ['female']
+          const presenter = new SearchResultsPresenter([], filter, [])
+
+          expect(presenter.genderFilters[1]).toMatchObject({ checked: true })
+        })
+      })
+    })
+  })
+
+  describe('ageFilters', () => {
+    it('has the correct name and value', () => {
+      const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [])
+
+      expect(presenter.ageFilters).toMatchObject([{ value: '18-to-25-only', text: 'Only for ages 18 to 25' }])
+    })
+
+    describe('checked', () => {
+      describe('when filter doesn’t specify age', () => {
+        it('is false for all values', () => {
+          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [])
+
+          expect(presenter.ageFilters).toMatchObject([{ checked: false }])
+        })
+      })
+
+      describe('when filter specifies 18 to 25 only', () => {
+        it('is true for 18 to 25 only', () => {
+          const filter = new InterventionsFilter()
+          filter.age = ['18-to-25-only']
+          const presenter = new SearchResultsPresenter([], filter, [])
+
+          expect(presenter.ageFilters).toMatchObject([{ checked: true }])
         })
       })
     })

--- a/server/routes/findInterventions/searchResultsPresenter.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.ts
@@ -1,6 +1,7 @@
 import { Intervention, PCCRegion } from '../../services/interventionsService'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
 import InterventionsFilter from './interventionsFilter'
+import SearchSummaryPresenter from './searchSummaryPresenter'
 
 export default class SearchResultsPresenter {
   constructor(
@@ -47,6 +48,8 @@ export default class SearchResultsPresenter {
       checked: this.filter.age?.includes('18-to-25-only') ?? false,
     },
   ]
+
+  readonly summary: SearchSummaryPresenter = new SearchSummaryPresenter(this.filter, this.pccRegions)
 
   readonly results: InterventionDetailsPresenter[] = this.interventions.map(
     intervention => new InterventionDetailsPresenter(intervention)

--- a/server/routes/findInterventions/searchResultsPresenter.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.ts
@@ -1,8 +1,52 @@
-import { Intervention } from '../../services/interventionsService'
+import { Intervention, PCCRegion } from '../../services/interventionsService'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
+import InterventionsFilter from './interventionsFilter'
 
 export default class SearchResultsPresenter {
-  constructor(private readonly interventions: Intervention[]) {}
+  constructor(
+    private readonly interventions: Intervention[],
+    private readonly filter: InterventionsFilter,
+    private readonly pccRegions: PCCRegion[]
+  ) {}
+
+  readonly pccRegionFilters: {
+    value: string
+    text: string
+    checked: boolean
+  }[] = this.pccRegions.map(region => ({
+    value: region.id,
+    text: region.name,
+    checked: this.filter.pccRegionIds?.includes(region.id) ?? false,
+  }))
+
+  readonly genderFilters: {
+    value: string
+    text: string
+    checked: boolean
+  }[] = [
+    {
+      value: 'male',
+      text: 'Male',
+      checked: this.filter.gender?.includes('male') ?? false,
+    },
+    {
+      value: 'female',
+      text: 'Female',
+      checked: this.filter.gender?.includes('female') ?? false,
+    },
+  ]
+
+  readonly ageFilters: {
+    value: string
+    text: string
+    checked: boolean
+  }[] = [
+    {
+      value: '18-to-25-only',
+      text: 'Only for ages 18 to 25',
+      checked: this.filter.age?.includes('18-to-25-only') ?? false,
+    },
+  ]
 
   readonly results: InterventionDetailsPresenter[] = this.interventions.map(
     intervention => new InterventionDetailsPresenter(intervention)

--- a/server/routes/findInterventions/searchResultsView.ts
+++ b/server/routes/findInterventions/searchResultsView.ts
@@ -5,6 +5,48 @@ import { SummaryListArgs, SummaryListItem } from '../../utils/summaryList'
 export default class SearchResultsView {
   constructor(private readonly presenter: SearchResultsPresenter) {}
 
+  private checkboxArgs({
+    name,
+    legend,
+    checkboxes,
+  }: {
+    name: string
+    legend: string
+    checkboxes: {
+      value: string
+      text: string
+      checked: boolean
+    }[]
+  }): Record<string, unknown> {
+    return {
+      idPrefix: name,
+      name: `${name}[]`,
+      fieldset: {
+        legend: {
+          text: legend,
+          classes: 'govuk-fieldset__legend--s',
+        },
+      },
+      items: checkboxes.map(checkbox => ({
+        value: checkbox.value,
+        text: checkbox.text,
+        checked: checkbox.checked,
+      })),
+    }
+  }
+
+  private get pccRegionCheckboxArgs(): Record<string, unknown> {
+    return this.checkboxArgs({ name: 'pcc-region-ids', legend: 'Regions', checkboxes: this.presenter.pccRegionFilters })
+  }
+
+  private get genderCheckboxArgs(): Record<string, unknown> {
+    return this.checkboxArgs({ name: 'gender', legend: 'Gender', checkboxes: this.presenter.genderFilters })
+  }
+
+  private get ageCheckboxArgs(): Record<string, unknown> {
+    return this.checkboxArgs({ name: 'age', legend: 'Age restrictions', checkboxes: this.presenter.ageFilters })
+  }
+
   static summaryListArgs(items: SummaryListItem[]): SummaryListArgs & { classes: string } {
     return { ...ViewUtils.summaryListArgs(items), classes: 'govuk-summary-list--no-border' }
   }
@@ -12,7 +54,13 @@ export default class SearchResultsView {
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'findInterventions/searchResults',
-      { presenter: this.presenter, summaryListArgs: SearchResultsView.summaryListArgs },
+      {
+        presenter: this.presenter,
+        pccRegionCheckboxArgs: this.pccRegionCheckboxArgs,
+        genderCheckboxArgs: this.genderCheckboxArgs,
+        ageCheckboxArgs: this.ageCheckboxArgs,
+        summaryListArgs: SearchResultsView.summaryListArgs,
+      },
     ]
   }
 }

--- a/server/routes/findInterventions/searchResultsView.ts
+++ b/server/routes/findInterventions/searchResultsView.ts
@@ -51,6 +51,8 @@ export default class SearchResultsView {
     return { ...ViewUtils.summaryListArgs(items), classes: 'govuk-summary-list--no-border' }
   }
 
+  private searchSummarySummaryListArgs = ViewUtils.summaryListArgs(this.presenter.summary.summary)
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'findInterventions/searchResults',
@@ -60,6 +62,7 @@ export default class SearchResultsView {
         genderCheckboxArgs: this.genderCheckboxArgs,
         ageCheckboxArgs: this.ageCheckboxArgs,
         summaryListArgs: SearchResultsView.summaryListArgs,
+        searchSummarySummaryListArgs: this.searchSummarySummaryListArgs,
       },
     ]
   }

--- a/server/routes/findInterventions/searchSummaryPresenter.test.ts
+++ b/server/routes/findInterventions/searchSummaryPresenter.test.ts
@@ -1,0 +1,54 @@
+import InterventionsFilter from './interventionsFilter'
+import SearchSummaryPresenter from './searchSummaryPresenter'
+import pccRegionFactory from '../../../testutils/factories/pccRegion'
+import { PCCRegion } from '../../services/interventionsService'
+import TestUtils from '../../../testutils/testUtils'
+
+describe(SearchSummaryPresenter, () => {
+  describe('summary', () => {
+    describe('with an empty filter', () => {
+      it('returns no summary list items', () => {
+        const presenter = new SearchSummaryPresenter(new InterventionsFilter(), [])
+
+        expect(presenter.summary).toEqual([])
+      })
+    })
+
+    function linesForKey(key: string, args: [InterventionsFilter, PCCRegion[]]): string[] | null {
+      return TestUtils.linesForKey(key, () => new SearchSummaryPresenter(...args).summary)
+    }
+
+    describe('when filter has PCC regions selected', () => {
+      it('describes the filter', () => {
+        const pccRegions = [
+          pccRegionFactory.build({ name: 'Cheshire' }),
+          pccRegionFactory.build({ name: 'Cumbria' }),
+          pccRegionFactory.build({ name: 'Lancashire' }),
+        ]
+
+        const filter = new InterventionsFilter()
+        filter.pccRegionIds = [pccRegions[0].id, pccRegions[1].id]
+
+        expect(linesForKey('In', [filter, pccRegions])).toEqual(['Cheshire, Cumbria'])
+      })
+    })
+
+    describe('when filter has gender selected', () => {
+      it('describes the filter', () => {
+        const filter = new InterventionsFilter()
+        filter.gender = ['male', 'female']
+
+        expect(linesForKey('For', [filter, []])).toEqual(['Male, Female'])
+      })
+    })
+
+    describe('when filter has ages selected', () => {
+      it('describes the filter', () => {
+        const filter = new InterventionsFilter()
+        filter.age = ['18-to-25-only']
+
+        expect(linesForKey('Aged', [filter, []])).toEqual(['18 to 25 only'])
+      })
+    })
+  })
+})

--- a/server/routes/findInterventions/searchSummaryPresenter.ts
+++ b/server/routes/findInterventions/searchSummaryPresenter.ts
@@ -1,0 +1,69 @@
+import { PCCRegion } from '../../services/interventionsService'
+import { SummaryListItem } from '../../utils/summaryList'
+import InterventionsFilter from './interventionsFilter'
+import utils from '../../utils/utils'
+
+export default class SearchSummaryPresenter {
+  constructor(private readonly filter: InterventionsFilter, private readonly pccRegions: PCCRegion[]) {}
+
+  get summary(): SummaryListItem[] {
+    const result: SummaryListItem[] = []
+
+    if (this.regionItem !== null) {
+      result.push(this.regionItem)
+    }
+
+    if (this.genderItem !== null) {
+      result.push(this.genderItem)
+    }
+
+    if (this.ageItem !== null) {
+      result.push(this.ageItem)
+    }
+
+    return result
+  }
+
+  private get regionItem(): SummaryListItem | null {
+    if (this.filter.pccRegionIds === undefined) {
+      return null
+    }
+
+    const names = this.filter.pccRegionIds.map(id => {
+      const region = this.pccRegions.find(aRegion => aRegion.id === id)
+      if (region === undefined) {
+        throw new Error(`Could not find PCC region with ID ${id}`)
+      }
+      return region.name
+    })
+
+    names.sort()
+
+    return { key: 'In', lines: [names.join(', ')], isList: false }
+  }
+
+  private get genderItem(): SummaryListItem | null {
+    if (this.filter.gender === undefined) {
+      return null
+    }
+
+    return { key: 'For', lines: [this.filter.gender.map(utils.convertToProperCase).join(', ')], isList: false }
+  }
+
+  private get ageItem(): SummaryListItem | null {
+    if (this.filter.age === undefined) {
+      return null
+    }
+
+    const names = this.filter.age.map(age => {
+      switch (age) {
+        case '18-to-25-only':
+          return '18 to 25 only'
+        default:
+          throw new Error(`No message for age filter ${age}`)
+      }
+    })
+
+    return { key: 'Aged', lines: [names.join(', ')], isList: false }
+  }
+}

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -1,4 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -25,7 +27,14 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
-      <p class="govuk-body">Filters to go here</p>
+      <form method="get">
+        {{ govukCheckboxes(genderCheckboxArgs) }}
+        {{ govukCheckboxes(ageCheckboxArgs) }}
+        {{ govukCheckboxes(pccRegionCheckboxArgs) }}
+
+        {{ govukButton({ text: "Filter results" }) }}
+      </form>
+
     </div>
 
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -40,6 +40,8 @@
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body"><span class="govuk-!-font-size-36 govuk-!-margin-right-1"><strong>{{presenter.text.results.count}}</strong></span> {{ presenter.text.results.countSuffix }}</p>
 
+      {{ govukSummaryList(searchSummarySummaryListArgs) }}
+
       {% for result in presenter.results %}
         <h2 class="govuk-heading-l">
           <a class="govuk-link" href="{{ result.href }}">{{ result.title }}</a>

--- a/testutils/factories/pccRegion.ts
+++ b/testutils/factories/pccRegion.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import { PCCRegion } from '../../server/services/interventionsService'
+
+export default Factory.define<PCCRegion>(({ sequence }) => ({
+  id: sequence.toString(),
+  name: 'Cheshire',
+}))

--- a/testutils/testUtils.ts
+++ b/testutils/testUtils.ts
@@ -1,0 +1,9 @@
+import { SummaryListItem } from '../server/utils/summaryList'
+
+export default class TestUtils {
+  static linesForKey(key: string, list: () => SummaryListItem[]): string[] | null {
+    const items = list()
+    const item = items.find(anItem => anItem.key === key)
+    return item?.lines ?? null
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Adds filtering controls to the list of intervention search results, and a summary of the filters chosen.

## What is the intent behind these changes?

To allow a probation practitioner to narrow down the search results.

## Screenshot

![image](https://user-images.githubusercontent.com/53756884/108056620-65562500-7049-11eb-8801-32d6d5279e27.png)
