### PR TITLE
IC-1249/ Confirmation-page-when-failure-attend

### DIFF
--- a/server/routes/staticContent/staticContentController.ts
+++ b/server/routes/staticContent/staticContentController.ts
@@ -55,11 +55,6 @@ export default class StaticContentController {
       description: 'IC-1058 (session feedback: review)',
     },
     {
-      path: '/service-provider/session-feedback/confirmation',
-      template: 'serviceProviderReferrals/sessions/feedback/confirmation',
-      description: 'IC-1085 (session feedback: confirmation)',
-    },
-    {
       path: '/service-provider/session-feedback/show',
       template: 'serviceProviderReferrals/sessions/feedback/show',
       description: 'IC-1083 (view submitted feedback)',
@@ -75,9 +70,19 @@ export default class StaticContentController {
       description: 'IC-1087 (session details: edit details amend)',
     },
     {
+      path: '/service-provider/session-feedback/confirmation',
+      template: 'serviceProviderReferrals/sessions/feedback/confirmation',
+      description: 'IC-1085 (session feedback: confirmation)',
+    },
+    {
       path: '/service-provider/sessions/feedback/confirmation-all-sessions-completed',
       template: 'serviceProviderReferrals/sessions/feedback/confirmationAllSessionsCompleted',
       description: 'IC-1177 (session feedback: confirmation - all sessions completed)',
+    },
+    {
+      path: '/service-provider/sessions/feedback/confirmation-failure-attend',
+      template: 'serviceProviderReferrals/sessions/feedback/confirmationFailureAttend',
+      description: 'IC-1177 (session feedback: confirmation - failure to attend)',
     },
     {
       path: '/service-provider/layout-all-components',

--- a/server/views/serviceProviderReferrals/sessions/feedback/confirmationFailureAttend.njk
+++ b/server/views/serviceProviderReferrals/sessions/feedback/confirmationFailureAttend.njk
@@ -1,0 +1,69 @@
+{% extends "../../../partials/layout.njk" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukPanel({
+        classes: 'govuk-!-margin-bottom-8',
+        titleText: "Session feedback form has been submitted"
+      }) }}
+      <h1 class="govuk-heading-l">Service user details</h1>
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: {
+              text: "Name"
+            },
+            value: {
+              text: "Alex River"
+            }
+          },
+          {
+            key: {
+              text: "Referral number"
+            },
+            value: {
+              text: "NR0001"
+            }
+          },
+          {
+            key: {
+              text: "Type of referral"
+            },
+            value: {
+              text: "Social inclusion"
+            }
+          }
+        ]
+      }) }}
+
+      <h1 class="govuk-heading-l">What happens next</h1>
+
+      <p class="govuk-body">
+        Session feedback form has been saved and submitted to Josie Bart, probation practitioner, they have been notified about the failure to attend.
+      </p>
+      <p class="govuk-body">
+        Please reschedule the session by editing the session details.
+      <form>
+      {{ govukButton({
+        text: "Return to service progress"
+      }) }}
+    </form>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">One-third column</h2>
+    <p class="govuk-body">one-third wide column</p>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?
**Jira card URL:**
https://dsdmoj.atlassian.net/browse/IC-1249
## Changes in this PR:
Update confirmation page when failure to attend
- to match the latest design
- Two-third layout
- Submit button
- confirmation pattern.

## Screenshots of UI changes:
<img width="763" alt="Screenshot 2021-02-25 at 13 55 01" src="https://user-images.githubusercontent.com/10596845/109163274-0f802c00-7771-11eb-8d26-d9cee25cedfd.png">


