### PR TITLE
IC-1432: Use long descriptions on search results and intervention details

### DIFF
--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -42,14 +42,14 @@ describe(InterventionDetailsPresenter, () => {
     })
   })
 
-  describe('body', () => {
+  describe('description', () => {
     const presenter = new InterventionDetailsPresenter(
       interventionFactory.build({
         description: 'Some information about the intervention',
       })
     )
     it('returns the intervention description', () => {
-      expect(presenter.body).toEqual('Some information about the intervention')
+      expect(presenter.description).toEqual('Some information about the intervention')
     })
   })
 

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -17,7 +17,7 @@ export default class InterventionDetailsPresenter {
     return `/find-interventions/intervention/${this.intervention.id}`
   }
 
-  get body(): string {
+  get description(): string {
     return this.intervention.description
   }
 

--- a/server/views/findInterventions/interventionDetails.njk
+++ b/server/views/findInterventions/interventionDetails.njk
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
 
-      <p class="govuk-body">{{ presenter.body }}</p>
+      <p class="govuk-body">{{ presenter.description | striptags(true) | escape | nl2br }}</p>
 
       {{ govukSummaryList(summaryListArgs(presenter.summary)) }}
 

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -47,7 +47,7 @@
           <a class="govuk-link" href="{{ result.hrefInterventionDetails }}">{{ result.title }}</a>
         </h2>
 
-        <p class="govuk-body">{{ result.body }}</p>
+        <p class="govuk-body">{{ result.description | striptags(true) | escape | nl2br }}</p>
 
         {{ govukSummaryList(summaryListArgs(result.summary)) }}
 

--- a/testutils/factories/intervention.ts
+++ b/testutils/factories/intervention.ts
@@ -7,8 +7,15 @@ import eligibilityFactory from './eligibility'
 export default Factory.define<Intervention>(sequence => ({
   id: sequence.toString(),
   title: 'Better solutions (anger management)',
-  description:
-    'To provide service users with key tools and strategies to address issues of anger management and temper control and explore the link between thoughts, emotions and behaviour. It provides the opportunity for service users to practice these strategies in a safe and closed environment.',
+  description: `To provide service users with key tools and strategies to address issues of anger management and temper control and
+explore the link between thoughts, emotions and behaviour. It provides the opportunity for service users to practice
+these strategies in a safe and closed environment.
+
+The service will use the following methods:
+
+• Group therapy sessions
+• One-to-one coaching
+• Hypnotherapy`,
   npsRegion: { id: 'B', name: 'North West' },
   pccRegions: [
     { id: 'cheshire', name: 'Cheshire' },


### PR DESCRIPTION
## What does this pull request do?

Support newlines (long descriptions) in intervention descriptions

## What is the intent behind these changes?

allow more information about the intervention to be displayed in the details page.

<img width="964" alt="Screenshot 2021-03-24 at 22 21 31" src="https://user-images.githubusercontent.com/63233073/112391630-1f4b4b80-8cf0-11eb-90cc-eb108b112d61.png">