### PR TITLE
IC-1156: Add NPS Region to intervention

### DIFF
--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -91,6 +91,16 @@ describe(InterventionDetailsPresenter, () => {
       })
     })
 
+    describe('Region', () => {
+      it('is the NPS region name', () => {
+        expect(
+          linesForKey('Region', {
+            npsRegion: { id: 'A', name: 'North East' },
+          })
+        ).toEqual(['North East'])
+      })
+    })
+
     describe('Location', () => {
       it('is a comma-separated list of PCC regions', () => {
         expect(

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -39,6 +39,11 @@ export default class InterventionDetailsPresenter {
         isList: false,
       },
       {
+        key: 'Region',
+        lines: [utils.convertToTitleCase(this.intervention.npsRegion.name)],
+        isList: false,
+      },
+      {
         key: 'Location',
         lines: [this.intervention.pccRegions.map(region => region.name).join(', ')],
         isList: false,

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1177,21 +1177,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   describe('getIntervention', () => {
     it('returns a single intervention', async () => {
       const interventionId = '15237ae5-a017-4de6-a033-abf350f14d99'
-      const intervention = {
-        id: interventionId,
-        title: 'Better solutions (anger management)',
-        description:
-          'To provide service users with key tools and strategies to address issues of anger management and temper control and explore the link between thoughts, emotions and behaviour. It provides the opportunity for service users to practice these strategies in a safe and closed environment.',
-        pccRegions: [
-          { id: 'cheshire', name: 'Cheshire' },
-          { id: 'cumbria', name: 'Cumbria' },
-          { id: 'lancashire', name: 'Lancashire' },
-          { id: 'merseyside', name: 'Merseyside' },
-        ],
-        serviceCategory: serviceCategoryFactory.build(),
-        serviceProvider: serviceProviderFactory.build(),
-        eligibility: eligibilityFactory.allAdults().build(),
-      }
+      const intervention = interventionFactory.build({ id: interventionId })
 
       await provider.addInteraction({
         state: 'There is an existing intervention with ID 15237ae5-a017-4de6-a033-abf350f14d99',

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -92,6 +92,7 @@ export interface Intervention {
   id: string
   title: string
   description: string
+  npsRegion: NPSRegion
   pccRegions: PCCRegion[]
   serviceCategory: ServiceCategory
   serviceProvider: ServiceProvider
@@ -99,6 +100,11 @@ export interface Intervention {
 }
 
 export interface PCCRegion {
+  id: string
+  name: string
+}
+
+export interface NPSRegion {
   id: string
   name: string
 }

--- a/testutils/factories/intervention.ts
+++ b/testutils/factories/intervention.ts
@@ -9,6 +9,7 @@ export default Factory.define<Intervention>(sequence => ({
   title: 'Better solutions (anger management)',
   description:
     'To provide service users with key tools and strategies to address issues of anger management and temper control and explore the link between thoughts, emotions and behaviour. It provides the opportunity for service users to practice these strategies in a safe and closed environment.',
+  npsRegion: { id: 'B', name: 'North West' },
   pccRegions: [
     { id: 'cheshire', name: 'Cheshire' },
     { id: 'cumbria', name: 'Cumbria' },


### PR DESCRIPTION
## What does this pull request do?

Adds Region line to Intervention details summary in the Find journey. This isn't filterable, just for the PP's information.

## What is the intent behind these changes?

To display region to PPs looking for an intervention.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/108223820-1f28c080-7132-11eb-8932-d3a2a218d390.png)
