### PR TITLE
trim down the intervention description in search results

### DIFF
--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -53,6 +53,47 @@ describe(InterventionDetailsPresenter, () => {
     })
   })
 
+  describe('truncatedDescription', () => {
+    it('does not modify short single line descriptions', () => {
+      const presenter = new InterventionDetailsPresenter(
+        interventionFactory.build({
+          description: 'Some information about the intervention',
+        })
+      )
+      expect(presenter.truncatedDescription).toEqual('Some information about the intervention')
+    })
+
+    it('trims down multiline descriptions to the first line', () => {
+      const presenter = new InterventionDetailsPresenter(
+        interventionFactory.build({
+          description: `Some information about the intervention
+that is longer than one line
+and even longer than
+three lines.`,
+        })
+      )
+      expect(presenter.truncatedDescription).toEqual('Some information about the intervention')
+    })
+
+    it('trims down long single line descriptions to 500 characters', () => {
+      const presenter = new InterventionDetailsPresenter(
+        interventionFactory.build({
+          description: new Array(1000).join('x'),
+        })
+      )
+      expect(presenter.truncatedDescription).toEqual(`${new Array(501).join('x')}...`)
+    })
+
+    it('trims down long multiline descriptions to 500 characters', () => {
+      const presenter = new InterventionDetailsPresenter(
+        interventionFactory.build({
+          description: `${new Array(1000).join('x')}\n${new Array(1000).join('z')}`,
+        })
+      )
+      expect(presenter.truncatedDescription).toEqual(`${new Array(501).join('x')}...`)
+    })
+  })
+
   describe('tabs', () => {
     const presenter = new InterventionDetailsPresenter(
       interventionFactory.build({

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -21,6 +21,12 @@ export default class InterventionDetailsPresenter {
     return this.intervention.description
   }
 
+  get truncatedDescription(): string {
+    // take just the first line of the description, up to a maximum of 500 characters
+    const firstLine = this.intervention.description.split('\n')[0]
+    return `${firstLine.substring(0, 500)}${firstLine.length > 500 ? '...' : ''}`
+  }
+
   get tabs(): { id: string; title: string; items: SummaryListItem[] }[] {
     return [
       {

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -47,7 +47,7 @@
           <a class="govuk-link" href="{{ result.hrefInterventionDetails }}">{{ result.title }}</a>
         </h2>
 
-        <p class="govuk-body">{{ result.description | striptags(true) | escape | nl2br }}</p>
+        <p class="govuk-body">{{ result.truncatedDescription }}</p>
 
         {{ govukSummaryList(summaryListArgs(result.summary)) }}
 


### PR DESCRIPTION
## What does this pull request do?

trim down the intervention description in search results to the first line, up to 500 characters

## What is the intent behind these changes?

make the search results more readable buy not including the full description text.
