### PR TITLE
IC-1237: Allow NPS Region to be null

### DIFF
--- a/mocks.ts
+++ b/mocks.ts
@@ -62,6 +62,7 @@ export default async function setUpMocks(): Promise<void> {
         'HELP - the Healthy Relationships programme, is a new, preventative approach to domestic abuse.' +
         'The course aims to help create successful relationships. Those who complete the group will have' +
         'skills and strategies to manage situations differently and avoid problems escalating into violence.',
+      npsRegion: null,
     },
   ].map(params => {
     return interventionFactory.build({
@@ -69,6 +70,7 @@ export default async function setUpMocks(): Promise<void> {
       title: params.title,
       serviceCategory: { name: params.categoryName },
       description: params.description,
+      npsRegion: params.npsRegion,
     })
   })
 

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -92,12 +92,24 @@ describe(InterventionDetailsPresenter, () => {
     })
 
     describe('Region', () => {
-      it('is the NPS region name', () => {
-        expect(
-          linesForKey('Region', {
-            npsRegion: { id: 'A', name: 'North East' },
-          })
-        ).toEqual(['North East'])
+      describe('when NPS Region is present on the intervention', () => {
+        it('is the NPS region name', () => {
+          expect(
+            linesForKey('Region', {
+              npsRegion: { id: 'A', name: 'North East' },
+            })
+          ).toEqual(['North East'])
+        })
+      })
+
+      describe('when NPS Region is not present on the intervention', () => {
+        it('is not present in the summary', () => {
+          expect(
+            linesForKey('Random', {
+              npsRegion: null,
+            })
+          ).toEqual(null)
+        })
       })
     })
 

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -32,15 +32,10 @@ export default class InterventionDetailsPresenter {
   }
 
   get summary(): SummaryListItem[] {
-    return [
+    const summary = [
       {
         key: 'Type',
         lines: ['Dynamic Framework'],
-        isList: false,
-      },
-      {
-        key: 'Region',
-        lines: [utils.convertToTitleCase(this.intervention.npsRegion.name)],
         isList: false,
       },
       {
@@ -69,6 +64,16 @@ export default class InterventionDetailsPresenter {
         isList: false,
       },
     ]
+
+    if (this.intervention.npsRegion !== null) {
+      summary.splice(1, 0, {
+        key: 'Region',
+        lines: [utils.convertToTitleCase(this.intervention.npsRegion.name)],
+        isList: false,
+      })
+    }
+
+    return summary
   }
 
   static ageGroupDescription(eligibility: Eligibility): string {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -94,7 +94,7 @@ export interface Intervention {
   id: string
   title: string
   description: string
-  npsRegion: NPSRegion
+  npsRegion: NPSRegion | null
   pccRegions: PCCRegion[]
   serviceCategory: ServiceCategory
   serviceProvider: ServiceProvider


### PR DESCRIPTION
## What does this pull request do?

Allows NPS Region to be `null` on an Intervention, only adding it to the summary list if it's present.

## What is the intent behind these changes?

We're not 100% sure whether an NPS region is required, as it's not currently filterable. Until we figure this out, it's safer to allow it to be null and not break the user journey.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/108838413-82e83900-75cb-11eb-9b34-3275417f5e16.png)

