### PR TITLE
IC-1388 add 'back' link to referral navigation template to return easily to the SP dashboard

### DIFF
--- a/server/views/serviceProviderReferrals/referralNavigationTemplate.njk
+++ b/server/views/serviceProviderReferrals/referralNavigationTemplate.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -12,6 +13,12 @@
   {{ govukNotificationBanner(serviceUserBannerArgs) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+        {{ govukBackLink({
+          text: "Back",
+          href: "/service-provider/dashboard"
+        }) }}
+
       <h1 class="govuk-heading-l">Referral overview</h1>
 
       {{ mojSubNavigation(subNavArgs) }}


### PR DESCRIPTION


## What does this pull request do?

IC-1388 add 'back' link to referral navigation template to return easily to the SP dashboard

## What is the intent behind these changes?

make it easier to return without using browser back button
