### PR TITLE
IC-1291: Post session feedback form - attendance

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -379,6 +379,7 @@ describe('Service provider referrals dashboard', () => {
       ...appointment,
       attendance: {
         attended: 'yes',
+        additionalAttendanceInformation: 'Alex attended the session',
       },
     }
 
@@ -389,6 +390,7 @@ describe('Service provider referrals dashboard', () => {
     )
 
     cy.contains('Yes').click()
+    cy.contains("Add additional information about Alex's attendance").type('Alex attended the session')
 
     cy.stubRecordAppointmentAttendance(actionPlan.id, 1, appointmentWithAttendanceRecorded)
 

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -337,4 +337,62 @@ describe('Service provider referrals dashboard', () => {
     cy.get('#duration-hours').should('have.value', '1')
     cy.get('#duration-minutes').should('have.value', '15')
   })
+
+  it('User records post session feedback', () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const referralParams = {
+      id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
+      referral: { serviceCategoryId: serviceCategory.id },
+    }
+    const deliusServiceUser = deliusServiceUserFactory.build()
+    const probationPractitioner = deliusUserFactory.build({
+      firstName: 'John',
+      surname: 'Smith',
+      username: 'john.smith',
+    })
+    const actionPlan = actionPlanFactory.submitted().build({
+      referralId: referralParams.id,
+      numberOfSessions: 4,
+    })
+
+    const appointment = actionPlanAppointmentFactory.build({
+      sessionNumber: 1,
+      appointmentTime: '2021-03-24T09:02:02Z',
+      durationInMinutes: 75,
+    })
+
+    const assignedReferral = sentReferralFactory.assigned().build({
+      ...referralParams,
+      assignedTo: { username: probationPractitioner.username },
+      actionPlanId: actionPlan.id,
+    })
+
+    cy.stubGetSentReferrals([assignedReferral])
+    cy.stubGetActionPlan(actionPlan.id, actionPlan)
+    cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointment)
+    cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+    cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+    cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
+
+    const appointmentWithAttendanceRecorded = {
+      ...appointment,
+      attendance: {
+        attended: 'yes',
+      },
+    }
+
+    cy.login()
+
+    cy.visit(
+      `/service-provider/action-plan/${actionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback`
+    )
+
+    cy.contains('Yes').click()
+
+    cy.stubRecordAppointmentAttendance(actionPlan.id, 1, appointmentWithAttendanceRecorded)
+
+    cy.contains('Submit for approval').click()
+    cy.contains('Session feedback form has been submitted').click()
+  })
 })

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -385,9 +385,9 @@ describe('Service provider referrals dashboard', () => {
 
     cy.login()
 
-    cy.visit(
-      `/service-provider/action-plan/${actionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback`
-    )
+    cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
+
+    cy.contains('Give feedback').click()
 
     cy.contains('Yes').click()
     cy.contains("Add additional information about Alex's attendance").type('Alex attended the session')

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -99,6 +99,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/service-provider/action-plan/:id/sessions/:sessionNumber/edit', (req, res) =>
     serviceProviderReferralsController.editSession(req, res)
   )
+  get('/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/', (req, res) =>
+    serviceProviderReferralsController.showPostSessionFeedbackForm(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -105,6 +105,10 @@ export default function routes(router: Router, services: Services): Router {
   post('/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/', (req, res) =>
     serviceProviderReferralsController.recordPostSessionFeedback(req, res)
   )
+  get(
+    '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation',
+    (req, res) => serviceProviderReferralsController.showPostSessionFeedbackConfirmation(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -102,6 +102,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/', (req, res) =>
     serviceProviderReferralsController.showPostSessionFeedbackForm(req, res)
   )
+  post('/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/', (req, res) =>
+    serviceProviderReferralsController.recordPostSessionFeedback(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -26,42 +26,56 @@ describe(InterventionProgressPresenter, () => {
       expect(presenter.sessionTableRows).toEqual([])
     })
 
-    it('populates the table with formatted session information', () => {
-      const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const serviceUser = serviceUserFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [
-        {
-          sessionNumber: 1,
-          appointmentTime: '2020-12-07T13:00:00.000000Z',
-          durationInMinutes: 120,
-        },
-        {
-          sessionNumber: 2,
-          appointmentTime: null,
-          durationInMinutes: null,
-        },
-      ])
-      expect(presenter.sessionTableRows).toEqual([
-        {
-          sessionNumber: 1,
-          appointmentTime: '07 Dec 2020, 13:00',
-          tagArgs: {
-            text: 'SCHEDULED',
-            classes: 'govuk-tag--blue',
+    describe('when a session exists but an appointment has not yet been scheduled', () => {
+      it('populates the table with formatted session information, with the "Edit session details" link displayed', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [
+          {
+            sessionNumber: 1,
+            appointmentTime: null,
+            durationInMinutes: null,
           },
-          linkHtml: '<a class="govuk-link" href="#">Reschedule session</a>',
-        },
-        {
-          sessionNumber: 2,
-          appointmentTime: '',
-          tagArgs: {
-            text: 'NOT SCHEDULED',
-            classes: 'govuk-tag--grey',
+        ])
+        expect(presenter.sessionTableRows).toEqual([
+          {
+            sessionNumber: 1,
+            appointmentTime: '',
+            tagArgs: {
+              text: 'NOT SCHEDULED',
+              classes: 'govuk-tag--grey',
+            },
+            linkHtml: '<a class="govuk-link" href="#">Edit session details</a>',
           },
-          linkHtml: '<a class="govuk-link" href="#">Edit session details</a>',
-        },
-      ])
+        ])
+      })
+    })
+
+    describe('when an appointment has been scheduled', () => {
+      it('populates the table with formatted session information, with the "Reschedule session" link displayed', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [
+          {
+            sessionNumber: 1,
+            appointmentTime: '2020-12-07T13:00:00.000000Z',
+            durationInMinutes: 120,
+          },
+        ])
+        expect(presenter.sessionTableRows).toEqual([
+          {
+            sessionNumber: 1,
+            appointmentTime: '07 Dec 2020, 13:00',
+            tagArgs: {
+              text: 'SCHEDULED',
+              classes: 'govuk-tag--blue',
+            },
+            linkHtml: '<a class="govuk-link" href="#">Reschedule session</a>',
+          },
+        ])
+      })
     })
   })
 

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -53,11 +53,12 @@ describe(InterventionProgressPresenter, () => {
     })
 
     describe('when an appointment has been scheduled', () => {
-      it('populates the table with formatted session information, with the "Reschedule session" link displayed', () => {
+      it('populates the table with formatted session information, with the "Reschedule session" and "Give feedback" links displayed', () => {
         const referral = sentReferralFactory.build()
+        const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
         const serviceCategory = serviceCategoryFactory.build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [
           {
             sessionNumber: 1,
             appointmentTime: '2020-12-07T13:00:00.000000Z',
@@ -72,7 +73,7 @@ describe(InterventionProgressPresenter, () => {
               text: 'SCHEDULED',
               classes: 'govuk-tag--blue',
             },
-            linkHtml: '<a class="govuk-link" href="#">Reschedule session</a>',
+            linkHtml: `<a class="govuk-link" href="#">Reschedule session</a><br><a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/1/post-session-feedback">Give feedback</a>`,
           },
         ])
       })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -59,7 +59,7 @@ export default class InterventionProgressPresenter {
           ? { text: 'SCHEDULED', classes: 'govuk-tag--blue' }
           : { text: 'NOT SCHEDULED', classes: 'govuk-tag--grey' },
         linkHtml: appointment.appointmentTime
-          ? '<a class="govuk-link" href="#">Reschedule session</a>'
+          ? `<a class="govuk-link" href="#">Reschedule session</a><br><a class="govuk-link" href="/service-provider/action-plan/${this.actionPlan?.id}/appointment/${appointment.sessionNumber}/post-session-feedback">Give feedback</a>`
           : '<a class="govuk-link" href="#">Edit session details</a>',
       }
     })

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackConfirmationPresenter.test.ts
@@ -1,0 +1,71 @@
+import deliusUser from '../../../testutils/factories/deliusUser'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import PostSessionFeedbackConfirmationPresenter from './postSessionFeedbackConfirmationPresenter'
+
+describe(PostSessionFeedbackConfirmationPresenter, () => {
+  describe('progressHref', () => {
+    it('returns the relative URL of the service provider referral progress page', () => {
+      const sentReferral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const probationPractitioner = deliusUser.build()
+      const presenter = new PostSessionFeedbackConfirmationPresenter(
+        sentReferral,
+        serviceCategory,
+        probationPractitioner
+      )
+
+      expect(presenter.progressHref).toEqual(`/service-provider/referrals/${sentReferral.id}/progress`)
+    })
+  })
+
+  describe('text', () => {
+    it('contains next steps, including the PP‘s name', () => {
+      const sentReferral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const probationPractitioner = deliusUser.build({
+        firstName: 'Josie',
+        surname: 'Bart',
+      })
+      const presenter = new PostSessionFeedbackConfirmationPresenter(
+        sentReferral,
+        serviceCategory,
+        probationPractitioner
+      )
+
+      expect(presenter.text.whatHappensNext).toEqual(
+        'The session feedback form has been saved and submitted to Josie Bart, probation practitioner. Please deliver the next session.'
+      )
+    })
+  })
+
+  describe('summary', () => {
+    it('returns a summary of the referral', () => {
+      const sentReferral = sentReferralFactory.build({
+        referenceNumber: 'CEF345',
+        referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
+      })
+      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+      const probationPractitioner = deliusUser.build()
+      const presenter = new PostSessionFeedbackConfirmationPresenter(
+        sentReferral,
+        serviceCategory,
+        probationPractitioner
+      )
+
+      expect(presenter.summary).toEqual([
+        { key: 'Name', lines: ['Johnny Davis'], isList: false },
+        {
+          key: 'Referral number',
+          lines: ['CEF345'],
+          isList: false,
+        },
+        {
+          key: 'Service type',
+          lines: ['Social inclusion'],
+          isList: false,
+        },
+      ])
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackConfirmationPresenter.ts
@@ -1,0 +1,37 @@
+import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { SummaryListItem } from '../../utils/summaryList'
+import utils from '../../utils/utils'
+import PresenterUtils from '../../utils/presenterUtils'
+import { DeliusUser } from '../../services/communityApiService'
+
+export default class PostSessionFeedbackConfirmationPresenter {
+  constructor(
+    private readonly sentReferral: SentReferral,
+    private readonly serviceCategory: ServiceCategory,
+    private readonly probationPractitioner: DeliusUser
+  ) {}
+
+  progressHref = `/service-provider/referrals/${this.sentReferral.id}/progress`
+
+  text = {
+    whatHappensNext: `The session feedback form has been saved and submitted to ${this.probationPractitioner.firstName} ${this.probationPractitioner.surname}, probation practitioner. Please deliver the next session.`,
+  }
+
+  readonly summary: SummaryListItem[] = [
+    {
+      key: 'Name',
+      lines: [PresenterUtils.fullName(this.sentReferral.referral.serviceUser)],
+      isList: false,
+    },
+    {
+      key: 'Referral number',
+      lines: [this.sentReferral.referenceNumber],
+      isList: false,
+    },
+    {
+      key: 'Service type',
+      lines: [utils.convertToProperCase(this.serviceCategory.name)],
+      isList: false,
+    },
+  ]
+}

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackConfirmationView.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackConfirmationView.ts
@@ -1,0 +1,18 @@
+import ViewUtils from '../../utils/viewUtils'
+import PostSessionFeedbackConfirmationPresenter from './postSessionFeedbackConfirmationPresenter'
+
+export default class PostSessionFeedbackConfirmationView {
+  constructor(private readonly presenter: PostSessionFeedbackConfirmationPresenter) {}
+
+  private readonly summaryListArgs = ViewUtils.summaryListArgs(this.presenter.summary)
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/postSessionFeedbackConfirmation',
+      {
+        presenter: this.presenter,
+        summaryListArgs: this.summaryListArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackForm.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackForm.test.ts
@@ -1,0 +1,82 @@
+import { Request } from 'express'
+import PostSessionFeedbackForm from './postSessionFeedbackForm'
+
+describe(PostSessionFeedbackForm, () => {
+  describe('isValid', () => {
+    it('returns true when the attendance property is present in the body', async () => {
+      const form = await PostSessionFeedbackForm.createForm({
+        body: { attended: 'yes' },
+      } as Request)
+
+      expect(form.isValid).toBe(true)
+    })
+
+    it('returns false when the attendance property is absent in the body', async () => {
+      const form = await PostSessionFeedbackForm.createForm({
+        body: {},
+      } as Request)
+
+      expect(form.isValid).toBe(false)
+    })
+
+    it('returns false when the attendance property is null in the body', async () => {
+      const form = await PostSessionFeedbackForm.createForm({
+        body: { attended: null },
+      } as Request)
+
+      expect(form.isValid).toBe(false)
+    })
+  })
+
+  describe('error', () => {
+    it('returns null when the attendance property is present in the body', async () => {
+      const form = await PostSessionFeedbackForm.createForm({
+        body: { attended: 'yes' },
+      } as Request)
+
+      expect(form.error).toBe(null)
+    })
+
+    it('returns an error object when the attendance property is absent in the body', async () => {
+      const form = await PostSessionFeedbackForm.createForm({
+        body: {},
+      } as Request)
+
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'attended',
+            formFields: ['attended'],
+            message: 'Select whether the service user attended or not',
+          },
+        ],
+      })
+    })
+
+    it('returns an error object when the attendance property is null in the body', async () => {
+      const form = await PostSessionFeedbackForm.createForm({
+        body: { attended: null },
+      } as Request)
+
+      expect(form.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'attended',
+            formFields: ['attended'],
+            message: 'Select whether the service user attended or not',
+          },
+        ],
+      })
+    })
+  })
+
+  describe('attendanceParams', () => {
+    it('returns the params to be sent to the backend, when the data in the body is valid', async () => {
+      const form = await PostSessionFeedbackForm.createForm({
+        body: { attended: 'yes' },
+      } as Request)
+
+      expect(form.attendanceParams).toEqual({ attended: 'yes' })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackForm.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackForm.test.ts
@@ -73,10 +73,13 @@ describe(PostSessionFeedbackForm, () => {
   describe('attendanceParams', () => {
     it('returns the params to be sent to the backend, when the data in the body is valid', async () => {
       const form = await PostSessionFeedbackForm.createForm({
-        body: { attended: 'yes' },
+        body: { attended: 'yes', additionalAttendanceInformation: 'Alex attended the session' },
       } as Request)
 
-      expect(form.attendanceParams).toEqual({ attended: 'yes' })
+      expect(form.attendanceParams).toEqual({
+        attended: 'yes',
+        additionalAttendanceInformation: 'Alex attended the session',
+      })
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackForm.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackForm.ts
@@ -1,0 +1,38 @@
+import { Request } from 'express'
+import { AppointmentAttendance } from '../../services/interventionsService'
+import errorMessages from '../../utils/errorMessages'
+import { FormValidationError } from '../../utils/formValidationError'
+
+export default class PostSessionFeedbackForm {
+  private constructor(private readonly request: Request) {}
+
+  static async createForm(request: Request): Promise<PostSessionFeedbackForm> {
+    return new PostSessionFeedbackForm(request)
+  }
+
+  get attendanceParams(): Partial<AppointmentAttendance> {
+    return {
+      attended: this.request.body.attended,
+    }
+  }
+
+  get isValid(): boolean {
+    return this.request.body.attended !== null && this.request.body.attended !== undefined
+  }
+
+  get error(): FormValidationError | null {
+    if (this.isValid) {
+      return null
+    }
+
+    return {
+      errors: [
+        {
+          formFields: ['attended'],
+          errorSummaryLinkedField: 'attended',
+          message: errorMessages.attendedAppointment.empty,
+        },
+      ],
+    }
+  }
+}

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackForm.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackForm.ts
@@ -13,6 +13,7 @@ export default class PostSessionFeedbackForm {
   get attendanceParams(): Partial<AppointmentAttendance> {
     return {
       attended: this.request.body.attended,
+      additionalAttendanceInformation: this.request.body.additionalAttendanceInformation,
     }
   }
 

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.test.ts
@@ -5,7 +5,7 @@ import PostSessionFeedbackPresenter from './postSessionFeedbackPresenter'
 
 describe(PostSessionFeedbackPresenter, () => {
   describe('text', () => {
-    it('contains a title including the name of the service category and a subtitle, and the attendance question', () => {
+    it('contains a title including the name of the service category and a subtitle, and the attendance questions', () => {
       const appointment = actionPlanAppointmentFactory.build()
       const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
       const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
@@ -15,6 +15,7 @@ describe(PostSessionFeedbackPresenter, () => {
         title: 'Social inclusion: add feedback',
         subTitle: 'Session details',
         attendanceQuestion: 'Did Alex attend this session?',
+        additionalAttendanceInformationLabel: "Add additional information about Alex's attendance:",
       })
     })
   })
@@ -177,6 +178,34 @@ describe(PostSessionFeedbackPresenter, () => {
             ])
           })
         })
+      })
+    })
+  })
+
+  describe('additionalAttendanceInformationValue', () => {
+    describe('when the appointment already has additionalAttendanceInformation set', () => {
+      it('uses that value as the value attribute', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          attendance: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
+        })
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = deliusServiceUserFactory.build()
+        const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+        expect(presenter.additionalAttendanceInformationValue).toEqual('Alex missed the bus')
+      })
+    })
+
+    describe('when the appointment has no value for additionalAttendanceInformation', () => {
+      it('uses sets the value to an empty string', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          attendance: { attended: 'late' },
+        })
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = deliusServiceUserFactory.build()
+        const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+        expect(presenter.additionalAttendanceInformationValue).toEqual('')
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.test.ts
@@ -5,13 +5,17 @@ import PostSessionFeedbackPresenter from './postSessionFeedbackPresenter'
 
 describe(PostSessionFeedbackPresenter, () => {
   describe('text', () => {
-    it('contains a title including the name of the service category and a subtitle', () => {
+    it('contains a title including the name of the service category and a subtitle, and the attendance question', () => {
       const appointment = actionPlanAppointmentFactory.build()
       const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-      const serviceUser = deliusServiceUserFactory.build()
+      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
       const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
 
-      expect(presenter.text).toMatchObject({ title: 'Social inclusion: add feedback', subTitle: 'Session details' })
+      expect(presenter.text).toMatchObject({
+        title: 'Social inclusion: add feedback',
+        subTitle: 'Session details',
+        attendanceQuestion: 'Did Alex attend this session?',
+      })
     })
   })
 
@@ -47,6 +51,71 @@ describe(PostSessionFeedbackPresenter, () => {
           isList: false,
         },
       ])
+    })
+  })
+
+  describe('attendanceResponses', () => {
+    describe('when attendance has not been set on the appointment', () => {
+      it('contains the attendance questions and values, and doesn’t set any value to "checked"', () => {
+        const appointment = actionPlanAppointmentFactory.build()
+        const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+        const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+        expect(presenter.attendanceResponses).toEqual([
+          {
+            value: 'yes',
+            text: 'Yes, they were on time',
+            checked: false,
+          },
+          {
+            value: 'late',
+            text: 'They were late',
+            checked: false,
+          },
+          {
+            value: 'no',
+            text: 'No',
+            checked: false,
+          },
+        ])
+      })
+    })
+
+    describe('when attendance has been set on the appointment', () => {
+      const responseValues = ['yes', 'late', 'no'] as ('yes' | 'late' | 'no')[]
+
+      responseValues.forEach(responseValue => {
+        const appointment = actionPlanAppointmentFactory.build({
+          attendance: { attended: responseValue },
+        })
+
+        describe(`service provider has selected ${responseValue}`, () => {
+          it(`contains the attendance questions and values, and marks ${responseValue} as "checked"`, () => {
+            const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+            const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+            const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+            expect(presenter.attendanceResponses).toEqual([
+              {
+                value: 'yes',
+                text: 'Yes, they were on time',
+                checked: responseValue === 'yes',
+              },
+              {
+                value: 'late',
+                text: 'They were late',
+                checked: responseValue === 'late',
+              },
+              {
+                value: 'no',
+                text: 'No',
+                checked: responseValue === 'no',
+              },
+            ])
+          })
+        })
+      })
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.test.ts
@@ -54,6 +54,68 @@ describe(PostSessionFeedbackPresenter, () => {
     })
   })
 
+  describe('errorSummary', () => {
+    const appointment = actionPlanAppointmentFactory.build()
+    const serviceCategory = serviceCategoryFactory.build()
+    const serviceUser = deliusServiceUserFactory.build()
+
+    describe('when there is an error', () => {
+      it('returns a summary of the error', () => {
+        const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory, {
+          errors: [
+            {
+              errorSummaryLinkedField: 'attended',
+              formFields: ['attended'],
+              message: 'Select whether the service user attended or not',
+            },
+          ],
+        })
+
+        expect(presenter.errorSummary).toEqual([
+          { field: 'attended', message: 'Select whether the service user attended or not' },
+        ])
+      })
+    })
+
+    describe('when there is no error', () => {
+      it('returns null', () => {
+        const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+  })
+
+  describe('errorMessage', () => {
+    const appointment = actionPlanAppointmentFactory.build()
+    const serviceCategory = serviceCategoryFactory.build()
+    const serviceUser = deliusServiceUserFactory.build()
+
+    describe('when there is an error', () => {
+      it('returns the error message', () => {
+        const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory, {
+          errors: [
+            {
+              errorSummaryLinkedField: 'attended',
+              formFields: ['attended'],
+              message: 'Select whether the service user attended or not',
+            },
+          ],
+        })
+
+        expect(presenter.errorMessage).toEqual('Select whether the service user attended or not')
+      })
+    })
+
+    describe('when there is no error', () => {
+      it('returns null', () => {
+        const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+        expect(presenter.errorMessage).toBeNull()
+      })
+    })
+  })
+
   describe('attendanceResponses', () => {
     describe('when attendance has not been set on the appointment', () => {
       it('contains the attendance questions and values, and doesn’t set any value to "checked"', () => {

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.test.ts
@@ -1,0 +1,52 @@
+import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
+import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import PostSessionFeedbackPresenter from './postSessionFeedbackPresenter'
+
+describe(PostSessionFeedbackPresenter, () => {
+  describe('text', () => {
+    it('contains a title including the name of the service category and a subtitle', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+      const serviceUser = deliusServiceUserFactory.build()
+      const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+      expect(presenter.text).toMatchObject({ title: 'Social inclusion: add feedback', subTitle: 'Session details' })
+    })
+  })
+
+  describe('serviceUserBannerPresenter', () => {
+    it('is instantiated with the service user', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+      const serviceUser = deliusServiceUserFactory.build()
+      const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+      expect(presenter.serviceUserBannerPresenter).toBeDefined()
+    })
+  })
+
+  describe('sessionDetailsSummary', () => {
+    it('extracts the date and time from the appointmentTime puts it in a SummaryList format', () => {
+      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+      const serviceUser = deliusServiceUserFactory.build()
+      const appointment = actionPlanAppointmentFactory.build({
+        appointmentTime: '2021-02-01T13:00:00Z',
+      })
+      const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+      expect(presenter.sessionDetailsSummary).toEqual([
+        {
+          key: 'Date',
+          lines: ['01 Feb 2021'],
+          isList: false,
+        },
+        {
+          key: 'Time',
+          lines: ['13:00'],
+          isList: false,
+        },
+      ])
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.test.ts
@@ -183,29 +183,46 @@ describe(PostSessionFeedbackPresenter, () => {
   })
 
   describe('additionalAttendanceInformationValue', () => {
-    describe('when the appointment already has additionalAttendanceInformation set', () => {
-      it('uses that value as the value attribute', () => {
+    describe('when there is no user input data', () => {
+      describe('when the appointment already has additionalAttendanceInformation set', () => {
+        it('uses that value as the value attribute', () => {
+          const appointment = actionPlanAppointmentFactory.build({
+            attendance: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
+          })
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = deliusServiceUserFactory.build()
+          const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+          expect(presenter.additionalAttendanceInformationValue).toEqual('Alex missed the bus')
+        })
+      })
+
+      describe('when the appointment has no value for additionalAttendanceInformation', () => {
+        it('uses sets the value to an empty string', () => {
+          const appointment = actionPlanAppointmentFactory.build({
+            attendance: { attended: 'late' },
+          })
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = deliusServiceUserFactory.build()
+          const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+
+          expect(presenter.additionalAttendanceInformationValue).toEqual('')
+        })
+      })
+    })
+
+    describe('when there is user input data', () => {
+      it('uses the user input data as the value attribute', () => {
         const appointment = actionPlanAppointmentFactory.build({
           attendance: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
         })
         const serviceCategory = serviceCategoryFactory.build()
         const serviceUser = deliusServiceUserFactory.build()
-        const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
-
-        expect(presenter.additionalAttendanceInformationValue).toEqual('Alex missed the bus')
-      })
-    })
-
-    describe('when the appointment has no value for additionalAttendanceInformation', () => {
-      it('uses sets the value to an empty string', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          attendance: { attended: 'late' },
+        const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory, null, {
+          'additional-attendance-information': "Alex's car broke down en route",
         })
-        const serviceCategory = serviceCategoryFactory.build()
-        const serviceUser = deliusServiceUserFactory.build()
-        const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
 
-        expect(presenter.additionalAttendanceInformationValue).toEqual('')
+        expect(presenter.additionalAttendanceInformationValue).toEqual("Alex's car broke down en route")
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
@@ -12,7 +12,8 @@ export default class PostSessionFeedbackPresenter {
     private readonly appointment: ActionPlanAppointment,
     private readonly serviceUser: DeliusServiceUser,
     private readonly serviceCategory: ServiceCategory,
-    private readonly error: FormValidationError | null = null
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
   readonly text = {
@@ -60,10 +61,11 @@ export default class PostSessionFeedbackPresenter {
   ]
 
   get additionalAttendanceInformationValue(): string {
-    if (this.appointment.attendance?.additionalAttendanceInformation) {
-      return this.appointment.attendance?.additionalAttendanceInformation
-    }
+    const presenterUtils = new PresenterUtils(this.userInputData)
 
-    return ''
+    return presenterUtils.stringValue(
+      this.appointment.attendance?.additionalAttendanceInformation || null,
+      'additional-attendance-information'
+    )
   }
 }

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
@@ -1,6 +1,8 @@
 import { DeliusServiceUser } from '../../services/communityApiService'
 import { ActionPlanAppointment, ServiceCategory } from '../../services/interventionsService'
 import DateUtils from '../../utils/dateUtils'
+import { FormValidationError } from '../../utils/formValidationError'
+import PresenterUtils from '../../utils/presenterUtils'
 import { SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
 import ServiceUserBannerPresenter from './serviceUserBannerPresenter'
@@ -9,7 +11,8 @@ export default class PostSessionFeedbackPresenter {
   constructor(
     private readonly appointment: ActionPlanAppointment,
     private readonly serviceUser: DeliusServiceUser,
-    private readonly serviceCategory: ServiceCategory
+    private readonly serviceCategory: ServiceCategory,
+    private readonly error: FormValidationError | null = null
   ) {}
 
   readonly text = {
@@ -17,6 +20,10 @@ export default class PostSessionFeedbackPresenter {
     subTitle: 'Session details',
     attendanceQuestion: `Did ${this.serviceUser.firstName} attend this session?`,
   }
+
+  readonly errorMessage = PresenterUtils.errorMessage(this.error, 'attended')
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
   readonly attendanceResponses = [
     {

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
@@ -22,12 +22,12 @@ export default class PostSessionFeedbackPresenter {
   readonly sessionDetailsSummary: SummaryListItem[] = [
     {
       key: 'Date',
-      lines: [DateUtils.getDateFromFormattedDateTime(this.appointment.appointmentTime)],
+      lines: [DateUtils.getDateStringFromDateTimeString(this.appointment.appointmentTime)],
       isList: false,
     },
     {
       key: 'Time',
-      lines: [DateUtils.getTimeFromFormattedDateTime(this.appointment.appointmentTime)],
+      lines: [DateUtils.getTimeStringFromDateTimeString(this.appointment.appointmentTime)],
       isList: false,
     },
   ]

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
@@ -15,7 +15,26 @@ export default class PostSessionFeedbackPresenter {
   readonly text = {
     title: `${utils.convertToProperCase(this.serviceCategory.name)}: add feedback`,
     subTitle: 'Session details',
+    attendanceQuestion: `Did ${this.serviceUser.firstName} attend this session?`,
   }
+
+  readonly attendanceResponses = [
+    {
+      value: 'yes',
+      text: 'Yes, they were on time',
+      checked: this.appointment.attendance?.attended === 'yes',
+    },
+    {
+      value: 'late',
+      text: 'They were late',
+      checked: this.appointment.attendance?.attended === 'late',
+    },
+    {
+      value: 'no',
+      text: 'No',
+      checked: this.appointment.attendance?.attended === 'no',
+    },
+  ]
 
   readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
 

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
@@ -19,6 +19,7 @@ export default class PostSessionFeedbackPresenter {
     title: `${utils.convertToProperCase(this.serviceCategory.name)}: add feedback`,
     subTitle: 'Session details',
     attendanceQuestion: `Did ${this.serviceUser.firstName} attend this session?`,
+    additionalAttendanceInformationLabel: `Add additional information about ${this.serviceUser.firstName}'s attendance:`,
   }
 
   readonly errorMessage = PresenterUtils.errorMessage(this.error, 'attended')
@@ -57,4 +58,12 @@ export default class PostSessionFeedbackPresenter {
       isList: false,
     },
   ]
+
+  get additionalAttendanceInformationValue(): string {
+    if (this.appointment.attendance?.additionalAttendanceInformation) {
+      return this.appointment.attendance?.additionalAttendanceInformation
+    }
+
+    return ''
+  }
 }

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackPresenter.ts
@@ -1,0 +1,34 @@
+import { DeliusServiceUser } from '../../services/communityApiService'
+import { ActionPlanAppointment, ServiceCategory } from '../../services/interventionsService'
+import DateUtils from '../../utils/dateUtils'
+import { SummaryListItem } from '../../utils/summaryList'
+import utils from '../../utils/utils'
+import ServiceUserBannerPresenter from './serviceUserBannerPresenter'
+
+export default class PostSessionFeedbackPresenter {
+  constructor(
+    private readonly appointment: ActionPlanAppointment,
+    private readonly serviceUser: DeliusServiceUser,
+    private readonly serviceCategory: ServiceCategory
+  ) {}
+
+  readonly text = {
+    title: `${utils.convertToProperCase(this.serviceCategory.name)}: add feedback`,
+    subTitle: 'Session details',
+  }
+
+  readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
+
+  readonly sessionDetailsSummary: SummaryListItem[] = [
+    {
+      key: 'Date',
+      lines: [DateUtils.getDateFromFormattedDateTime(this.appointment.appointmentTime)],
+      isList: false,
+    },
+    {
+      key: 'Time',
+      lines: [DateUtils.getTimeFromFormattedDateTime(this.appointment.appointmentTime)],
+      isList: false,
+    },
+  ]
+}

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackView.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackView.ts
@@ -1,3 +1,4 @@
+import { TextareaArgs } from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
 import PostSessionFeedbackPresenter from './postSessionFeedbackPresenter'
 
@@ -31,6 +32,19 @@ export default class PostSessionFeedbackView {
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
+  private get textAreaArgs(): TextareaArgs {
+    return {
+      name: 'additional-attendance-information',
+      id: 'additional-attendance-information',
+      label: {
+        text: this.presenter.text.additionalAttendanceInformationLabel,
+        classes: 'govuk-label--s',
+        isPageHeading: false,
+      },
+      value: this.presenter.additionalAttendanceInformationValue,
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/postSessionFeedback',
@@ -40,6 +54,7 @@ export default class PostSessionFeedbackView {
         summaryListArgs: this.summaryListArgs,
         radioButtonArgs: this.radioButtonArgs,
         errorSummaryArgs: this.errorSummaryArgs,
+        textAreaArgs: this.textAreaArgs,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackView.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackView.ts
@@ -1,0 +1,19 @@
+import ViewUtils from '../../utils/viewUtils'
+import PostSessionFeedbackPresenter from './postSessionFeedbackPresenter'
+
+export default class PostSessionFeedbackView {
+  constructor(private readonly presenter: PostSessionFeedbackPresenter) {}
+
+  private readonly summaryListArgs = ViewUtils.summaryListArgs(this.presenter.sessionDetailsSummary)
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/postSessionFeedback',
+      {
+        presenter: this.presenter,
+        serviceUserNotificationBannerArgs: this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs,
+        summaryListArgs: this.summaryListArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackView.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackView.ts
@@ -18,6 +18,7 @@ export default class PostSessionFeedbackView {
           classes: 'govuk-fieldset__legend--m',
         },
       },
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
       items: this.presenter.attendanceResponses.map(response => {
         return {
           value: response.value,
@@ -28,6 +29,8 @@ export default class PostSessionFeedbackView {
     }
   }
 
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/postSessionFeedback',
@@ -36,6 +39,7 @@ export default class PostSessionFeedbackView {
         serviceUserNotificationBannerArgs: this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs,
         summaryListArgs: this.summaryListArgs,
         radioButtonArgs: this.radioButtonArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackView.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackView.ts
@@ -6,6 +6,28 @@ export default class PostSessionFeedbackView {
 
   private readonly summaryListArgs = ViewUtils.summaryListArgs(this.presenter.sessionDetailsSummary)
 
+  private get radioButtonArgs(): Record<string, unknown> {
+    return {
+      classes: 'govuk-radios',
+      idPrefix: 'attended',
+      name: 'attended',
+      fieldset: {
+        legend: {
+          text: this.presenter.text.attendanceQuestion,
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--m',
+        },
+      },
+      items: this.presenter.attendanceResponses.map(response => {
+        return {
+          value: response.value,
+          text: response.text,
+          checked: response.checked,
+        }
+      }),
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/postSessionFeedback',
@@ -13,6 +35,7 @@ export default class PostSessionFeedbackView {
         presenter: this.presenter,
         serviceUserNotificationBannerArgs: this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs,
         summaryListArgs: this.summaryListArgs,
+        radioButtonArgs: this.radioButtonArgs,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -620,6 +620,7 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
       sessionNumber: 1,
       attendance: {
         attended: 'yes',
+        additionalAttendanceInformation: 'Alex made the session on time',
       },
     })
 
@@ -634,6 +635,7 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
       .type('form')
       .send({
         attended: 'yes',
+        additionalAttendanceInformation: 'Alex made the session on time',
       })
       .expect(302)
       .expect(

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -578,3 +578,38 @@ describe('GET /service-provider/action-plan/:id/sessions/:sessionNumber/edit', (
       })
   })
 })
+
+describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/', () => {
+  it('renders a page with which the Service Provider can record the Service User‘s attendance', async () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const serviceUser = deliusServiceUser.build()
+    const referral = sentReferralFactory.assigned().build({
+      referral: {
+        serviceCategoryId: serviceCategory.id,
+        serviceUser: { firstName: 'Alex', lastName: 'River' },
+      },
+    })
+    const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+    const appointment = actionPlanAppointmentFactory.build({
+      appointmentTime: '2021-02-01T13:00:00Z',
+    })
+
+    communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+    interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
+
+    await request(app)
+      .get(
+        `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback`
+      )
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Accommodation: add feedback')
+        expect(res.text).toContain('Session details')
+        expect(res.text).toContain('01 Feb 2021')
+        expect(res.text).toContain('13:00')
+      })
+  })
+})

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -613,3 +613,32 @@ describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNu
       })
   })
 })
+
+describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/', () => {
+  it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the confirmation page', async () => {
+    const updatedAppointment = actionPlanAppointmentFactory.build({
+      sessionNumber: 1,
+      attendance: {
+        attended: 'yes',
+      },
+    })
+
+    const actionPlan = actionPlanFactory.build()
+
+    interventionsService.recordAppointmentAttendance.mockResolvedValue(updatedAppointment)
+
+    await request(app)
+      .post(
+        `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback`
+      )
+      .type('form')
+      .send({
+        attended: 'yes',
+      })
+      .expect(302)
+      .expect(
+        'Location',
+        `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/confirmation`
+      )
+  })
+})

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -642,3 +642,27 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
       )
   })
 })
+
+describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation', () => {
+  it('renders a page confirming that the action plan has been submitted', async () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const referral = sentReferralFactory.assigned().build({
+      referral: {
+        serviceCategoryId: serviceCategory.id,
+        serviceUser: { firstName: 'Alex', lastName: 'River' },
+      },
+    })
+    const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+
+    interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+
+    await request(app)
+      .get(`/service-provider/action-plan/${submittedActionPlan.id}/appointment/2/post-session-feedback/confirmation`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Session feedback form has been submitted')
+      })
+  })
+})

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -28,6 +28,8 @@ import AddActionPlanNumberOfSessionsPresenter from './actionPlanNumberOfSessions
 import ActionPlanNumberOfSessionsForm from './actionPlanNumberOfSessionsForm'
 import EditSessionPresenter from './editSessionPresenter'
 import EditSessionView from './editSessionView'
+import PostSessionFeedbackView from './postSessionFeedbackView'
+import PostSessionFeedbackPresenter from './postSessionFeedbackPresenter'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -374,6 +376,30 @@ export default class ServiceProviderReferralsController {
     )
     const presenter = new EditSessionPresenter(appointment)
     const view = new EditSessionView(presenter)
+    return res.render(...view.renderArgs)
+  }
+
+  async showPostSessionFeedbackForm(req: Request, res: Response): Promise<void> {
+    const { user } = res.locals
+    const { actionPlanId, sessionNumber } = req.params
+
+    const actionPlan = await this.interventionsService.getActionPlan(user.token, actionPlanId)
+    const referral = await this.interventionsService.getSentReferral(user.token, actionPlan.referralId)
+
+    const appointment = await this.interventionsService.getActionPlanAppointment(
+      user.token,
+      actionPlanId,
+      Number(sessionNumber)
+    )
+    const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      user.token,
+      referral.referral.serviceCategoryId
+    )
+
+    const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory)
+    const view = new PostSessionFeedbackView(presenter)
+
     return res.render(...view.renderArgs)
   }
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -441,7 +441,7 @@ export default class ServiceProviderReferralsController {
       referral.referral.serviceCategoryId
     )
 
-    const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory, formError)
+    const presenter = new PostSessionFeedbackPresenter(appointment, serviceUser, serviceCategory, formError, req.body)
     const view = new PostSessionFeedbackView(presenter)
 
     res.status(formError === null ? 200 : 400)

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -165,7 +165,7 @@ export interface ActionPlanAppointmentUpdate {
   durationInMinutes: number
 }
 
-interface AppointmentAttendance {
+export interface AppointmentAttendance {
   attended: 'yes' | 'no' | 'late'
   additionalAttendanceInformation?: string
 }

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -61,4 +61,7 @@ export default {
     notWholeNumber: 'The number of sessions must be a whole number, like 5',
     tooSmall: 'The number of sessions must be 1 or more',
   },
+  attendedAppointment: {
+    empty: 'Select whether the service user attended or not',
+  },
 }

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
@@ -20,7 +20,9 @@
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
 
-      <p class="govuk-hint">Page {{ presenter.text.pageNumber }} of 3</p>
+      {% if presenter.text.pageNumber %}
+        <p class="govuk-hint">Page {{ presenter.text.pageNumber }} of 3</p>
+      {% endif %}
 
       {% block formSection %}{% endblock %}
     </div>

--- a/server/views/serviceProviderReferrals/postSessionFeedback.njk
+++ b/server/views/serviceProviderReferrals/postSessionFeedback.njk
@@ -1,0 +1,13 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "./actionPlan/actionPlanFormTemplate.njk" %}
+
+{% block formSection %}
+  {{ govukSummaryList(summaryListArgs) }}
+
+  <form method="post" action="#">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {{ govukButton({ text: "Submit for approval" }) }}
+  </form>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/postSessionFeedback.njk
+++ b/server/views/serviceProviderReferrals/postSessionFeedback.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% extends "./actionPlan/actionPlanFormTemplate.njk" %}
@@ -6,8 +7,12 @@
 {% block formSection %}
   {{ govukSummaryList(summaryListArgs) }}
 
+  <h2 class="govuk-heading-l">Attendance</h2>
+
   <form method="post" action="#">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {{ govukRadios(radioButtonArgs) }}
+
     {{ govukButton({ text: "Submit for approval" }) }}
   </form>
 {% endblock %}

--- a/server/views/serviceProviderReferrals/postSessionFeedback.njk
+++ b/server/views/serviceProviderReferrals/postSessionFeedback.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% extends "./actionPlan/actionPlanFormTemplate.njk" %}
 
@@ -12,6 +13,8 @@
   <form method="post" action="#">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukRadios(radioButtonArgs) }}
+
+    {{ govukTextarea(textAreaArgs) }}
 
     {{ govukButton({ text: "Submit for approval" }) }}
   </form>

--- a/server/views/serviceProviderReferrals/postSessionFeedbackConfirmation.njk
+++ b/server/views/serviceProviderReferrals/postSessionFeedbackConfirmation.njk
@@ -1,0 +1,28 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}
+  HMPPS Inteventions - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({titleText: "Session feedback form has been submitted"}) }}
+
+      <h2 class="govuk-heading-m">Service user details</h2>
+
+      {{ govukSummaryList(summaryListArgs) }}
+
+      <h2 class="govuk-heading-m">What happens next?</h2>
+
+      <p class="govuk-body">
+      {{ presenter.text.whatHappensNext }}
+      </p>
+
+      <a href="{{ presenter.progressHref }}" class="govuk-button">Return to service progress</a>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds post session feedback form with attendance question, a required checkbox with optional freetext answer.

I've cherry-picked a few commits from https://github.com/ministryofjustice/hmpps-interventions-ui/pull/194, and would like to incorporate some other changes from that branch (e.g. 12 hr time formats), so am marking this as draft until that one gets merged and I can rebase it.

## What is the intent behind these changes?

To record service user's attendance for action plan sessions.

## Screenshots

### Form
<img width="979" alt="image" src="https://user-images.githubusercontent.com/19826940/112971047-be37d380-9146-11eb-8c82-62899859e925.png">

<img width="833" alt="image" src="https://user-images.githubusercontent.com/19826940/112971055-c09a2d80-9146-11eb-801a-7775f29f012d.png">

### Confirmation screen
<img width="783" alt="image" src="https://user-images.githubusercontent.com/19826940/112971172-ddcefc00-9146-11eb-803f-0f8a4a079da8.png">

