### PR TITLE
IC-1433: Add contract test for recording attendance

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -108,5 +108,13 @@ module.exports = on => {
     stubSubmitActionPlan: arg => {
       return interventionsService.stubSubmitActionPlan(arg.id, arg.responseJson)
     },
+
+    stubRecordAppointmentAttendance: arg => {
+      return interventionsService.stubRecordAppointmentAttendance(
+        arg.actionPlanId,
+        arg.sessionNumber,
+        arg.response.json
+      )
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -65,3 +65,7 @@ Cypress.Commands.add('stubUpdateDraftActionPlan', (id, responseJson) => {
 Cypress.Commands.add('stubSubmitActionPlan', (id, responseJson) => {
   cy.task('stubSubmitActionPlan', { id, responseJson })
 })
+
+Cypress.Commands.add('stubRecordAppointmentAttendance', (actionPlanId, sessionNumber, responseJson) => {
+  cy.task('stubRecordAppointmentAttendence', { actionPlanId, sessionNumber, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -260,4 +260,24 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubRecordAppointmentAttendance = async (
+    actionPlanId: string,
+    sessionNumber: string,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/action-plan/${actionPlanId}/appointment/${sessionNumber}/record-attendance`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1798,6 +1798,52 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       ).toMatchObject(actionPlanAppointment)
     })
   })
+
+  describe('recordAppointmentAttendance', () => {
+    it('returns an updated action plan appointment with the service user‘s attendance', async () => {
+      await provider.addInteraction({
+        state: 'a draft action plan with ID 345059d4-1697-467b-8914-fedec9957279 exists',
+        uponReceiving:
+          'a POST request to set the attendance for session 2 on action plan with ID 345059d4-1697-467b-8914-fedec9957279',
+        withRequest: {
+          method: 'POST',
+          path: '/action-plan/345059d4-1697-467b-8914-fedec9957279/appointment/2/record-attendance',
+          body: {
+            attended: 'late',
+            additionalAttendanceInformation: 'Alex missed the bus',
+          },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            sessionNumber: 2,
+            appointmentTime: '2021-05-13T13:30:00+01:00',
+            durationInMinutes: 60,
+            attendance: {
+              attended: 'late',
+              additionalAttendanceInformation: 'Alex missed the bus',
+            },
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const appointment = await interventionsService.recordAppointmentAttendance(
+        token,
+        '345059d4-1697-467b-8914-fedec9957279',
+        2,
+        {
+          attended: 'late',
+          additionalAttendanceInformation: 'Alex missed the bus',
+        }
+      )
+      expect(appointment.attendance!.attended).toEqual('late')
+      expect(appointment.attendance!.additionalAttendanceInformation).toEqual('Alex missed the bus')
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -157,11 +157,17 @@ export interface ActionPlanAppointment {
   sessionNumber: number
   appointmentTime: string | null
   durationInMinutes: number | null
+  attendance?: AppointmentAttendance
 }
 
 export interface ActionPlanAppointmentUpdate {
   appointmentTime: string
   durationInMinutes: number
+}
+
+interface AppointmentAttendance {
+  attended: 'yes' | 'no' | 'late'
+  additionalAttendanceInformation?: string
 }
 
 export default class InterventionsService {
@@ -445,6 +451,21 @@ export default class InterventionsService {
       path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}`,
       headers: { Accept: 'application/json' },
       data: { ...appointmentUpdate },
+    })) as ActionPlanAppointment
+  }
+
+  async recordAppointmentAttendance(
+    token: string,
+    actionPlanId: string,
+    sessionNumber: number,
+    appointmentAttendanceUpdate: Partial<AppointmentAttendance>
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}/record-attendance`,
+      headers: { Accept: 'application/json' },
+      data: appointmentAttendanceUpdate,
     })) as ActionPlanAppointment
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds a contract test and Interventions Service client function to set a SU's attendance on an appointment.

Posting to `/action-plan/{action-plan-id}/appointment/{session-number}/record-attendance` with:

```
{ 
  attended: 'late',
  additionalAttendanceInformation: 'Alex missed the bus',
}
```

will return the whole updated `appointment` object.

## What is the intent behind these changes?

To allow Service Providers to notify Probation Practitioners if a Service User fails to attend a session.

Next up, we'll build the screen to actually allow users to enter this feedback.
