### PR TITLE
Add missing mocks for action plan appointment calls

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -116,5 +116,13 @@ module.exports = on => {
         arg.response.json
       )
     },
+
+    stubGetActionPlanAppointments: arg => {
+      return interventionsService.stubGetActionPlanAppointments(arg.id, arg.responseJson)
+    },
+
+    stubGetActionPlanAppointment: arg => {
+      return interventionsService.stubGetActionPlanAppointment(arg.id, arg.session, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -69,3 +69,11 @@ Cypress.Commands.add('stubSubmitActionPlan', (id, responseJson) => {
 Cypress.Commands.add('stubRecordAppointmentAttendance', (actionPlanId, sessionNumber, responseJson) => {
   cy.task('stubRecordAppointmentAttendence', { actionPlanId, sessionNumber, responseJson })
 })
+
+Cypress.Commands.add('stubGetActionPlanAppointments', (id, responseJson) => {
+  cy.task('stubGetActionPlanAppointments', { id, responseJson })
+})
+
+Cypress.Commands.add('stubGetActionPlanAppointment', (id, session, responseJson) => {
+  cy.task('stubGetActionPlanAppointment', { id, session, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -280,4 +280,36 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubGetActionPlanAppointments = async (id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/action-plan/${id}/appointments`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  stubGetActionPlanAppointment = async (id: string, session: number, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/action-plan/${id}/appointments/${session}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds mocks for some calls, which weren't added when the calls were added.

## What is the intent behind these changes?

To allow us to write tests for the upcoming "edit action plan appointment" screen.