### PR TITLE
Hide create action plan button if one already exists

### DIFF
--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -104,4 +104,29 @@ describe(InterventionProgressPresenter, () => {
       })
     })
   })
+
+  describe('allowActionPlanCreation', () => {
+    describe('when there is no action plan', () => {
+      it('returns true', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser)
+
+        expect(presenter.allowActionPlanCreation).toEqual(true)
+      })
+    })
+
+    describe('when there is an action plan', () => {
+      it('returns false', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build()
+        const actionPlan = actionPlanFactory.notSubmitted().build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser)
+
+        expect(presenter.allowActionPlanCreation).toEqual(false)
+      })
+    })
+  })
 })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -31,4 +31,8 @@ export default class InterventionProgressPresenter {
   private get actionPlanSubmitted() {
     return this.actionPlan !== null && this.actionPlan.submittedAt !== null
   }
+
+  get allowActionPlanCreation(): boolean {
+    return this.actionPlan === null
+  }
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -1,4 +1,4 @@
-import { TagArgs, SummaryListArgs } from '../../utils/govukFrontendTypes'
+import { TagArgs, SummaryListArgs, SummaryListRow } from '../../utils/govukFrontendTypes'
 
 import ViewUtils from '../../utils/viewUtils'
 import InterventionProgressPresenter from './interventionProgressPresenter'
@@ -34,31 +34,34 @@ export default class InterventionProgressView {
   }
 
   private actionPlanSummaryListArgs(tagMacro: (args: TagArgs) => string, csrfToken: string): SummaryListArgs {
-    return {
-      rows: [
-        {
-          key: { text: 'Action plan status' },
-          value: {
-            text: tagMacro({
-              text: this.presenter.text.actionPlanStatus,
-              classes: this.actionPlanTagClass,
-              attributes: { id: 'action-plan-status' },
-            }),
-          },
+    const rows: SummaryListRow[] = [
+      {
+        key: { text: 'Action plan status' },
+        value: {
+          text: tagMacro({
+            text: this.presenter.text.actionPlanStatus,
+            classes: this.actionPlanTagClass,
+            attributes: { id: 'action-plan-status' },
+          }),
         },
-        {
-          key: { text: 'Action' },
-          value: {
-            html: `<form method="post" action="${ViewUtils.escape(this.presenter.createActionPlanFormAction)}">
-                     <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken)}">
-                     <button class="govuk-button govuk-button--secondary">
-                       Create action plan
-                     </button>
-                   </form>`,
-          },
+      },
+    ]
+
+    if (this.presenter.allowActionPlanCreation) {
+      rows.push({
+        key: { text: 'Action' },
+        value: {
+          html: `<form method="post" action="${ViewUtils.escape(this.presenter.createActionPlanFormAction)}">
+                   <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken)}">
+                   <button class="govuk-button govuk-button--secondary">
+                     Create action plan
+                   </button>
+                 </form>`,
         },
-      ],
+      })
     }
+
+    return { rows }
   }
 
   private readonly actionPlanTagClass = this.presenter.actionPlanStatusStyle === 'active' ? '' : 'govuk-tag--grey'

--- a/server/utils/govukFrontendTypes.ts
+++ b/server/utils/govukFrontendTypes.ts
@@ -33,7 +33,7 @@ export interface SummaryListArgs {
   rows: SummaryListRow[]
 }
 
-interface SummaryListRow {
+export interface SummaryListRow {
   key: { text: string }
   value: { html?: string; text?: string }
 }


### PR DESCRIPTION
## What does this pull request do?

Hides the "Create action plan" button on the service provider intervention progress page if an action plan already exists for that referral.

## What is the intent behind these changes?

To prevent the user from creating multiple action plans for a referral (which isn't supported by the backend).