### PR TITLE
IC-1383 Add subnav to referral overview pages

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -98,8 +98,8 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('.govuk-table__row', 'Jenny Jones').within(() => {
       cy.contains('View').click()
     })
-    cy.location('pathname').should('equal', `/service-provider/referrals/${referralToSelect.id}`)
-    cy.get('h1').contains('Who do you want to assign this social inclusion referral to?')
+    cy.location('pathname').should('equal', `/service-provider/referrals/${referralToSelect.id}/details`)
+    cy.get('h2').contains('Who do you want to assign this referral to?')
     cy.contains('07123456789 | jenny.jones@example.com')
     cy.contains('Social inclusion intervention details')
     cy.contains('Service User makes progress in obtaining accommodation')
@@ -146,9 +146,9 @@ describe('Service provider referrals dashboard', () => {
 
     cy.login()
 
-    cy.visit(`/service-provider/referrals/${referral.id}`)
+    cy.visit(`/service-provider/referrals/${referral.id}/details`)
 
-    cy.get('h1').contains('Who do you want to assign this accommodation referral to?')
+    cy.get('h2').contains('Who do you want to assign this referral to?')
 
     cy.get('#email').type('john@harmonyliving.org.uk')
     cy.contains('Save and continue').click()
@@ -173,7 +173,7 @@ describe('Service provider referrals dashboard', () => {
     cy.location('pathname').should('equal', `/service-provider/dashboard`)
     cy.contains('john.smith')
 
-    cy.visit(`/service-provider/referrals/${referral.id}`)
+    cy.visit(`/service-provider/referrals/${referral.id}/details`)
     cy.contains('This intervention is assigned to John Smith.')
   })
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -54,7 +54,9 @@ export default function routes(router: Router, services: Services): Router {
   })
 
   get('/service-provider/dashboard', (req, res) => serviceProviderReferralsController.showDashboard(req, res))
-  get('/service-provider/referrals/:id', (req, res) => serviceProviderReferralsController.showReferral(req, res))
+  get('/service-provider/referrals/:id/details', (req, res) =>
+    serviceProviderReferralsController.showReferral(req, res)
+  )
   get('/service-provider/referrals/:id/progress', (req, res) =>
     serviceProviderReferralsController.showInterventionProgress(req, res)
   )

--- a/server/routes/referrals/referralDataPresenterUtils.ts
+++ b/server/routes/referrals/referralDataPresenterUtils.ts
@@ -120,4 +120,16 @@ export default class ReferralDataPresenterUtils {
   static fullNameSortValue(serviceUser: ServiceUser): string {
     return `${serviceUser.lastName ?? ''}, ${serviceUser.firstName ?? ''}`.toLocaleLowerCase('en-GB')
   }
+
+  static govukFormattedDateFromStringOrNull(date: string | null): string {
+    const notFoundMessage = 'Not found'
+
+    if (date) {
+      const iso8601date = CalendarDay.parseIso8601(date)
+
+      return iso8601date ? this.govukFormattedDate(iso8601date) : notFoundMessage
+    }
+
+    return notFoundMessage
+  }
 }

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -53,7 +53,7 @@ describe(DashboardPresenter, () => {
           { text: 'George Michael', sortValue: 'michael, george', href: null },
           { text: 'Accommodation', sortValue: null, href: null },
           { text: '', sortValue: null, href: null },
-          { text: 'View', sortValue: null, href: `/service-provider/referrals/${sentReferrals[0].id}` },
+          { text: 'View', sortValue: null, href: `/service-provider/referrals/${sentReferrals[0].id}/details` },
         ],
         [
           { text: '13 Sep 2020', sortValue: '2020-09-13', href: null },
@@ -61,7 +61,7 @@ describe(DashboardPresenter, () => {
           { text: 'Jenny Jones', sortValue: 'jones, jenny', href: null },
           { text: 'Social inclusion', sortValue: null, href: null },
           { text: '', sortValue: null, href: null },
-          { text: 'View', sortValue: null, href: `/service-provider/referrals/${sentReferrals[1].id}` },
+          { text: 'View', sortValue: null, href: `/service-provider/referrals/${sentReferrals[1].id}/details` },
         ],
       ])
     })

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -40,7 +40,7 @@ export default class DashboardPresenter {
 
   private static hrefForViewing(referral: SentReferral): string {
     if (referral.assignedTo === null) {
-      return `/service-provider/referrals/${referral.id}`
+      return `/service-provider/referrals/${referral.id}/details`
     }
 
     return `/service-provider/referrals/${referral.id}/progress`

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -1,6 +1,7 @@
 import InterventionProgressPresenter from './interventionProgressPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import serviceUserFactory from '../../../testutils/factories/deliusServiceUser'
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
 
 describe(InterventionProgressPresenter, () => {
@@ -8,7 +9,8 @@ describe(InterventionProgressPresenter, () => {
     it('returns the relative URL for creating a draft action plan', () => {
       const referral = sentReferralFactory.build()
       const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null)
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser)
 
       expect(presenter.createActionPlanFormAction).toEqual(`/service-provider/referrals/${referral.id}/action-plan`)
     })
@@ -19,7 +21,8 @@ describe(InterventionProgressPresenter, () => {
       it('returns a title to be displayed', () => {
         const referral = sentReferralFactory.build()
         const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null)
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser)
 
         expect(presenter.text).toMatchObject({
           title: 'Accommodation',
@@ -32,7 +35,8 @@ describe(InterventionProgressPresenter, () => {
         it('returns “Not submitted”', () => {
           const referral = sentReferralFactory.build()
           const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null)
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser)
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Not submitted' })
         })
@@ -43,7 +47,8 @@ describe(InterventionProgressPresenter, () => {
           const referral = sentReferralFactory.build()
           const serviceCategory = serviceCategoryFactory.build()
           const actionPlan = actionPlanFactory.notSubmitted().build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan)
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Not submitted' })
         })
@@ -54,7 +59,8 @@ describe(InterventionProgressPresenter, () => {
           const referral = sentReferralFactory.build()
           const serviceCategory = serviceCategoryFactory.build()
           const actionPlan = actionPlanFactory.submitted().build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan)
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Submitted' })
         })
@@ -67,7 +73,8 @@ describe(InterventionProgressPresenter, () => {
       it('returns the inactive style', () => {
         const referral = sentReferralFactory.build()
         const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null)
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser)
 
         expect(presenter.actionPlanStatusStyle).toEqual('inactive')
       })
@@ -78,7 +85,8 @@ describe(InterventionProgressPresenter, () => {
         const referral = sentReferralFactory.build()
         const serviceCategory = serviceCategoryFactory.build()
         const actionPlan = actionPlanFactory.notSubmitted().build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan)
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
 
         expect(presenter.actionPlanStatusStyle).toEqual('inactive')
       })
@@ -89,7 +97,8 @@ describe(InterventionProgressPresenter, () => {
         const referral = sentReferralFactory.build()
         const serviceCategory = serviceCategoryFactory.build()
         const actionPlan = actionPlanFactory.submitted().build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan)
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
 
         expect(presenter.actionPlanStatusStyle).toEqual('active')
       })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -1,12 +1,23 @@
 import { ActionPlan, SentReferral, ServiceCategory } from '../../services/interventionsService'
 import utils from '../../utils/utils'
+import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from './referralOverviewPagePresenter'
+import { DeliusServiceUser } from '../../services/communityApiService'
 
 export default class InterventionProgressPresenter {
+  referralOverviewPagePresenter: ReferralOverviewPagePresenter
+
   constructor(
     private readonly referral: SentReferral,
     private readonly serviceCategory: ServiceCategory,
-    private readonly actionPlan: ActionPlan | null
-  ) {}
+    private readonly actionPlan: ActionPlan | null,
+    serviceUser: DeliusServiceUser
+  ) {
+    this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
+      ReferralOverviewPageSection.Progress,
+      referral,
+      serviceUser
+    )
+  }
 
   readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
 

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -62,6 +62,8 @@ export default class InterventionProgressView {
       'serviceProviderReferrals/interventionProgress',
       {
         presenter: this.presenter,
+        subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
+        serviceUserBannerArgs: this.presenter.referralOverviewPagePresenter.serviceUserBannerArgs,
         initialAssessmentSummaryListArgs: this.initialAssessmentSummaryListArgs.bind(this),
         actionPlanSummaryListArgs: this.actionPlanSummaryListArgs.bind(this),
       },

--- a/server/routes/serviceProviderReferrals/referralOverviewPagePresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/referralOverviewPagePresenter.test.ts
@@ -1,0 +1,44 @@
+import serviceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+
+import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from './referralOverviewPagePresenter'
+
+describe(ReferralOverviewPagePresenter, () => {
+  describe('serviceUserBannerArgs', () => {
+    it('returns the embedded serviceUserBannerArgs', () => {
+      const serviceUser = serviceUserFactory.build()
+      const sentReferral = sentReferralFactory.build()
+      const presenter = new ReferralOverviewPagePresenter(
+        ReferralOverviewPageSection.Details,
+        sentReferral,
+        serviceUser
+      )
+      expect(presenter.serviceUserBannerArgs).toBeDefined()
+    })
+  })
+
+  describe('subNavArgs', () => {
+    it('has the correct tab selected', () => {
+      const serviceUser = serviceUserFactory.build()
+      const sentReferral = sentReferralFactory.build()
+
+      const detailsPresenter = new ReferralOverviewPagePresenter(
+        ReferralOverviewPageSection.Details,
+        sentReferral,
+        serviceUser
+      )
+      let activeTabs = detailsPresenter.subNavArgs.items.filter(x => x.active === true)
+      expect(activeTabs.length).toEqual(1)
+      expect(activeTabs[0].text).toEqual('Referral details')
+
+      const progressPresenter = new ReferralOverviewPagePresenter(
+        ReferralOverviewPageSection.Progress,
+        sentReferral,
+        serviceUser
+      )
+      activeTabs = progressPresenter.subNavArgs.items.filter(x => x.active === true)
+      expect(activeTabs.length).toEqual(1)
+      expect(activeTabs[0].text).toEqual('Progress')
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/referralOverviewPagePresenter.ts
+++ b/server/routes/serviceProviderReferrals/referralOverviewPagePresenter.ts
@@ -1,0 +1,45 @@
+import { DeliusServiceUser } from '../../services/communityApiService'
+import ServiceUserBannerPresenter from './serviceUserBannerPresenter'
+import { SentReferral } from '../../services/interventionsService'
+
+export enum ReferralOverviewPageSection {
+  Progress = 1,
+  CaseNotes,
+  Details,
+}
+
+export default class ReferralOverviewPagePresenter {
+  private serviceUserBannerPresenter: ServiceUserBannerPresenter
+
+  constructor(
+    private readonly section: ReferralOverviewPageSection,
+    private readonly referral: SentReferral,
+    serviceUser: DeliusServiceUser
+  ) {
+    this.serviceUserBannerPresenter = new ServiceUserBannerPresenter(serviceUser)
+  }
+
+  get serviceUserBannerArgs(): Record<string, string> {
+    return this.serviceUserBannerPresenter.serviceUserBannerArgs
+  }
+
+  readonly subNavArgs = {
+    items: [
+      {
+        text: 'Progress',
+        href: `/service-provider/referrals/${this.referral.id}/progress`,
+        active: this.section === ReferralOverviewPageSection.Progress,
+      },
+      {
+        text: 'Case notes',
+        href: `/service-provider/referrals/${this.referral.id}/case-notes`,
+        active: this.section === ReferralOverviewPageSection.CaseNotes,
+      },
+      {
+        text: 'Referral details',
+        href: `/service-provider/referrals/${this.referral.id}/details`,
+        active: this.section === ReferralOverviewPageSection.Details,
+      },
+    ],
+  }
+}

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -76,7 +76,7 @@ describe('GET /service-provider/dashboard', () => {
   })
 })
 
-describe('GET /service-provider/referrals/:id', () => {
+describe('GET /service-provider/referrals/:id/details', () => {
   it('displays information about the referral and service user', async () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const sentReferral = sentReferralFactory.unassigned().build({
@@ -107,10 +107,10 @@ describe('GET /service-provider/referrals/:id', () => {
     communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
 
     await request(app)
-      .get(`/service-provider/referrals/${sentReferral.id}`)
+      .get(`/service-provider/referrals/${sentReferral.id}/details`)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Who do you want to assign this accommodation referral to?')
+        expect(res.text).toContain('Who do you want to assign this referral to?')
         expect(res.text).toContain('Bernard Beaks')
         expect(res.text).toContain('bernard.beaks@justice.gov.uk')
         expect(res.text).toContain('alex.river@example.com')
@@ -134,7 +134,7 @@ describe('GET /service-provider/referrals/:id', () => {
       hmppsAuthClient.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
 
       await request(app)
-        .get(`/service-provider/referrals/${sentReferral.id}`)
+        .get(`/service-provider/referrals/${sentReferral.id}/details`)
         .expect(200)
         .expect(res => {
           expect(res.text).toContain('This intervention is assigned to')
@@ -147,18 +147,20 @@ describe('GET /service-provider/referrals/:id', () => {
 describe('GET /service-provider/referrals/:id/progress', () => {
   it('displays information about the intervention progress', async () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const serviceUser = deliusServiceUser.build()
     const sentReferral = sentReferralFactory.assigned().build({
       referral: { serviceCategoryId: serviceCategory.id },
     })
 
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
+    communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
 
     await request(app)
       .get(`/service-provider/referrals/${sentReferral.id}/progress`)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Accommodation')
+        expect(res.text).toContain('Session progress')
       })
   })
 })
@@ -187,7 +189,7 @@ describe('GET /service-provider/referrals/:id/assignment/check', () => {
     await request(app)
       .get(`/service-provider/referrals/123456/assignment/check`)
       .expect(302)
-      .expect('Location', '/service-provider/referrals/123456?error=An%20email%20address%20is%20required')
+      .expect('Location', '/service-provider/referrals/123456/details?error=An%20email%20address%20is%20required')
   })
   it('redirects to referral details page with an error if the assignee email address is not found in hmpps auth', async () => {
     hmppsAuthClient.getSPUserByEmailAddress.mockRejectedValue(new Error(''))
@@ -195,7 +197,7 @@ describe('GET /service-provider/referrals/:id/assignment/check', () => {
     await request(app)
       .get(`/service-provider/referrals/123456/assignment/check?email=tom@tom.com`)
       .expect(302)
-      .expect('Location', '/service-provider/referrals/123456?error=Email%20address%20not%20found')
+      .expect('Location', '/service-provider/referrals/123456/details?error=Email%20address%20not%20found')
   })
 })
 

--- a/server/routes/serviceProviderReferrals/serviceUserBannerPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceUserBannerPresenter.test.ts
@@ -1,0 +1,49 @@
+import ServiceUserBannerPresenter from './serviceUserBannerPresenter'
+import serviceUserFactory from '../../../testutils/factories/deliusServiceUser'
+
+describe(ServiceUserBannerPresenter, () => {
+  describe('serviceUserBannerArgs', () => {
+    it('has email address or not found message', () => {
+      const serviceUser = serviceUserFactory.build()
+      const emailAddress = serviceUser.contactDetails.emailAddresses![0]
+
+      const presenterWithEmail = new ServiceUserBannerPresenter(serviceUser)
+      expect(presenterWithEmail.serviceUserBannerArgs.html).toContain(emailAddress)
+
+      serviceUser.contactDetails.emailAddresses = null
+      const presenterWithoutEmail = new ServiceUserBannerPresenter(serviceUser)
+      expect(presenterWithoutEmail.serviceUserBannerArgs.html).toContain('Email address not found')
+    })
+    it('has mobile number or not found message', () => {
+      const serviceUser = serviceUserFactory.build()
+      const mobileNumber = serviceUser.contactDetails.phoneNumbers!.filter(x => x.type === 'MOBILE')[0].number
+
+      const presenterWithMobile = new ServiceUserBannerPresenter(serviceUser)
+      expect(presenterWithMobile.serviceUserBannerArgs.html).toContain(mobileNumber)
+
+      serviceUser.contactDetails.phoneNumbers = null
+      const presenterWithoutMobile = new ServiceUserBannerPresenter(serviceUser)
+      expect(presenterWithoutMobile.serviceUserBannerArgs.html).toContain('Mobile number not found')
+    })
+    it('has a formatted date of birth or empty string', () => {
+      const serviceUser = serviceUserFactory.build()
+      serviceUser.dateOfBirth = '1989-02-10'
+      const formattedDOB = '10 February 1989'
+
+      const presenterWithDOB = new ServiceUserBannerPresenter(serviceUser)
+      expect(presenterWithDOB.serviceUserBannerArgs.html).toContain(formattedDOB)
+
+      serviceUser.dateOfBirth = null
+      const presenterWithoutDOB = new ServiceUserBannerPresenter(serviceUser)
+      expect(presenterWithoutDOB.serviceUserBannerArgs.html).toContain('Date of birth: Not found')
+    })
+    it('has a formatted full name', () => {
+      const serviceUser = serviceUserFactory.build()
+      serviceUser.firstName = 'tom'
+      serviceUser.surname = 'jones'
+
+      const presenter = new ServiceUserBannerPresenter(serviceUser)
+      expect(presenter.serviceUserBannerArgs.html).toContain('Tom Jones')
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/serviceUserBannerPresenter.ts
+++ b/server/routes/serviceProviderReferrals/serviceUserBannerPresenter.ts
@@ -1,0 +1,42 @@
+import { DeliusServiceUser } from '../../services/communityApiService'
+import utils from '../../utils/utils'
+import ReferralDataPresenterUtils from '../referrals/referralDataPresenterUtils'
+
+export default class ServiceUserBannerPresenter {
+  constructor(private readonly serviceUser: DeliusServiceUser) {}
+
+  readonly serviceUserBannerArgs = {
+    titleText: 'Service user details',
+    html:
+      `<p class="govuk-notification-banner__heading">${utils.convertToTitleCase(
+        `${this.serviceUser.firstName} ${this.serviceUser.surname}`
+      )}<p>` +
+      `<p>Date of birth: ${ReferralDataPresenterUtils.govukFormattedDateFromStringOrNull(
+        this.serviceUser.dateOfBirth
+      )}</p>` +
+      `<p class="govuk-body">${this.serviceUserMobile} | ${this.serviceUserEmail}</p>`,
+  }
+
+  private get serviceUserEmail(): string {
+    const { emailAddresses } = this.serviceUser.contactDetails
+
+    if (emailAddresses && emailAddresses.length > 0) {
+      return emailAddresses[0]
+    }
+
+    return 'Email address not found'
+  }
+
+  private get serviceUserMobile(): string {
+    const { phoneNumbers } = this.serviceUser.contactDetails
+    const notFoundMessage = 'Mobile number not found'
+
+    if (phoneNumbers) {
+      const mobileNumber = phoneNumbers.find(phoneNumber => phoneNumber.type === 'MOBILE')
+
+      return mobileNumber && mobileNumber.number ? mobileNumber.number : notFoundMessage
+    }
+
+    return notFoundMessage
+  }
+}

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -4,7 +4,6 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import deliusUserFactory from '../../../testutils/factories/deliusUser'
 import deliusServiceUser from '../../../testutils/factories/deliusServiceUser'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
-import { DeliusServiceUser } from '../../services/communityApiService'
 
 describe(ShowReferralPresenter, () => {
   const serviceCategory = serviceCategoryFactory.build({
@@ -84,40 +83,6 @@ describe(ShowReferralPresenter, () => {
   })
 
   describe('text', () => {
-    describe('title', () => {
-      describe('when the referral doesn’t have an assigned caseworker', () => {
-        it('returns a title to be displayed', () => {
-          const sentReferral = sentReferralFactory.build(referralParams)
-          const presenter = new ShowReferralPresenter(
-            sentReferral,
-            serviceCategory,
-            deliusUser,
-            serviceUser,
-            null,
-            null
-          )
-
-          expect(presenter.text.title).toEqual('Who do you want to assign this accommodation referral to?')
-        })
-      })
-
-      describe('when the referral has an assigned caseworker', () => {
-        it('returns a title to be displayed', () => {
-          const sentReferral = sentReferralFactory.assigned().build(referralParams)
-          const presenter = new ShowReferralPresenter(
-            sentReferral,
-            serviceCategory,
-            deliusUser,
-            serviceUser,
-            hmppsAuthUser,
-            null
-          )
-
-          expect(presenter.text.title).toEqual('Accommodation referral for Jenny Jones')
-        })
-      })
-    })
-
     describe('interventionDetailsSummaryHeading', () => {
       it('returns text to be displayed including service category name', () => {
         const sentReferral = sentReferralFactory.assigned().build(referralParams)
@@ -518,52 +483,6 @@ describe(ShowReferralPresenter, () => {
             isList: false,
           },
         ])
-      })
-    })
-  })
-
-  describe('serviceUserNotificationBannerArgs', () => {
-    describe('when all contact details are present on the Delius Service User', () => {
-      it('returns a notification banner with service user details', () => {
-        const referral = sentReferralFactory.build(referralParams)
-        const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, serviceUser, null, null)
-
-        expect(presenter.serviceUserNotificationBannerArgs).toEqual({
-          titleText: 'Service user details',
-          html:
-            `<p class="govuk-notification-banner__heading">Alex River<p>` +
-            `<p>Date of birth: 1 January 1980</p>` +
-            `<p class="govuk-body">07123456789 | alex.river@example.com</p>`,
-        })
-      })
-    })
-
-    describe('if contact details are missing on the Delius Service User', () => {
-      it('displays a useful message to the user in the banner', () => {
-        const sentReferral = sentReferralFactory.build(referralParams)
-        const serviceUserWithoutContactDetails = {
-          firstName: 'Alex',
-          surname: 'River',
-          dateOfBirth: '1980-01-01',
-          contactDetails: {},
-        } as DeliusServiceUser
-
-        const presenter = new ShowReferralPresenter(
-          sentReferral,
-          serviceCategory,
-          deliusUser,
-          serviceUserWithoutContactDetails,
-          null,
-          null
-        )
-
-        expect(presenter.serviceUserNotificationBannerArgs).toEqual({
-          titleText: 'Service user details',
-          html:
-            `<p class="govuk-notification-banner__heading">Alex River<p>` +
-            `<p>Date of birth: 1 January 1980</p>` +
-            `<p class="govuk-body">Mobile number not found | Email address not found</p>`,
-        })
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -1,32 +1,34 @@
 import { AuthUser } from '../../data/hmppsAuthClient'
 import { DeliusServiceUser, DeliusUser } from '../../services/communityApiService'
 import { SentReferral, ServiceCategory } from '../../services/interventionsService'
-import CalendarDay from '../../utils/calendarDay'
 import { SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
 import ReferralDataPresenterUtils from '../referrals/referralDataPresenterUtils'
 import ServiceUserDetailsPresenter from '../referrals/serviceUserDetailsPresenter'
 import { FormValidationError } from '../../utils/formValidationError'
+import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from './referralOverviewPagePresenter'
 
 export default class ShowReferralPresenter {
+  referralOverviewPagePresenter: ReferralOverviewPagePresenter
+
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly serviceCategory: ServiceCategory,
     private readonly sentBy: DeliusUser,
-    private readonly serviceUser: DeliusServiceUser,
+    serviceUser: DeliusServiceUser,
     private readonly assignee: AuthUser | null,
     private readonly assignEmailError: FormValidationError | null
-  ) {}
+  ) {
+    this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
+      ReferralOverviewPageSection.Details,
+      sentReferral,
+      serviceUser
+    )
+  }
 
   readonly assignmentFormAction = `/service-provider/referrals/${this.sentReferral.id}/assignment/check`
 
   readonly text = {
-    title:
-      this.sentReferral.assignedTo === null
-        ? `Who do you want to assign this ${this.serviceCategory.name} referral to?`
-        : `${utils.convertToProperCase(this.serviceCategory.name)} referral for ${ReferralDataPresenterUtils.fullName(
-            this.sentReferral.referral.serviceUser
-          )}`,
     interventionDetailsSummaryHeading: `${utils.convertToProperCase(this.serviceCategory.name)} intervention details`,
     assignedTo: this.assigneeFullNameOrUnassigned,
     errorMessage: ReferralDataPresenterUtils.errorMessage(this.assignEmailError, 'email'),
@@ -58,7 +60,7 @@ export default class ShowReferralPresenter {
       {
         key: 'Date to be completed by',
         lines: [
-          ShowReferralPresenter.govukFormattedDateFromStringOrNull(this.sentReferral.referral.completionDeadline),
+          ReferralDataPresenterUtils.govukFormattedDateFromStringOrNull(this.sentReferral.referral.completionDeadline),
         ],
         isList: false,
       },
@@ -128,51 +130,6 @@ export default class ShowReferralPresenter {
         isList: false,
       },
     ]
-  }
-
-  readonly serviceUserNotificationBannerArgs = {
-    titleText: 'Service user details',
-    html:
-      `<p class="govuk-notification-banner__heading">${this.serviceUser.firstName} ${this.serviceUser.surname}<p>` +
-      `<p>Date of birth: ${ShowReferralPresenter.govukFormattedDateFromStringOrNull(
-        this.serviceUser.dateOfBirth
-      )}</p>` +
-      `<p class="govuk-body">${this.serviceUserMobile} | ${this.serviceUserEmail}</p>`,
-  }
-
-  static govukFormattedDateFromStringOrNull(date: string | null): string {
-    const notFoundMessage = 'Not found'
-
-    if (date) {
-      const iso8601date = CalendarDay.parseIso8601(date)
-
-      return iso8601date ? ReferralDataPresenterUtils.govukFormattedDate(iso8601date) : notFoundMessage
-    }
-
-    return notFoundMessage
-  }
-
-  private get serviceUserEmail(): string {
-    const { emailAddresses } = this.serviceUser.contactDetails
-
-    if (emailAddresses && emailAddresses.length > 0) {
-      return emailAddresses[0]
-    }
-
-    return 'Email address not found'
-  }
-
-  private get serviceUserMobile(): string {
-    const { phoneNumbers } = this.serviceUser.contactDetails
-    const notFoundMessage = 'Mobile number not found'
-
-    if (phoneNumbers) {
-      const mobileNumber = phoneNumbers.find(phoneNumber => phoneNumber.type === 'MOBILE')
-
-      return mobileNumber && mobileNumber.number ? mobileNumber.number : notFoundMessage
-    }
-
-    return notFoundMessage
   }
 
   private get assigneeFullNameOrUnassigned(): string | null {

--- a/server/routes/serviceProviderReferrals/showReferralView.ts
+++ b/server/routes/serviceProviderReferrals/showReferralView.ts
@@ -30,11 +30,12 @@ export default class ShowReferralView {
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [
-      'serviceProviderReferrals/showReferral',
+      'serviceProviderReferrals/referralDetails',
       {
         presenter: this.presenter,
+        subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         probationPractitionerSummaryListArgs: this.probationPractitionerSummaryListArgs,
-        serviceUserNotificationBannerArgs: this.presenter.serviceUserNotificationBannerArgs,
+        serviceUserBannerArgs: this.presenter.referralOverviewPagePresenter.serviceUserBannerArgs,
         interventionDetailsSummaryListArgs: this.interventionDetailsSummaryListArgs,
         serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs,
         serviceUserRisksSummaryListArgs: this.serviceUserRisksSummaryListArgs,

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -8,6 +8,7 @@ export default function nunjucksSetup(app: express.Application, path: pathModule
       path.join(__dirname, '../../server/views'),
       'node_modules/govuk-frontend/',
       'node_modules/govuk-frontend/components/',
+      'node_modules/@ministryofjustice/frontend/',
       'node_modules/@ministryofjustice/frontend/moj/components/',
     ],
     {

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -1,18 +1,9 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% extends "../partials/layout.njk" %}
+{% extends "./referralNavigationTemplate.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
-{% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+{% block referralPageSection %}
 
       <h2 class="govuk-heading-m">Initial assessment appointment</h2>
 
@@ -47,4 +38,5 @@
       </p>
     </div>
   </div>
+
 {% endblock %}

--- a/server/views/serviceProviderReferrals/referralDetails.njk
+++ b/server/views/serviceProviderReferrals/referralDetails.njk
@@ -1,23 +1,8 @@
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
+{% extends "./referralNavigationTemplate.njk" %}
 
-{% extends "../partials/layout.njk" %}
-
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
-{% block content %}
-  {{ govukNotificationBanner(serviceUserNotificationBannerArgs) }}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
-
+{% block referralPageSection %}
       {% if presenter.text.assignedTo == null %}
+        <h2 class="govuk-heading-m">Who do you want to assign this referral to?</h2>
         <form method="get" action={{ presenter.assignmentFormAction }}>
           {{ govukInput(emailInputArgs) }}
           {{ govukButton({ text: "Save and continue" }) }}
@@ -36,6 +21,4 @@
       {{ govukSummaryList(serviceUserNeedsSummaryListArgs) }}
       <h2 class="govuk-heading-m">Referring probation practitioner details</h2>
       {{ govukSummaryList(probationPractitionerSummaryListArgs) }}
-    </div>
-  </div>
 {% endblock %}

--- a/server/views/serviceProviderReferrals/referralNavigationTemplate.njk
+++ b/server/views/serviceProviderReferrals/referralNavigationTemplate.njk
@@ -1,0 +1,23 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
+
+{% block content %}
+  {{ govukNotificationBanner(serviceUserBannerArgs) }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Referral overview</h1>
+
+      {{ mojSubNavigation(subNavArgs) }}
+
+      {% block referralPageSection %}{% endblock %}
+
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a subnav bar to the referall progress and referral details pages. 

Adds some common presenter logic for the SU banner and subnav bar.

Changes the URL of the 'details' page from `/service-provider/referrals/id` to `service-provider/referrals/id/details`

## What is the intent behind these changes?

Improve the overall useability of SP referral interactions
