### PR TITLE
Rename `activity` param to `newActivity`

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1374,7 +1374,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           path: `/draft-action-plan/${draftActionPlanId}`,
           headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
           body: {
-            activity: {
+            newActivity: {
               description: 'Attend training course',
               desiredOutcomeId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
             },
@@ -1406,7 +1406,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const draftActionPlan = await interventionsService.updateDraftActionPlan(token, draftActionPlanId, {
-        activity: {
+        newActivity: {
           description: 'Attend training course',
           desiredOutcomeId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
         },

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -148,7 +148,7 @@ interface UpdateActivityParams {
 }
 
 interface UpdateDraftActionPlanParams {
-  activity?: UpdateActivityParams
+  newActivity?: UpdateActivityParams
   numberOfSessions?: number
 }
 


### PR DESCRIPTION
## What does this pull request do?

Renames `activity` param to `newActivity`

## What is the intent behind these changes?

To more clearly indicate that activities can only be added to an action
plan, rather than edited or deleted.
