### PR TITLE
IC-1400: Add contract for updating Sentence ID

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -434,6 +434,41 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(referral.furtherInformation).toBe('Some information about the service user')
     })
 
+    it('returns the updated referral when selecting the relevant sentence', async () => {
+      await provider.addInteraction({
+        state: 'There is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962',
+        uponReceiving: 'a PATCH request to update the sentence ID',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/d496e4a7-7cc1-44ea-ba67-c295084f1962',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: {
+            relevantSentenceId: 2600295124,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
+            relevantSentenceId: 2600295124,
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962', {
+        relevantSentenceId: 2600295124,
+      })
+      expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
+      expect(referral.relevantSentenceId).toEqual(2600295124)
+    })
+
     it('returns the updated referral when selecting desired outcomes', async () => {
       await provider.addInteraction({
         state:
@@ -956,6 +991,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
       complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
       furtherInformation: 'Some information about the service user',
+      relevantSentenceId: 2600295124,
       desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
       additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
       accessibilityNeeds: 'She uses a wheelchair',

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -21,6 +21,7 @@ export interface ReferralFields {
   serviceCategoryId: string
   complexityLevelId: string
   furtherInformation: string
+  relevantSentenceId: number
   desiredOutcomesIds: string[]
   additionalNeedsInformation: string
   accessibilityNeeds: string

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -58,6 +58,7 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   serviceCategoryId: null,
   complexityLevelId: null,
   furtherInformation: null,
+  relevantSentenceId: null,
   desiredOutcomesIds: null,
   additionalNeedsInformation: null,
   accessibilityNeeds: null,

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -12,6 +12,7 @@ const exampleReferralFields = () => {
     serviceCategoryId: serviceCategoryFactory.build().id,
     complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
     furtherInformation: 'Some information about the service user',
+    relevantSentenceId: 2600295124,
     desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
     additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
     accessibilityNeeds: 'She uses a wheelchair',


### PR DESCRIPTION
## What does this pull request do?

Adds a contract test for updating the referral on the Interventions Service with a Sentence ID.

Users will select the relevant sentence in the Refer journey based on values fetched from the Community API for that Service User's CRN.

## What is the intent behind these changes?

The sentence against which the referral is being made must be associated with the referral by way of a sentence identifier from nDelius. This must be recorded for every referral. 
