### PR TITLE
Fix: `await` response of assigning referral

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -75,7 +75,7 @@ export default class ServiceProviderReferralsController {
     const { email } = req.body
     const assignee = await this.hmppsAuthClient.getUserByEmailAddress(res.locals.user.token, email)
 
-    this.interventionsService.assignSentReferral(res.locals.user.token, req.params.id, {
+    await this.interventionsService.assignSentReferral(res.locals.user.token, req.params.id, {
       username: assignee.username,
       userId: assignee.userId,
       authSource: 'auth',


### PR DESCRIPTION
## What does this pull request do?

Adds `await` keyword to async function that was left off in error.


## What is the intent behind these changes?

This was causing assignments to fail locally, as we weren't waiting for
a response before redirecting.

I've tried to get the compiler to complain when this is an issue when
running the build, using Typescript-ESLint's `no-floating-promises`
setting, but haven't been able to get it working yet.
