### PR TITLE
Do not log the user out on authentication errors.

### DIFF
--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -6,11 +6,6 @@ export default function createErrorHandler(production: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
     logger.error(`Error handling request for '${req.originalUrl}', user '${res.locals.user?.username}'`, error)
 
-    if (error.status === 401 || error.status === 403) {
-      logger.info('Logging user out')
-      return res.redirect('/logout')
-    }
-
     res.locals.message = production
       ? 'Something went wrong. The error has been logged. Please try again'
       : error.message


### PR DESCRIPTION
## What does this pull request do?

Do not log the user out on authentication errors.

I find this behaviour really annoying and confusing. When a page
returns a 403 or 401 response, the user is redirected to /logout,
and ends up back at the login page. It's much better to tell the user
why they can't view the page.

We can tidy up this behaviour later, but for now just removing the
redirect it miles better IMO.

## What is the intent behind these changes?

In the short term - make it easier to see what's going on when you hit 403s. 
