### PR TITLE
IC-1387: Add manual deployment to user research environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,21 @@ workflows:
             - vulnerability_scan_and_monitor
           context:
             - hmpps-common-vars
+      - approve_research:
+          type: approval
+          requires:
+            - deploy_dev
+      - hmpps/deploy_env:
+          name: deploy_research
+          env: "research"
+          retrieve_secrets: "none"
+          slack_notification: true
+          slack_channel_name: "interventions-dev-notifications"
+          requires:
+            - approve_research
+          context:
+            - hmpps-common-vars
+            - hmpps-interventions-ui-research
       - approve_preprod:
           type: approval
           requires:

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -1,0 +1,21 @@
+replicaCount: 2
+
+image:
+  repository: quay.io/hmpps/hmpps-interventions-ui
+  tag: latest
+  pullPolicy: IfNotPresent
+  port: 3000
+
+ingress:
+  enabled: true
+  host: hmpps-interventions-ui-research.apps.live-1.cloud-platform.service.justice.gov.uk
+  path: /
+
+env:
+  HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+  COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
+  OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/
+  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+  TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
+  TOKEN_VERIFICATION_ENABLED: true
+  REDIS_TLS_ENABLED: true


### PR DESCRIPTION
## What does this pull request do?

Adds a manual deployment "gate" to CircleCI.

There will be a new "approve_research" and "deploy_research" button, similar to the preprod ones:

![image](https://user-images.githubusercontent.com/1526295/112001998-5dd9de00-8b17-11eb-870d-7383dfd24355.png)


## What is the intent behind these changes?

To enable user research.