### PR TITLE
IC-1246: Use correct AuthUser response object when assigning a referral

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -132,14 +132,14 @@ describe('Service provider referrals dashboard', () => {
     const referral = sentReferralFactory.build(referralParams)
     const deliusUser = deliusUserFactory.build()
     const deliusServiceUser = deliusServiceUserFactory.build()
-    const hmppsAuthUser = hmppsAuthUserFactory.build({ name: 'John Smith', username: 'john.smith' })
+    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
 
     cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
     cy.stubGetSentReferral(referral.id, referral)
     cy.stubGetSentReferrals([referral])
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
-    cy.stubGetUserByEmailAddress(hmppsAuthUser)
+    cy.stubGetUserByEmailAddress([hmppsAuthUser])
     cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
     cy.stubAssignSentReferral(referral.id, referral)
 

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -54,34 +54,61 @@ describe('hmppsAuthClient', () => {
   })
 
   describe('getUserByEmailAddress', () => {
-    it('should return data from api', async () => {
-      const response = {
-        username: 'AUTH_ADM',
-        active: true,
-        name: 'Auth Adm',
-        authSource: 'auth',
-        userId: '5105a589-75b3-4ca0-9433-b96228c1c8f3',
-      }
+    describe('when a matching user is found with the requested email address', () => {
+      it('should return the first matching user from the API response', async () => {
+        const response = [
+          {
+            userId: '91229A16-B5F4-4784-942E-A484A97AC865',
+            username: 'authuser',
+            email: 'user@example.com',
+            firstName: 'Auth',
+            lastName: 'User',
+            locked: true,
+            enabled: false,
+            verified: false,
+            lastLoggedIn: '01/01/2001',
+          },
+        ]
 
-      fakeHmppsAuthApi
-        .get('/api/authuser')
-        .query({ email: 'user@example.com' })
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, response)
+        fakeHmppsAuthApi
+          .get('/api/authuser')
+          .query({ email: 'user@example.com' })
+          .matchHeader('authorization', `Bearer ${token.access_token}`)
+          .reply(200, response)
 
-      const output = await hmppsAuthClient.getUserByEmailAddress(token.access_token, 'user@example.com')
-      expect(output).toEqual(response)
+        const output = await hmppsAuthClient.getUserByEmailAddress(token.access_token, 'user@example.com')
+        expect(output).toEqual(response[0])
+      })
+    })
+
+    describe('when no user is found with the requested email address', () => {
+      it('should raise an error', async () => {
+        const noUserResponse = {}
+        fakeHmppsAuthApi
+          .get('/api/authuser')
+          .query({ email: 'user@example.com' })
+          .matchHeader('authorization', `Bearer ${token.access_token}`)
+          .reply(204, noUserResponse)
+
+        expect(hmppsAuthClient.getUserByEmailAddress(token.access_token, 'user@example.com')).rejects.toThrow(
+          'Email not found'
+        )
+      })
     })
   })
 
   describe('getUserByUsername', () => {
-    it('should return data from api', async () => {
+    it('should return the matching user from the API response', async () => {
       const response = {
-        username: 'AUTH_ADM',
-        active: true,
-        name: 'Auth Adm',
-        authSource: 'auth',
-        userId: '5105a589-75b3-4ca0-9433-b96228c1c8f3',
+        userId: '91229A16-B5F4-4784-942E-A484A97AC865',
+        username: 'authuser',
+        email: 'user@example.com',
+        firstName: 'Auth',
+        lastName: 'User',
+        locked: true,
+        enabled: false,
+        verified: false,
+        lastLoggedIn: '01/01/2001',
       }
 
       fakeHmppsAuthApi

--- a/server/routes/referrals/referralDataPresenterUtils.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.ts
@@ -1,3 +1,4 @@
+import { AuthUser } from '../../data/hmppsAuthClient'
 import { DraftReferral, ServiceUser } from '../../services/interventionsService'
 import CalendarDay from '../../utils/calendarDay'
 import utils from '../../utils/utils'
@@ -112,8 +113,8 @@ export default class ReferralDataPresenterUtils {
     return format.format(date)
   }
 
-  static fullName(serviceUser: ServiceUser): string {
-    return utils.convertToTitleCase(`${serviceUser.firstName ?? ''} ${serviceUser.lastName ?? ''}`)
+  static fullName(user: ServiceUser | AuthUser): string {
+    return utils.convertToTitleCase(`${user.firstName ?? ''} ${user.lastName ?? ''}`)
   }
 
   static fullNameSortValue(serviceUser: ServiceUser): string {

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.test.ts
@@ -22,7 +22,7 @@ describe(AssignmentConfirmationPresenter, () => {
         referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
       })
       const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-      const assignee = hmppsAuthUserFactory.build({ name: 'Bernard Beaks' })
+      const assignee = hmppsAuthUserFactory.build({ firstName: 'Bernard', lastName: 'Beaks' })
       const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
 
       expect(presenter.summary).toEqual([

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.test.ts
@@ -16,37 +16,144 @@ describe(AssignmentConfirmationPresenter, () => {
   })
 
   describe('summary', () => {
-    it('returns a summary of the referral and the assigned caseworker', () => {
-      const sentReferral = sentReferralFactory.build({
-        referenceNumber: 'CEF345',
-        referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
-      })
-      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-      const assignee = hmppsAuthUserFactory.build({ firstName: 'Bernard', lastName: 'Beaks' })
-      const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
+    describe('when the selected caseworker has a first and last name', () => {
+      it('returns a summary of the selected caseworker with both names', () => {
+        const sentReferral = sentReferralFactory.build({
+          referenceNumber: 'CEF345',
+          referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
+        })
+        const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const assignee = hmppsAuthUserFactory.build({ firstName: 'Bernard', lastName: 'Beaks' })
+        const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
 
-      expect(presenter.summary).toEqual([
-        {
-          key: 'Name',
-          lines: ['Johnny Davis'],
-          isList: false,
-        },
-        {
-          key: 'Referral number',
-          lines: ['CEF345'],
-          isList: false,
-        },
-        {
-          key: 'Service type',
-          lines: ['Social inclusion'],
-          isList: false,
-        },
-        {
-          key: 'Assigned to',
-          lines: ['Bernard Beaks'],
-          isList: false,
-        },
-      ])
+        expect(presenter.summary).toEqual([
+          {
+            key: 'Name',
+            lines: ['Johnny Davis'],
+            isList: false,
+          },
+          {
+            key: 'Referral number',
+            lines: ['CEF345'],
+            isList: false,
+          },
+          {
+            key: 'Service type',
+            lines: ['Social inclusion'],
+            isList: false,
+          },
+          {
+            key: 'Assigned to',
+            lines: ['Bernard Beaks'],
+            isList: false,
+          },
+        ])
+      })
+    })
+
+    describe('when the selected caseworker has only a first name', () => {
+      it('returns a summary of the selected caseworker with just the first name', () => {
+        const sentReferral = sentReferralFactory.build({
+          referenceNumber: 'CEF345',
+          referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
+        })
+        const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const assignee = hmppsAuthUserFactory.build({ firstName: 'Bernard', lastName: '' })
+        const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
+
+        expect(presenter.summary).toEqual([
+          {
+            key: 'Name',
+            lines: ['Johnny Davis'],
+            isList: false,
+          },
+          {
+            key: 'Referral number',
+            lines: ['CEF345'],
+            isList: false,
+          },
+          {
+            key: 'Service type',
+            lines: ['Social inclusion'],
+            isList: false,
+          },
+          {
+            key: 'Assigned to',
+            lines: ['Bernard '],
+            isList: false,
+          },
+        ])
+      })
+    })
+
+    describe('when the selected caseworker has only a last name', () => {
+      it('returns a summary of the selected caseworker with just the last name', () => {
+        const sentReferral = sentReferralFactory.build({
+          referenceNumber: 'CEF345',
+          referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
+        })
+        const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const assignee = hmppsAuthUserFactory.build({ firstName: '', lastName: 'Beaks' })
+        const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
+
+        expect(presenter.summary).toEqual([
+          {
+            key: 'Name',
+            lines: ['Johnny Davis'],
+            isList: false,
+          },
+          {
+            key: 'Referral number',
+            lines: ['CEF345'],
+            isList: false,
+          },
+          {
+            key: 'Service type',
+            lines: ['Social inclusion'],
+            isList: false,
+          },
+          {
+            key: 'Assigned to',
+            lines: [' Beaks'],
+            isList: false,
+          },
+        ])
+      })
+    })
+
+    describe('when the selected caseworker has neither a first or last name', () => {
+      it('returns a summary of the selected caseworker with an empty string', () => {
+        const sentReferral = sentReferralFactory.build({
+          referenceNumber: 'CEF345',
+          referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
+        })
+        const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const assignee = hmppsAuthUserFactory.build({ firstName: '', lastName: '' })
+        const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
+
+        expect(presenter.summary).toEqual([
+          {
+            key: 'Name',
+            lines: ['Johnny Davis'],
+            isList: false,
+          },
+          {
+            key: 'Referral number',
+            lines: ['CEF345'],
+            isList: false,
+          },
+          {
+            key: 'Service type',
+            lines: ['Social inclusion'],
+            isList: false,
+          },
+          {
+            key: 'Assigned to',
+            lines: [''],
+            isList: false,
+          },
+        ])
+      })
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
@@ -31,7 +31,7 @@ export default class AssignmentConfirmationPresenter {
     },
     {
       key: 'Assigned to',
-      lines: [`${this.assignee.firstName} ${this.assignee.lastName}`],
+      lines: [ReferralDataPresenterUtils.fullName(this.assignee)],
       isList: false,
     },
   ]

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
@@ -1,4 +1,4 @@
-import { User } from '../../data/hmppsAuthClient'
+import { AuthUser } from '../../data/hmppsAuthClient'
 import { SentReferral, ServiceCategory } from '../../services/interventionsService'
 import { SummaryListItem } from '../../utils/summaryList'
 import ReferralDataPresenterUtils from '../referrals/referralDataPresenterUtils'
@@ -8,7 +8,7 @@ export default class AssignmentConfirmationPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly serviceCategory: ServiceCategory,
-    private readonly assignee: User
+    private readonly assignee: AuthUser
   ) {}
 
   readonly dashboardHref = '/service-provider/dashboard'
@@ -31,7 +31,7 @@ export default class AssignmentConfirmationPresenter {
     },
     {
       key: 'Assigned to',
-      lines: [this.assignee.name],
+      lines: [`${this.assignee.firstName} ${this.assignee.lastName}`],
       isList: false,
     },
   ]

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
@@ -15,7 +15,7 @@ describe(CheckAssignmentPresenter, () => {
 
   describe('summary', () => {
     it('returns a summary of the selected caseworker', () => {
-      const user = hmppsAuthUserFactory.build({ name: 'John Smith' })
+      const user = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
       const serviceCategory = serviceCategoryFactory.build()
       const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', serviceCategory)
 

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
@@ -14,15 +14,56 @@ describe(CheckAssignmentPresenter, () => {
   })
 
   describe('summary', () => {
-    it('returns a summary of the selected caseworker', () => {
-      const user = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', serviceCategory)
+    describe('when the selected caseworker has a first and last name', () => {
+      it('returns a summary of the selected caseworker with both names', () => {
+        const user = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
+        const serviceCategory = serviceCategoryFactory.build()
+        const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', serviceCategory)
 
-      expect(presenter.summary).toEqual([
-        { key: 'Name', lines: ['John Smith'], isList: false },
-        { key: 'Email address', lines: ['john@harmonyliving.org.uk'], isList: false },
-      ])
+        expect(presenter.summary).toEqual([
+          { key: 'Name', lines: ['John Smith'], isList: false },
+          { key: 'Email address', lines: ['john@harmonyliving.org.uk'], isList: false },
+        ])
+      })
+    })
+
+    describe('when the selected caseworker has only a first name', () => {
+      it('returns a summary of the selected caseworker with just the first name', () => {
+        const user = hmppsAuthUserFactory.build({ firstName: 'John', lastName: '' })
+        const serviceCategory = serviceCategoryFactory.build()
+        const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', serviceCategory)
+
+        expect(presenter.summary).toEqual([
+          { key: 'Name', lines: ['John '], isList: false },
+          { key: 'Email address', lines: ['john@harmonyliving.org.uk'], isList: false },
+        ])
+      })
+    })
+
+    describe('when the selected caseworker has only a last name', () => {
+      it('returns a summary of the selected caseworker with just the last name', () => {
+        const user = hmppsAuthUserFactory.build({ firstName: '', lastName: 'smith' })
+        const serviceCategory = serviceCategoryFactory.build()
+        const presenter = new CheckAssignmentPresenter('', user, 'smith@harmonyliving.org.uk', serviceCategory)
+
+        expect(presenter.summary).toEqual([
+          { key: 'Name', lines: [' Smith'], isList: false },
+          { key: 'Email address', lines: ['smith@harmonyliving.org.uk'], isList: false },
+        ])
+      })
+    })
+
+    describe('when the selected caseworker has neither a first or last name', () => {
+      it('returns a summary with an empty string for the caseworker name', () => {
+        const user = hmppsAuthUserFactory.build({ firstName: '', lastName: '' })
+        const serviceCategory = serviceCategoryFactory.build()
+        const presenter = new CheckAssignmentPresenter('', user, 'unknown@harmonyliving.org.uk', serviceCategory)
+
+        expect(presenter.summary).toEqual([
+          { key: 'Name', lines: [''], isList: false },
+          { key: 'Email address', lines: ['unknown@harmonyliving.org.uk'], isList: false },
+        ])
+      })
     })
   })
 

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
@@ -1,6 +1,7 @@
 import { AuthUser } from '../../data/hmppsAuthClient'
 import { ServiceCategory } from '../../services/interventionsService'
 import { SummaryListItem } from '../../utils/summaryList'
+import ReferralDataPresenterUtils from '../referrals/referralDataPresenterUtils'
 
 export default class CheckAssignmentPresenter {
   constructor(
@@ -15,7 +16,7 @@ export default class CheckAssignmentPresenter {
   }
 
   readonly summary: SummaryListItem[] = [
-    { key: 'Name', lines: [`${this.assignee.firstName} ${this.assignee.lastName}`], isList: false },
+    { key: 'Name', lines: [ReferralDataPresenterUtils.fullName(this.assignee)], isList: false },
     { key: 'Email address', lines: [this.email], isList: false },
   ]
 

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
@@ -1,11 +1,11 @@
-import { User } from '../../data/hmppsAuthClient'
+import { AuthUser } from '../../data/hmppsAuthClient'
 import { ServiceCategory } from '../../services/interventionsService'
 import { SummaryListItem } from '../../utils/summaryList'
 
 export default class CheckAssignmentPresenter {
   constructor(
     private readonly referralId: string,
-    private readonly assignee: User,
+    private readonly assignee: AuthUser,
     private readonly email: string,
     private readonly serviceCategory: ServiceCategory
   ) {}
@@ -15,7 +15,7 @@ export default class CheckAssignmentPresenter {
   }
 
   readonly summary: SummaryListItem[] = [
-    { key: 'Name', lines: [this.assignee.name], isList: false },
+    { key: 'Name', lines: [`${this.assignee.firstName} ${this.assignee.lastName}`], isList: false },
     { key: 'Email address', lines: [this.email], isList: false },
   ]
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -124,7 +124,7 @@ describe('GET /service-provider/referrals/:id', () => {
       const sentReferral = sentReferralFactory.assigned().build()
       const deliusUser = deliusUserFactory.build()
       const serviceUser = deliusServiceUser.build()
-      const hmppsAuthUser = hmppsAuthUserFactory.build({ name: 'John Smith' })
+      const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
 
       interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
@@ -147,7 +147,7 @@ describe('GET /service-provider/referrals/:id/assignment/check', () => {
   it('displays the name of the selected caseworker', async () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const referral = sentReferralFactory.build({ referral: { serviceCategoryId: serviceCategory.id } })
-    const hmppsAuthUser = hmppsAuthUserFactory.build({ name: 'John Smith' })
+    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
 
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     interventionsService.getSentReferral.mockResolvedValue(referral)
@@ -171,7 +171,7 @@ describe('POST /service-provider/referrals/:id/assignment', () => {
     const referral = sentReferralFactory.build({
       referral: { serviceCategoryId: serviceCategory.id, serviceUser: { firstName: 'Alex', lastName: 'River' } },
     })
-    const hmppsAuthUser = hmppsAuthUserFactory.build({ name: 'John Smith', username: 'john.smith' })
+    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
 
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     interventionsService.getSentReferral.mockResolvedValue(referral)
@@ -203,7 +203,7 @@ describe('GET /service-provider/referrals/:id/assignment/confirmation', () => {
       },
       assignedTo: { username: 'john.smith' },
     })
-    const hmppsAuthUser = hmppsAuthUserFactory.build({ name: 'John Smith', username: 'john.smith' })
+    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
 
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     interventionsService.getSentReferral.mockResolvedValue(referral)

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -72,7 +72,7 @@ describe(ShowReferralPresenter, () => {
       ],
     },
   })
-  const hmppsAuthUser = hmppsAuthUserFactory.build({ name: 'John Smith' })
+  const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
 
   describe('assignmentFormAction', () => {
     it('returns the relative URL for the check assignment page', () => {

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -1,4 +1,4 @@
-import { User } from '../../data/hmppsAuthClient'
+import { AuthUser } from '../../data/hmppsAuthClient'
 import { DeliusServiceUser, DeliusUser } from '../../services/communityApiService'
 import { SentReferral, ServiceCategory } from '../../services/interventionsService'
 import CalendarDay from '../../utils/calendarDay'
@@ -13,7 +13,7 @@ export default class ShowReferralPresenter {
     private readonly serviceCategory: ServiceCategory,
     private readonly sentBy: DeliusUser,
     private readonly serviceUser: DeliusServiceUser,
-    private readonly assignee: User | null
+    private readonly assignee: AuthUser | null
   ) {}
 
   readonly assignmentFormAction = `/service-provider/referrals/${this.sentReferral.id}/assignment/check`
@@ -26,7 +26,7 @@ export default class ShowReferralPresenter {
             this.sentReferral.referral.serviceUser
           )}`,
     interventionDetailsSummaryHeading: `${utils.convertToProperCase(this.serviceCategory.name)} intervention details`,
-    assignedTo: this.assignee?.name ?? null,
+    assignedTo: this.assigneeFullNameOrUnassigned,
   }
 
   readonly probationPractitionerDetails: SummaryListItem[] = [
@@ -170,5 +170,13 @@ export default class ShowReferralPresenter {
     }
 
     return notFoundMessage
+  }
+
+  private get assigneeFullNameOrUnassigned(): string | null {
+    if (!this.assignee) {
+      return null
+    }
+
+    return `${this.assignee.firstName} ${this.assignee.lastName}`
   }
 }

--- a/testutils/factories/hmppsAuthUser.ts
+++ b/testutils/factories/hmppsAuthUser.ts
@@ -1,10 +1,14 @@
 import { Factory } from 'fishery'
-import { User } from '../../server/data/hmppsAuthClient'
+import { AuthUser } from '../../server/data/hmppsAuthClient'
 
-export default Factory.define<User>(({ sequence }) => ({
-  username: `AUTH_ADM_${sequence}`,
-  active: true,
-  name: `Auth Adm ${sequence}`,
-  authSource: 'auth',
+export default Factory.define<AuthUser>(({ sequence }) => ({
   userId: sequence.toString(),
+  username: `AUTH_ADM_${sequence}`,
+  email: 'auth.user@someagency.justice.gov.uk',
+  firstName: 'Auth',
+  lastName: `Adm ${sequence}`,
+  locked: false,
+  enabled: true,
+  verified: true,
+  lastLoggedIn: '01/01/2001',
 }))


### PR DESCRIPTION
## What does this pull request do?

Uses the correct `AuthUser` from HMPPS Auth's '/api/authuser' endpoint when assigning a referral to a caseworker.

If the user doesn't exist, we render an ugly error page for now - we're going to be handling the case better in IC-1180.

## What is the intent behind these changes?

This object has a different structure to the usual User model we were attempting to use before, meaning the journey silently never returned a name for the user.

What also made this tricky was that this the 'api/authuser' endpoints we consume return an array of AuthUsers, rather than a single one. If this were to return multiple users, we'd probably want to handle this better.
