### PR TITLE
IC-1170-two-empty-pages

### DIFF
--- a/server/routes/staticContent/staticContentController.ts
+++ b/server/routes/staticContent/staticContentController.ts
@@ -69,6 +69,16 @@ export default class StaticContentController {
       template: 'serviceProviderReferrals/sessions/amend',
       description: 'IC-1087 (session details: amend)',
     },
+    {
+      path: '/service-provider/sessions/feedback/confirmation-all-sessions-completed',
+      template: 'serviceProviderReferrals/sessions/feedback/confirmationAllSessionsCompleted',
+      description: 'IC-1177 (session feedback: confirmation - all sessions completed)',
+    },
+    {
+      path: '/service-provider/session-progress-all-sessions-completed',
+      template: 'serviceProviderReferrals/sessionProgressAllSessionsCompleted',
+      description: 'IC-1078 (session progress - all sessions completed, with notification banner)',
+    },
   ]
 
   static get allPaths(): string[] {

--- a/server/views/serviceProviderReferrals/sessionProgressAllSessionsCompleted.njk
+++ b/server/views/serviceProviderReferrals/sessionProgressAllSessionsCompleted.njk
@@ -1,0 +1,16 @@
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {# TO DO #}
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-m"> sidebar</h3>
+        <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
+      </div>
+
+{% endblock %}

--- a/server/views/serviceProviderReferrals/sessions/feedback/confirmationAllSessionsCompleted.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/confirmationAllSessionsCompleted.njk
@@ -1,0 +1,18 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {# TO DO #}
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">One-third column</h2>
+    <p class="govuk-body">one-third wide column</p>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?
 
Adding two new static pages for remainder two Record attendance tasks

## What is the intent behind these changes?

To make it easy for designers to contribute to the codebase.

https://dsdmoj.atlassian.net/browse/IC-1179

## Screenshot

Listing of all static pages (`/static-pages`):


![Screenshot_2021-02-04 HMPPS Interventions - GOV UK(1)](https://user-images.githubusercontent.com/53756884/106883676-38645280-66d8-11eb-8a44-214255b52f39.png)