### PR TITLE
Catch floating awaits

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     {
       "plugins": ["@typescript-eslint"],
       "parser": "@typescript-eslint/parser",
+      "parserOptions": { "project": "./tsconfig.json" },
       "files": ["**/*.ts"],
       "excludedFiles": "*.js",
       "extends": [
@@ -56,7 +57,8 @@
             "arrowParens": "avoid"
           }
         ],
-        "@typescript-eslint/no-non-null-assertion": 0
+        "@typescript-eslint/no-non-null-assertion": 0,
+        "@typescript-eslint/no-floating-promises": 1
       }
     }
   ],

--- a/mocks.ts
+++ b/mocks.ts
@@ -96,9 +96,9 @@ export default async function setUpMocks(): Promise<void> {
     interventionsMocks.stubGetInterventions(interventions),
     // Adding mocks for assigning locally is a bit tricky - it's very hard to mock a real assignment here due to the state transition.
     // I've opted to just mark these as assigned to unblock the next story for now.
-    assignedSentReferrals.forEach(referral => {
-      interventionsMocks.stubAssignSentReferral(referral.id, referral)
-      interventionsMocks.stubGetSentReferral(referral.id, referral)
+    assignedSentReferrals.forEach(async referral => {
+      await interventionsMocks.stubAssignSentReferral(referral.id, referral)
+      await interventionsMocks.stubGetSentReferral(referral.id, referral)
     }),
   ])
 }

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -90,7 +90,7 @@ describe('hmppsAuthClient', () => {
           .matchHeader('authorization', `Bearer ${token.access_token}`)
           .reply(204, noUserResponse)
 
-        expect(hmppsAuthClient.getUserByEmailAddress(token.access_token, 'user@example.com')).rejects.toThrow(
+        await expect(hmppsAuthClient.getUserByEmailAddress(token.access_token, 'user@example.com')).rejects.toThrow(
           'Email not found'
         )
       })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -67,12 +67,12 @@ export default function routes(router: Router, services: Services): Router {
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {
-      staticContentController.index(req, res)
+      return staticContentController.index(req, res)
     })
 
     StaticContentController.allPaths.forEach(path => {
       get(path, (req, res) => {
-        staticContentController.renderStaticPage(req, res)
+        return staticContentController.renderStaticPage(req, res)
       })
     })
   }

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -62,6 +62,7 @@ const apiChecks = [
 ]
 
 export default function healthCheck(callback: HealthCheckCallback, checks = apiChecks): void {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   Promise.all(checks.map(fn => fn())).then(checkResults => {
     const allOk = checkResults.every(item => item.status === 'ok')
 


### PR DESCRIPTION
## What does this pull request do?

Adds `no-floating-awaits` rule to ESLint rules, to ensure we don't miss any async behaviour we need to `await`.

Also fixes/ignores rule violations throughout the codebase.

## What is the intent behind these changes?

This came about as we missed an `await` when assigning a referral to a caseworker and it was very difficult to debug, so should warn us if we're trying to do this in future.
