### PR TITLE
IC-1265: Fix referral assignment CSRF and add local testing state

### DIFF
--- a/server/views/serviceProviderReferrals/checkAssignment.njk
+++ b/server/views/serviceProviderReferrals/checkAssignment.njk
@@ -22,6 +22,8 @@
 
       {{ govukSummaryList(summaryListArgs) }}
       <form method="post" action={{ presenter.formAction }}>
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
         {% for name, value in presenter.hiddenFields %}
           <input type="hidden" name={{ name }} value={{ value }}>
         {% endfor %}


### PR DESCRIPTION
## What does this pull request do?

- Ensures the CSRF token is sent via a hidden field when assigning a referral, otherwise we get a 401.
- Sets up mocks to mark referrals as already assigned when running locally with mocked setup.

## What is the intent behind these changes?

I've spent hours trying to get referral assignment working properly locally, but due to
the state transition, it's very tricky to mock the different stages of
assigning a referral and the different users being assigned.

I've decided to mark them as assigned so at least we can move onto the
next step of the user journey (the action plan).

Eventually, we'll be able to remove these mocks once we've properly
linked up the Interventions Service plumbing here, so I didn't think it
was worth spending any more time on.
