### PR TITLE
IC-1281 filter disabled and unverified auth users from 'getSPByEmailAddress'.

### DIFF
--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -95,7 +95,12 @@ export default class HmppsAuthClient {
       return Promise.reject(new Error('Email not found'))
     }
 
-    const authUsers = res.body as AuthUser[]
+    const authUsers = (res.body as AuthUser[]).filter(user => user.verified && user.enabled)
+
+    if (authUsers.length === 0) {
+      return Promise.reject(new Error('No verified and active accounts found for this email address'))
+    }
+
     return Promise.resolve(authUsers[0])
   }
 


### PR DESCRIPTION
## What does this pull request do?

in HMPPS Auth there are 'inactive' users who have had their account disabled.
there are also users who have unverified email addresses, i.e. auth can't be sure
the email they have provided is actually theirs. in both cases, we should assume
that these user accounts are not able to use our service properly and the users
should filtered out.

## What is the intent behind these changes?

do not allow referral assignments to inactive or unverified auth accounts.