### PR TITLE
Add missing page number to activities page

### DIFF
--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -43,6 +43,7 @@ export default class AddActionPlanActivitiesPresenter {
 
   readonly text = {
     title: `${utils.convertToProperCase(this.serviceCategory.name)} - create action plan`,
+    pageNumber: 1,
     subTitle: `Add suggested activities to ${this.sentReferral.referral.serviceUser.firstName}’s action plan`,
   }
 


### PR DESCRIPTION
## What does this pull request do?

Adds the missing "Page 1 of 3" to the service provider action plan add activities page.

## What is the intent behind these changes?

To fix the missing page number.