### PR TITLE
IC-1357: Service provider intervention progress page

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -200,7 +200,7 @@ describe('Service provider referrals dashboard', () => {
 
     cy.login()
 
-    cy.visit(`/service-provider/referrals/${assignedReferral.id}`)
+    cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
     cy.contains('Create action plan').click()
 
     cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -93,6 +93,10 @@ module.exports = on => {
       return interventionsService.stubGetDraftActionPlan(arg.id, arg.responseJson)
     },
 
+    stubGetActionPlan: arg => {
+      return interventionsService.stubGetActionPlan(arg.id, arg.responseJson)
+    },
+
     stubCreateDraftActionPlan: arg => {
       return interventionsService.stubCreateDraftActionPlan(arg.responseJson)
     },

--- a/integration_tests/support/commands.js
+++ b/integration_tests/support/commands.js
@@ -15,6 +15,10 @@ Cypress.Commands.add('stubGetDraftActionPlan', (id, responseJson) => {
   cy.task('stubGetDraftActionPlan', { id, responseJson })
 })
 
+Cypress.Commands.add('stubGetActionPlan', (id, responseJson) => {
+  cy.task('stubGetActionPlan', { id, responseJson })
+})
+
 Cypress.Commands.add('stubCreateDraftActionPlan', responseJson => {
   cy.task('stubCreateDraftActionPlan', { responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -228,4 +228,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubGetActionPlan = async (id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/action-plan/${id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/mocks.ts
+++ b/mocks.ts
@@ -4,6 +4,7 @@ import sentReferralFactory from './testutils/factories/sentReferral'
 import serviceCategoryFactory from './testutils/factories/serviceCategory'
 import interventionFactory from './testutils/factories/intervention'
 import deliusUserFactory from './testutils/factories/deliusUser'
+import actionPlanFactory from './testutils/factories/actionPlan'
 
 const wiremock = new Wiremock('http://localhost:9092/__admin')
 const interventionsMocks = new InterventionsServiceMocks(wiremock, '')
@@ -19,6 +20,8 @@ export default async function setUpMocks(): Promise<void> {
     authSource: 'delius',
   }
 
+  const actionPlan = actionPlanFactory.notSubmitted().build()
+
   const sentReferrals = [
     sentReferralFactory.build({
       sentAt: '2021-01-26T13:00:00.000000Z',
@@ -29,6 +32,7 @@ export default async function setUpMocks(): Promise<void> {
         desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
       },
       sentBy,
+      actionPlanId: actionPlan.id,
     }),
     sentReferralFactory.build({
       sentAt: '2020-09-13T13:00:00.000000Z',
@@ -100,5 +104,6 @@ export default async function setUpMocks(): Promise<void> {
       await interventionsMocks.stubAssignSentReferral(referral.id, referral)
       await interventionsMocks.stubGetSentReferral(referral.id, referral)
     }),
+    interventionsMocks.stubGetActionPlan(actionPlan.id, actionPlan),
   ])
 }

--- a/server/routes/findInterventions/interventionDetailsView.ts
+++ b/server/routes/findInterventions/interventionDetailsView.ts
@@ -1,8 +1,7 @@
 import ViewUtils from '../../utils/viewUtils'
 import { SummaryListItem } from '../../utils/summaryList'
-import { SummaryListArgs } from '../../utils/govukFrontendTypes'
+import { SummaryListArgs, TabsArgs } from '../../utils/govukFrontendTypes'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
-import { TabsArgs } from '../../utils/govukFrontendTypes'
 
 export default class InterventionDetailsView {
   constructor(private readonly presenter: InterventionDetailsPresenter) {}

--- a/server/routes/findInterventions/interventionDetailsView.ts
+++ b/server/routes/findInterventions/interventionDetailsView.ts
@@ -1,5 +1,6 @@
 import ViewUtils from '../../utils/viewUtils'
-import { SummaryListArgs, SummaryListItem } from '../../utils/summaryList'
+import { SummaryListItem } from '../../utils/summaryList'
+import { SummaryListArgs } from '../../utils/govukFrontendTypes'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
 import { TabsArgs } from '../../utils/govukFrontendTypes'
 

--- a/server/routes/findInterventions/searchResultsView.ts
+++ b/server/routes/findInterventions/searchResultsView.ts
@@ -1,6 +1,7 @@
 import SearchResultsPresenter from './searchResultsPresenter'
 import ViewUtils from '../../utils/viewUtils'
-import { SummaryListArgs, SummaryListItem } from '../../utils/summaryList'
+import { SummaryListItem } from '../../utils/summaryList'
+import { SummaryListArgs } from '../../utils/govukFrontendTypes'
 
 export default class SearchResultsView {
   constructor(private readonly presenter: SearchResultsPresenter) {}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -55,6 +55,9 @@ export default function routes(router: Router, services: Services): Router {
 
   get('/service-provider/dashboard', (req, res) => serviceProviderReferralsController.showDashboard(req, res))
   get('/service-provider/referrals/:id', (req, res) => serviceProviderReferralsController.showReferral(req, res))
+  get('/service-provider/referrals/:id/progress', (req, res) =>
+    serviceProviderReferralsController.showInterventionProgress(req, res)
+  )
   get('/service-provider/referrals/:id/assignment/check', (req, res) =>
     serviceProviderReferralsController.checkAssignment(req, res)
   )

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -77,7 +77,24 @@ describe(DashboardPresenter, () => {
 
         const presenter = new DashboardPresenter(sentReferrals, [serviceCategory])
 
-        expect(presenter.tableRows[0][4]).toEqual({ text: 'john.smith', sortValue: null, href: null })
+        expect(presenter.tableRows[0][4]).toMatchObject({ text: 'john.smith' })
+      })
+    })
+
+    describe('the View link', () => {
+      describe('when a referral has been assigned to a caseworker', () => {
+        it('links to the intervention progress page', () => {
+          const serviceCategory = serviceCategoryFactory.build()
+          const sentReferrals = [
+            sentReferralFactory.assigned().build({ referral: { serviceCategoryId: serviceCategory.id } }),
+          ]
+
+          const presenter = new DashboardPresenter(sentReferrals, [serviceCategory])
+
+          expect(presenter.tableRows[0][5]).toMatchObject({
+            href: `/service-provider/referrals/${sentReferrals[0].id}/progress`,
+          })
+        })
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -33,8 +33,16 @@ export default class DashboardPresenter {
         },
         { text: utils.convertToProperCase(serviceCategory.name), sortValue: null, href: null },
         { text: referral.assignedTo?.username ?? '', sortValue: null, href: null },
-        { text: 'View', sortValue: null, href: `/service-provider/referrals/${referral.id}` },
+        { text: 'View', sortValue: null, href: DashboardPresenter.hrefForViewing(referral) },
       ]
     }
   )
+
+  private static hrefForViewing(referral: SentReferral): string {
+    if (referral.assignedTo === null) {
+      return `/service-provider/referrals/${referral.id}`
+    }
+
+    return `/service-provider/referrals/${referral.id}/progress`
+  }
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -1,0 +1,38 @@
+import InterventionProgressPresenter from './interventionProgressPresenter'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+
+describe(InterventionProgressPresenter, () => {
+  describe('createActionPlanFormAction', () => {
+    it('returns the relative URL for creating a draft action plan', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory)
+
+      expect(presenter.createActionPlanFormAction).toEqual(`/service-provider/referrals/${referral.id}/action-plan`)
+    })
+  })
+
+  describe('text', () => {
+    it('returns text to be displayed', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory)
+
+      expect(presenter.text).toEqual({
+        actionPlanStatus: 'Not submitted',
+        title: 'Accommodation',
+      })
+    })
+  })
+
+  describe('actionPlanStatusColour', () => {
+    it('returns the inactive colour', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory)
+
+      expect(presenter.actionPlanStatusColour).toEqual('inactive')
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -1,38 +1,98 @@
 import InterventionProgressPresenter from './interventionProgressPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import actionPlanFactory from '../../../testutils/factories/actionPlan'
 
 describe(InterventionProgressPresenter, () => {
   describe('createActionPlanFormAction', () => {
     it('returns the relative URL for creating a draft action plan', () => {
       const referral = sentReferralFactory.build()
       const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory)
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null)
 
       expect(presenter.createActionPlanFormAction).toEqual(`/service-provider/referrals/${referral.id}/action-plan`)
     })
   })
 
   describe('text', () => {
-    it('returns text to be displayed', () => {
-      const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory)
+    describe('title', () => {
+      it('returns a title to be displayed', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null)
 
-      expect(presenter.text).toEqual({
-        actionPlanStatus: 'Not submitted',
-        title: 'Accommodation',
+        expect(presenter.text).toMatchObject({
+          title: 'Accommodation',
+        })
+      })
+    })
+
+    describe('actionPlanStatus', () => {
+      describe('when there is no action plan', () => {
+        it('returns “Not submitted”', () => {
+          const referral = sentReferralFactory.build()
+          const serviceCategory = serviceCategoryFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null)
+
+          expect(presenter.text).toMatchObject({ actionPlanStatus: 'Not submitted' })
+        })
+      })
+
+      describe('when the action plan has not been submitted', () => {
+        it('returns “Not submitted”', () => {
+          const referral = sentReferralFactory.build()
+          const serviceCategory = serviceCategoryFactory.build()
+          const actionPlan = actionPlanFactory.notSubmitted().build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan)
+
+          expect(presenter.text).toMatchObject({ actionPlanStatus: 'Not submitted' })
+        })
+      })
+
+      describe('when the action plan has been submitted', () => {
+        it('returns “Submitted”', () => {
+          const referral = sentReferralFactory.build()
+          const serviceCategory = serviceCategoryFactory.build()
+          const actionPlan = actionPlanFactory.submitted().build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan)
+
+          expect(presenter.text).toMatchObject({ actionPlanStatus: 'Submitted' })
+        })
       })
     })
   })
 
-  describe('actionPlanStatusColour', () => {
-    it('returns the inactive colour', () => {
-      const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory)
+  describe('actionPlanStatusStyle', () => {
+    describe('when there is no action plan', () => {
+      it('returns the inactive style', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null)
 
-      expect(presenter.actionPlanStatusColour).toEqual('inactive')
+        expect(presenter.actionPlanStatusStyle).toEqual('inactive')
+      })
+    })
+
+    describe('when the action plan has not been submitted', () => {
+      it('returns the active style', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build()
+        const actionPlan = actionPlanFactory.notSubmitted().build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan)
+
+        expect(presenter.actionPlanStatusStyle).toEqual('inactive')
+      })
+    })
+
+    describe('when the action plan has been submitted', () => {
+      it('returns the active style', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build()
+        const actionPlan = actionPlanFactory.submitted().build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan)
+
+        expect(presenter.actionPlanStatusStyle).toEqual('active')
+      })
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -1,0 +1,15 @@
+import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import utils from '../../utils/utils'
+
+export default class InterventionProgressPresenter {
+  constructor(private readonly referral: SentReferral, private readonly serviceCategory: ServiceCategory) {}
+
+  readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
+
+  readonly text = {
+    title: utils.convertToTitleCase(this.serviceCategory.name),
+    actionPlanStatus: 'Not submitted',
+  }
+
+  readonly actionPlanStatusColour: 'active' | 'inactive' = 'inactive'
+}

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -1,15 +1,23 @@
-import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { ActionPlan, SentReferral, ServiceCategory } from '../../services/interventionsService'
 import utils from '../../utils/utils'
 
 export default class InterventionProgressPresenter {
-  constructor(private readonly referral: SentReferral, private readonly serviceCategory: ServiceCategory) {}
+  constructor(
+    private readonly referral: SentReferral,
+    private readonly serviceCategory: ServiceCategory,
+    private readonly actionPlan: ActionPlan | null
+  ) {}
 
   readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
 
   readonly text = {
     title: utils.convertToTitleCase(this.serviceCategory.name),
-    actionPlanStatus: 'Not submitted',
+    actionPlanStatus: this.actionPlanSubmitted ? 'Submitted' : 'Not submitted',
   }
 
-  readonly actionPlanStatusColour: 'active' | 'inactive' = 'inactive'
+  readonly actionPlanStatusStyle: 'active' | 'inactive' = this.actionPlanSubmitted ? 'active' : 'inactive'
+
+  private get actionPlanSubmitted() {
+    return this.actionPlan !== null && this.actionPlan.submittedAt !== null
+  }
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -1,0 +1,70 @@
+import { TagArgs, SummaryListArgs } from '../../utils/govukFrontendTypes'
+
+import ViewUtils from '../../utils/viewUtils'
+import InterventionProgressPresenter from './interventionProgressPresenter'
+
+export default class InterventionProgressView {
+  constructor(private readonly presenter: InterventionProgressPresenter) {}
+
+  private initialAssessmentSummaryListArgs(tagMacro: (args: TagArgs) => string): SummaryListArgs {
+    return {
+      rows: [
+        {
+          key: { text: 'Date' },
+          value: { text: '' },
+        },
+        {
+          key: { text: 'Time' },
+          value: { text: '' },
+        },
+        {
+          key: { text: 'Address' },
+          value: { text: '' },
+        },
+        {
+          key: { text: 'Appointment status' },
+          value: { html: tagMacro({ text: 'Not scheduled', classes: 'govuk-tag--grey' }) },
+        },
+        {
+          key: { text: 'Action' },
+          value: { html: '<a href="#" class="govuk-link">Schedule</a>' },
+        },
+      ],
+    }
+  }
+
+  private actionPlanSummaryListArgs(tagMacro: (args: TagArgs) => string, csrfToken: string): SummaryListArgs {
+    return {
+      rows: [
+        {
+          key: { text: 'Action plan status' },
+          value: { text: tagMacro({ text: this.presenter.text.actionPlanStatus, classes: this.actionPlanTagClass }) },
+        },
+        {
+          key: { text: 'Action' },
+          value: {
+            html: `<form method="post" action="${ViewUtils.escape(this.presenter.createActionPlanFormAction)}">
+                     <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken)}">
+                     <button class="govuk-button govuk-button--secondary">
+                       Create action plan
+                     </button>
+                   </form>`,
+          },
+        },
+      ],
+    }
+  }
+
+  private readonly actionPlanTagClass = this.presenter.actionPlanStatusStyle === 'active' ? '' : 'govuk-tag--grey'
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/interventionProgress',
+      {
+        presenter: this.presenter,
+        initialAssessmentSummaryListArgs: this.initialAssessmentSummaryListArgs.bind(this),
+        actionPlanSummaryListArgs: this.actionPlanSummaryListArgs.bind(this),
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -144,6 +144,25 @@ describe('GET /service-provider/referrals/:id', () => {
   })
 })
 
+describe('GET /service-provider/referrals/:id/progress', () => {
+  it('displays information about the intervention progress', async () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const sentReferral = sentReferralFactory.assigned().build({
+      referral: { serviceCategoryId: serviceCategory.id },
+    })
+
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getSentReferral.mockResolvedValue(sentReferral)
+
+    await request(app)
+      .get(`/service-provider/referrals/${sentReferral.id}/progress`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Accommodation')
+      })
+  })
+})
+
 describe('GET /service-provider/referrals/:id/assignment/check', () => {
   it('displays the name of the selected caseworker', async () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -15,6 +15,8 @@ import { FormValidationError } from '../../utils/formValidationError'
 import errorMessages from '../../utils/errorMessages'
 import AddActionPlanActivitiesPresenter from './addActionPlanActivitiesPresenter'
 import AddActionPlanActivitiesView from './addActionPlanActivitiesView'
+import InterventionProgressView from './interventionProgressView'
+import InterventionProgressPresenter from './interventionProgressPresenter'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -70,6 +72,19 @@ export default class ServiceProviderReferralsController {
 
     const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, sentBy, serviceUser, assignee, formError)
     const view = new ShowReferralView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async showInterventionProgress(req: Request, res: Response): Promise<void> {
+    const sentReferral = await this.interventionsService.getSentReferral(res.locals.user.token, req.params.id)
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      res.locals.user.token,
+      sentReferral.referral.serviceCategoryId
+    )
+
+    const presenter = new InterventionProgressPresenter(sentReferral, serviceCategory)
+    const view = new InterventionProgressView(presenter)
 
     res.render(...view.renderArgs)
   }

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -83,15 +83,6 @@ describe(ShowReferralPresenter, () => {
     })
   })
 
-  describe('createActionPlanFormAction', () => {
-    it('returns the relative URL for creating a draft action plan', () => {
-      const referral = sentReferralFactory.build(referralParams)
-      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser, null, null)
-
-      expect(presenter.createActionPlanFormAction).toEqual(`/service-provider/referrals/${referral.id}/action-plan`)
-    })
-  })
-
   describe('text', () => {
     describe('title', () => {
       describe('when the referral doesn’t have an assigned caseworker', () => {

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -20,8 +20,6 @@ export default class ShowReferralPresenter {
 
   readonly assignmentFormAction = `/service-provider/referrals/${this.sentReferral.id}/assignment/check`
 
-  readonly createActionPlanFormAction = `/service-provider/referrals/${this.sentReferral.id}/action-plan`
-
   readonly text = {
     title:
       this.sentReferral.assignedTo === null

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1391,6 +1391,62 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('getActionPlan', () => {
+    it('returns an existing draft action plan', async () => {
+      const actionPlanId = 'dfb64747-f658-40e0-a827-87b4b0bdcfed'
+
+      await provider.addInteraction({
+        state: `an action plan exists with ID ${actionPlanId}, and it has not been submitted`,
+        uponReceiving: `a GET request to view the action plan with ID ${actionPlanId}`,
+        withRequest: {
+          method: 'GET',
+          path: `/action-plan/${actionPlanId}`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            id: actionPlanId,
+            submittedAt: null,
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const actionPlan = await interventionsService.getActionPlan(token, actionPlanId)
+      expect(actionPlan).toMatchObject({ id: actionPlanId, submittedAt: null })
+    })
+
+    it('returns an existing submitted action plan', async () => {
+      const actionPlanId = '7a165933-d851-48c1-9ab0-ff5b8da12695'
+
+      await provider.addInteraction({
+        state: `an action plan exists with ID ${actionPlanId}, and it has been submitted`,
+        uponReceiving: `a GET request to view the action plan with ID ${actionPlanId}`,
+        withRequest: {
+          method: 'GET',
+          path: `/action-plan/${actionPlanId}`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            id: actionPlanId,
+            submittedAt: '2021-03-09T15:08:38Z',
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const actionPlan = await interventionsService.getActionPlan(token, actionPlanId)
+      expect(actionPlan).toMatchObject({ id: actionPlanId, submittedAt: '2021-03-09T15:08:38Z' })
+    })
+  })
+
   describe('updateDraftActionPlan', () => {
     it('updates and returns the newly-updated draft action plan when adding an activity', async () => {
       const draftActionPlanId = 'dfb64747-f658-40e0-a827-87b4b0bdcfed'

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -945,6 +945,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       authSource: 'delius',
     },
     assignedTo: null,
+    actionPlanId: null,
     referenceNumber: 'HDJ2123F',
     referral: {
       createdAt: '2021-01-11T10:32:12.382884Z',
@@ -1042,6 +1043,34 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         expect(await interventionsService.getSentReferral(token, '2f4e91bf-5f73-4ca8-ad84-afee3f12ed8e')).toMatchObject(
           {
             assignedTo: { username: 'UserABC', userId: '555224b3-865c-4b56-97dd-c3e817592ba3', authSource: 'auth' },
+          }
+        )
+      })
+    })
+
+    describe('for a referral that has an action plan', () => {
+      it('populates the actionPlanId property', async () => {
+        await provider.addInteraction({
+          state:
+            'There is an existing sent referral with ID of 8b423e17-9b60-4cc2-a927-8941ac76fdf9, and it has an action plan',
+          uponReceiving: 'a request for the sent referral with ID of 8b423e17-9b60-4cc2-a927-8941ac76fdf9',
+          withRequest: {
+            method: 'GET',
+            path: '/sent-referral/8b423e17-9b60-4cc2-a927-8941ac76fdf9',
+            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like({
+              actionPlanId: '8b423e17-9b60-4cc2-a927-8941ac76fdf9',
+            }),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        expect(await interventionsService.getSentReferral(token, '8b423e17-9b60-4cc2-a927-8941ac76fdf9')).toMatchObject(
+          {
+            actionPlanId: '8b423e17-9b60-4cc2-a927-8941ac76fdf9',
           }
         )
       })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -160,6 +160,11 @@ export interface SubmittedActionPlan {
   actionPlanFields: ActionPlanFields
 }
 
+export interface ActionPlan {
+  id: string
+  submittedAt: string | null
+}
+
 export default class InterventionsService {
   constructor(private readonly config: ApiConfig) {}
 
@@ -372,6 +377,15 @@ export default class InterventionsService {
       path: `/draft-action-plan/${actionPlanId}`,
       headers: { Accept: 'application/json' },
     })) as DraftActionPlan
+  }
+
+  async getActionPlan(token: string, id: string): Promise<ActionPlan> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/action-plan/${id}`,
+      headers: { Accept: 'application/json' },
+    })) as ActionPlan
   }
 
   async updateDraftActionPlan(

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -47,6 +47,7 @@ export interface SentReferral {
   referral: ReferralFields
   sentBy: AuthUser
   assignedTo: AuthUser | null
+  actionPlanId: string | null
 }
 
 export interface ServiceCategory {

--- a/server/utils/govukFrontendTypes.ts
+++ b/server/utils/govukFrontendTypes.ts
@@ -37,3 +37,8 @@ interface SummaryListRow {
   key: { text: string }
   value: { html?: string; text?: string }
 }
+
+export interface TagArgs {
+  text: string
+  classes?: string
+}

--- a/server/utils/govukFrontendTypes.ts
+++ b/server/utils/govukFrontendTypes.ts
@@ -28,3 +28,12 @@ export interface InputArgs {
 export interface PanelArgs {
   titleText: string
 }
+
+export interface SummaryListArgs {
+  rows: SummaryListRow[]
+}
+
+interface SummaryListRow {
+  key: { text: string }
+  value: { html?: string; text?: string }
+}

--- a/server/utils/summaryList.ts
+++ b/server/utils/summaryList.ts
@@ -3,11 +3,3 @@ export interface SummaryListItem {
   lines: string[]
   isList: boolean
 }
-export interface SummaryListArgs {
-  rows: SummaryListRow[]
-}
-
-interface SummaryListRow {
-  key: { text: string }
-  value: { html?: string; text?: string }
-}

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -1,5 +1,6 @@
 import * as nunjucks from 'nunjucks'
-import { SummaryListArgs, SummaryListItem } from './summaryList'
+import { SummaryListItem } from './summaryList'
+import { SummaryListArgs } from './govukFrontendTypes'
 
 export default class ViewUtils {
   static escape(val: string): string {

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -1,0 +1,50 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}
+  {{ pageTitle }}
+  - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      <h2 class="govuk-heading-m">Initial assessment appointment</h2>
+
+      <p class="govuk-body">
+      Complete the initial assessment within 10 working days from receiving a new referral. Once you enter the appointment details, you will be able to change them.
+      </p>
+
+      {{ govukSummaryList(initialAssessmentSummaryListArgs(govukTag)) }}
+
+      <h2 class="govuk-heading-m">Action plan</h2>
+
+      <p class="govuk-body">
+      Please complete the service user’s action plan and submit it to the probation practitioner for approval.
+      </p>
+
+      {{ govukSummaryList(actionPlanSummaryListArgs(govukTag, csrfToken)) }}
+
+      <h2 class="govuk-heading-m">Session progress</h2>
+
+      <p class="govuk-body">
+      Track the progress of each intervention session.
+      </p>
+
+      <p class="govuk-body">
+      Sessions will appear here when the action plan is ready.
+      </p>
+
+      <h2 class="govuk-heading-m">End of service report</h2>
+
+      <p class="govuk-body">
+      You can start the end of service report when all sessions are delivered.
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/showReferral.njk
+++ b/server/views/serviceProviderReferrals/showReferral.njk
@@ -24,10 +24,6 @@
         </form>
       {% else %}
         <p class="govuk-body">This intervention is assigned to <strong>{{ presenter.text.assignedTo }}</strong>.</p>
-
-        <form method="post" action="{{ presenter.createActionPlanFormAction }}">
-          {{ govukButton({ text: "Create action plan" }) }}
-        </form>
       {% endif %}
 
       <h2 class="govuk-heading-m">{{ presenter.text.interventionDetailsSummaryHeading }}</h2>

--- a/testutils/factories/actionPlan.ts
+++ b/testutils/factories/actionPlan.ts
@@ -1,0 +1,17 @@
+import { Factory } from 'fishery'
+import { ActionPlan } from '../../server/services/interventionsService'
+
+class ActionPlanFactory extends Factory<ActionPlan> {
+  notSubmitted() {
+    return this
+  }
+
+  submitted() {
+    return this.params({ submittedAt: new Date().toISOString() })
+  }
+}
+
+export default ActionPlanFactory.define(({ sequence }) => ({
+  id: sequence.toString(),
+  submittedAt: null,
+}))

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -76,4 +76,5 @@ export default SentReferralFactory.define(({ sequence }) => ({
   referenceNumber: sequence.toString().padStart(8, 'ABC'),
   referral: exampleReferralFields(),
   assignedTo: null,
+  actionPlanId: null,
 }))


### PR DESCRIPTION
## What does this pull request do?

Creates a basic page to display intervention progress to a service provider user, and then moves the create action plan journey from the referral details page to this new page. It also tells the user whether an action plan has already been submitted.

## What is the intent behind these changes?

To allow a service provider user to progress an intervention and view the progress of an intervention.

## Screenshots

### Action plan not yet submitted

![Screenshot_2021-03-09 HMPPS Interventions - GOV UK(1)](https://user-images.githubusercontent.com/53756884/110496491-6d0b6580-80ed-11eb-9936-e4ede93d0484.png)

### Action plan already submitted

![Screenshot_2021-03-09 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/110496513-7399dd00-80ed-11eb-8db5-08a72fd282bf.png)
