### PR TITLE
IC-1334 add session progress section to the intervention progress page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "passport": "^0.4.1",
         "passport-oauth2": "^1.5.0",
         "redis": "^3.0.2",
-        "superagent": "^6.1.0"
+        "superagent": "^6.1.0",
+        "timezone-support": "^2.0.2"
       },
       "devDependencies": {
         "@pact-foundation/pact": "^9.13.0",
@@ -16183,6 +16184,25 @@
         "next-tick": "1"
       }
     },
+    "node_modules/timezone-support": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/timezone-support/-/timezone-support-2.0.2.tgz",
+      "integrity": "sha512-J/1PyHCX76vOPuJzCyHMQMH2wTjXCJ30R5EXaS/QTi+xYsL0thS0pubDrHCWnfG4zU1jpPJtctnBBRCOpcJZeQ==",
+      "dependencies": {
+        "commander": "2.20.0"
+      },
+      "bin": {
+        "create-timezone-data": "bin/create-timezone-data"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/timezone-support/node_modules/commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -30937,6 +30957,21 @@
       "requires": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
+      }
+    },
+    "timezone-support": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/timezone-support/-/timezone-support-2.0.2.tgz",
+      "integrity": "sha512-J/1PyHCX76vOPuJzCyHMQMH2wTjXCJ30R5EXaS/QTi+xYsL0thS0pubDrHCWnfG4zU1jpPJtctnBBRCOpcJZeQ==",
+      "requires": {
+        "commander": "2.20.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+        }
       }
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
     "passport": "^0.4.1",
     "passport-oauth2": "^1.5.0",
     "redis": "^3.0.2",
-    "superagent": "^6.1.0"
+    "superagent": "^6.1.0",
+    "timezone-support": "^2.0.2"
   },
   "devDependencies": {
     "@pact-foundation/pact": "^9.13.0",

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -10,9 +10,58 @@ describe(InterventionProgressPresenter, () => {
       const referral = sentReferralFactory.build()
       const serviceCategory = serviceCategoryFactory.build()
       const serviceUser = serviceUserFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser)
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
 
       expect(presenter.createActionPlanFormAction).toEqual(`/service-provider/referrals/${referral.id}/action-plan`)
+    })
+  })
+
+  describe('sessionTableRows', () => {
+    it('returns an empty list if there are no appointments', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+      expect(presenter.sessionTableRows).toEqual([])
+    })
+
+    it('populates the table with formatted session information', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [
+        {
+          sessionNumber: 1,
+          appointmentTime: '2020-12-07T13:00:00.000000Z',
+          durationInMinutes: 120,
+        },
+        {
+          sessionNumber: 2,
+          appointmentTime: null,
+          durationInMinutes: null,
+        },
+      ])
+      expect(presenter.sessionTableRows).toEqual([
+        {
+          sessionNumber: 1,
+          appointmentTime: '2020-12-07T13:00:00.000000Z',
+          tagArgs: {
+            text: 'SCHEDULED',
+            classes: 'govuk-tag--blue',
+          },
+          linkHtml: '<a class="govuk-link" href="#">Reschedule session</a>',
+        },
+        {
+          sessionNumber: 2,
+          appointmentTime: '',
+          tagArgs: {
+            text: 'NOT SCHEDULED',
+            classes: 'govuk-tag--grey',
+          },
+          linkHtml: '<a class="govuk-link" href="#">Edit session details</a>',
+        },
+      ])
     })
   })
 
@@ -22,7 +71,7 @@ describe(InterventionProgressPresenter, () => {
         const referral = sentReferralFactory.build()
         const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser)
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
 
         expect(presenter.text).toMatchObject({
           title: 'Accommodation',
@@ -36,7 +85,7 @@ describe(InterventionProgressPresenter, () => {
           const referral = sentReferralFactory.build()
           const serviceCategory = serviceCategoryFactory.build()
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser)
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Not submitted' })
         })
@@ -48,7 +97,7 @@ describe(InterventionProgressPresenter, () => {
           const serviceCategory = serviceCategoryFactory.build()
           const actionPlan = actionPlanFactory.notSubmitted().build()
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Not submitted' })
         })
@@ -60,7 +109,7 @@ describe(InterventionProgressPresenter, () => {
           const serviceCategory = serviceCategoryFactory.build()
           const actionPlan = actionPlanFactory.submitted().build()
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Submitted' })
         })
@@ -74,7 +123,7 @@ describe(InterventionProgressPresenter, () => {
         const referral = sentReferralFactory.build()
         const serviceCategory = serviceCategoryFactory.build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser)
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
 
         expect(presenter.actionPlanStatusStyle).toEqual('inactive')
       })
@@ -86,7 +135,7 @@ describe(InterventionProgressPresenter, () => {
         const serviceCategory = serviceCategoryFactory.build()
         const actionPlan = actionPlanFactory.notSubmitted().build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
 
         expect(presenter.actionPlanStatusStyle).toEqual('inactive')
       })
@@ -98,7 +147,7 @@ describe(InterventionProgressPresenter, () => {
         const serviceCategory = serviceCategoryFactory.build()
         const actionPlan = actionPlanFactory.submitted().build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
 
         expect(presenter.actionPlanStatusStyle).toEqual('active')
       })
@@ -111,7 +160,7 @@ describe(InterventionProgressPresenter, () => {
         const referral = sentReferralFactory.build()
         const serviceCategory = serviceCategoryFactory.build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser)
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
 
         expect(presenter.allowActionPlanCreation).toEqual(true)
       })
@@ -123,7 +172,7 @@ describe(InterventionProgressPresenter, () => {
         const serviceCategory = serviceCategoryFactory.build()
         const actionPlan = actionPlanFactory.notSubmitted().build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
 
         expect(presenter.allowActionPlanCreation).toEqual(false)
       })
@@ -136,7 +185,7 @@ describe(InterventionProgressPresenter, () => {
       const serviceCategory = serviceCategoryFactory.build()
       const actionPlan = actionPlanFactory.submitted().build()
       const serviceUser = serviceUserFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
 
       expect(presenter.referralAssigned).toEqual(false)
     })
@@ -145,7 +194,7 @@ describe(InterventionProgressPresenter, () => {
       const serviceCategory = serviceCategoryFactory.build()
       const actionPlan = actionPlanFactory.submitted().build()
       const serviceUser = serviceUserFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
 
       expect(presenter.referralAssigned).toEqual(true)
     })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -45,7 +45,7 @@ describe(InterventionProgressPresenter, () => {
       expect(presenter.sessionTableRows).toEqual([
         {
           sessionNumber: 1,
-          appointmentTime: '2020-12-07T13:00:00.000000Z',
+          appointmentTime: '07 Dec 2020, 13:00',
           tagArgs: {
             text: 'SCHEDULED',
             classes: 'govuk-tag--blue',

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -2,6 +2,7 @@ import { ActionPlan, ActionPlanAppointment, SentReferral, ServiceCategory } from
 import utils from '../../utils/utils'
 import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from './referralOverviewPagePresenter'
 import { DeliusServiceUser } from '../../services/communityApiService'
+import dateUtils from '../../utils/dateUtils'
 
 export default class InterventionProgressPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
@@ -53,7 +54,7 @@ export default class InterventionProgressPresenter {
     return this.actionPlanAppointments.map(appointment => {
       return {
         sessionNumber: appointment.sessionNumber,
-        appointmentTime: appointment.appointmentTime || '',
+        appointmentTime: dateUtils.formatDateTimeOrEmptyString(appointment.appointmentTime),
         tagArgs: appointment.appointmentTime
           ? { text: 'SCHEDULED', classes: 'govuk-tag--blue' }
           : { text: 'NOT SCHEDULED', classes: 'govuk-tag--grey' },

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -1,4 +1,4 @@
-import { ActionPlan, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { ActionPlan, ActionPlanAppointment, SentReferral, ServiceCategory } from '../../services/interventionsService'
 import utils from '../../utils/utils'
 import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from './referralOverviewPagePresenter'
 import { DeliusServiceUser } from '../../services/communityApiService'
@@ -10,7 +10,8 @@ export default class InterventionProgressPresenter {
     private readonly referral: SentReferral,
     private readonly serviceCategory: ServiceCategory,
     private readonly actionPlan: ActionPlan | null,
-    serviceUser: DeliusServiceUser
+    serviceUser: DeliusServiceUser,
+    private readonly actionPlanAppointments: ActionPlanAppointment[]
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Progress,
@@ -38,5 +39,28 @@ export default class InterventionProgressPresenter {
 
   get allowActionPlanCreation(): boolean {
     return this.actionPlan === null
+  }
+
+  readonly hasSessions = this.actionPlanAppointments.length !== 0
+
+  readonly sessionTableHeaders = ['Session details', 'Date and time', 'Status', 'Action']
+
+  get sessionTableRows(): Record<string, unknown>[] {
+    if (!this.hasSessions) {
+      return []
+    }
+
+    return this.actionPlanAppointments.map(appointment => {
+      return {
+        sessionNumber: appointment.sessionNumber,
+        appointmentTime: appointment.appointmentTime || '',
+        tagArgs: appointment.appointmentTime
+          ? { text: 'SCHEDULED', classes: 'govuk-tag--blue' }
+          : { text: 'NOT SCHEDULED', classes: 'govuk-tag--grey' },
+        linkHtml: appointment.appointmentTime
+          ? '<a class="govuk-link" href="#">Reschedule session</a>'
+          : '<a class="govuk-link" href="#">Edit session details</a>',
+      }
+    })
   }
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -1,4 +1,4 @@
-import { TagArgs, SummaryListArgs, SummaryListRow } from '../../utils/govukFrontendTypes'
+import { TagArgs, SummaryListArgs, SummaryListRow, TableArgs } from '../../utils/govukFrontendTypes'
 
 import ViewUtils from '../../utils/viewUtils'
 import InterventionProgressPresenter from './interventionProgressPresenter'
@@ -66,6 +66,22 @@ export default class InterventionProgressView {
 
   private readonly actionPlanTagClass = this.presenter.actionPlanStatusStyle === 'active' ? '' : 'govuk-tag--grey'
 
+  private sessionTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
+    return {
+      head: this.presenter.sessionTableHeaders.map((header: string) => {
+        return { text: header }
+      }),
+      rows: this.presenter.sessionTableRows.map(row => {
+        return [
+          { text: `Session ${row.sessionNumber}` },
+          { text: `${row.appointmentTime}` },
+          { text: tagMacro(row.tagArgs as TagArgs) },
+          { html: `${row.linkHtml}` },
+        ]
+      }),
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/interventionProgress',
@@ -75,6 +91,7 @@ export default class InterventionProgressView {
         serviceUserBannerArgs: this.presenter.referralOverviewPagePresenter.serviceUserBannerArgs,
         initialAssessmentSummaryListArgs: this.initialAssessmentSummaryListArgs.bind(this),
         actionPlanSummaryListArgs: this.actionPlanSummaryListArgs.bind(this),
+        sessionTableArgs: this.sessionTableArgs.bind(this),
       },
     ]
   }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -155,8 +155,8 @@ export interface UpdateDraftActionPlanParams {
 
 export interface ActionPlanAppointment {
   sessionNumber: number
-  appointmentTime: string
-  durationInMinutes: number
+  appointmentTime: string | null
+  durationInMinutes: number | null
 }
 
 export interface ActionPlanAppointmentUpdate {
@@ -411,6 +411,14 @@ export default class InterventionsService {
       path: `/action-plan/${actionPlanId}/appointments`,
       headers: { Accept: 'application/json' },
     })) as ActionPlanAppointment[]
+  }
+
+  async getActionPlanAppointment(token: string, actionPlanId: string, session: number): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.get({
+      path: `/action-plan/${actionPlanId}/appointments/${session}`,
+      headers: { Accept: 'application/json' },
+    })) as ActionPlanAppointment
   }
 
   async createActionPlanAppointment(

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,0 +1,24 @@
+import dateUtils from './dateUtils'
+
+describe('dateUtils', () => {
+  describe('formatDateTime', () => {
+    it('returns empty string for null datetime input', () => {
+      expect(dateUtils.formatDateTimeOrEmptyString(null)).toEqual('')
+    })
+
+    it('returns a formatted string with local timezone offset for a valid ISO8601 datetime input', () => {
+      expect(dateUtils.formatDateTimeOrEmptyString('2021-02-01T13:00:00Z')).toEqual('01 Feb 2021, 13:00')
+      expect(dateUtils.formatDateTimeOrEmptyString('2021-06-01T13:00:00Z')).toEqual('01 Jun 2021, 14:00')
+      expect(dateUtils.formatDateTimeOrEmptyString('2020-12-07T13:00:00.000000Z')).toEqual('07 Dec 2020, 13:00')
+
+      expect(dateUtils.formatDateTimeOrEmptyString('2021-02-02T00:30:00+01:00')).toEqual('01 Feb 2021, 23:30')
+      expect(dateUtils.formatDateTimeOrEmptyString('2021-06-02T00:30:00+01:00')).toEqual('02 Jun 2021, 00:30')
+    })
+
+    it('returns an emtpy string for invalid datetime input', () => {
+      expect(dateUtils.formatDateTimeOrEmptyString(' ')).toEqual('')
+      expect(dateUtils.formatDateTimeOrEmptyString('abcdefg')).toEqual('')
+      expect(dateUtils.formatDateTimeOrEmptyString('2021-06-02T00:30:00+01000:00')).toEqual('')
+    })
+  })
+})

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,0 +1,32 @@
+import { findTimeZone, getZonedTime } from 'timezone-support'
+
+function getMonthName(num: number): string {
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec']
+  return months[num - 1]
+}
+
+function formatDateTimeOrEmptyString(d: string | null): string {
+  if (d === null) {
+    return ''
+  }
+
+  const date = new Date(d)
+
+  if (Number.isNaN(Number(date))) {
+    return ''
+  }
+
+  const ukDate = getZonedTime(date, findTimeZone('Europe/London'))
+
+  const { year } = ukDate
+  const month = getMonthName(ukDate.month)
+  const day = `0${ukDate.day}`.slice(-2)
+  const hour = `0${ukDate.hours}`.slice(-2)
+  const minutes = `0${ukDate.minutes}`.slice(-2)
+
+  return `${day} ${month} ${year}, ${hour}:${minutes}`
+}
+
+export default {
+  formatDateTimeOrEmptyString,
+}

--- a/server/utils/govukFrontendTypes.ts
+++ b/server/utils/govukFrontendTypes.ts
@@ -48,3 +48,15 @@ export interface TagArgs {
   classes?: string
   attributes?: Record<string, string>
 }
+
+interface TableRowItem {
+  text?: string
+  html?: string
+}
+
+export type TableRows = TableRowItem[][]
+
+export interface TableArgs {
+  head: TableRowItem[]
+  rows: TableRows
+}

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% extends "./referralNavigationTemplate.njk" %}
 
@@ -39,16 +40,20 @@
       {% endif %}
 
       <h2 class="govuk-heading-m">Session progress</h2>
-
       <p class="govuk-body">
-      Track the progress of each intervention session.
+        Track the progress of each intervention session.
       </p>
 
-      <p class="govuk-body">
-      Sessions will appear here when the action plan is ready.
-      </p>
+      {% if presenter.hasSessions %}
+        {{ govukTable(sessionTableArgs(govukTag)) }}
+      {% else %}
+          <p class="govuk-body">
+          Sessions will appear here when the action plan is ready.
+          </p>
 
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {% endif %}
+
 
       <h2 class="govuk-heading-m">End of service report</h2>
 


### PR DESCRIPTION
## What does this pull request do?

Adds a 'session progress' section to the intervention progress page.

This PR also contains is package for parsing ISO8061 date time strings to human readable strings for presentation. 

## What is the intent behind these changes?

Allow SPs to view and update sessions for interventions.

<img width="886" alt="Screenshot 2021-03-24 at 12 58 24" src="https://user-images.githubusercontent.com/63233073/112314230-affa3b00-8ca0-11eb-9bab-2079ae00c161.png">
