### PR TITLE
do not show tables and buttons on intervention progress page for unassigned interventions

### DIFF
--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -129,4 +129,25 @@ describe(InterventionProgressPresenter, () => {
       })
     })
   })
+
+  describe('referralAssigned', () => {
+    it('returns false when the referral has no assignee', () => {
+      const referral = sentReferralFactory.unassigned().build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const actionPlan = actionPlanFactory.submitted().build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
+
+      expect(presenter.referralAssigned).toEqual(false)
+    })
+    it('returns true when the referral has an assignee', () => {
+      const referral = sentReferralFactory.assigned().build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const actionPlan = actionPlanFactory.submitted().build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
+
+      expect(presenter.referralAssigned).toEqual(true)
+    })
+  })
 })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -19,6 +19,10 @@ export default class InterventionProgressPresenter {
     )
   }
 
+  get referralAssigned(): boolean {
+    return this.referral.assignedTo !== null
+  }
+
   readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
 
   readonly text = {

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -7,19 +7,36 @@
 
       <h2 class="govuk-heading-m">Initial assessment appointment</h2>
 
-      <p class="govuk-body">
-      Complete the initial assessment within 10 working days from receiving a new referral. Once you enter the appointment details, you will be able to change them.
-      </p>
+      {% if presenter.referralAssigned %}
+          <p class="govuk-body">
+          Complete the initial assessment within 10 working days from receiving a new referral. Once you enter the appointment details, you will be able to change them.
+          </p>
 
-      {{ govukSummaryList(initialAssessmentSummaryListArgs(govukTag)) }}
+          {{ govukSummaryList(initialAssessmentSummaryListArgs(govukTag)) }}
+      {% else %}
+            <p class="govuk-body">
+            Once a caseworker has been assigned the initial assessment can be booked.
+            </p>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {% endif %}
 
       <h2 class="govuk-heading-m">Action plan</h2>
+
+       {% if presenter.referralAssigned %}
 
       <p class="govuk-body">
       Please complete the service user’s action plan and submit it to the probation practitioner for approval.
       </p>
 
       {{ govukSummaryList(actionPlanSummaryListArgs(govukTag, csrfToken)) }}
+
+      {% else %}
+            <p class="govuk-body">
+            Once a caseworker has been assigned the action plan can be sumbitted.
+            </p>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+      {% endif %}
 
       <h2 class="govuk-heading-m">Session progress</h2>
 
@@ -30,6 +47,8 @@
       <p class="govuk-body">
       Sessions will appear here when the action plan is ready.
       </p>
+
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <h2 class="govuk-heading-m">End of service report</h2>
 


### PR DESCRIPTION

## What does this pull request do?

do not show tables and buttons on intervention progress page for unassigned interventions

## What is the intent behind these changes?
avoid the potential for action plan/initial assessment to be started without a caseworker being assigned.

<img width="899" alt="Screenshot 2021-03-17 at 17 04 50" src="https://user-images.githubusercontent.com/63233073/111507820-f4d31e80-8742-11eb-83b5-bdeda3c5c78d.png">

