### PR TITLE
IC-1401 & IC-1402: Allow users to select relevant sentence on a referral

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -2,6 +2,7 @@ import draftReferralFactory from '../../testutils/factories/draftReferral'
 import sentReferralFactory from '../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
+import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 
 describe('Referral form', () => {
   beforeEach(() => {
@@ -76,6 +77,38 @@ describe('Referral form', () => {
       maximumRarDays: 10,
     }
 
+    const convictionWithSentenceToSelect = deliusConvictionFactory.build({
+      convictionId: 123456789,
+      active: true,
+      offences: [
+        {
+          mainOffence: true,
+          detail: {
+            mainCategoryDescription: 'Burglary',
+            subCategoryDescription: 'Theft act, 1968',
+          },
+        },
+        {
+          mainOffence: false,
+          detail: {
+            mainCategoryDescription: 'Common and other types of assault',
+            subCategoryDescription: 'Common assault and battery',
+          },
+        },
+      ],
+      sentence: {
+        sentenceId: 2500284169,
+        description: 'Absolute/Conditional Discharge',
+        expectedSentenceEndDate: '2025-11-15',
+        sentenceType: {
+          code: 'SC',
+          description: 'CJA - Indeterminate Public Prot.',
+        },
+      },
+    })
+
+    const convictions = [convictionWithSentenceToSelect, deliusConvictionFactory.build()]
+
     const sentReferral = sentReferralFactory.fromFields(completedDraftReferral).build()
 
     cy.stubGetServiceUserByCRN('X320741', deliusServiceUser)
@@ -86,6 +119,7 @@ describe('Referral form', () => {
     cy.stubPatchDraftReferral(draftReferral.id, draftReferral)
     cy.stubSendDraftReferral(draftReferral.id, sentReferral)
     cy.stubGetSentReferral(sentReferral.id, sentReferral)
+    cy.stubGetActiveConvictionsByCRN('X320741', convictions)
 
     cy.login()
 
@@ -141,7 +175,15 @@ describe('Referral form', () => {
     cy.contains('Save and continue').click()
 
     cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
-    cy.contains('Select desired outcomes').click()
+
+    cy.contains('Select the relevant sentence for the accommodation referral').click()
+
+    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/relevant-sentence`)
+    cy.get('h1').contains('Select the relevant sentence for the accommodation referral')
+
+    cy.contains('Burglary').click()
+
+    cy.contains('Save and continue').click()
 
     cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/desired-outcomes`)
     cy.get('h1').contains('What are the desired outcomes for the accommodation service?')

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -65,6 +65,7 @@ describe('Referral form', () => {
       completionDeadline: '2021-04-01',
       complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
       furtherInformation: 'Some information about the service user',
+      relevantSentenceId: 12345678910,
       desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
       additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
       accessibilityNeeds: 'She uses a wheelchair',

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -41,6 +41,10 @@ module.exports = on => {
       return communityApi.stubGetUserByUsername(arg.username, arg.responseJson)
     },
 
+    stubGetActiveConvictionsByCRN: arg => {
+      return communityApi.stubGetActiveConvictionsByCRN(arg.crn, arg.responseJson)
+    },
+
     stubGetDraftReferral: arg => {
       return interventionsService.stubGetDraftReferral(arg.id, arg.responseJson)
     },

--- a/integration_tests/support/communityApiStubs.js
+++ b/integration_tests/support/communityApiStubs.js
@@ -5,3 +5,7 @@ Cypress.Commands.add('stubGetServiceUserByCRN', (crn, responseJson) => {
 Cypress.Commands.add('stubGetUserByUsername', (username, responseJson) => {
   cy.task('stubGetUserByUsername', { username, responseJson })
 })
+
+Cypress.Commands.add('stubGetActiveConvictionsByCRN', (crn, responseJson) => {
+  cy.task('stubGetActiveConvictionsByCRN', { crn, responseJson })
+})

--- a/mockApis/communityApi.ts
+++ b/mockApis/communityApi.ts
@@ -34,4 +34,20 @@ export default class CommunityApiMocks {
       },
     })
   }
+
+  stubGetActiveConvictionsByCRN = async (crn: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/community-api/secure/offenders/crn/${crn}/convictions`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -127,6 +127,8 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals/:id/completion-deadline', (req, res) => referralsController.updateCompletionDeadline(req, res))
   get('/referrals/:id/further-information', (req, res) => referralsController.viewFurtherInformation(req, res))
   post('/referrals/:id/further-information', (req, res) => referralsController.updateFurtherInformation(req, res))
+  get('/referrals/:id/relevant-sentence', (req, res) => referralsController.viewRelevantSentence(req, res))
+  post('/referrals/:id/relevant-sentence', (req, res) => referralsController.updateRelevantSentence(req, res))
   get('/referrals/:id/desired-outcomes', (req, res) => referralsController.viewDesiredOutcomes(req, res))
   post('/referrals/:id/desired-outcomes', (req, res) => referralsController.updateDesiredOutcomes(req, res))
   get('/referrals/:id/needs-and-requirements', (req, res) => referralsController.viewNeedsAndRequirements(req, res))

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -74,6 +74,7 @@ describe('ReferralFormPresenter', () => {
           serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
           complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
           furtherInformation: 'Some information about the service user',
+          relevantSentenceId: 123456789,
           desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
           additionalNeedsInformation: null,
           accessibilityNeeds: null,

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -31,7 +31,7 @@ describe('ReferralFormPresenter', () => {
             number: '2',
             status: ReferralFormStatus.NotStarted,
             tasks: [
-              { title: 'Select the relevant sentence for the social inclusion referral', url: null },
+              { title: 'Select the relevant sentence for the social inclusion referral', url: 'relevant-sentence' },
               { title: 'Select desired outcomes', url: 'desired-outcomes' },
               { title: 'Select required complexity level', url: 'complexity-level' },
               {
@@ -105,7 +105,7 @@ describe('ReferralFormPresenter', () => {
             number: '2',
             status: ReferralFormStatus.Completed,
             tasks: [
-              { title: 'Select the relevant sentence for the accommodation referral', url: null },
+              { title: 'Select the relevant sentence for the accommodation referral', url: 'relevant-sentence' },
               { title: 'Select desired outcomes', url: 'desired-outcomes' },
               { title: 'Select required complexity level', url: 'complexity-level' },
               {

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -86,6 +86,7 @@ export default class ReferralFormPresenter {
 
   private determineInterventionDetailsSectionStatus(): ReferralFormStatus {
     const hasCompletedSection = [
+      this.referral.relevantSentenceId,
       this.referral.desiredOutcomesIds,
       this.referral.complexityLevelId,
       this.referral.completionDeadline,

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -33,7 +33,7 @@ export default class ReferralFormPresenter {
         tasks: [
           {
             title: `Select the relevant sentence for the ${this.serviceCategoryName} referral`,
-            url: null,
+            url: 'relevant-sentence',
           },
           {
             title: 'Select desired outcomes',

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -35,6 +35,9 @@ import logger from '../../../log'
 import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
 import ServiceUserDetailsView from './serviceUserDetailsView'
 import ReferralStartForm from './referralStartForm'
+import RelevantSentencePresenter from './relevantSentencePresenter'
+import RelevantSentenceView from './relevantSentenceView'
+import RelevantSentenceForm from './relevantSentenceForm'
 
 export default class ReferralsController {
   constructor(
@@ -138,6 +141,73 @@ export default class ReferralsController {
     const view = new ReferralFormView(presenter)
 
     res.render(...view.renderArgs)
+  }
+
+  async viewRelevantSentence(req: Request, res: Response): Promise<void> {
+    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+    if (referral.serviceCategoryId === null) {
+      throw new Error('Attempting to view relevant sentence without service category selected')
+    }
+
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      res.locals.user.token,
+      referral.serviceCategoryId
+    )
+
+    const convictions = await this.communityApiService.getActiveConvictionsByCRN(referral.serviceUser.crn)
+
+    if (convictions.length < 1) {
+      throw new Error(`No active convictions found for service user ${referral.serviceUser.crn}`)
+    }
+
+    const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+    const view = new RelevantSentenceView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async updateRelevantSentence(req: Request, res: Response): Promise<void> {
+    const form = await RelevantSentenceForm.createForm(req)
+
+    let error: FormValidationError | null = null
+
+    if (form.isValid) {
+      try {
+        await this.interventionsService.patchDraftReferral(res.locals.user.token, req.params.id, form.paramsForUpdate)
+      } catch (e) {
+        error = createFormValidationErrorOrRethrow(e)
+      }
+    } else {
+      error = form.error
+    }
+
+    if (!error) {
+      res.redirect(`/referrals/${req.params.id}/desired-outcomes`)
+    } else {
+      const referral = await this.interventionsService.getDraftReferral(res.locals.user.token, req.params.id)
+
+      if (!referral.serviceCategoryId) {
+        throw new Error('Attempting to view relevant sentence without service category selected')
+      }
+
+      const serviceCategory = await this.interventionsService.getServiceCategory(
+        res.locals.user.token,
+        referral.serviceCategoryId
+      )
+
+      const convictions = await this.communityApiService.getActiveConvictionsByCRN(referral.serviceUser.crn)
+
+      if (convictions.length < 1) {
+        throw new Error(`No active convictions found for service user ${referral.serviceUser.crn}`)
+      }
+
+      const presenter = new RelevantSentencePresenter(serviceCategory, convictions, error)
+      const view = new RelevantSentenceView(presenter)
+
+      res.status(400)
+      res.render(...view.renderArgs)
+    }
   }
 
   async viewComplexityLevel(req: Request, res: Response): Promise<void> {

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -161,7 +161,7 @@ export default class ReferralsController {
       throw new Error(`No active convictions found for service user ${referral.serviceUser.crn}`)
     }
 
-    const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+    const presenter = new RelevantSentencePresenter(referral, serviceCategory, convictions)
     const view = new RelevantSentenceView(presenter)
 
     res.render(...view.renderArgs)
@@ -202,7 +202,7 @@ export default class ReferralsController {
         throw new Error(`No active convictions found for service user ${referral.serviceUser.crn}`)
       }
 
-      const presenter = new RelevantSentencePresenter(serviceCategory, convictions, error)
+      const presenter = new RelevantSentencePresenter(referral, serviceCategory, convictions, error)
       const view = new RelevantSentenceView(presenter)
 
       res.status(400)

--- a/server/routes/referrals/relevantSentenceForm.test.ts
+++ b/server/routes/referrals/relevantSentenceForm.test.ts
@@ -1,0 +1,82 @@
+import { Request } from 'express'
+import RelevantSentenceForm from './relevantSentenceForm'
+
+describe(RelevantSentenceForm, () => {
+  describe('isValid', () => {
+    it('returns true when the relevant-sentence-id property is present in the body', async () => {
+      const form = await RelevantSentenceForm.createForm({
+        body: { 'relevant-sentence-id': '2500284169' },
+      } as Request)
+
+      expect(form.isValid).toBe(true)
+    })
+
+    it('returns false when the relevant-sentence-id property is absent in the body', async () => {
+      const form = await RelevantSentenceForm.createForm({
+        body: {},
+      } as Request)
+
+      expect(form.isValid).toBe(false)
+    })
+
+    it('returns false when the relevant-sentence-id property is null in the body', async () => {
+      const form = await RelevantSentenceForm.createForm({
+        body: { 'relevant-sentence-id': null },
+      } as Request)
+
+      expect(form.isValid).toBe(false)
+    })
+  })
+
+  describe('error', () => {
+    it('returns null when the relevant-sentence-id property is present in the body', async () => {
+      const form = await RelevantSentenceForm.createForm({
+        body: { 'relevant-sentence-id': '2500284169' },
+      } as Request)
+
+      expect(form.error).toBe(null)
+    })
+
+    it('returns an error object when the relevant-sentence-id property is absent in the body', async () => {
+      const form = await RelevantSentenceForm.createForm({
+        body: {},
+      } as Request)
+
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'relevant-sentence-id',
+            formFields: ['relevant-sentence-id'],
+            message: 'Select the relevant sentence',
+          },
+        ],
+      })
+    })
+
+    it('returns an error object when the relevant-sentence-id property is null in the body', async () => {
+      const form = await RelevantSentenceForm.createForm({
+        body: { 'relevant-sentence-id': null },
+      } as Request)
+
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'relevant-sentence-id',
+            formFields: ['relevant-sentence-id'],
+            message: 'Select the relevant sentence',
+          },
+        ],
+      })
+    })
+  })
+
+  describe('paramsForUpdate', () => {
+    it('returns the params to be sent to the backend, when the data in the body is valid', async () => {
+      const form = await RelevantSentenceForm.createForm({
+        body: { 'relevant-sentence-id': '2500284169' },
+      } as Request)
+
+      expect(form.paramsForUpdate).toEqual({ relevantSentenceId: 2500284169 })
+    })
+  })
+})

--- a/server/routes/referrals/relevantSentenceForm.ts
+++ b/server/routes/referrals/relevantSentenceForm.ts
@@ -1,0 +1,38 @@
+import { Request } from 'express'
+import { DraftReferral } from '../../services/interventionsService'
+import errorMessages from '../../utils/errorMessages'
+import { FormValidationError } from '../../utils/formValidationError'
+
+export default class RelevantSentenceForm {
+  private constructor(private readonly request: Request) {}
+
+  static async createForm(request: Request): Promise<RelevantSentenceForm> {
+    return new RelevantSentenceForm(request)
+  }
+
+  get paramsForUpdate(): Partial<DraftReferral> {
+    return {
+      relevantSentenceId: Number(this.request.body['relevant-sentence-id']),
+    }
+  }
+
+  get isValid(): boolean {
+    return this.request.body['relevant-sentence-id'] !== null && this.request.body['relevant-sentence-id'] !== undefined
+  }
+
+  get error(): FormValidationError | null {
+    if (this.isValid) {
+      return null
+    }
+
+    return {
+      errors: [
+        {
+          formFields: ['relevant-sentence-id'],
+          errorSummaryLinkedField: 'relevant-sentence-id',
+          message: errorMessages.relevantSentence.empty,
+        },
+      ],
+    }
+  }
+}

--- a/server/routes/referrals/relevantSentencePresenter.test.ts
+++ b/server/routes/referrals/relevantSentencePresenter.test.ts
@@ -153,4 +153,62 @@ describe(RelevantSentencePresenter, () => {
       })
     })
   })
+
+  describe('errorSummary', () => {
+    const convictions = deliusConvictionFactory.buildList(2)
+
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
+        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when an error is passed in', () => {
+      it('returns error information', () => {
+        const presenter = new RelevantSentencePresenter(serviceCategory, convictions, {
+          errors: [
+            {
+              formFields: ['relevant-sentence-id'],
+              errorSummaryLinkedField: 'relevant-sentence-id',
+              message: 'Select the relevant sentence',
+            },
+          ],
+        })
+
+        expect(presenter.errorSummary).toEqual([
+          { field: 'relevant-sentence-id', message: 'Select the relevant sentence' },
+        ])
+      })
+    })
+  })
+
+  describe('errorMessage', () => {
+    const convictions = deliusConvictionFactory.buildList(2)
+
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
+        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+
+        expect(presenter.errorMessage).toBeNull()
+      })
+    })
+
+    describe('when an error is passed in', () => {
+      it('returns error information', () => {
+        const presenter = new RelevantSentencePresenter(serviceCategory, convictions, {
+          errors: [
+            {
+              formFields: ['relevant-sentence-id'],
+              errorSummaryLinkedField: 'relevant-sentence-id',
+              message: 'Select the relevant sentence',
+            },
+          ],
+        })
+
+        expect(presenter.errorMessage).toEqual('Select the relevant sentence')
+      })
+    })
+  })
 })

--- a/server/routes/referrals/relevantSentencePresenter.test.ts
+++ b/server/routes/referrals/relevantSentencePresenter.test.ts
@@ -152,6 +152,36 @@ describe(RelevantSentencePresenter, () => {
         expect(presenter.relevantSentenceFields[0].value).toEqual(123456789)
       })
     })
+
+    describe('checked', () => {
+      describe('when there is no user input data', () => {
+        it('sets the `checked` value to `false`', () => {
+          const convictions = deliusConvictionFactory.buildList(2)
+
+          const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+
+          expect(presenter.relevantSentenceFields[0].checked).toBe(false)
+          expect(presenter.relevantSentenceFields[1].checked).toBe(false)
+        })
+      })
+
+      describe('when there is user input data', () => {
+        it('sets checked to true for the sentence that the user chose', () => {
+          const convictionWithSelectedSentence = deliusConvictionFactory.build({ convictionId: 123456789 })
+
+          const convictions = [deliusConvictionFactory.build(), convictionWithSelectedSentence]
+
+          const presenter = new RelevantSentencePresenter(serviceCategory, convictions, null, {
+            'relevant-sentence-id': convictionWithSelectedSentence.convictionId,
+          })
+
+          expect(
+            presenter.relevantSentenceFields.find(field => field.value === convictionWithSelectedSentence.convictionId)!
+              .checked
+          ).toEqual(true)
+        })
+      })
+    })
   })
 
   describe('errorSummary', () => {

--- a/server/routes/referrals/relevantSentencePresenter.test.ts
+++ b/server/routes/referrals/relevantSentencePresenter.test.ts
@@ -1,0 +1,156 @@
+import RelevantSentencePresenter from './relevantSentencePresenter'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
+
+describe(RelevantSentencePresenter, () => {
+  const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+
+  describe('title', () => {
+    it('includes the service category name', () => {
+      const convictions = [deliusConvictionFactory.build()]
+      const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+
+      expect(presenter.title).toEqual('Select the relevant sentence for the social inclusion referral')
+    })
+  })
+
+  describe('relevantSentenceFields', () => {
+    describe('category', () => {
+      it('returns the main offence‘s category', () => {
+        const offences = [
+          {
+            offenceId: 'M2500297061',
+            mainOffence: false,
+            detail: {
+              code: '10400',
+              description: 'Assault on Police Officer - 10400',
+              mainCategoryCode: '104',
+              mainCategoryDescription: 'Assault on Police Officer',
+              mainCategoryAbbreviation: 'Assault on Police Officer',
+              ogrsOffenceCategory: 'Violence',
+              subCategoryCode: '00',
+              subCategoryDescription: 'Assault on Police Officer',
+              form20Code: '88',
+            },
+            offenceDate: '2019-09-09T00:00:00',
+            offenceCount: 1,
+            offenderId: 2500343964,
+            createdDatetime: '2019-09-17T00:00:00',
+            lastUpdatedDatetime: '2019-09-17T00:00:00',
+          },
+          {
+            offenceId: 'M2600297062',
+            mainOffence: true,
+            detail: {
+              code: '10501',
+              description: 'Common assault and battery - 10501',
+              mainCategoryCode: '105',
+              mainCategoryDescription: 'Common and other types of assault',
+              mainCategoryAbbreviation: 'Common and other types of assault',
+              ogrsOffenceCategory: 'Violence',
+              subCategoryCode: '01',
+              subCategoryDescription: 'Common assault and battery',
+              form20Code: '88',
+            },
+            offenceDate: '2019-09-09T00:00:00',
+            offenceCount: 1,
+            offenderId: 2600343964,
+            createdDatetime: '2019-09-17T00:00:00',
+            lastUpdatedDatetime: '2019-09-17T00:00:00',
+          },
+        ]
+
+        const convictions = [deliusConvictionFactory.build({ offences })]
+
+        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+
+        expect(presenter.relevantSentenceFields[0].category).toEqual('Common and other types of assault')
+      })
+    })
+
+    describe('subcategory', () => {
+      it('returns the main offence‘s subcategory', () => {
+        const offences = [
+          {
+            offenceId: 'M2500297061',
+            mainOffence: false,
+            detail: {
+              code: '10400',
+              description: 'Assault on Police Officer - 10400',
+              mainCategoryCode: '104',
+              mainCategoryDescription: 'Assault on Police Officer',
+              mainCategoryAbbreviation: 'Assault on Police Officer',
+              ogrsOffenceCategory: 'Violence',
+              subCategoryCode: '00',
+              subCategoryDescription: 'Assault on Police Officer',
+              form20Code: '88',
+            },
+            offenceDate: '2019-09-09T00:00:00',
+            offenceCount: 1,
+            offenderId: 2500343964,
+            createdDatetime: '2019-09-17T00:00:00',
+            lastUpdatedDatetime: '2019-09-17T00:00:00',
+          },
+          {
+            offenceId: 'M2600297062',
+            mainOffence: true,
+            detail: {
+              code: '10501',
+              description: 'Common assault and battery - 10501',
+              mainCategoryCode: '105',
+              mainCategoryDescription: 'Common and other types of assault',
+              mainCategoryAbbreviation: 'Common and other types of assault',
+              ogrsOffenceCategory: 'Violence',
+              subCategoryCode: '01',
+              subCategoryDescription: 'Common assault and battery',
+              form20Code: '88',
+            },
+            offenceDate: '2019-09-09T00:00:00',
+            offenceCount: 1,
+            offenderId: 2600343964,
+            createdDatetime: '2019-09-17T00:00:00',
+            lastUpdatedDatetime: '2019-09-17T00:00:00',
+          },
+        ]
+
+        const convictions = [deliusConvictionFactory.build({ offences })]
+
+        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+
+        expect(presenter.relevantSentenceFields[0].subcategory).toEqual('Common assault and battery')
+      })
+    })
+
+    describe('endOfSentenceDate', () => {
+      it('uses the GOV UK date format', () => {
+        const convictions = [
+          deliusConvictionFactory.build({
+            sentence: {
+              sentenceId: 2500284169,
+              description: 'Absolute/Conditional Discharge',
+              expectedSentenceEndDate: '2025-09-15',
+              sentenceType: {
+                code: 'SC',
+                description: 'CJA - Indeterminate Public Prot.',
+              },
+            },
+          }),
+        ]
+
+        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+
+        expect(presenter.relevantSentenceFields[0].endOfSentenceDate).toEqual('15 September 2025')
+      })
+    })
+
+    describe('value', () => {
+      it('uses the conviction ID', () => {
+        const convictions = [deliusConvictionFactory.build({ convictionId: 123456789 })]
+
+        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+
+        expect(presenter.relevantSentenceFields[0].value).toEqual(123456789)
+      })
+    })
+  })
+})

--- a/server/routes/referrals/relevantSentencePresenter.test.ts
+++ b/server/routes/referrals/relevantSentencePresenter.test.ts
@@ -1,14 +1,16 @@
 import RelevantSentencePresenter from './relevantSentencePresenter'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
 
 describe(RelevantSentencePresenter, () => {
   const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+  const draftReferral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
 
   describe('title', () => {
     it('includes the service category name', () => {
       const convictions = [deliusConvictionFactory.build()]
-      const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+      const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
 
       expect(presenter.title).toEqual('Select the relevant sentence for the social inclusion referral')
     })
@@ -62,7 +64,7 @@ describe(RelevantSentencePresenter, () => {
 
         const convictions = [deliusConvictionFactory.build({ offences })]
 
-        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
 
         expect(presenter.relevantSentenceFields[0].category).toEqual('Common and other types of assault')
       })
@@ -115,7 +117,7 @@ describe(RelevantSentencePresenter, () => {
 
         const convictions = [deliusConvictionFactory.build({ offences })]
 
-        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
 
         expect(presenter.relevantSentenceFields[0].subcategory).toEqual('Common assault and battery')
       })
@@ -137,7 +139,7 @@ describe(RelevantSentencePresenter, () => {
           }),
         ]
 
-        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
 
         expect(presenter.relevantSentenceFields[0].endOfSentenceDate).toEqual('15 September 2025')
       })
@@ -147,7 +149,7 @@ describe(RelevantSentencePresenter, () => {
       it('uses the conviction ID', () => {
         const convictions = [deliusConvictionFactory.build({ convictionId: 123456789 })]
 
-        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
 
         expect(presenter.relevantSentenceFields[0].value).toEqual(123456789)
       })
@@ -158,10 +160,24 @@ describe(RelevantSentencePresenter, () => {
         it('sets the `checked` value to `false`', () => {
           const convictions = deliusConvictionFactory.buildList(2)
 
-          const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+          const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
 
           expect(presenter.relevantSentenceFields[0].checked).toBe(false)
           expect(presenter.relevantSentenceFields[1].checked).toBe(false)
+        })
+
+        describe('when the referral already has a selected sentence ID', () => {
+          it('sets checked to true for the referral’s selected sentence ID', () => {
+            const convictionWithSelectedSentence = deliusConvictionFactory.build({ convictionId: 123456789 })
+            draftReferral.relevantSentenceId = convictionWithSelectedSentence.convictionId
+
+            const convictions = [deliusConvictionFactory.build(), convictionWithSelectedSentence]
+
+            const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
+
+            expect(presenter.relevantSentenceFields[0].checked).toBe(false)
+            expect(presenter.relevantSentenceFields[1].checked).toBe(true)
+          })
         })
       })
 
@@ -171,7 +187,7 @@ describe(RelevantSentencePresenter, () => {
 
           const convictions = [deliusConvictionFactory.build(), convictionWithSelectedSentence]
 
-          const presenter = new RelevantSentencePresenter(serviceCategory, convictions, null, {
+          const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions, null, {
             'relevant-sentence-id': convictionWithSelectedSentence.convictionId,
           })
 
@@ -179,6 +195,24 @@ describe(RelevantSentencePresenter, () => {
             presenter.relevantSentenceFields.find(field => field.value === convictionWithSelectedSentence.convictionId)!
               .checked
           ).toEqual(true)
+        })
+
+        describe('when the referral already has a selected sentence ID', () => {
+          it('sets checked to true for the sentence that the user chose', () => {
+            draftReferral.relevantSentenceId = 123456789
+
+            const convictionWithSentenceChosenByUser = deliusConvictionFactory.build({ convictionId: 987654321 })
+            const convictionWithSentenceAlreadyOnReferral = deliusConvictionFactory.build({ convictionId: 123456789 })
+
+            const convictions = [convictionWithSentenceAlreadyOnReferral, convictionWithSentenceChosenByUser]
+
+            const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions, null, {
+              'relevant-sentence-id': convictionWithSentenceChosenByUser.convictionId,
+            })
+
+            expect(presenter.relevantSentenceFields[0].checked).toBe(false)
+            expect(presenter.relevantSentenceFields[1].checked).toBe(true)
+          })
         })
       })
     })
@@ -189,7 +223,7 @@ describe(RelevantSentencePresenter, () => {
 
     describe('when no error is passed in', () => {
       it('returns null', () => {
-        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
 
         expect(presenter.errorSummary).toBeNull()
       })
@@ -197,7 +231,7 @@ describe(RelevantSentencePresenter, () => {
 
     describe('when an error is passed in', () => {
       it('returns error information', () => {
-        const presenter = new RelevantSentencePresenter(serviceCategory, convictions, {
+        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions, {
           errors: [
             {
               formFields: ['relevant-sentence-id'],
@@ -219,7 +253,7 @@ describe(RelevantSentencePresenter, () => {
 
     describe('when no error is passed in', () => {
       it('returns null', () => {
-        const presenter = new RelevantSentencePresenter(serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
 
         expect(presenter.errorMessage).toBeNull()
       })
@@ -227,7 +261,7 @@ describe(RelevantSentencePresenter, () => {
 
     describe('when an error is passed in', () => {
       it('returns error information', () => {
-        const presenter = new RelevantSentencePresenter(serviceCategory, convictions, {
+        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions, {
           errors: [
             {
               formFields: ['relevant-sentence-id'],

--- a/server/routes/referrals/relevantSentencePresenter.ts
+++ b/server/routes/referrals/relevantSentencePresenter.ts
@@ -1,0 +1,42 @@
+import { DeliusConviction } from '../../services/communityApiService'
+import { ServiceCategory } from '../../services/interventionsService'
+import PresenterUtils from '../../utils/presenterUtils'
+
+export default class RelevantSentencePresenter {
+  constructor(private readonly serviceCategory: ServiceCategory, private readonly convictions: DeliusConviction[]) {}
+
+  readonly title = `Select the relevant sentence for the ${this.serviceCategory.name.toLocaleLowerCase()} referral`
+
+  get relevantSentenceFields(): {
+    category: string
+    subcategory: string
+    endOfSentenceDate: string
+    value: number
+    checked: boolean
+  }[] {
+    return this.convictions.map(conviction => {
+      if (!conviction.offences) {
+        throw new Error(`No offences found for conviction id: ${conviction.convictionId}`)
+      }
+
+      if (!conviction.sentence) {
+        throw new Error(`No sentences found for conviction id: ${conviction.convictionId}`)
+      }
+
+      const mainOffence = conviction.offences.find(offence => offence.mainOffence)
+
+      if (!mainOffence) {
+        throw new Error('No main offence found')
+      }
+
+      return {
+        category: mainOffence.detail.mainCategoryDescription,
+        subcategory: mainOffence.detail.subCategoryDescription,
+        endOfSentenceDate:
+          PresenterUtils.govukFormattedDateFromStringOrNull(conviction.sentence.expectedSentenceEndDate) ?? 'Not found',
+        value: conviction.convictionId,
+        checked: false,
+      }
+    })
+  }
+}

--- a/server/routes/referrals/relevantSentencePresenter.ts
+++ b/server/routes/referrals/relevantSentencePresenter.ts
@@ -1,11 +1,20 @@
 import { DeliusConviction } from '../../services/communityApiService'
 import { ServiceCategory } from '../../services/interventionsService'
+import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class RelevantSentencePresenter {
-  constructor(private readonly serviceCategory: ServiceCategory, private readonly convictions: DeliusConviction[]) {}
+  constructor(
+    private readonly serviceCategory: ServiceCategory,
+    private readonly convictions: DeliusConviction[],
+    private readonly error: FormValidationError | null = null
+  ) {}
 
   readonly title = `Select the relevant sentence for the ${this.serviceCategory.name.toLocaleLowerCase()} referral`
+
+  readonly errorMessage = PresenterUtils.errorMessage(this.error, 'relevant-sentence-id')
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
   get relevantSentenceFields(): {
     category: string

--- a/server/routes/referrals/relevantSentencePresenter.ts
+++ b/server/routes/referrals/relevantSentencePresenter.ts
@@ -7,7 +7,8 @@ export default class RelevantSentencePresenter {
   constructor(
     private readonly serviceCategory: ServiceCategory,
     private readonly convictions: DeliusConviction[],
-    private readonly error: FormValidationError | null = null
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
   readonly title = `Select the relevant sentence for the ${this.serviceCategory.name.toLocaleLowerCase()} referral`
@@ -44,8 +45,12 @@ export default class RelevantSentencePresenter {
         endOfSentenceDate:
           PresenterUtils.govukFormattedDateFromStringOrNull(conviction.sentence.expectedSentenceEndDate) ?? 'Not found',
         value: conviction.convictionId,
-        checked: false,
+        checked: this.selectedRelevantSentenceId === conviction.convictionId,
       }
     })
+  }
+
+  private get selectedRelevantSentenceId() {
+    return this.userInputData ? this.userInputData['relevant-sentence-id'] : ''
   }
 }

--- a/server/routes/referrals/relevantSentencePresenter.ts
+++ b/server/routes/referrals/relevantSentencePresenter.ts
@@ -1,10 +1,11 @@
 import { DeliusConviction } from '../../services/communityApiService'
-import { ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class RelevantSentencePresenter {
   constructor(
+    private readonly referral: DraftReferral,
     private readonly serviceCategory: ServiceCategory,
     private readonly convictions: DeliusConviction[],
     private readonly error: FormValidationError | null = null,
@@ -51,6 +52,6 @@ export default class RelevantSentencePresenter {
   }
 
   private get selectedRelevantSentenceId() {
-    return this.userInputData ? this.userInputData['relevant-sentence-id'] : ''
+    return this.userInputData ? this.userInputData['relevant-sentence-id'] : this.referral.relevantSentenceId
   }
 }

--- a/server/routes/referrals/relevantSentenceView.ts
+++ b/server/routes/referrals/relevantSentenceView.ts
@@ -25,8 +25,11 @@ export default class RelevantSentenceView {
           checked: relevantSentence.checked,
         }
       }),
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
     }
   }
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [
@@ -34,6 +37,7 @@ export default class RelevantSentenceView {
       {
         presenter: this.presenter,
         radioButtonArgs: this.radioButtonArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
       },
     ]
   }

--- a/server/routes/referrals/relevantSentenceView.ts
+++ b/server/routes/referrals/relevantSentenceView.ts
@@ -1,0 +1,40 @@
+import ViewUtils from '../../utils/viewUtils'
+import RelevantSentencePresenter from './relevantSentencePresenter'
+
+export default class RelevantSentenceView {
+  constructor(readonly presenter: RelevantSentencePresenter) {}
+
+  get radioButtonArgs(): Record<string, unknown> {
+    return {
+      classes: 'govuk-radios',
+      idPrefix: 'relevant-sentence-id',
+      name: 'relevant-sentence-id',
+      fieldset: {
+        legend: {
+          text: this.presenter.title,
+          isPageHeading: true,
+          classes: 'govuk-fieldset__legend--xl',
+        },
+      },
+      items: this.presenter.relevantSentenceFields.map(relevantSentence => {
+        return {
+          value: relevantSentence.value,
+          html: `${ViewUtils.escape(relevantSentence.category)}<br>Subcategory: ${ViewUtils.escape(
+            relevantSentence.subcategory
+          )}<br>End of sentence date: ${ViewUtils.escape(relevantSentence.endOfSentenceDate)}`,
+          checked: relevantSentence.checked,
+        }
+      }),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/relevantSentence',
+      {
+        presenter: this.presenter,
+        radioButtonArgs: this.radioButtonArgs,
+      },
+    ]
+  }
+}

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -62,6 +62,32 @@ interface PhoneNumber {
   type: string | null
 }
 
+export interface DeliusConviction {
+  active: boolean
+  convictionDate: string
+  convictionId: number
+  sentence: Sentence
+  offences: Offence[]
+}
+
+interface Sentence {
+  description: string
+  sentenceId: number
+  expectedSentenceEndDate: string
+  sentenceType: {
+    code: string
+    description: string
+  }
+}
+
+interface Offence {
+  detail: {
+    mainCategoryDescription: string
+    subCategoryDescription: string
+  }
+  mainOffence: boolean
+}
+
 export default class CommunityApiService {
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
 
@@ -80,5 +106,15 @@ export default class CommunityApiService {
     const token = await this.hmppsAuthClient.getApiClientToken()
     logger.info({ crn }, 'getting details for offender')
     return (await this.restClient(token).get({ path: `/secure/offenders/crn/${crn}` })) as DeliusServiceUser
+  }
+
+  async getActiveConvictionsByCRN(crn: string): Promise<DeliusConviction[]> {
+    const token = await this.hmppsAuthClient.getApiClientToken()
+    logger.info({ crn }, 'getting conviction for service user')
+    const convictions = (await this.restClient(token).get({
+      path: `/secure/offenders/crn/${crn}/convictions`,
+    })) as DeliusConviction[]
+
+    return convictions.filter(conviction => conviction.active)
   }
 }

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -18,6 +18,9 @@ export default {
   complexityLevel: {
     empty: 'Select a complexity level',
   },
+  relevantSentence: {
+    empty: 'Select the relevant sentence',
+  },
   desiredOutcomes: {
     empty: 'Select desired outcomes',
   },

--- a/server/views/referrals/relevantSentence.njk
+++ b/server/views/referrals/relevantSentence.njk
@@ -1,0 +1,23 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {{ govukRadios(radioButtonArgs) }}
+
+        {{ govukButton({ text: "Save and continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/deliusConviction.ts
+++ b/testutils/factories/deliusConviction.ts
@@ -1,0 +1,34 @@
+import { Factory } from 'fishery'
+import { DeliusConviction } from '../../server/services/communityApiService'
+
+export default Factory.define<DeliusConviction>(({ sequence }) => ({
+  id: sequence,
+  convictionId: 2500297061,
+  active: true,
+  convictionDate: '2019-09-16',
+  offences: [
+    {
+      mainOffence: true,
+      detail: {
+        mainCategoryDescription: 'Assault on Police Officer',
+        subCategoryDescription: 'Assault on Police Officer',
+      },
+    },
+    {
+      mainOffence: false,
+      detail: {
+        mainCategoryDescription: 'Common and other types of assault',
+        subCategoryDescription: 'Common assault and battery',
+      },
+    },
+  ],
+  sentence: {
+    sentenceId: 2500284169,
+    description: 'Absolute/Conditional Discharge',
+    expectedSentenceEndDate: '2025-09-15',
+    sentenceType: {
+      code: 'SC',
+      description: 'CJA - Indeterminate Public Prot.',
+    },
+  },
+}))


### PR DESCRIPTION
## What does this pull request do?

Adds screen for selecting relevant sentence on a referral during the Refer journey.

This currently doesn't display the "order" specified in the designs, as we're not quite sure where this comes from, but it displays the active convictions for a CRN returned by the Community API.

If only one active conviction comes back from the Community API, we pre-select that field for the user.

### NOTE:

- The data in our local Community API environment is lacking for our test users, and Convictions are returned without `sentence`s, or `offence`s. In real life, we shouldn't be referring any service users who don't have a sentence or an offence, so I've chosen to raise an error if this is the case, so this won't work locally until we add some better test data to the local instance of the Community API.

## What is the intent behind these changes?

To link a referral with a sentence in Delius.

## Screenshot

<img width="998" alt="image" src="https://user-images.githubusercontent.com/19826940/112197078-96ef7c80-8c03-11eb-8172-a78a95f08819.png">

