### PR TITLE
IC-1215: Add draft action plan contract tests

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1290,6 +1290,43 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(await interventionsService.getPccRegions(token)).toEqual(pccRegions)
     })
   })
+
+  describe('createDraftActionPlan', () => {
+    it('returns a newly created draft action plan', async () => {
+      const referralId = '81d754aa-d868-4347-9c0f-50690773014e'
+      await provider.addInteraction({
+        state: 'a caseworker has been assigned to a sent referral and an action plan can be created',
+        uponReceiving: 'a POST request to create a draft action plan',
+        withRequest: {
+          method: 'POST',
+          path: '/draft-action-plan',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          body: {
+            referralId,
+          },
+        },
+        willRespondWith: {
+          status: 201,
+          body: Matchers.like({
+            id: 'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+            referralId: '81d754aa-d868-4347-9c0f-50690773014e',
+            numberOfSessions: null,
+            activities: [],
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Location: Matchers.like(
+              'https://hmpps-interventions-service.com/draft-action-plan/dfb64747-f658-40e0-a827-87b4b0bdcfed'
+            ),
+          },
+        },
+      })
+
+      const draftActionPlan = await interventionsService.createDraftActionPlan(token, referralId)
+      expect(draftActionPlan.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1484,6 +1484,69 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(draftActionPlan.activities[0].createdAt).toEqual('2020-12-07T20:45:21.986389Z')
     })
   })
+
+  describe('submitDraftActionPlan', () => {
+    const submittedActionPlan = {
+      id: '486ba46a-0b57-46ab-82c0-d8c5c43710c6',
+      referralId: '81d754aa-d868-4347-9c0f-50690773014e',
+      numberOfSessions: 4,
+      activities: [
+        {
+          id: '91e7ceab-74fd-45d8-97c8-ec58844618dd',
+          description: 'Attend training course',
+          desiredOutcome: {
+            id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+            description:
+              'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+          },
+          createdAt: '2020-12-07T20:45:21.986389Z',
+        },
+        {
+          id: 'e5755c27-2c85-448b-9f6d-e3959ec9c2d0',
+          description: 'Attend session',
+          desiredOutcome: {
+            id: '65924ac6-9724-455b-ad30-906936291421',
+            description: 'Service User makes progress in obtaining accommodation.',
+          },
+          createdAt: '2020-12-07T20:47:21.986389Z',
+        },
+      ],
+      submittedBy: {
+        username: 'BERNARD.BEAKS',
+        userId: '555224b3-865c-4b56-97dd-c3e817592ba3',
+        authSource: 'delius',
+      },
+      submittedAt: '2020-12-08T20:47:21.986389Z',
+    }
+
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: 'a draft action plan with ID 6e8dfb5c-127f-46ea-9846-f82b5fd60d27 exists and is ready to be submitted',
+        uponReceiving: 'a POST request to send the draft action plan with ID 6e8dfb5c-127f-46ea-9846-f82b5fd60d27',
+        withRequest: {
+          method: 'POST',
+          path: '/draft-action-plan/6e8dfb5c-127f-46ea-9846-f82b5fd60d27/submit',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 201,
+          body: Matchers.like(submittedActionPlan),
+          headers: {
+            'Content-Type': 'application/json',
+            Location: Matchers.like(
+              'https://hmpps-interventions-service.com/action-plan/6e8dfb5c-127f-46ea-9846-f82b5fd60d27'
+            ),
+          },
+        },
+      })
+    })
+
+    it('returns a sent referral', async () => {
+      expect(await interventionsService.submitActionPlan(token, '6e8dfb5c-127f-46ea-9846-f82b5fd60d27')).toMatchObject(
+        submittedActionPlan
+      )
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1361,6 +1361,129 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(draftActionPlan.activities.length).toBe(0)
     })
   })
+
+  describe('updateDraftActionPlan', () => {
+    it('updates and returns the newly-updated draft action plan when adding an activity', async () => {
+      const draftActionPlanId = 'dfb64747-f658-40e0-a827-87b4b0bdcfed'
+
+      await provider.addInteraction({
+        state: `an action plan exists with id ${draftActionPlanId}`,
+        uponReceiving: 'a PATCH request to set the activities on the action plan',
+        withRequest: {
+          method: 'PATCH',
+          path: `/draft-action-plan/${draftActionPlanId}`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          body: {
+            activity: {
+              description: 'Attend training course',
+              desiredOutcomeId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+            },
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            id: draftActionPlanId,
+            referralId: '81d754aa-d868-4347-9c0f-50690773014e',
+            numberOfSessions: null,
+            activities: [
+              {
+                id: '91e7ceab-74fd-45d8-97c8-ec58844618dd',
+                description: 'Attend training course',
+                desiredOutcome: {
+                  id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+                  description:
+                    'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+                },
+                createdAt: '2020-12-07T20:45:21.986389Z',
+              },
+            ],
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const draftActionPlan = await interventionsService.updateDraftActionPlan(token, draftActionPlanId, {
+        activity: {
+          description: 'Attend training course',
+          desiredOutcomeId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+        },
+      })
+
+      expect(draftActionPlan.id).toBe(draftActionPlanId)
+      expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
+      expect(draftActionPlan.numberOfSessions).toBe(null)
+      expect(draftActionPlan.activities[0].id).toEqual('91e7ceab-74fd-45d8-97c8-ec58844618dd')
+      expect(draftActionPlan.activities[0].description).toEqual('Attend training course')
+      expect(draftActionPlan.activities[0].desiredOutcome.id).toEqual('301ead30-30a4-4c7c-8296-2768abfb59b5')
+      expect(draftActionPlan.activities[0].desiredOutcome.description).toEqual(
+        'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed'
+      )
+      expect(draftActionPlan.activities[0].createdAt).toEqual('2020-12-07T20:45:21.986389Z')
+    })
+
+    it('updates and returns the newly-updated draft action plan when setting number of sessions', async () => {
+      const draftActionPlanId = 'dfb64747-f658-40e0-a827-87b4b0bdcfed'
+
+      await provider.addInteraction({
+        state: `an action plan exists with id ${draftActionPlanId}`,
+        uponReceiving: 'a PATCH request to set the number of sessions on the action plan',
+        withRequest: {
+          method: 'PATCH',
+          path: `/draft-action-plan/${draftActionPlanId}`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          body: {
+            numberOfSessions: 4,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            id: draftActionPlanId,
+            referralId: '81d754aa-d868-4347-9c0f-50690773014e',
+            numberOfSessions: 4,
+            activities: [
+              {
+                id: '91e7ceab-74fd-45d8-97c8-ec58844618dd',
+                description: 'Attend training course',
+                desiredOutcome: {
+                  id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+                  description:
+                    'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+                },
+                createdAt: '2020-12-07T20:45:21.986389Z',
+              },
+            ],
+            createdBy: {
+              username: 'BERNARD.BEAKS',
+              userId: '555224b3-865c-4b56-97dd-c3e817592ba3',
+              authSource: 'delius',
+            },
+            createdAt: '2020-12-07T20:45:21.986389Z',
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const draftActionPlan = await interventionsService.updateDraftActionPlan(token, draftActionPlanId, {
+        numberOfSessions: 4,
+      })
+      expect(draftActionPlan.id).toBe(draftActionPlanId)
+      expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
+      expect(draftActionPlan.numberOfSessions).toBe(4)
+      expect(draftActionPlan.activities[0].id).toEqual('91e7ceab-74fd-45d8-97c8-ec58844618dd')
+      expect(draftActionPlan.activities[0].description).toEqual('Attend training course')
+      expect(draftActionPlan.activities[0].desiredOutcome.id).toEqual('301ead30-30a4-4c7c-8296-2768abfb59b5')
+      expect(draftActionPlan.activities[0].desiredOutcome.description).toEqual(
+        'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed'
+      )
+      expect(draftActionPlan.activities[0].createdAt).toEqual('2020-12-07T20:45:21.986389Z')
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1327,6 +1327,40 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
     })
   })
+
+  describe('getDraftActionPlan', () => {
+    it('returns an existing action plan', async () => {
+      const draftActionPlanId = 'dfb64747-f658-40e0-a827-87b4b0bdcfed'
+
+      await provider.addInteraction({
+        state: `an action plan exists with id ${draftActionPlanId}`,
+        uponReceiving: 'a GET request to view the draft action plan',
+        withRequest: {
+          method: 'GET',
+          path: `/draft-action-plan/${draftActionPlanId}`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            id: draftActionPlanId,
+            referralId: '81d754aa-d868-4347-9c0f-50690773014e',
+            numberOfSessions: null,
+            activities: [],
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const draftActionPlan = await interventionsService.getDraftActionPlan(token, draftActionPlanId)
+      expect(draftActionPlan.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
+      expect(draftActionPlan.numberOfSessions).toBe(null)
+      expect(draftActionPlan.activities.length).toBe(0)
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -125,8 +125,11 @@ export interface InterventionsFilterParams {
   maximumAge?: number
 }
 
-export interface DraftActionPlan {
+export interface DraftActionPlan extends ActionPlanFields {
   id: string
+}
+
+interface ActionPlanFields {
   referralId: string
   activities: Activity[]
   numberOfSessions: number | null

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -125,6 +125,20 @@ export interface InterventionsFilterParams {
   maximumAge?: number
 }
 
+export interface DraftActionPlan {
+  id: string
+  referralId: string
+  activities: Activity[] | null
+  numberOfSessions: number | null
+}
+
+interface Activity {
+  id: string
+  desiredOutcomeId: string
+  description: string
+  createdAt: string
+}
+
 export default class InterventionsService {
   constructor(private readonly config: ApiConfig) {}
 
@@ -314,5 +328,19 @@ export default class InterventionsService {
       path: `/pcc-regions`,
       headers: { Accept: 'application/json' },
     })) as PCCRegion[]
+  }
+
+  async createDraftActionPlan(token: string, referralId: string): Promise<DraftActionPlan> {
+    const restClient = this.createRestClient(token)
+
+    try {
+      return (await restClient.post({
+        path: '/draft-action-plan',
+        headers: { Accept: 'application/json' },
+        data: { referralId },
+      })) as DraftActionPlan
+    } catch (e) {
+      throw this.createServiceError(e)
+    }
   }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -152,6 +152,13 @@ interface UpdateDraftActionPlanParams {
   numberOfSessions?: number
 }
 
+export interface SubmittedActionPlan {
+  id: string
+  submittedBy: AuthUser
+  submittedAt: string
+  actionPlanFields: ActionPlanFields
+}
+
 export default class InterventionsService {
   constructor(private readonly config: ApiConfig) {}
 
@@ -382,5 +389,14 @@ export default class InterventionsService {
     } catch (e) {
       throw this.createServiceError(e)
     }
+  }
+
+  async submitActionPlan(token: string, id: string): Promise<SubmittedActionPlan> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/draft-action-plan/${id}/submit`,
+      headers: { Accept: 'application/json' },
+    })) as SubmittedActionPlan
   }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -134,9 +134,19 @@ export interface DraftActionPlan {
 
 interface Activity {
   id: string
-  desiredOutcomeId: string
+  desiredOutcome: DesiredOutcome
   description: string
   createdAt: string
+}
+
+interface UpdateActivityParams {
+  description: string
+  desiredOutcomeId: string
+}
+
+interface UpdateDraftActionPlanParams {
+  activity?: UpdateActivityParams
+  numberOfSessions?: number
 }
 
 export default class InterventionsService {
@@ -351,5 +361,23 @@ export default class InterventionsService {
       path: `/draft-action-plan/${actionPlanId}`,
       headers: { Accept: 'application/json' },
     })) as DraftActionPlan
+  }
+
+  async updateDraftActionPlan(
+    token: string,
+    id: string,
+    patch: Partial<UpdateDraftActionPlanParams>
+  ): Promise<DraftActionPlan> {
+    const restClient = this.createRestClient(token)
+
+    try {
+      return (await restClient.patch({
+        path: `/draft-action-plan/${id}`,
+        headers: { Accept: 'application/json' },
+        data: patch,
+      })) as DraftActionPlan
+    } catch (e) {
+      throw this.createServiceError(e)
+    }
   }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -128,7 +128,7 @@ export interface InterventionsFilterParams {
 export interface DraftActionPlan {
   id: string
   referralId: string
-  activities: Activity[] | null
+  activities: Activity[]
   numberOfSessions: number | null
 }
 
@@ -342,5 +342,14 @@ export default class InterventionsService {
     } catch (e) {
       throw this.createServiceError(e)
     }
+  }
+
+  async getDraftActionPlan(token: string, actionPlanId: string): Promise<DraftActionPlan> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/draft-action-plan/${actionPlanId}`,
+      headers: { Accept: 'application/json' },
+    })) as DraftActionPlan
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds contract tests for getting and creating a draft action plan on the backend.

## What is the intent behind these changes?

To allow caseworkers to create an action plan (and eventually update it) for Service Users
