### PR TITLE
IC-1180 validate user email address for assigning referrals to SP users

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -139,7 +139,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetSentReferrals([referral])
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
-    cy.stubGetUserByEmailAddress([hmppsAuthUser])
+    cy.stubGetAuthUserByEmailAddress([hmppsAuthUser])
     cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
     cy.stubAssignSentReferral(referral.id, referral)
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -20,11 +20,11 @@ module.exports = on => {
     stubLogin: auth.stubLogin,
     stubServiceProviderToken: auth.stubServiceProviderToken,
     stubProbationPractitionerToken: auth.stubProbationPractitionerToken,
-    stubGetUserByEmailAddress: arg => {
-      return auth.stubGetUserByEmailAddress(arg.responseJson)
+    stubGetAuthUserByEmailAddress: arg => {
+      return auth.stubGetSPUserByEmailAddress(arg.responseJson)
     },
     stubGetAuthUserByUsername: arg => {
-      return auth.stubGetAuthUserByUsername(arg.username, arg.responseJson)
+      return auth.stubGetSPUserByUsername(arg.username, arg.responseJson)
     },
 
     stubServiceProviderAuthUser: auth.stubServiceProviderUser,

--- a/integration_tests/support/commands.js
+++ b/integration_tests/support/commands.js
@@ -3,8 +3,8 @@ Cypress.Commands.add('login', () => {
   cy.task('getLoginUrl').then(cy.visit)
 })
 
-Cypress.Commands.add('stubGetUserByEmailAddress', responseJson => {
-  cy.task('stubGetUserByEmailAddress', { responseJson })
+Cypress.Commands.add('stubGetAuthUserByEmailAddress', responseJson => {
+  cy.task('stubGetAuthUserByEmailAddress', { responseJson })
 })
 
 Cypress.Commands.add('stubGetAuthUserByUsername', (username, responseJson) => {

--- a/mockApis/auth.ts
+++ b/mockApis/auth.ts
@@ -164,7 +164,7 @@ export default class AuthServiceMocks {
     })
   }
 
-  stubGetUserByEmailAddress = async (responseJson: Record<string, unknown>): Promise<unknown> => {
+  stubGetSPUserByEmailAddress = async (responseJson: Record<string, unknown>): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
@@ -181,7 +181,7 @@ export default class AuthServiceMocks {
     })
   }
 
-  stubGetAuthUserByUsername = async (username: string, responseJson: Record<string, unknown>): Promise<unknown> => {
+  stubGetSPUserByUsername = async (username: string, responseJson: Record<string, unknown>): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -53,7 +53,7 @@ describe('hmppsAuthClient', () => {
     })
   })
 
-  describe('getUserByEmailAddress', () => {
+  describe('getSPUserByEmailAddress', () => {
     describe('when a matching user is found with the requested email address', () => {
       it('should return the first matching user from the API response', async () => {
         const response = [
@@ -76,7 +76,7 @@ describe('hmppsAuthClient', () => {
           .matchHeader('authorization', `Bearer ${token.access_token}`)
           .reply(200, response)
 
-        const output = await hmppsAuthClient.getUserByEmailAddress(token.access_token, 'user@example.com')
+        const output = await hmppsAuthClient.getSPUserByEmailAddress(token.access_token, 'user@example.com')
         expect(output).toEqual(response[0])
       })
     })
@@ -90,14 +90,14 @@ describe('hmppsAuthClient', () => {
           .matchHeader('authorization', `Bearer ${token.access_token}`)
           .reply(204, noUserResponse)
 
-        await expect(hmppsAuthClient.getUserByEmailAddress(token.access_token, 'user@example.com')).rejects.toThrow(
+        await expect(hmppsAuthClient.getSPUserByEmailAddress(token.access_token, 'user@example.com')).rejects.toThrow(
           'Email not found'
         )
       })
     })
   })
 
-  describe('getUserByUsername', () => {
+  describe('getSPUserByUsername', () => {
     it('should return the matching user from the API response', async () => {
       const response = {
         userId: '91229A16-B5F4-4784-942E-A484A97AC865',
@@ -116,7 +116,7 @@ describe('hmppsAuthClient', () => {
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(200, response)
 
-      const output = await hmppsAuthClient.getUserByUsername(token.access_token, 'AUTH_ADM')
+      const output = await hmppsAuthClient.getSPUserByUsername(token.access_token, 'AUTH_ADM')
       expect(output).toEqual(response)
     })
   })

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -83,7 +83,7 @@ export default class HmppsAuthClient {
     return this.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
   }
 
-  async getUserByEmailAddress(token: string, emailAddress: string): Promise<AuthUser> {
+  async getSPUserByEmailAddress(token: string, emailAddress: string): Promise<AuthUser> {
     logger.info(`Getting auth user detail by email address: calling HMPPS Auth`)
     const res: Response = (await this.restClient(token).get({
       path: `/api/authuser`,
@@ -99,7 +99,7 @@ export default class HmppsAuthClient {
     return Promise.resolve(authUsers[0])
   }
 
-  getUserByUsername(token: string, username: string): Promise<AuthUser> {
+  getSPUserByUsername(token: string, username: string): Promise<AuthUser> {
     logger.info(`Getting user detail by username: calling HMPPS Auth`)
     return this.restClient(token).get({
       path: `/api/authuser/${username}`,

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -163,6 +163,20 @@ describe('GET /service-provider/referrals/:id/assignment/check', () => {
         expect(res.text).toContain('john@harmonyliving.org.uk')
       })
   })
+  it('redirects to referral details page with an error if the assignee email address is missing from the URL', async () => {
+    await request(app)
+      .get(`/service-provider/referrals/123456/assignment/check`)
+      .expect(302)
+      .expect('Location', '/service-provider/referrals/123456?error=An%20email%20address%20is%20required')
+  })
+  it('redirects to referral details page with an error if the assignee email address is not found in hmpps auth', async () => {
+    hmppsAuthClient.getSPUserByEmailAddress.mockRejectedValue(new Error(''))
+
+    await request(app)
+      .get(`/service-provider/referrals/123456/assignment/check?email=tom@tom.com`)
+      .expect(302)
+      .expect('Location', '/service-provider/referrals/123456?error=Email%20address%20not%20found')
+  })
 })
 
 describe('POST /service-provider/referrals/:id/assignment', () => {
@@ -190,6 +204,9 @@ describe('POST /service-provider/referrals/:id/assignment', () => {
       userId: hmppsAuthUser.userId,
       authSource: 'auth',
     })
+  })
+  it('fails if the assignee email address is missing', async () => {
+    await request(app).post(`/service-provider/referrals/123456/assignment`).type('form').send({}).expect(400)
   })
 })
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -130,7 +130,7 @@ describe('GET /service-provider/referrals/:id', () => {
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
       communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
       communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
-      hmppsAuthClient.getUserByUsername.mockResolvedValue(hmppsAuthUser)
+      hmppsAuthClient.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
 
       await request(app)
         .get(`/service-provider/referrals/${sentReferral.id}`)
@@ -151,7 +151,7 @@ describe('GET /service-provider/referrals/:id/assignment/check', () => {
 
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     interventionsService.getSentReferral.mockResolvedValue(referral)
-    hmppsAuthClient.getUserByEmailAddress.mockResolvedValue(hmppsAuthUser)
+    hmppsAuthClient.getSPUserByEmailAddress.mockResolvedValue(hmppsAuthUser)
 
     await request(app)
       .get(`/service-provider/referrals/${referral.id}/assignment/check`)
@@ -189,7 +189,7 @@ describe('POST /service-provider/referrals/:id/assignment', () => {
 
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     interventionsService.getSentReferral.mockResolvedValue(referral)
-    hmppsAuthClient.getUserByEmailAddress.mockResolvedValue(hmppsAuthUser)
+    hmppsAuthClient.getSPUserByEmailAddress.mockResolvedValue(hmppsAuthUser)
     interventionsService.assignSentReferral.mockResolvedValue(referral)
 
     await request(app)
@@ -224,7 +224,7 @@ describe('GET /service-provider/referrals/:id/assignment/confirmation', () => {
 
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     interventionsService.getSentReferral.mockResolvedValue(referral)
-    hmppsAuthClient.getUserByUsername.mockResolvedValue(hmppsAuthUser)
+    hmppsAuthClient.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
 
     await request(app)
       .get(`/service-provider/referrals/${referral.id}/assignment/confirmation`)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -48,7 +48,7 @@ export default class ServiceProviderReferralsController {
     const assignee =
       sentReferral.assignedTo === null
         ? null
-        : await this.hmppsAuthClient.getUserByUsername(res.locals.user.token, sentReferral.assignedTo.username)
+        : await this.hmppsAuthClient.getSPUserByUsername(res.locals.user.token, sentReferral.assignedTo.username)
 
     let formError: FormValidationError | null = null
     if (assignee === null) {
@@ -87,7 +87,7 @@ export default class ServiceProviderReferralsController {
     const token = await this.hmppsAuthClient.getApiClientToken()
 
     try {
-      assignee = await this.hmppsAuthClient.getUserByEmailAddress(token, email)
+      assignee = await this.hmppsAuthClient.getSPUserByEmailAddress(token, email)
     } catch (e) {
       return res.redirect(
         `/service-provider/referrals/${req.params.id}?${querystring.stringify({
@@ -115,7 +115,7 @@ export default class ServiceProviderReferralsController {
       return
     }
 
-    const assignee = await this.hmppsAuthClient.getUserByEmailAddress(res.locals.user.token, email)
+    const assignee = await this.hmppsAuthClient.getSPUserByEmailAddress(res.locals.user.token, email)
 
     await this.interventionsService.assignSentReferral(res.locals.user.token, req.params.id, {
       username: assignee.username,
@@ -134,7 +134,7 @@ export default class ServiceProviderReferralsController {
     }
 
     const [assignee, serviceCategory] = await Promise.all([
-      this.hmppsAuthClient.getUserByUsername(res.locals.user.token, referral.assignedTo.username),
+      this.hmppsAuthClient.getSPUserByUsername(res.locals.user.token, referral.assignedTo.username),
       this.interventionsService.getServiceCategory(res.locals.user.token, referral.referral.serviceCategoryId),
     ])
 

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -77,7 +77,7 @@ describe(ShowReferralPresenter, () => {
   describe('assignmentFormAction', () => {
     it('returns the relative URL for the check assignment page', () => {
       const referral = sentReferralFactory.build(referralParams)
-      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser, null)
+      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser, null, null)
 
       expect(presenter.assignmentFormAction).toEqual(`/service-provider/referrals/${referral.id}/assignment/check`)
     })
@@ -88,7 +88,14 @@ describe(ShowReferralPresenter, () => {
       describe('when the referral doesn’t have an assigned caseworker', () => {
         it('returns a title to be displayed', () => {
           const sentReferral = sentReferralFactory.build(referralParams)
-          const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, serviceUser, null)
+          const presenter = new ShowReferralPresenter(
+            sentReferral,
+            serviceCategory,
+            deliusUser,
+            serviceUser,
+            null,
+            null
+          )
 
           expect(presenter.text.title).toEqual('Who do you want to assign this accommodation referral to?')
         })
@@ -102,7 +109,8 @@ describe(ShowReferralPresenter, () => {
             serviceCategory,
             deliusUser,
             serviceUser,
-            hmppsAuthUser
+            hmppsAuthUser,
+            null
           )
 
           expect(presenter.text.title).toEqual('Accommodation referral for Jenny Jones')
@@ -113,7 +121,7 @@ describe(ShowReferralPresenter, () => {
     describe('interventionDetailsSummaryHeading', () => {
       it('returns text to be displayed including service category name', () => {
         const sentReferral = sentReferralFactory.assigned().build(referralParams)
-        const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, serviceUser, null)
+        const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, serviceUser, null, null)
 
         expect(presenter.text.interventionDetailsSummaryHeading).toEqual('Accommodation intervention details')
       })
@@ -123,7 +131,7 @@ describe(ShowReferralPresenter, () => {
       describe('when the referral doesn’t have an assigned caseworker', () => {
         it('returns null', () => {
           const referral = sentReferralFactory.unassigned().build()
-          const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser, null)
+          const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser, null, null)
 
           expect(presenter.text.assignedTo).toBeNull()
         })
@@ -132,7 +140,14 @@ describe(ShowReferralPresenter, () => {
       describe('when the referral has an assigned caseworker', () => {
         it('returns the name of the assignee', () => {
           const referral = sentReferralFactory.unassigned().build()
-          const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser, hmppsAuthUser)
+          const presenter = new ShowReferralPresenter(
+            referral,
+            serviceCategory,
+            deliusUser,
+            serviceUser,
+            hmppsAuthUser,
+            null
+          )
 
           expect(presenter.text.assignedTo).toEqual('John Smith')
         })
@@ -143,7 +158,7 @@ describe(ShowReferralPresenter, () => {
   describe('probationPractitionerDetails', () => {
     it('returns a summary list of probation practitioner details', () => {
       const sentReferral = sentReferralFactory.build(referralParams)
-      const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, serviceUser, null)
+      const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, serviceUser, null, null)
 
       expect(presenter.probationPractitionerDetails).toEqual([
         { isList: false, key: 'Name', lines: ['Bernard Beaks'] },
@@ -195,6 +210,7 @@ describe(ShowReferralPresenter, () => {
           serviceCategory,
           deliusUser,
           serviceUser,
+          null,
           null
         )
 
@@ -273,6 +289,7 @@ describe(ShowReferralPresenter, () => {
           serviceCategory,
           deliusUser,
           serviceUser,
+          null,
           null
         )
 
@@ -313,7 +330,7 @@ describe(ShowReferralPresenter, () => {
   describe('serviceUserPersonalDetails', () => {
     it("returns a summary list of the service user's personal details", () => {
       const sentReferral = sentReferralFactory.build(referralParams)
-      const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, serviceUser, null)
+      const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, serviceUser, null, null)
 
       expect(presenter.serviceUserDetails).toEqual([
         { key: 'CRN', lines: [sentReferral.referral.serviceUser.crn], isList: false },
@@ -333,7 +350,7 @@ describe(ShowReferralPresenter, () => {
   describe('serviceUserRisks', () => {
     it("returns a summary list of the service user's risk information", () => {
       const sentReferral = sentReferralFactory.build(referralParams)
-      const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, serviceUser, null)
+      const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, serviceUser, null, null)
 
       expect(presenter.serviceUserRisks).toEqual([
         { key: 'Risk to known adult', lines: ['Medium'], isList: false },
@@ -388,6 +405,7 @@ describe(ShowReferralPresenter, () => {
           serviceCategory,
           deliusUser,
           serviceUser,
+          null,
           null
         )
 
@@ -466,6 +484,7 @@ describe(ShowReferralPresenter, () => {
           serviceCategory,
           deliusUser,
           serviceUser,
+          null,
           null
         )
 
@@ -507,7 +526,7 @@ describe(ShowReferralPresenter, () => {
     describe('when all contact details are present on the Delius Service User', () => {
       it('returns a notification banner with service user details', () => {
         const referral = sentReferralFactory.build(referralParams)
-        const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser, null)
+        const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser, null, null)
 
         expect(presenter.serviceUserNotificationBannerArgs).toEqual({
           titleText: 'Service user details',
@@ -534,6 +553,7 @@ describe(ShowReferralPresenter, () => {
           serviceCategory,
           deliusUser,
           serviceUserWithoutContactDetails,
+          null,
           null
         )
 

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -6,6 +6,7 @@ import { SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
 import ReferralDataPresenterUtils from '../referrals/referralDataPresenterUtils'
 import ServiceUserDetailsPresenter from '../referrals/serviceUserDetailsPresenter'
+import { FormValidationError } from '../../utils/formValidationError'
 
 export default class ShowReferralPresenter {
   constructor(
@@ -13,7 +14,8 @@ export default class ShowReferralPresenter {
     private readonly serviceCategory: ServiceCategory,
     private readonly sentBy: DeliusUser,
     private readonly serviceUser: DeliusServiceUser,
-    private readonly assignee: AuthUser | null
+    private readonly assignee: AuthUser | null,
+    private readonly assignEmailError: FormValidationError | null
   ) {}
 
   readonly assignmentFormAction = `/service-provider/referrals/${this.sentReferral.id}/assignment/check`
@@ -27,6 +29,7 @@ export default class ShowReferralPresenter {
           )}`,
     interventionDetailsSummaryHeading: `${utils.convertToProperCase(this.serviceCategory.name)} intervention details`,
     assignedTo: this.assigneeFullNameOrUnassigned,
+    errorMessage: ReferralDataPresenterUtils.errorMessage(this.assignEmailError, 'email'),
   }
 
   readonly probationPractitionerDetails: SummaryListItem[] = [

--- a/server/routes/serviceProviderReferrals/showReferralView.ts
+++ b/server/routes/serviceProviderReferrals/showReferralView.ts
@@ -24,6 +24,7 @@ export default class ShowReferralView {
       label: {
         text: 'Please enter the email address of the caseworker',
       },
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.errorMessage),
     }
   }
 

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -42,4 +42,9 @@ export default {
     notWholeNumber: (name: string) =>
       `The maximum number of RAR days for the ${name} service must be a whole number, like 5`,
   },
+  assignReferral: {
+    emailEmpty: 'An email address is required',
+    emailNotFound: 'Email address not found',
+    unknownError: 'Could not find email address due to service interruption; please try again later',
+  },
 }

--- a/server/utils/govukFrontendTypes.ts
+++ b/server/utils/govukFrontendTypes.ts
@@ -17,7 +17,12 @@ export interface InputArgs {
   label: {
     text?: string
     html?: string
+    classes?: string
   }
+  autocomplete?: string
+  errorMessage?: {
+    text: string
+  } | null
 }
 
 export interface PanelArgs {


### PR DESCRIPTION
## What does this pull request do?

validate user email address for assigning referrals to SP users

## What is the intent behind these changes?

ensure referrals cannot be assigned to non-existent or mistyped email addresses
