### PR TITLE
IC-1078: Update referral form to match new design

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -99,7 +99,7 @@ describe('Referral form', () => {
 
     cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
 
-    cy.contains('Confirm service user details').click()
+    cy.contains('Confirm service user’s personal details').click()
 
     cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/service-user-details`)
     cy.get('h1').contains("Geoffrey's information")
@@ -115,7 +115,8 @@ describe('Referral form', () => {
 
     cy.contains('Save and continue').click()
 
-    cy.contains('Service user’s needs and requirements').click()
+    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/risk-information`)
+    cy.contains('Save and continue').click()
 
     cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/needs-and-requirements`)
     cy.get('h1').contains('Geoffrey’s needs and requirements')

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -16,30 +16,11 @@ describe('ReferralFormPresenter', () => {
         const expected = [
           {
             type: 'single',
-            title: 'Retrieve service user record',
+            title: 'Review service user’s information',
             number: '1',
             status: ReferralFormStatus.Completed,
             tasks: [
-              { title: 'Enter service user case identifier', url: null },
-              { title: 'Confirm service user details', url: 'service-user-details' },
-            ],
-          },
-          {
-            type: 'single',
-            title: 'Find and select service user interventions',
-            number: '2',
-            status: ReferralFormStatus.Completed,
-            tasks: [
-              { title: 'Find and select service user interventions', url: null },
-              { title: 'Confirm interventions', url: null },
-            ],
-          },
-          {
-            type: 'single',
-            title: 'Review service user’s information',
-            number: '3',
-            status: ReferralFormStatus.Completed,
-            tasks: [
+              { title: 'Confirm service user’s personal details', url: 'service-user-details' },
               { title: 'Service user’s risk information', url: 'risk-information' },
               { title: 'Service user’s needs and requirements', url: 'needs-and-requirements' },
             ],
@@ -47,7 +28,7 @@ describe('ReferralFormPresenter', () => {
           {
             type: 'single',
             title: `Add social inclusion referral details`,
-            number: '4',
+            number: '2',
             status: ReferralFormStatus.NotStarted,
             tasks: [
               { title: 'Select the relevant sentence for the social inclusion referral', url: null },
@@ -64,14 +45,14 @@ describe('ReferralFormPresenter', () => {
           {
             type: 'single',
             title: 'Review responsible officer’s information',
-            number: '5',
+            number: '3',
             status: ReferralFormStatus.NotStarted,
             tasks: [{ title: 'Responsible officer information', url: null }],
           },
           {
             type: 'single',
             title: 'Check your answers',
-            number: '6',
+            number: '4',
             status: ReferralFormStatus.CannotStartYet,
             tasks: [{ title: 'Check your answers', url: null }],
           },
@@ -109,30 +90,11 @@ describe('ReferralFormPresenter', () => {
         const expected = [
           {
             type: 'single',
-            title: 'Retrieve service user record',
+            title: 'Review service user’s information',
             number: '1',
             status: ReferralFormStatus.Completed,
             tasks: [
-              { title: 'Enter service user case identifier', url: null },
-              { title: 'Confirm service user details', url: 'service-user-details' },
-            ],
-          },
-          {
-            type: 'single',
-            title: 'Find and select service user interventions',
-            number: '2',
-            status: ReferralFormStatus.Completed,
-            tasks: [
-              { title: 'Find and select service user interventions', url: null },
-              { title: 'Confirm interventions', url: null },
-            ],
-          },
-          {
-            type: 'single',
-            title: 'Review service user’s information',
-            number: '3',
-            status: ReferralFormStatus.Completed,
-            tasks: [
+              { title: 'Confirm service user’s personal details', url: 'service-user-details' },
               { title: 'Service user’s risk information', url: 'risk-information' },
               { title: 'Service user’s needs and requirements', url: 'needs-and-requirements' },
             ],
@@ -140,7 +102,7 @@ describe('ReferralFormPresenter', () => {
           {
             type: 'single',
             title: 'Add accommodation referral details',
-            number: '4',
+            number: '2',
             status: ReferralFormStatus.Completed,
             tasks: [
               { title: 'Select the relevant sentence for the accommodation referral', url: null },
@@ -157,14 +119,14 @@ describe('ReferralFormPresenter', () => {
           {
             type: 'single',
             title: 'Review responsible officer’s information',
-            number: '5',
+            number: '3',
             status: ReferralFormStatus.NotStarted,
             tasks: [{ title: 'Responsible officer information', url: null }],
           },
           {
             type: 'single',
             title: 'Check your answers',
-            number: '6',
+            number: '4',
             status: ReferralFormStatus.NotStarted,
             tasks: [{ title: 'Check your answers', url: 'check-answers' }],
           },

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -7,42 +7,14 @@ export default class ReferralFormPresenter {
     return [
       {
         type: 'single',
-        title: 'Retrieve service user record',
+        title: 'Review service user’s information',
         number: '1',
         status: ReferralFormStatus.Completed,
         tasks: [
           {
-            title: 'Enter service user case identifier',
-            url: null,
-          },
-          {
-            title: 'Confirm service user details',
+            title: 'Confirm service user’s personal details',
             url: 'service-user-details',
           },
-        ],
-      },
-      {
-        type: 'single',
-        title: 'Find and select service user interventions',
-        number: '2',
-        status: ReferralFormStatus.Completed,
-        tasks: [
-          {
-            title: 'Find and select service user interventions',
-            url: null,
-          },
-          {
-            title: 'Confirm interventions',
-            url: null,
-          },
-        ],
-      },
-      {
-        type: 'single',
-        title: 'Review service user’s information',
-        number: '3',
-        status: ReferralFormStatus.Completed,
-        tasks: [
           {
             title: 'Service user’s risk information',
             url: 'risk-information',
@@ -56,7 +28,7 @@ export default class ReferralFormPresenter {
       {
         type: 'single',
         title: `Add ${this.serviceCategoryName} referral details`,
-        number: '4',
+        number: '2',
         status: this.determineInterventionDetailsSectionStatus(),
         tasks: [
           {
@@ -88,7 +60,7 @@ export default class ReferralFormPresenter {
       {
         type: 'single',
         title: 'Review responsible officer’s information',
-        number: '5',
+        number: '3',
         status: ReferralFormStatus.NotStarted,
         tasks: [
           {
@@ -100,7 +72,7 @@ export default class ReferralFormPresenter {
       {
         type: 'single',
         title: 'Check your answers',
-        number: '6',
+        number: '4',
         status: this.canSubmitReferral ? ReferralFormStatus.NotStarted : ReferralFormStatus.CannotStartYet,
         tasks: [
           {

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -119,9 +119,7 @@ export default class ReferralsController {
   }
 
   async confirmServiceUserDetails(req: Request, res: Response): Promise<void> {
-    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
-
-    res.redirect(303, `/referrals/${referral.id}/form`)
+    res.redirect(`/referrals/${req.params.id}/risk-information`)
   }
 
   async viewReferralForm(req: Request, res: Response): Promise<void> {


### PR DESCRIPTION
## What does this pull request do?

Removes "Find" part of referral form and condenses service user information into single section.

## What is the intent behind these changes?

Now that we're coming straight from Find into Refer, we have no need for the "Find" part of the referral form.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/108093295-774dbd00-7075-11eb-845c-085081694897.png)
