### PR TITLE
IC-1216: Add activities to action plan

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -279,5 +279,8 @@ describe('Service provider referrals dashboard', () => {
     cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
     cy.contains('Attend training course')
     cy.contains('Create appointment with local authority')
+
+    cy.contains('Save and continue').click()
+    cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/progress`)
   })
 })

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -100,5 +100,9 @@ module.exports = on => {
     stubCreateDraftActionPlan: arg => {
       return interventionsService.stubCreateDraftActionPlan(arg.responseJson)
     },
+
+    stubUpdateDraftActionPlan: arg => {
+      return interventionsService.stubUpdateDraftActionPlan(arg.id, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/commands.js
+++ b/integration_tests/support/commands.js
@@ -23,6 +23,10 @@ Cypress.Commands.add('stubCreateDraftActionPlan', responseJson => {
   cy.task('stubCreateDraftActionPlan', { responseJson })
 })
 
+Cypress.Commands.add('stubUpdateDraftActionPlan', (id, responseJson) => {
+  cy.task('stubUpdateDraftActionPlan', { id, responseJson })
+})
+
 Cypress.Commands.add('withinFieldsetThatContains', (text, action) => {
   cy.contains(text).parent('fieldset').within(action)
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -229,6 +229,22 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubUpdateDraftActionPlan = async (id: string, responseJson: Record<string, unknown>): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/draft-action-plan/${id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
   stubGetActionPlan = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -71,7 +71,7 @@ export default function routes(router: Router, services: Services): Router {
     await serviceProviderReferralsController.createDraftActionPlan(req, res)
   })
   get('/service-provider/action-plan/:id/add-activities', (req, res) =>
-    serviceProviderReferralsController.addActivitiesToActionPlan(req, res)
+    serviceProviderReferralsController.showActionPlanAddActivitiesForm(req, res)
   )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -76,6 +76,9 @@ export default function routes(router: Router, services: Services): Router {
   post('/service-provider/action-plan/:id/add-activity', (req, res) =>
     serviceProviderReferralsController.addActivityToActionPlan(req, res)
   )
+  post('/service-provider/action-plan/:id/add-activities', (req, res) =>
+    serviceProviderReferralsController.finaliseActionPlanActivities(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -73,6 +73,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/service-provider/action-plan/:id/add-activities', (req, res) =>
     serviceProviderReferralsController.showActionPlanAddActivitiesForm(req, res)
   )
+  post('/service-provider/action-plan/:id/add-activity', (req, res) =>
+    serviceProviderReferralsController.addActivityToActionPlan(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.test.ts
@@ -1,0 +1,91 @@
+import { Request } from 'express'
+import AddActionPlanActivitiesForm from './addActionPlanActivitiesForm'
+
+describe(AddActionPlanActivitiesForm, () => {
+  describe('activityParamsForUpdate', () => {
+    it('returns the params to be sent to the backend, when the data in the body is valid', async () => {
+      const form = await AddActionPlanActivitiesForm.createForm({
+        body: {
+          description: 'Attend a training course',
+          'desired-outcome-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
+        },
+      } as Request)
+
+      expect(form.activityParamsForUpdate).toEqual({
+        newActivity: {
+          description: 'Attend a training course',
+          desiredOutcomeId: '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
+        },
+      })
+    })
+  })
+
+  describe('isValid', () => {
+    describe('when there is a non-empty text string for "description"', () => {
+      it('returns true', async () => {
+        const form = await AddActionPlanActivitiesForm.createForm({
+          body: {
+            description: 'Attend a training course',
+            'desired-outcome-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
+          },
+        } as Request)
+
+        expect(form.isValid).toEqual(true)
+      })
+    })
+
+    describe('when there is an empty string for "description"', () => {
+      it('returns false', async () => {
+        const form = await AddActionPlanActivitiesForm.createForm({
+          body: {
+            description: '',
+            'desired-outcome-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
+          },
+        } as Request)
+
+        expect(form.isValid).toEqual(false)
+      })
+    })
+  })
+
+  describe('errors', () => {
+    describe('when there is a non-empty text string for "description"', () => {
+      it('returns an empty array', async () => {
+        const form = await AddActionPlanActivitiesForm.createForm({
+          body: {
+            description: 'Attend a training course',
+            'desired-outcome-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
+          },
+        } as Request)
+
+        expect(form.errors).toEqual([])
+      })
+    })
+
+    describe('when there is an empty string for "description"', () => {
+      it('returns an array with an error for the relevant desired outcome ID', async () => {
+        const form = await AddActionPlanActivitiesForm.createForm({
+          body: {
+            description: '',
+            'desired-outcome-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
+          },
+        } as Request)
+
+        expect(form.errors).toEqual([
+          {
+            desiredOutcomeId: '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
+            error: {
+              errors: [
+                {
+                  errorSummaryLinkedField: 'description',
+                  formFields: ['description'],
+                  message: 'Enter an activity',
+                },
+              ],
+            },
+          },
+        ])
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.ts
@@ -1,0 +1,50 @@
+import { Request } from 'express'
+import { UpdateDraftActionPlanParams } from '../../services/interventionsService'
+import errorMessages from '../../utils/errorMessages'
+import { FormValidationError } from '../../utils/formValidationError'
+
+export default class AddActionPlanActivitiesForm {
+  private constructor(private readonly request: Request) {}
+
+  static async createForm(request: Request): Promise<AddActionPlanActivitiesForm> {
+    return new AddActionPlanActivitiesForm(request)
+  }
+
+  get activityParamsForUpdate(): Partial<UpdateDraftActionPlanParams> {
+    return {
+      newActivity: {
+        description: this.request.body.description,
+        desiredOutcomeId: this.desiredOutcomeId,
+      },
+    }
+  }
+
+  private get desiredOutcomeId(): string {
+    return this.request.body['desired-outcome-id']
+  }
+
+  get isValid(): boolean {
+    return this.request.body.description !== ''
+  }
+
+  get errors(): { desiredOutcomeId: string; error: FormValidationError }[] {
+    if (this.isValid) {
+      return []
+    }
+
+    return [
+      {
+        desiredOutcomeId: this.desiredOutcomeId,
+        error: {
+          errors: [
+            {
+              errorSummaryLinkedField: 'description',
+              formFields: ['description'],
+              message: errorMessages.actionPlanActivity.empty,
+            },
+          ],
+        },
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
@@ -1,20 +1,22 @@
 import AddActionPlanActivitiesPresenter from './addActionPlanActivitiesPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import draftActionPlan from '../../../testutils/factories/draftActionPlan'
 
 describe(AddActionPlanActivitiesPresenter, () => {
-  const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-
-  const referralParams = {
-    referral: { serviceCategoryId: serviceCategory.id, serviceUser: { firstName: 'Jenny', lastName: 'Jones' } },
-  }
-
   describe('text', () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+
+    const referralParams = {
+      referral: { serviceCategoryId: serviceCategory.id, serviceUser: { firstName: 'Jenny', lastName: 'Jones' } },
+    }
+
     describe('title', () => {
       it('includes the name of the service category', () => {
         const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
         const sentReferral = sentReferralFactory.assigned().build(referralParams)
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, socialInclusionServiceCategory)
+        const actionPlan = draftActionPlan.justCreated(sentReferral.id).build()
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, socialInclusionServiceCategory, actionPlan)
 
         expect(presenter.text.title).toEqual('Social inclusion - create action plan')
       })
@@ -23,10 +25,66 @@ describe(AddActionPlanActivitiesPresenter, () => {
     describe('subTitle', () => {
       it('includes the name of the service user', () => {
         const sentReferral = sentReferralFactory.assigned().build(referralParams)
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory)
+        const actionPlan = draftActionPlan.justCreated(sentReferral.id).build()
+
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
 
         expect(presenter.text.subTitle).toEqual('Add suggested activities to Jenny’s action plan')
       })
+    })
+  })
+
+  describe('desiredOutcomes', () => {
+    it('returns the desired outcomes on the Service Category that match those populated on the SentReferral', () => {
+      const desiredOutcomes = [
+        {
+          id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+          description:
+            'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+        },
+        {
+          id: '65924ac6-9724-455b-ad30-906936291421',
+          description: 'Service User makes progress in obtaining accommodation',
+        },
+        {
+          id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
+          description: 'Service User is helped to secure social or supported housing',
+        },
+        {
+          id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
+          description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+        },
+      ]
+      const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
+
+      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })
+
+      const referralParams = {
+        referral: {
+          serviceCategoryId: serviceCategory.id,
+          serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+          desiredOutcomesIds: selectedDesiredOutcomesIds,
+        },
+      }
+
+      const sentReferral = sentReferralFactory.assigned().build(referralParams)
+      const actionPlan = draftActionPlan.justCreated(sentReferral.id).build()
+
+      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
+
+      expect(presenter.desiredOutcomes).toEqual([
+        {
+          description:
+            'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+          addActivityAction: `/service-provider/action-plan/${actionPlan.id}/add-activity`,
+          id: selectedDesiredOutcomesIds[0],
+        },
+        {
+          description: 'Service User makes progress in obtaining accommodation',
+          addActivityAction: `/service-provider/action-plan/${actionPlan.id}/add-activity`,
+          id: selectedDesiredOutcomesIds[1],
+        },
+      ])
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
@@ -1,7 +1,7 @@
 import AddActionPlanActivitiesPresenter from './addActionPlanActivitiesPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
-import draftActionPlan from '../../../testutils/factories/draftActionPlan'
+import draftActionPlanFactory from '../../../testutils/factories/draftActionPlan'
 
 describe(AddActionPlanActivitiesPresenter, () => {
   describe('text', () => {
@@ -15,7 +15,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
       it('includes the name of the service category', () => {
         const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
         const sentReferral = sentReferralFactory.assigned().build(referralParams)
-        const actionPlan = draftActionPlan.justCreated(sentReferral.id).build()
+        const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build()
         const presenter = new AddActionPlanActivitiesPresenter(sentReferral, socialInclusionServiceCategory, actionPlan)
 
         expect(presenter.text.title).toEqual('Social inclusion - create action plan')
@@ -25,7 +25,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
     describe('subTitle', () => {
       it('includes the name of the service user', () => {
         const sentReferral = sentReferralFactory.assigned().build(referralParams)
-        const actionPlan = draftActionPlan.justCreated(sentReferral.id).build()
+        const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build()
 
         const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
 
@@ -35,30 +35,29 @@ describe(AddActionPlanActivitiesPresenter, () => {
   })
 
   describe('desiredOutcomes', () => {
+    const desiredOutcomes = [
+      {
+        id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+        description:
+          'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+      },
+      {
+        id: '65924ac6-9724-455b-ad30-906936291421',
+        description: 'Service User makes progress in obtaining accommodation',
+      },
+      {
+        id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
+        description: 'Service User is helped to secure social or supported housing',
+      },
+      {
+        id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
+        description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+      },
+    ]
+    const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
+
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })
     it('returns the desired outcomes on the Service Category that match those populated on the SentReferral', () => {
-      const desiredOutcomes = [
-        {
-          id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
-          description:
-            'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
-        },
-        {
-          id: '65924ac6-9724-455b-ad30-906936291421',
-          description: 'Service User makes progress in obtaining accommodation',
-        },
-        {
-          id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-          description: 'Service User is helped to secure social or supported housing',
-        },
-        {
-          id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-          description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
-        },
-      ]
-      const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
-
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })
-
       const referralParams = {
         referral: {
           serviceCategoryId: serviceCategory.id,
@@ -68,7 +67,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
       }
 
       const sentReferral = sentReferralFactory.assigned().build(referralParams)
-      const actionPlan = draftActionPlan.justCreated(sentReferral.id).build()
+      const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build({ activities: [] })
 
       const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
 
@@ -78,13 +77,78 @@ describe(AddActionPlanActivitiesPresenter, () => {
             'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
           addActivityAction: `/service-provider/action-plan/${actionPlan.id}/add-activity`,
           id: selectedDesiredOutcomesIds[0],
+          activities: [],
         },
         {
           description: 'Service User makes progress in obtaining accommodation',
           addActivityAction: `/service-provider/action-plan/${actionPlan.id}/add-activity`,
           id: selectedDesiredOutcomesIds[1],
+          activities: [],
         },
       ])
+    })
+
+    describe('activities', () => {
+      it('adds the activities to the correct desired outcome', () => {
+        const sentReferral = sentReferralFactory
+          .assigned()
+          .build({ referral: { desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id] } })
+        const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build({
+          activities: [
+            {
+              id: '1',
+              description: 'description 1',
+              desiredOutcome: desiredOutcomes[0],
+              createdAt: '2021-03-15T10:00:00Z',
+            },
+            {
+              id: '2',
+              description: 'description 2',
+              desiredOutcome: desiredOutcomes[0],
+              createdAt: '2021-03-15T10:00:00Z',
+            },
+            {
+              id: '3',
+              description: 'description 3',
+              desiredOutcome: desiredOutcomes[1],
+              createdAt: '2021-03-15T10:00:00Z',
+            },
+          ],
+        })
+
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
+        expect(presenter.desiredOutcomes).toMatchObject([
+          { activities: [{ text: 'description 1' }, { text: 'description 2' }] },
+          { activities: [{ text: 'description 3' }] },
+        ])
+      })
+
+      it('sorts an outcome’s referrals into oldest-to-newest order', () => {
+        const sentReferral = sentReferralFactory
+          .assigned()
+          .build({ referral: { desiredOutcomesIds: [desiredOutcomes[0].id] } })
+        const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build({
+          activities: [
+            {
+              id: '1',
+              description: 'description 1',
+              desiredOutcome: desiredOutcomes[0],
+              createdAt: '2021-03-15T10:05:00Z',
+            },
+            {
+              id: '2',
+              description: 'description 2',
+              desiredOutcome: desiredOutcomes[0],
+              createdAt: '2021-03-15T10:00:00Z',
+            },
+          ],
+        })
+
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
+        expect(presenter.desiredOutcomes).toMatchObject([
+          { activities: [{ text: 'description 2' }, { text: 'description 1' }] },
+        ])
+      })
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
@@ -33,6 +33,17 @@ describe(AddActionPlanActivitiesPresenter, () => {
     },
   })
 
+  describe('saveAndContinueFormAction', () => {
+    it('returns a relative URL of the action plan’s add-activities page', () => {
+      const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build()
+      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
+
+      expect(presenter.saveAndContinueFormAction).toEqual(
+        `/service-provider/action-plan/${actionPlan.id}/add-activities`
+      )
+    })
+  })
+
   describe('text', () => {
     describe('title', () => {
       it('includes the name of the service category', () => {

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
@@ -4,17 +4,39 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import draftActionPlanFactory from '../../../testutils/factories/draftActionPlan'
 
 describe(AddActionPlanActivitiesPresenter, () => {
+  const desiredOutcomes = [
+    {
+      id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+      description:
+        'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+    },
+    {
+      id: '65924ac6-9724-455b-ad30-906936291421',
+      description: 'Service User makes progress in obtaining accommodation',
+    },
+    {
+      id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
+      description: 'Service User is helped to secure social or supported housing',
+    },
+    {
+      id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
+      description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+    },
+  ]
+  const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })
+  const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
+  const sentReferral = sentReferralFactory.assigned().build({
+    referral: {
+      serviceCategoryId: serviceCategory.id,
+      serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+      desiredOutcomesIds: selectedDesiredOutcomesIds,
+    },
+  })
+
   describe('text', () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-
-    const referralParams = {
-      referral: { serviceCategoryId: serviceCategory.id, serviceUser: { firstName: 'Jenny', lastName: 'Jones' } },
-    }
-
     describe('title', () => {
       it('includes the name of the service category', () => {
         const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-        const sentReferral = sentReferralFactory.assigned().build(referralParams)
         const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build()
         const presenter = new AddActionPlanActivitiesPresenter(sentReferral, socialInclusionServiceCategory, actionPlan)
 
@@ -24,7 +46,6 @@ describe(AddActionPlanActivitiesPresenter, () => {
 
     describe('subTitle', () => {
       it('includes the name of the service user', () => {
-        const sentReferral = sentReferralFactory.assigned().build(referralParams)
         const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build()
 
         const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
@@ -34,39 +55,43 @@ describe(AddActionPlanActivitiesPresenter, () => {
     })
   })
 
+  describe('errorSummary', () => {
+    describe('when an empty array of errors is passed in', () => {
+      it('returns null', () => {
+        const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build()
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan, [])
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when a non-empty array of errors is passed in', () => {
+      it('returns a summary of the errors, with the correct index appended to the field ID', () => {
+        const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build()
+        const errors = [
+          {
+            desiredOutcomeId: desiredOutcomes[0].id,
+            error: {
+              errors: [
+                {
+                  formFields: ['description'],
+                  errorSummaryLinkedField: 'description',
+                  message: 'Enter an activity',
+                },
+              ],
+            },
+          },
+        ]
+
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan, errors)
+
+        expect(presenter.errorSummary).toEqual([{ field: 'description-1', message: 'Enter an activity' }])
+      })
+    })
+  })
+
   describe('desiredOutcomes', () => {
-    const desiredOutcomes = [
-      {
-        id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
-        description:
-          'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
-      },
-      {
-        id: '65924ac6-9724-455b-ad30-906936291421',
-        description: 'Service User makes progress in obtaining accommodation',
-      },
-      {
-        id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-        description: 'Service User is helped to secure social or supported housing',
-      },
-      {
-        id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-        description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
-      },
-    ]
-    const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
-
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })
     it('returns the desired outcomes on the Service Category that match those populated on the SentReferral', () => {
-      const referralParams = {
-        referral: {
-          serviceCategoryId: serviceCategory.id,
-          serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
-          desiredOutcomesIds: selectedDesiredOutcomesIds,
-        },
-      }
-
-      const sentReferral = sentReferralFactory.assigned().build(referralParams)
       const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build({ activities: [] })
 
       const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
@@ -78,21 +103,20 @@ describe(AddActionPlanActivitiesPresenter, () => {
           addActivityAction: `/service-provider/action-plan/${actionPlan.id}/add-activity`,
           id: selectedDesiredOutcomesIds[0],
           activities: [],
+          errorMessage: null,
         },
         {
           description: 'Service User makes progress in obtaining accommodation',
           addActivityAction: `/service-provider/action-plan/${actionPlan.id}/add-activity`,
           id: selectedDesiredOutcomesIds[1],
           activities: [],
+          errorMessage: null,
         },
       ])
     })
 
     describe('activities', () => {
       it('adds the activities to the correct desired outcome', () => {
-        const sentReferral = sentReferralFactory
-          .assigned()
-          .build({ referral: { desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id] } })
         const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build({
           activities: [
             {
@@ -124,9 +148,6 @@ describe(AddActionPlanActivitiesPresenter, () => {
       })
 
       it('sorts an outcome’s referrals into oldest-to-newest order', () => {
-        const sentReferral = sentReferralFactory
-          .assigned()
-          .build({ referral: { desiredOutcomesIds: [desiredOutcomes[0].id] } })
         const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build({
           activities: [
             {
@@ -145,9 +166,41 @@ describe(AddActionPlanActivitiesPresenter, () => {
         })
 
         const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
-        expect(presenter.desiredOutcomes).toMatchObject([
-          { activities: [{ text: 'description 2' }, { text: 'description 1' }] },
-        ])
+        expect(presenter.desiredOutcomes[0]).toMatchObject({
+          activities: [{ text: 'description 2' }, { text: 'description 1' }],
+        })
+      })
+    })
+
+    describe('errorMessage', () => {
+      const actionPlan = draftActionPlanFactory.justCreated(sentReferral.id).build()
+      const errors = [
+        {
+          desiredOutcomeId: desiredOutcomes[0].id,
+          error: {
+            errors: [
+              {
+                formFields: ['description'],
+                errorSummaryLinkedField: 'description',
+                message: 'Enter an activity',
+              },
+            ],
+          },
+        },
+      ]
+
+      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan, errors)
+
+      describe('when there is an error on the description field for that desired outcome', () => {
+        it('returns that error’s message', () => {
+          expect(presenter.desiredOutcomes[0]?.errorMessage).toEqual('Enter an activity')
+        })
+      })
+
+      describe('when there is no error for that desired outcome', () => {
+        it('returns null', () => {
+          expect(presenter.desiredOutcomes[1]?.errorMessage).toBeNull()
+        })
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -1,11 +1,29 @@
-import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { DraftActionPlan, SentReferral, ServiceCategory } from '../../services/interventionsService'
 import utils from '../../utils/utils'
 
 export default class AddActionPlanActivitiesPresenter {
-  constructor(private readonly sentReferral: SentReferral, private readonly serviceCategory: ServiceCategory) {}
+  constructor(
+    private readonly sentReferral: SentReferral,
+    private readonly serviceCategory: ServiceCategory,
+    private readonly actionPlan: DraftActionPlan
+  ) {}
 
   readonly text = {
     title: `${utils.convertToProperCase(this.serviceCategory.name)} - create action plan`,
     subTitle: `Add suggested activities to ${this.sentReferral.referral.serviceUser.firstName}’s action plan`,
   }
+
+  readonly desiredOutcomes = this.sentReferral.referral.desiredOutcomesIds.map(id => {
+    const desiredOutcome = this.serviceCategory.desiredOutcomes.find(outcome => id === outcome.id)
+
+    if (!desiredOutcome) {
+      return null
+    }
+
+    return {
+      description: desiredOutcome.description,
+      id: desiredOutcome.id,
+      addActivityAction: `/service-provider/action-plan/${this.actionPlan.id}/add-activity`,
+    }
+  })
 }

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -17,6 +17,8 @@ export default class AddActionPlanActivitiesPresenter {
     private readonly errors: { desiredOutcomeId: string; error: FormValidationError }[] = []
   ) {}
 
+  readonly saveAndContinueFormAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activities`
+
   private readonly desiredOutcomesIds = this.sentReferral.referral.desiredOutcomesIds
 
   readonly errorSummary = (() => {

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -5,21 +5,46 @@ import {
   SentReferral,
   ServiceCategory,
 } from '../../services/interventionsService'
+import { FormValidationError } from '../../utils/formValidationError'
 import utils from '../../utils/utils'
+import ReferralDataPresenterUtils from '../referrals/referralDataPresenterUtils'
 
 export default class AddActionPlanActivitiesPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly serviceCategory: ServiceCategory,
-    private readonly actionPlan: DraftActionPlan
+    private readonly actionPlan: DraftActionPlan,
+    private readonly errors: { desiredOutcomeId: string; error: FormValidationError }[] = []
   ) {}
+
+  private readonly desiredOutcomesIds = this.sentReferral.referral.desiredOutcomesIds
+
+  readonly errorSummary = (() => {
+    const errorSummary = this.errors.reduce((accumIndexedSummary, error) => {
+      const unindexedSummary = ReferralDataPresenterUtils.errorSummary(error.error)
+      if (unindexedSummary === null) {
+        return accumIndexedSummary
+      }
+
+      const index = this.desiredOutcomesIds.indexOf(error.desiredOutcomeId)
+      const indexedSummary = unindexedSummary.map(item => ({ ...item, field: `${item.field}-${index + 1}` }))
+
+      return [...accumIndexedSummary, ...indexedSummary]
+    }, new Array<{ field: string; message: string }>())
+
+    if (errorSummary.length === 0) {
+      return null
+    }
+
+    return errorSummary
+  })()
 
   readonly text = {
     title: `${utils.convertToProperCase(this.serviceCategory.name)} - create action plan`,
     subTitle: `Add suggested activities to ${this.sentReferral.referral.serviceUser.firstName}’s action plan`,
   }
 
-  readonly desiredOutcomes = this.sentReferral.referral.desiredOutcomesIds.map(id => {
+  readonly desiredOutcomes = this.desiredOutcomesIds.map(id => {
     const desiredOutcome = this.serviceCategory.desiredOutcomes.find(outcome => id === outcome.id)
 
     if (!desiredOutcome) {
@@ -31,8 +56,14 @@ export default class AddActionPlanActivitiesPresenter {
       id: desiredOutcome.id,
       addActivityAction: `/service-provider/action-plan/${this.actionPlan.id}/add-activity`,
       activities: this.orderedActivitiesForOutcome(desiredOutcome).map(activity => ({ text: activity.description })),
+      errorMessage: this.errorMessageForOutcome(desiredOutcome),
     }
   })
+
+  private errorMessageForOutcome(desiredOutcome: DesiredOutcome): string | null {
+    const error = this.errors.find(anError => anError.desiredOutcomeId === desiredOutcome.id)?.error ?? null
+    return ReferralDataPresenterUtils.errorMessage(error, 'description')
+  }
 
   private orderedActivitiesForOutcome(outcome: DesiredOutcome): Activity[] {
     return this.actionPlan.activities

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -1,4 +1,10 @@
-import { DraftActionPlan, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import {
+  Activity,
+  DesiredOutcome,
+  DraftActionPlan,
+  SentReferral,
+  ServiceCategory,
+} from '../../services/interventionsService'
 import utils from '../../utils/utils'
 
 export default class AddActionPlanActivitiesPresenter {
@@ -24,6 +30,13 @@ export default class AddActionPlanActivitiesPresenter {
       description: desiredOutcome.description,
       id: desiredOutcome.id,
       addActivityAction: `/service-provider/action-plan/${this.actionPlan.id}/add-activity`,
+      activities: this.orderedActivitiesForOutcome(desiredOutcome).map(activity => ({ text: activity.description })),
     }
   })
+
+  private orderedActivitiesForOutcome(outcome: DesiredOutcome): Activity[] {
+    return this.actionPlan.activities
+      .filter(activity => activity.desiredOutcome.id === outcome.id)
+      .sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1))
+  }
 }

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesView.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesView.ts
@@ -1,3 +1,4 @@
+import ViewUtils from '../../utils/viewUtils'
 import AddActionPlanActivitiesPresenter from './addActionPlanActivitiesPresenter'
 
 export default class AddActionPlanActivitiesView {
@@ -8,7 +9,25 @@ export default class AddActionPlanActivitiesView {
       'serviceProviderReferrals/actionPlan/addActivities',
       {
         presenter: this.presenter,
+        addActivityTextareaArgs: this.addActivityTextareaArgs,
       },
     ]
+  }
+
+  private addActivityTextareaArgs = (index: number) => {
+    const desiredOutcome = this.presenter.desiredOutcomes[index]!
+
+    return {
+      name: 'description',
+      id: `description-${index + 1}`,
+      label: {
+        html: `<h4 class="govuk-heading-s">${ViewUtils.escape(
+          `Activity ${desiredOutcome.activities.length + 1}`
+        )}</h4>`,
+      },
+      hint: {
+        text: 'What activity will you deliver to achieve this outcome?',
+      },
+    }
   }
 }

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesView.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesView.ts
@@ -10,9 +10,12 @@ export default class AddActionPlanActivitiesView {
       {
         presenter: this.presenter,
         addActivityTextareaArgs: this.addActivityTextareaArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
       },
     ]
   }
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   private addActivityTextareaArgs = (index: number) => {
     const desiredOutcome = this.presenter.desiredOutcomes[index]!
@@ -28,6 +31,7 @@ export default class AddActionPlanActivitiesView {
       hint: {
         text: 'What activity will you deliver to achieve this outcome?',
       },
+      errorMessage: ViewUtils.govukErrorMessage(desiredOutcome.errorMessage),
     }
   }
 }

--- a/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.test.ts
+++ b/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.test.ts
@@ -1,0 +1,78 @@
+import FinaliseActionPlanActivitiesForm from './finaliseActionPlanActivitiesForm'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import draftActionPlanFactory from '../../../testutils/factories/draftActionPlan'
+
+describe(FinaliseActionPlanActivitiesForm, () => {
+  describe('errors', () => {
+    const desiredOutcomes = [
+      {
+        id: '1',
+        description: 'Description 1',
+      },
+      {
+        id: '2',
+        description: 'Description 2',
+      },
+      {
+        id: '3',
+        description: 'Description 3',
+      },
+    ]
+    const serviceCategory = serviceCategoryFactory.build({ desiredOutcomes })
+    const referral = sentReferralFactory.build({
+      referral: {
+        serviceCategoryId: serviceCategory.id,
+        desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id],
+      },
+    })
+
+    describe('when there is an activity in the action plan for every desired outcome of the referral', () => {
+      it('returns an empty array', () => {
+        const actionPlan = draftActionPlanFactory.build({
+          activities: [
+            { id: '1', desiredOutcome: desiredOutcomes[0], createdAt: new Date().toISOString(), description: '' },
+            { id: '2', desiredOutcome: desiredOutcomes[1], createdAt: new Date().toISOString(), description: '' },
+          ],
+        })
+        const form = new FinaliseActionPlanActivitiesForm(referral, actionPlan, serviceCategory)
+
+        expect(form.errors).toEqual([])
+      })
+    })
+
+    describe('when there is a desired outcome in the referral for which there is no activity in the action plan', () => {
+      it('returns an error for each outcome without an activity', () => {
+        const actionPlan = draftActionPlanFactory.build({ activities: [] })
+        const form = new FinaliseActionPlanActivitiesForm(referral, actionPlan, serviceCategory)
+
+        expect(form.errors).toEqual([
+          {
+            desiredOutcomeId: '1',
+            error: {
+              errors: [
+                {
+                  errorSummaryLinkedField: 'description',
+                  formFields: ['description'],
+                  message: 'You must add at least one activity for the desired outcome “Description 1”',
+                },
+              ],
+            },
+          },
+          {
+            desiredOutcomeId: '2',
+            error: {
+              errors: [
+                {
+                  errorSummaryLinkedField: 'description',
+                  formFields: ['description'],
+                  message: 'You must add at least one activity for the desired outcome “Description 2”',
+                },
+              ],
+            },
+          },
+        ])
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.ts
+++ b/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.ts
@@ -1,0 +1,38 @@
+import { DraftActionPlan, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { FormValidationError } from '../../utils/formValidationError'
+import errorMessages from '../../utils/errorMessages'
+
+export default class FinaliseActionPlanActivitiesForm {
+  constructor(
+    private readonly referral: SentReferral,
+    private readonly actionPlan: DraftActionPlan,
+    private readonly serviceCategory: ServiceCategory
+  ) {}
+
+  get isValid(): boolean {
+    return this.errors.length === 0
+  }
+
+  get errors(): { desiredOutcomeId: string; error: FormValidationError }[] {
+    const desiredOutcomeIdsWithoutActivities = this.referral.referral.desiredOutcomesIds.filter(
+      desiredOutcomeId => !this.actionPlan.activities.some(activity => activity.desiredOutcome.id === desiredOutcomeId)
+    )
+
+    return desiredOutcomeIdsWithoutActivities.map(desiredOutcomeId => {
+      const desiredOutcome = this.serviceCategory.desiredOutcomes.find(outcome => desiredOutcomeId === outcome.id)
+
+      return {
+        desiredOutcomeId,
+        error: {
+          errors: [
+            {
+              formFields: ['description'],
+              message: errorMessages.actionPlanActivity.noneAdded(desiredOutcome?.description ?? ''),
+              errorSummaryLinkedField: 'description',
+            },
+          ],
+        },
+      }
+    })
+  }
+}

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -260,14 +260,18 @@ describe('GET /service-provider/referrals/:id/assignment/confirmation', () => {
 
 describe('GET /service-provider/action-plan/:actionPlanId/add-activities', () => {
   it('displays a page to add activities to an action plan', async () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const desiredOutcome = { id: '1', description: 'Achieve a thing' }
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes: [desiredOutcome] })
     const referral = sentReferralFactory.assigned().build({
       referral: {
         serviceCategoryId: serviceCategory.id,
         serviceUser: { firstName: 'Alex', lastName: 'River' },
+        desiredOutcomesIds: [desiredOutcome.id],
       },
     })
-    const draftActionPlan = draftActionPlanFactory.justCreated(referral.id).build()
+    const draftActionPlan = draftActionPlanFactory.justCreated(referral.id).build({
+      activities: [{ id: '1', description: 'Do a thing', desiredOutcome, createdAt: '2021-03-01T10:00:00Z' }],
+    })
 
     interventionsService.getDraftActionPlan.mockResolvedValue(draftActionPlan)
     interventionsService.getSentReferral.mockResolvedValue(referral)
@@ -279,6 +283,8 @@ describe('GET /service-provider/action-plan/:actionPlanId/add-activities', () =>
       .expect(res => {
         expect(res.text).toContain('Accommodation - create action plan')
         expect(res.text).toContain('Add suggested activities to Alex’s action plan')
+        expect(res.text).toContain('Achieve a thing')
+        expect(res.text).toContain('Do a thing')
       })
   })
 })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -173,7 +173,7 @@ export default class ServiceProviderReferralsController {
     res.redirect(303, `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
   }
 
-  async addActivitiesToActionPlan(req: Request, res: Response): Promise<void> {
+  async showActionPlanAddActivitiesForm(req: Request, res: Response): Promise<void> {
     const actionPlan = await this.interventionsService.getDraftActionPlan(res.locals.user.token, req.params.id)
     const sentReferral = await this.interventionsService.getSentReferral(res.locals.user.token, actionPlan.referralId)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -182,7 +182,7 @@ export default class ServiceProviderReferralsController {
       sentReferral.referral.serviceCategoryId
     )
 
-    const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory)
+    const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
     const view = new AddActionPlanActivitiesView(presenter)
 
     res.render(...view.renderArgs)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -85,7 +85,7 @@ export default class ServiceProviderReferralsController {
     const actionPlanPromise =
       sentReferral.actionPlanId === null
         ? Promise.resolve(null)
-        : this.interventionsService.getActionPlan(res.locals.user.token, req.params.id)
+        : this.interventionsService.getActionPlan(res.locals.user.token, sentReferral.actionPlanId)
 
     const [serviceCategory, actionPlan] = await Promise.all([serviceCategoryPromise, actionPlanPromise])
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -148,7 +148,7 @@ interface UpdateActivityParams {
   desiredOutcomeId: string
 }
 
-interface UpdateDraftActionPlanParams {
+export interface UpdateDraftActionPlanParams {
   newActivity?: UpdateActivityParams
   numberOfSessions?: number
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -136,7 +136,7 @@ interface ActionPlanFields {
   numberOfSessions: number | null
 }
 
-interface Activity {
+export interface Activity {
   id: string
   desiredOutcome: DesiredOutcome
   description: string

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -47,4 +47,7 @@ export default {
     emailNotFound: 'Email address not found',
     unknownError: 'Could not find email address due to service interruption; please try again later',
   },
+  actionPlanActivity: {
+    empty: 'Enter an activity',
+  },
 }

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -49,5 +49,7 @@ export default {
   },
   actionPlanActivity: {
     empty: 'Enter an activity',
+    noneAdded: (desiredOutcomeDescription: string) =>
+      `You must add at least one activity for the desired outcome “${desiredOutcomeDescription}”`,
   },
 }

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -7,6 +8,11 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
       {% block formSection %}{% endblock %}

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
@@ -7,7 +7,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h2>
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+      <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
       {% block formSection %}{% endblock %}
     </div>
   </div>

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -1,4 +1,27 @@
 {% extends "./actionPlanFormTemplate.njk" %}
 
 {% block formSection %}
+  <p class="govuk-body-m">This will be shared with the service user's probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
+
+  {% for desiredOutcome in presenter.desiredOutcomes %}
+    <form method="post" action="{{ desiredOutcome.addActivityAction }}">
+      <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      <input type="hidden" name="desired-outcome-id" value="{{ desiredOutcome.id }}">
+
+      <h3 class="govuk-heading-m">
+        Desired outcome {{ loop.index }}
+      </h3>
+
+      <p class="govuk-body">
+      {{ desiredOutcome.description }}
+      </p>
+
+      {% for activity in desiredOutcome.activities %}
+        <h4 class="govuk-heading-s">
+          Activity {{ loop.index }}
+        </h4>
+        <p class="govuk-body">{{ activity.text }}</p>
+      {% endfor %}
+    </form>
+  {% endfor %}
 {% endblock %}

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -1,3 +1,6 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
 {% extends "./actionPlanFormTemplate.njk" %}
 
 {% block formSection %}
@@ -22,6 +25,10 @@
         </h4>
         <p class="govuk-body">{{ activity.text }}</p>
       {% endfor %}
+
+      {{ govukTextarea(addActivityTextareaArgs(loop.index0)) }}
+
+      {{ govukButton({ text: "Add activity", classes: "govuk-button--secondary", attributes: { id: 'add-activity-' + loop.index } }) }}
     </form>
   {% endfor %}
 {% endblock %}

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -31,4 +31,9 @@
       {{ govukButton({ text: "Add activity", classes: "govuk-button--secondary", attributes: { id: 'add-activity-' + loop.index } }) }}
     </form>
   {% endfor %}
+
+  <form method="post" action="{{ presenter.saveAndContinueFormAction }}">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+    {{ govukButton({ text: "Save and continue" }) }}
+  </form>
 {% endblock %}

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -1,17 +1,4 @@
-{% extends "../../partials/layout.njk" %}
+{% extends "./actionPlanFormTemplate.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
-{% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
-
-      <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
-    </div>
-  </div>
+{% block formSection %}
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds page for adding activities to an action plan, viewable at `/service-provider/action-plan/{action-plan-id}/add-activities`.

A service provider user is able to:

- add activities to the action plan for a given desired outcome
- see the activities added so far
- press a button to move to the next page of the action plan journey (currently just the referral progress page), displaying an validation error if they haven't added an activity for each of the referral's desired outcomes

## What is the intent behind these changes?

To allow SPs to add activities to a SU's action plan.

## Screenshots

### Form

![Screenshot_2021-03-15 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/111182286-ad179000-85a6-11eb-9a7e-19c6b6d01f55.png)

### Form when user doesn't enter any text

![Screenshot_2021-03-15 HMPPS Interventions - GOV UK(1)](https://user-images.githubusercontent.com/53756884/111182329-b86abb80-85a6-11eb-9f74-0df7cf0977e8.png)

### Form when user tries to go to next page without adding activities for all desired outcomes

![Screenshot_2021-03-15 HMPPS Interventions - GOV UK(2)](https://user-images.githubusercontent.com/53756884/111182413-cae4f500-85a6-11eb-8f4b-e16551adbde5.png)



