### PR TITLE
Add an action plan appointment factory

### DIFF
--- a/testutils/factories/actionPlanAppointment.ts
+++ b/testutils/factories/actionPlanAppointment.ts
@@ -1,0 +1,21 @@
+import { Factory } from 'fishery'
+import { ActionPlanAppointment } from '../../server/services/interventionsService'
+
+class ActionPlanAppointmentFactory extends Factory<ActionPlanAppointment> {
+  newlyCreated() {
+    return this.params({})
+  }
+
+  scheduled() {
+    return this.params({
+      appointmentTime: new Date().toISOString(),
+      durationInMinutes: 60,
+    })
+  }
+}
+
+export default ActionPlanAppointmentFactory.define(() => ({
+  sessionNumber: 1,
+  appointmentTime: null,
+  durationInMinutes: null,
+}))


### PR DESCRIPTION
## What does this pull request do?

Adds a factory to create `ActionPlanAppointment` instances.

## What is the intent behind these changes?

To make it easier to generate test data for the upcoming "edit action plan appointment" screen.