### PR TITLE
IC-1233: Escape HTML to fix HTML injection vulnerabilities

### DIFF
--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -1,3 +1,4 @@
+import ViewUtils from '../../utils/viewUtils'
 import DashboardPresenter from './dashboardPresenter'
 
 export default class DashboardView {
@@ -8,7 +9,10 @@ export default class DashboardView {
       firstCellIsHeader: true,
       head: [{ text: 'Service User' }, { text: 'Started on' }],
       rows: this.presenter.orderedReferrals.map(referral => {
-        return [{ html: `<a href="${referral.url}">${referral.serviceUserFullName}</a>` }, { text: referral.createdAt }]
+        return [
+          { html: `<a href="${ViewUtils.escape(referral.url)}">${ViewUtils.escape(referral.serviceUserFullName)}</a>` },
+          { text: referral.createdAt },
+        ]
       }),
     }
   }

--- a/server/routes/referrals/confirmationView.ts
+++ b/server/routes/referrals/confirmationView.ts
@@ -1,3 +1,4 @@
+import ViewUtils from '../../utils/viewUtils'
 import ConfirmationPresenter from './confirmationPresenter'
 
 export default class ConfirmationView {
@@ -5,7 +6,9 @@ export default class ConfirmationView {
 
   private readonly panelArgs = {
     titleText: this.presenter.text.title,
-    html: `${this.presenter.text.referenceNumberIntro}<br><strong>${this.presenter.text.referenceNumber}`,
+    html: `${ViewUtils.escape(this.presenter.text.referenceNumberIntro)}<br><strong>${ViewUtils.escape(
+      this.presenter.text.referenceNumber
+    )}`,
   }
 
   get renderArgs(): [string, Record<string, unknown>] {

--- a/server/routes/referrals/confirmationView.ts
+++ b/server/routes/referrals/confirmationView.ts
@@ -8,7 +8,7 @@ export default class ConfirmationView {
     titleText: this.presenter.text.title,
     html: `${ViewUtils.escape(this.presenter.text.referenceNumberIntro)}<br><strong>${ViewUtils.escape(
       this.presenter.text.referenceNumber
-    )}`,
+    )}</strong>`,
   }
 
   get renderArgs(): [string, Record<string, unknown>] {


### PR DESCRIPTION
## What does this pull request do?

Uses `ViewUtils.escape` to escape anywhere we're rendering pure HTML in GOV UK components. Although some of these are probably over the top (e.g. escaping `href`s), it feels safest to escape everything.

I haven't worried about escaping the `staticContentController` views or methods, as these won't be part of the production UI.

## What is the intent behind these changes?

To ensure we don't unwillingly render any HTML in our views where we pass pure HTML to a GOV UK component.
