### PR TITLE
Always pull base image during Docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   integration:
     docker:
-      - image: circleci/node:14-stretch-browsers
+      - image: cimg/node:14.16.0-browsers
       - image: rodolpheche/wiremock:2.27.2-alpine
         command: ["--port", "9091"]
       - image: bitnami/redis:6.0
@@ -23,7 +23,7 @@ jobs:
       PACT_BROKER_USERNAME: "interventions"
     executor:
       name: hmpps/node
-      tag: 14-stretch-browsers
+      tag: 14.16.0-browsers
     steps:
       - checkout
       - node/install-npm:
@@ -64,7 +64,7 @@ jobs:
   vulnerability_scan:
     executor:
       name: hmpps/node
-      tag: 14-stretch-browsers
+      tag: 14.16.0-browsers
     parameters:
       monitor:
         type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@2.1.0
+  hmpps: ministryofjustice/hmpps@2.3.2
   snyk: snyk/snyk@0.0.12
   node: circleci/node@4.1.0
 


### PR DESCRIPTION
## What does this pull request do?

Makes the build always pull the latest base image.

## What is the intent behind these changes?

The main build is currently failing due to yesterday's base image which still has a vulnerability that Snyk picks up.

The latest orb changes make the docker build always pull the latest available base image, fixing this issue for us.

Full list of changes: [here](https://github.com/ministryofjustice/hmpps-circleci-orb/compare/4fb6601a7a557b2838bff3d67f5e5627f144a38e..84e2338f90610e1d4c7f10b7ebbe00aec87a004c)