### PR TITLE
IC-1289 add contracts for appointment APIs

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1637,17 +1637,17 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     const actionPlanAppointments = [
       {
         sessionNumber: 1,
-        appointmentTime: '2021-05-13T12:30:000000Z',
+        appointmentTime: '2021-05-13T13:30:00+01:00',
         durationInMinutes: 120,
       },
       {
         sessionNumber: 2,
-        appointmentTime: '2021-05-20T12:30:000000Z',
+        appointmentTime: '2021-05-20T13:30:00+01:00',
         durationInMinutes: 120,
       },
       {
         sessionNumber: 3,
-        appointmentTime: '2021-05-27T12:30:000000Z',
+        appointmentTime: '2021-05-27T13:30:00+01:00',
         durationInMinutes: 120,
       },
     ]
@@ -1681,7 +1681,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   describe('createActionPlanAppointment', () => {
     const actionPlanAppointment = {
       sessionNumber: 1,
-      appointmentTime: '2021-05-13T12:30:000000Z',
+      appointmentTime: '2021-05-13T13:30:00+01:00',
       durationInMinutes: 120,
     }
 
@@ -1720,7 +1720,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   describe('updateActionPlanAppointment', () => {
     const actionPlanAppointment = {
       sessionNumber: 2,
-      appointmentTime: '2021-05-13T12:30:000000Z',
+      appointmentTime: '2021-05-13T13:30:00+01:00',
       durationInMinutes: 60,
     }
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1632,6 +1632,51 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       )
     })
   })
+
+  describe('getActionPlanAppointments', () => {
+    const actionPlanAppointments = [
+      {
+        sessionNumber: 1,
+        appointmentTime: '2021-05-13T12:30:000000Z',
+        durationInMinutes: 120,
+      },
+      {
+        sessionNumber: 2,
+        appointmentTime: '2021-05-20T12:30:000000Z',
+        durationInMinutes: 120,
+      },
+      {
+        sessionNumber: 3,
+        appointmentTime: '2021-05-27T12:30:000000Z',
+        durationInMinutes: 120,
+      },
+    ]
+
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: 'a draft action plan with ID e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d exists and has some appointments',
+        uponReceiving: 'a GET request for the appointments on action plan with ID e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d',
+        withRequest: {
+          method: 'GET',
+          path: '/action-plan/e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d/appointments',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(actionPlanAppointments),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns action plan appointments', async () => {
+      expect(
+        await interventionsService.getActionPlanAppointments(token, 'e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d')
+      ).toMatchObject(actionPlanAppointments)
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1716,6 +1716,47 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       ).toMatchObject(actionPlanAppointment)
     })
   })
+
+  describe('updateActionPlanAppointment', () => {
+    const actionPlanAppointment = {
+      sessionNumber: 2,
+      appointmentTime: '2021-05-13T12:30:000000Z',
+      durationInMinutes: 60,
+    }
+
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state:
+          'a draft action plan with ID 345059d4-1697-467b-8914-fedec9957279 exists and has 2 2-hour appointments already',
+        uponReceiving:
+          'a PATCH request to update the appointment for session 2 to change the duration to an hour on action plan with ID 345059d4-1697-467b-8914-fedec9957279',
+        withRequest: {
+          method: 'PATCH',
+          path: '/action-plan/345059d4-1697-467b-8914-fedec9957279/appointment/2',
+          body: {
+            durationInMinutes: 60,
+          },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        // note - this is an exact match
+        willRespondWith: {
+          status: 200,
+          body: actionPlanAppointment,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns an updated action plan appointment', async () => {
+      expect(
+        await interventionsService.updateActionPlanAppointment(token, '345059d4-1697-467b-8914-fedec9957279', 2, {
+          durationInMinutes: 60,
+        })
+      ).toMatchObject(actionPlanAppointment)
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1677,6 +1677,45 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       ).toMatchObject(actionPlanAppointments)
     })
   })
+
+  describe('createActionPlanAppointment', () => {
+    const actionPlanAppointment = {
+      sessionNumber: 1,
+      appointmentTime: '2021-05-13T12:30:000000Z',
+      durationInMinutes: 120,
+    }
+
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: 'a draft action plan with ID ebe841a8-c33f-4772-8b01-ad58a16e5b6c exists and has no appointments',
+        uponReceiving:
+          'a POST request to create appointment for session 1 on action plan with ID ebe841a8-c33f-4772-8b01-ad58a16e5b6c',
+        withRequest: {
+          method: 'POST',
+          path: '/action-plan/ebe841a8-c33f-4772-8b01-ad58a16e5b6c/appointment',
+          body: actionPlanAppointment,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 201,
+          body: Matchers.like(actionPlanAppointment),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns an action plan appointment', async () => {
+      expect(
+        await interventionsService.createActionPlanAppointment(
+          token,
+          'ebe841a8-c33f-4772-8b01-ad58a16e5b6c',
+          actionPlanAppointment
+        )
+      ).toMatchObject(actionPlanAppointment)
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -165,6 +165,12 @@ export interface ActionPlan {
   submittedAt: string | null
 }
 
+export interface ActionPlanAppointment {
+  sessionNumber: number
+  appointmentTime: string
+  durationInMinutes: number
+}
+
 export default class InterventionsService {
   constructor(private readonly config: ApiConfig) {}
 
@@ -413,5 +419,13 @@ export default class InterventionsService {
       path: `/draft-action-plan/${id}/submit`,
       headers: { Accept: 'application/json' },
     })) as SubmittedActionPlan
+  }
+
+  async getActionPlanAppointments(token: string, id: string): Promise<ActionPlanAppointment[]> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.get({
+      path: `/action-plan/${id}/appointments`,
+      headers: { Accept: 'application/json' },
+    })) as ActionPlanAppointment[]
   }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -421,11 +421,24 @@ export default class InterventionsService {
     })) as SubmittedActionPlan
   }
 
-  async getActionPlanAppointments(token: string, id: string): Promise<ActionPlanAppointment[]> {
+  async getActionPlanAppointments(token: string, actionPlanId: string): Promise<ActionPlanAppointment[]> {
     const restClient = this.createRestClient(token)
     return (await restClient.get({
-      path: `/action-plan/${id}/appointments`,
+      path: `/action-plan/${actionPlanId}/appointments`,
       headers: { Accept: 'application/json' },
     })) as ActionPlanAppointment[]
+  }
+
+  async createActionPlanAppointment(
+    token: string,
+    actionPlanId: string,
+    appointment: ActionPlanAppointment
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.post({
+      path: `/action-plan/${actionPlanId}/appointment`,
+      headers: { Accept: 'application/json' },
+      data: { ...appointment },
+    })) as ActionPlanAppointment
   }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -171,6 +171,11 @@ export interface ActionPlanAppointment {
   durationInMinutes: number
 }
 
+export interface ActionPlanAppointmentUpdate {
+  appointmentTime: string
+  durationInMinutes: number
+}
+
 export default class InterventionsService {
   constructor(private readonly config: ApiConfig) {}
 
@@ -439,6 +444,20 @@ export default class InterventionsService {
       path: `/action-plan/${actionPlanId}/appointment`,
       headers: { Accept: 'application/json' },
       data: { ...appointment },
+    })) as ActionPlanAppointment
+  }
+
+  async updateActionPlanAppointment(
+    token: string,
+    actionPlanId: string,
+    sessionNumber: number,
+    appointmentUpdate: Partial<ActionPlanAppointmentUpdate>
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.patch({
+      path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}`,
+      headers: { Accept: 'application/json' },
+      data: { ...appointmentUpdate },
     })) as ActionPlanAppointment
   }
 }


### PR DESCRIPTION
## What does this pull request do?

adds contracts for creating, updating, getting, and deleting action plan appointments (sessions)

## What is the intent behind these changes?

implement the SP side of viewing appointments/sessions for an assigned referral
