### PR TITLE
IC-926: Add manual deploy to pre-production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,20 @@ workflows:
             - vulnerability_scan_and_monitor
           context:
             - moj-slack-notifications
+      - approve_preprod:
+          type: approval
+          requires:
+            - deploy_dev
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          retrieve_secrets: "none"
+          slack_notification: true
+          slack_channel_name: "interventions-dev-notifications"
+          requires:
+            - approve_preprod
+          context:
+            - moj-slack-notifications
 
   nightly:
     triggers:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,0 +1,24 @@
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+
+image:
+  repository: quay.io/hmpps/hmpps-interventions-ui
+  tag: latest
+  pullPolicy: IfNotPresent
+  port: 3000
+
+ingress:
+  enabled: true
+  host: hmpps-interventions-ui-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
+  path: /
+
+env:
+  HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+  COMMUNITY_API_URL: https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io
+  OFFENDER_ASSESSMENTS_API_URL: https://offender-prprod.aks-live-1.studio-hosting.service.justice.gov.uk
+  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
+  TOKEN_VERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
+  TOKEN_VERIFICATION_ENABLED: true
+  REDIS_TLS_ENABLED: true


### PR DESCRIPTION
## What does this pull request do?

Adds the required CircleCI workflow to have pre-production deployments.

Currently depending on:

1. successful dev deployment
2. manual approval

Related: https://github.com/ministryofjustice/cloud-platform-environments/pull/4369
Related: https://github.com/ministryofjustice/hmpps-interventions-service/pull/120

## What is the intent behind these changes?

To allow us to further test the application on realistic data environments, leading to quicker feedback.