### PR TITLE
IC-1291: Filter out convictions with no sentence

### DIFF
--- a/server/routes/referrals/relevantSentencePresenter.ts
+++ b/server/routes/referrals/relevantSentencePresenter.ts
@@ -30,10 +30,6 @@ export default class RelevantSentencePresenter {
         throw new Error(`No offences found for conviction id: ${conviction.convictionId}`)
       }
 
-      if (!conviction.sentence) {
-        throw new Error(`No sentences found for conviction id: ${conviction.convictionId}`)
-      }
-
       const mainOffence = conviction.offences.find(offence => offence.mainOffence)
 
       if (!mainOffence) {

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -115,6 +115,6 @@ export default class CommunityApiService {
       path: `/secure/offenders/crn/${crn}/convictions`,
     })) as DeliusConviction[]
 
-    return convictions.filter(conviction => conviction.active)
+    return convictions.filter(conviction => conviction.active && conviction.sentence)
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Filters out convictions with no sentence.

## What is the intent behind these changes?

Sentence doesn't appear to be a required field in nDelius, so it may not
be set. If this is the case, we don't want to throw an error in the user
journey as there's nothing the user can do to solve this - we simply
shouldn't display the conviction.

## TODO:

The community api service doesn't appear to be tested at all - it's a tricky one to test because we instantiate it with a Rest Client which we'll need to mock a lot of the responses for. I've added a Jira ticket to the tech debt epic (https://dsdmoj.atlassian.net/browse/IC-1471) to make sure we address this, but I don't want to dedicate much more time to this right now.
