### PR TITLE
Add margin below relevant sentence page header

### DIFF
--- a/server/routes/referrals/relevantSentenceView.ts
+++ b/server/routes/referrals/relevantSentenceView.ts
@@ -14,7 +14,7 @@ export default class RelevantSentenceView {
         legend: {
           text: this.presenter.title,
           isPageHeading: true,
-          classes: 'govuk-fieldset__legend--xl',
+          classes: 'govuk-fieldset__legend--xl govuk-!-margin-bottom-8',
         },
       },
       items: this.presenter.relevantSentenceFields.map(relevantSentence => {


### PR DESCRIPTION
## What does this pull request do?

Adds spacing below header.

## What is the intent behind these changes?

`margin-bottom-8` is 50px, which is the spacing we use on other sections
of the form.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/112827891-de07c280-9086-11eb-9e76-e60fc94b4e11.png)

