### PR TITLE
IC-1028: Switch off local mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,34 @@ npm run start:dev
 
 Navigate to `http://localhost:3000` and log in:
 
-- To log in as a service provider user, use HMPPS Auth dev credentials e.g. `TEST_INTERVENTIONS_SP_1 / password123456`
+- To log in as a service provider user, use HMPPS Auth dev credentials e.g. `TEST_INTERVENTIONS_SP_1 / password123456` (and, this user has an email address of `test.interventions.sp.1@digital.justice.gov.uk` if you want to assign a referral to them)
 - To log in as a probation practitioner user, use [Community API dev credentials](https://github.com/ministryofjustice/community-api/blob/main/src/main/resources/schema.ldif) e.g. `bernard.beaks/secret`.
 
-### Mocking out the interventions service
+If you need a service user’s CRN in local development, you can use anything from `CRN11` through to `CRN30`.
 
-In development mode, you might want to selectively mock out some calls to the
+### How to use the local services
+
+Sometimes you might find it useful to be able to view or change the data held in the local databases.
+
+#### Interventions service
+
+The interventions service comes already seeded with some referrals.
+
+If you want to connect to the interventions service database, run
+
+```
+psql -h localhost -d interventions -U postgres
+```
+
+and enter a password of `password`. From there you can for example execute `\dt` to see all the tables, and run whatever SQL query you want.
+
+#### HMPPS Auth
+
+To connect to the local HMPPS Auth database, visit http://localhost:8090/auth/h2-console and enter a JDBC URL of `jdbc:h2:mem:authdb`, with empty username and password, then click Connect.
+
+### Mocking out the interventions service locally
+
+In local development mode, you might want to selectively mock out some calls to the
 interventions service. For example, for endpoints that have not yet been built.
 
 You can do this by configuring mocks in [`mocks.ts`](mocks.ts).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm run start:dev
 
 Navigate to `http://localhost:3000` and log in:
 
-- To log in as a service provider user, use HMPPS Auth dev credentials e.g. `AUTH_ADM/password123456`
+- To log in as a service provider user, use HMPPS Auth dev credentials e.g. `TEST_INTERVENTIONS_SP_1 / password123456`
 - To log in as a probation practitioner user, use [Community API dev credentials](https://github.com/ministryofjustice/community-api/blob/main/src/main/resources/schema.ldif) e.g. `bernard.beaks/secret`.
 
 ### Mocking out the interventions service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
     environment:
-      - SPRING_PROFILES_ACTIVE=local
+      - SPRING_PROFILES_ACTIVE=local,seed
       - POSTGRES_URI=postgres:5432
 
   postgres:

--- a/mocks.ts
+++ b/mocks.ts
@@ -1,17 +1,22 @@
 import Wiremock from './mockApis/wiremock'
+/*
 import InterventionsServiceMocks from './mockApis/interventionsService'
 import sentReferralFactory from './testutils/factories/sentReferral'
 import serviceCategoryFactory from './testutils/factories/serviceCategory'
 import interventionFactory from './testutils/factories/intervention'
 import deliusUserFactory from './testutils/factories/deliusUser'
 import actionPlanFactory from './testutils/factories/actionPlan'
+*/
 
 const wiremock = new Wiremock('http://localhost:9092/__admin')
+/*
 const interventionsMocks = new InterventionsServiceMocks(wiremock, '')
+*/
 
 export default async function setUpMocks(): Promise<void> {
   await wiremock.resetStubs()
 
+  /*
   const accommodationServiceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
   const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
 
@@ -106,4 +111,5 @@ export default async function setUpMocks(): Promise<void> {
     }),
     interventionsMocks.stubGetActionPlan(actionPlan.id, actionPlan),
   ])
+  */
 }


### PR DESCRIPTION
## What does this pull request do?

- Turns off the mocks of the intervention service in local development environment
- Adds documentation about how to interact with the locally-running Interventions and HMPPS Auth services

## What is the intent behind these changes?

To use the real interventions service, since at the moment all of the functionality that we require has been built in the real service. This allows us to test things that involve mutations, like adding activities to an action plan.

We might need to turn on some of the mocks again in the future, if there are endpoints that we need that haven't been built yet.
