### PR TITLE
IC-1216: Add skeleton action plan activities page

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -3,6 +3,7 @@ import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
 import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
 import hmppsAuthUserFactory from '../../testutils/factories/hmppsAuthUser'
+import draftActionPlanFactory from '../../testutils/factories/draftActionPlan'
 
 describe('Service provider referrals dashboard', () => {
   beforeEach(() => {
@@ -174,5 +175,30 @@ describe('Service provider referrals dashboard', () => {
 
     cy.visit(`/service-provider/referrals/${referral.id}`)
     cy.contains('This intervention is assigned to John Smith.')
+  })
+
+  it('User adds desired outcomes to an action plan', () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const referralParams = { referral: { serviceCategoryId: serviceCategory.id } }
+    const deliusServiceUser = deliusServiceUserFactory.build()
+    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
+    const assignedReferral = sentReferralFactory
+      .assigned()
+      .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username } })
+    const draftActionPlan = draftActionPlanFactory.justCreated(assignedReferral.id).build()
+
+    cy.stubGetSentReferrals([assignedReferral])
+
+    cy.stubGetDraftActionPlan(draftActionPlan.id, draftActionPlan)
+    cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+    cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+    cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+
+    cy.login()
+
+    cy.visit(`/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
+
+    cy.contains('Accommodation - create action plan')
+    cy.contains('Add suggested activities to Alex’s action plan')
   })
 })

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -181,6 +181,7 @@ describe('Service provider referrals dashboard', () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const referralParams = { referral: { serviceCategoryId: serviceCategory.id } }
     const deliusServiceUser = deliusServiceUserFactory.build()
+    const deliusUser = deliusUserFactory.build()
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
     const assignedReferral = sentReferralFactory
       .assigned()
@@ -190,13 +191,19 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetSentReferrals([assignedReferral])
 
     cy.stubGetDraftActionPlan(draftActionPlan.id, draftActionPlan)
+    cy.stubCreateDraftActionPlan(draftActionPlan)
     cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
     cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
     cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+    cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
 
     cy.login()
 
-    cy.visit(`/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
+    cy.visit(`/service-provider/referrals/${assignedReferral.id}`)
+    cy.contains('Create action plan').click()
+
+    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
 
     cy.contains('Accommodation - create action plan')
     cy.contains('Add suggested activities to Alex’s action plan')

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -88,5 +88,9 @@ module.exports = on => {
     stubGetPccRegions: arg => {
       return interventionsService.stubGetPccRegions(arg.responseJson)
     },
+
+    stubGetDraftActionPlan: arg => {
+      return interventionsService.stubGetDraftActionPlan(arg.id, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -92,5 +92,9 @@ module.exports = on => {
     stubGetDraftActionPlan: arg => {
       return interventionsService.stubGetDraftActionPlan(arg.id, arg.responseJson)
     },
+
+    stubCreateDraftActionPlan: arg => {
+      return interventionsService.stubCreateDraftActionPlan(arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/commands.js
+++ b/integration_tests/support/commands.js
@@ -15,6 +15,10 @@ Cypress.Commands.add('stubGetDraftActionPlan', (id, responseJson) => {
   cy.task('stubGetDraftActionPlan', { id, responseJson })
 })
 
+Cypress.Commands.add('stubCreateDraftActionPlan', responseJson => {
+  cy.task('stubCreateDraftActionPlan', { responseJson })
+})
+
 Cypress.Commands.add('withinFieldsetThatContains', (text, action) => {
   cy.contains(text).parent('fieldset').within(action)
 })

--- a/integration_tests/support/commands.js
+++ b/integration_tests/support/commands.js
@@ -11,6 +11,10 @@ Cypress.Commands.add('stubGetAuthUserByUsername', (username, responseJson) => {
   cy.task('stubGetAuthUserByUsername', { username, responseJson })
 })
 
+Cypress.Commands.add('stubGetDraftActionPlan', (id, responseJson) => {
+  cy.task('stubGetDraftActionPlan', { id, responseJson })
+})
+
 Cypress.Commands.add('withinFieldsetThatContains', (text, action) => {
   cy.contains(text).parent('fieldset').within(action)
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -196,4 +196,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubGetDraftActionPlan = async (id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/draft-action-plan/${id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -197,6 +197,22 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubCreateDraftActionPlan = async (responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/draft-action-plan`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
   stubGetDraftActionPlan = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -64,6 +64,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/service-provider/referrals/:id/assignment/confirmation', (req, res) =>
     serviceProviderReferralsController.confirmAssignment(req, res)
   )
+  get('/service-provider/action-plan/:id/add-activities', (req, res) =>
+    serviceProviderReferralsController.addActivitiesToActionPlan(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -64,6 +64,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/service-provider/referrals/:id/assignment/confirmation', (req, res) =>
     serviceProviderReferralsController.confirmAssignment(req, res)
   )
+  post('/service-provider/referrals/:id/action-plan', async (req, res) => {
+    await serviceProviderReferralsController.createDraftActionPlan(req, res)
+  })
   get('/service-provider/action-plan/:id/add-activities', (req, res) =>
     serviceProviderReferralsController.addActivitiesToActionPlan(req, res)
   )

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
@@ -1,0 +1,32 @@
+import AddActionPlanActivitiesPresenter from './addActionPlanActivitiesPresenter'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+
+describe(AddActionPlanActivitiesPresenter, () => {
+  const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+
+  const referralParams = {
+    referral: { serviceCategoryId: serviceCategory.id, serviceUser: { firstName: 'Jenny', lastName: 'Jones' } },
+  }
+
+  describe('text', () => {
+    describe('title', () => {
+      it('includes the name of the service category', () => {
+        const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const sentReferral = sentReferralFactory.assigned().build(referralParams)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, socialInclusionServiceCategory)
+
+        expect(presenter.text.title).toEqual('Social inclusion - create action plan')
+      })
+    })
+
+    describe('subTitle', () => {
+      it('includes the name of the service user', () => {
+        const sentReferral = sentReferralFactory.assigned().build(referralParams)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory)
+
+        expect(presenter.text.subTitle).toEqual('Add suggested activities to Jenny’s action plan')
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -1,0 +1,11 @@
+import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import utils from '../../utils/utils'
+
+export default class AddActionPlanActivitiesPresenter {
+  constructor(private readonly sentReferral: SentReferral, private readonly serviceCategory: ServiceCategory) {}
+
+  readonly text = {
+    title: `${utils.convertToProperCase(this.serviceCategory.name)} - create action plan`,
+    subTitle: `Add suggested activities to ${this.sentReferral.referral.serviceUser.firstName}’s action plan`,
+  }
+}

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesView.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesView.ts
@@ -1,0 +1,14 @@
+import AddActionPlanActivitiesPresenter from './addActionPlanActivitiesPresenter'
+
+export default class AddActionPlanActivitiesView {
+  constructor(private readonly presenter: AddActionPlanActivitiesPresenter) {}
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/actionPlan/addActivities',
+      {
+        presenter: this.presenter,
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -12,6 +12,7 @@ import deliusServiceUser from '../../../testutils/factories/deliusServiceUser'
 import HmppsAuthClient from '../../data/hmppsAuthClient'
 import MockedHmppsAuthClient from '../../data/testutils/hmppsAuthClientSetup'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
+import draftActionPlanFactory from '../../../testutils/factories/draftActionPlan'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -234,6 +235,31 @@ describe('GET /service-provider/referrals/:id/assignment/confirmation', () => {
         expect(res.text).toContain(referral.referenceNumber)
         expect(res.text).toContain('Accommodation')
         expect(res.text).toContain('John Smith')
+      })
+  })
+})
+
+describe('GET /service-provider/action-plan/:actionPlanId/add-activities', () => {
+  it('displays a page to add activities to an action plan', async () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const referral = sentReferralFactory.assigned().build({
+      referral: {
+        serviceCategoryId: serviceCategory.id,
+        serviceUser: { firstName: 'Alex', lastName: 'River' },
+      },
+    })
+    const draftActionPlan = draftActionPlanFactory.justCreated(referral.id).build()
+
+    interventionsService.getDraftActionPlan.mockResolvedValue(draftActionPlan)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+
+    await request(app)
+      .get(`/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Accommodation - create action plan')
+        expect(res.text).toContain('Add suggested activities to Alex’s action plan')
       })
   })
 })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -146,6 +146,12 @@ export default class ServiceProviderReferralsController {
     res.render(...view.renderArgs)
   }
 
+  async createDraftActionPlan(req: Request, res: Response): Promise<void> {
+    const draftActionPlan = await this.interventionsService.createDraftActionPlan(res.locals.user.token, req.params.id)
+
+    res.redirect(303, `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
+  }
+
   async addActivitiesToActionPlan(req: Request, res: Response): Promise<void> {
     const actionPlan = await this.interventionsService.getDraftActionPlan(res.locals.user.token, req.params.id)
     const sentReferral = await this.interventionsService.getSentReferral(res.locals.user.token, actionPlan.referralId)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -13,6 +13,8 @@ import AssignmentConfirmationView from './assignmentConfirmationView'
 import AssignmentConfirmationPresenter from './assignmentConfirmationPresenter'
 import { FormValidationError } from '../../utils/formValidationError'
 import errorMessages from '../../utils/errorMessages'
+import AddActionPlanActivitiesPresenter from './addActionPlanActivitiesPresenter'
+import AddActionPlanActivitiesView from './addActionPlanActivitiesView'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -140,6 +142,21 @@ export default class ServiceProviderReferralsController {
 
     const presenter = new AssignmentConfirmationPresenter(referral, serviceCategory, assignee)
     const view = new AssignmentConfirmationView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async addActivitiesToActionPlan(req: Request, res: Response): Promise<void> {
+    const actionPlan = await this.interventionsService.getDraftActionPlan(res.locals.user.token, req.params.id)
+    const sentReferral = await this.interventionsService.getSentReferral(res.locals.user.token, actionPlan.referralId)
+
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      res.locals.user.token,
+      sentReferral.referral.serviceCategoryId
+    )
+
+    const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory)
+    const view = new AddActionPlanActivitiesView(presenter)
 
     res.render(...view.renderArgs)
   }

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -83,6 +83,15 @@ describe(ShowReferralPresenter, () => {
     })
   })
 
+  describe('createActionPlanFormAction', () => {
+    it('returns the relative URL for creating a draft action plan', () => {
+      const referral = sentReferralFactory.build(referralParams)
+      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser, null, null)
+
+      expect(presenter.createActionPlanFormAction).toEqual(`/service-provider/referrals/${referral.id}/action-plan`)
+    })
+  })
+
   describe('text', () => {
     describe('title', () => {
       describe('when the referral doesn’t have an assigned caseworker', () => {

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -20,6 +20,8 @@ export default class ShowReferralPresenter {
 
   readonly assignmentFormAction = `/service-provider/referrals/${this.sentReferral.id}/assignment/check`
 
+  readonly createActionPlanFormAction = `/service-provider/referrals/${this.sentReferral.id}/action-plan`
+
   readonly text = {
     title:
       this.sentReferral.assignedTo === null

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
@@ -1,0 +1,14 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h2>
+      {% block formSection %}{% endblock %}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -1,0 +1,17 @@
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/showReferral.njk
+++ b/server/views/serviceProviderReferrals/showReferral.njk
@@ -24,6 +24,10 @@
         </form>
       {% else %}
         <p class="govuk-body">This intervention is assigned to <strong>{{ presenter.text.assignedTo }}</strong>.</p>
+
+        <form method="post" action="{{ presenter.createActionPlanFormAction }}">
+          {{ govukButton({ text: "Create action plan" }) }}
+        </form>
       {% endif %}
 
       <h2 class="govuk-heading-m">{{ presenter.text.interventionDetailsSummaryHeading }}</h2>

--- a/testutils/factories/draftActionPlan.ts
+++ b/testutils/factories/draftActionPlan.ts
@@ -1,0 +1,43 @@
+import { Factory } from 'fishery'
+import { DraftActionPlan } from '../../server/services/interventionsService'
+
+class DraftActionPlanFactory extends Factory<DraftActionPlan> {
+  justCreated(referralId: string) {
+    return this.params({ referralId })
+  }
+
+  readyToSubmit(referralId: string) {
+    return this.params({
+      referralId,
+      numberOfSessions: 4,
+      activities: [
+        {
+          id: '91e7ceab-74fd-45d8-97c8-ec58844618dd',
+          description: 'Attend training course',
+          desiredOutcome: {
+            id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+            description:
+              'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+          },
+          createdAt: '2020-12-07T20:45:21.986389Z',
+        },
+        {
+          id: 'e5755c27-2c85-448b-9f6d-e3959ec9c2d0',
+          description: 'Attend session',
+          desiredOutcome: {
+            id: '65924ac6-9724-455b-ad30-906936291421',
+            description: 'Service User makes progress in obtaining accommodation.',
+          },
+          createdAt: '2020-12-07T20:47:21.986389Z',
+        },
+      ],
+    })
+  }
+}
+
+export default DraftActionPlanFactory.define(({ sequence }) => ({
+  id: sequence.toString(),
+  referralId: '81d754aa-d868-4347-9c0f-50690773014e',
+  numberOfSessions: null,
+  activities: [],
+}))


### PR DESCRIPTION
## What does this pull request do?

Adds a blank action plan "add activities" page with just the titles. This is currently linked from the Show Referral page, but will actually come from an SP progress page (still to build, but probably as a separate PR).

## What is the intent behind these changes?

To provide a skeleton so we can build the "add number of sessions page" in parallel.

### Screenshot

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/19826940/109779262-ad567980-7bfd-11eb-884d-8eb4ba6c1756.png">



