### PR TITLE
Add time input component

### DIFF
--- a/script/generateGovukFrontendTypes/component.ts
+++ b/script/generateGovukFrontendTypes/component.ts
@@ -2,7 +2,11 @@ import Type from './type'
 import { kebabCaseToUpperCamelCase } from './utils'
 
 export default class Component {
-  constructor(private readonly directoryName: string, private readonly macroOptions: Record<string, unknown>[]) {}
+  constructor(
+    private readonly directoryName: string,
+    private readonly macroOptions: Record<string, unknown>[],
+    private readonly isGovUk: boolean
+  ) {}
 
   private get types(): Type[] {
     return new Type(`${this.upperCamelCaseComponentName}Args`, this.macroOptions).flattenedWithIntroducedTypes
@@ -13,10 +17,11 @@ export default class Component {
   }
 
   get definitions(): string {
-    return `// The ${this.directoryName.replace(
-      '-',
-      ' '
-    )} component is described at https://design-system.service.gov.uk/components/${this.directoryName}.
+    const componentLocation = this.isGovUk
+      ? `is described at https://design-system.service.gov.uk/components/${this.directoryName}`
+      : `is custom to this application`
+
+    return `// The ${this.directoryName.replace('-', ' ')} component ${componentLocation}.
 ${this.types.map(type => type.definition).join('\n')}`
   }
 }

--- a/server/utils/govukFrontendTypes.ts
+++ b/server/utils/govukFrontendTypes.ts
@@ -1975,3 +1975,100 @@ export interface WarningTextArgs {
   */
   attributes?: Record<string, unknown> | null
 }
+
+// The time input component is custom to this application.
+export interface TimeInputArgs {
+  /*
+    This is used for the main component and to compose id attribute for each item.
+  */
+  id: string
+
+  /*
+    Optional prefix. This is used to prefix each `item.name` using `-`.
+  */
+  namePrefix?: string | null
+
+  /*
+    An array of input objects with name, value and classes.
+  */
+  items?: TimeInputArgsItem[] | null
+
+  /*
+    Options for the hint component.
+  */
+  hint?: HintArgs | null
+
+  /*
+    Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
+  */
+  errorMessage?: ErrorMessageArgs | null
+
+  /*
+    Options for the form-group wrapper
+  */
+  formGroup?: TimeInputArgsFormGroup | null
+
+  /*
+    Options for the fieldset component (e.g. legend).
+  */
+  fieldset?: FieldsetArgs | null
+
+  /*
+    Classes to add to the date-input container.
+  */
+  classes?: string | null
+
+  /*
+    HTML attributes (for example data attributes) to add to the date-input container.
+  */
+  attributes?: Record<string, unknown> | null
+}
+
+export interface TimeInputArgsItem {
+  /*
+    Item-specific id. If provided, it will be used instead of the generated id.
+  */
+  id?: string | null
+
+  /*
+    Item-specific name attribute.
+  */
+  name: string
+
+  /*
+    Item-specific label text. If provided, this will be used instead of `name` for item label text.
+  */
+  label?: string | null
+
+  /*
+    If provided, it will be used as the initial value of the input.
+  */
+  value?: string | null
+
+  /*
+    Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "bday-day". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
+  */
+  autocomplete?: string | null
+
+  /*
+    Attribute to [provide a regular expression pattern](https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value.
+  */
+  pattern?: string | null
+
+  /*
+    Classes to add to date input item.
+  */
+  classes?: string | null
+
+  /*
+    HTML attributes (for example data attributes) to add to the date input tag.
+  */
+  attributes?: Record<string, unknown> | null
+}
+
+export interface TimeInputArgsFormGroup {
+  /*
+    Classes to add to the form group (e.g. to show error state for the whole group)
+  */
+  classes?: string | null
+}

--- a/server/utils/govukFrontendTypes.ts
+++ b/server/utils/govukFrontendTypes.ts
@@ -2022,6 +2022,11 @@ export interface TimeInputArgs {
     HTML attributes (for example data attributes) to add to the date-input container.
   */
   attributes?: Record<string, unknown> | null
+
+  /*
+    Arguments for the AM / PM select component.
+  */
+  select: SelectArgs
 }
 
 export interface TimeInputArgsItem {

--- a/server/views/components/time-input/macro-options.json
+++ b/server/views/components/time-input/macro-options.json
@@ -1,0 +1,117 @@
+[
+    {
+        "name": "id",
+        "type": "string",
+        "required": true,
+        "description": "This is used for the main component and to compose id attribute for each item."
+    },
+    {
+        "name": "namePrefix",
+        "type": "string",
+        "required": false,
+        "description": "Optional prefix. This is used to prefix each `item.name` using `-`."
+    },
+    {
+        "name": "items",
+        "type": "array",
+        "required": false,
+        "description": "An array of input objects with name, value and classes.",
+        "params": [
+            {
+                "name": "id",
+                "type": "string",
+                "required": false,
+                "description": "Item-specific id. If provided, it will be used instead of the generated id."
+            },
+            {
+                "name": "name",
+                "type": "string",
+                "required": true,
+                "description": "Item-specific name attribute."
+            },
+            {
+                "name": "label",
+                "type": "string",
+                "required": false,
+                "description": "Item-specific label text. If provided, this will be used instead of `name` for item label text."
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "required": false,
+                "description": "If provided, it will be used as the initial value of the input."
+            },
+            {
+                "name": "autocomplete",
+                "type": "string",
+                "required": false,
+                "description": "Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance \"bday-day\". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used."
+            },
+            {
+                "name": "pattern",
+                "type": "string",
+                "required": false,
+                "description": "Attribute to [provide a regular expression pattern](https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value."
+            },
+            {
+                "name": "classes",
+                "type": "string",
+                "required": false,
+                "description": "Classes to add to date input item."
+            },
+            {
+                "name": "attributes",
+                "type": "object",
+                "required": false,
+                "description": "HTML attributes (for example data attributes) to add to the date input tag."
+            }
+        ]
+    },
+    {
+        "name": "hint",
+        "type": "object",
+        "required": false,
+        "description": "Options for the hint component.",
+        "isComponent": true
+    },
+    {
+        "name": "errorMessage",
+        "type": "object",
+        "required": false,
+        "description": "Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.",
+        "isComponent": true
+    },
+    {
+        "name": "formGroup",
+        "type": "object",
+        "required": false,
+        "description": "Options for the form-group wrapper",
+        "params": [
+            {
+                "name": "classes",
+                "type": "string",
+                "required": false,
+                "description": "Classes to add to the form group (e.g. to show error state for the whole group)"
+            }
+        ]
+    },
+    {
+        "name": "fieldset",
+        "type": "object",
+        "required": false,
+        "description": "Options for the fieldset component (e.g. legend).",
+        "isComponent": true
+    },
+    {
+        "name": "classes",
+        "type": "string",
+        "required": false,
+        "description": "Classes to add to the date-input container."
+    },
+    {
+        "name": "attributes",
+        "type": "object",
+        "required": false,
+        "description": "HTML attributes (for example data attributes) to add to the date-input container."
+    }
+]

--- a/server/views/components/time-input/macro-options.json
+++ b/server/views/components/time-input/macro-options.json
@@ -113,5 +113,12 @@
         "type": "object",
         "required": false,
         "description": "HTML attributes (for example data attributes) to add to the date-input container."
+    },
+    {
+        "name": "select",
+        "type": "object",
+        "required": true,
+        "isComponent": true,
+        "description": "Arguments for the AM / PM select component."
     }
 ]

--- a/server/views/components/time-input/macro.njk
+++ b/server/views/components/time-input/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukDateInput(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/time-input/macro.njk
+++ b/server/views/components/time-input/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukDateInput(params) %}
+{% macro appTimeInput(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/server/views/components/time-input/template.njk
+++ b/server/views/components/time-input/template.njk
@@ -1,0 +1,97 @@
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../fieldset/macro.njk" import govukFieldset %}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../input/macro.njk" import govukInput %}
+
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
+{% set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" %}
+
+{% if params.items | length %}
+  {% set dateInputItems = params.items %}
+{% else %}
+  {% set dateInputItems = [
+    {
+      name: "day",
+      classes: "govuk-input--width-2"
+    },
+    {
+      name: "month",
+      classes: "govuk-input--width-2"
+    },
+    {
+      name: "year",
+      classes: "govuk-input--width-4"
+    }
+  ] %}
+{% endif %}
+
+{#- Capture the HTML so we can optionally nest it in a fieldset -#}
+{% set innerHtml %}
+{% if params.hint %}
+  {% set hintId = params.id + "-hint" %}
+  {% set describedBy = describedBy + " " + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + "-error" %}
+  {% set describedBy = describedBy + " " + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    attributes: params.errorMessage.attributes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
+  }) | indent(2) | trim }}
+{% endif %}
+  <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
+    {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
+    {%- if params.id %} id="{{ params.id }}"{% endif %}>
+    {% for item in dateInputItems %}
+    <div class="govuk-date-input__item">
+      {{ govukInput({
+        label: {
+          text: item.label if item.label else item.name | capitalize,
+          classes: "govuk-date-input__label"
+        },
+        id: item.id if item.id else (params.id + "-" + item.name),
+        classes: "govuk-date-input__input " + (item.classes if item.classes),
+        name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
+        value: item.value,
+        type: "text",
+        inputmode: item.inputmode if item.inputmode else "numeric",
+        autocomplete: item.autocomplete,
+        pattern: item.pattern if item.pattern else "[0-9]*",
+        attributes: item.attributes
+      }) | indent(6) | trim }}
+    </div>
+  {% endfor %}
+  </div>
+{% endset %}
+
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+{% if params.fieldset %}
+{#- We override the fieldset's role to 'group' because otherwise JAWS does not
+    announce the description for a fieldset comprised of text inputs, but
+    adding the role to the fieldset always makes the output overly verbose for
+    radio buttons or checkboxes. -#}
+  {% call govukFieldset({
+    describedBy: describedBy,
+    classes: params.fieldset.classes,
+    role: 'group',
+    attributes: params.fieldset.attributes,
+    legend: params.fieldset.legend
+  }) %}
+  {{ innerHtml | trim | safe }}
+  {% endcall %}
+{% else %}
+  {{ innerHtml | trim | safe }}
+{% endif %}
+</div>

--- a/server/views/components/time-input/template.njk
+++ b/server/views/components/time-input/template.njk
@@ -1,7 +1,11 @@
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../fieldset/macro.njk" import govukFieldset %}
-{% from "../hint/macro.njk" import govukHint %}
-{% from "../input/macro.njk" import govukInput %}
+{# This is a fork of the GOV.UK Frontend date-input component, with an 
+extra select component displayed for AM / PM. #}
+
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage -%}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/hint/macro.njk" import govukHint %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
@@ -73,6 +77,10 @@
       }) | indent(6) | trim }}
     </div>
   {% endfor %}
+
+    <div class="govuk-date-input__item">
+      {{ govukSelect(params.select) }}
+    </div>
   </div>
 {% endset %}
 


### PR DESCRIPTION
## What does this pull request do?

- Introduces a way of adding custom view components, similar to the components offered by the GOV.UK Frontend library
- Extends the existing script, to generate TypeScript types for the arguments of these components' Nunjucks macros
- Adds a time input component, which is a fork of the GOV.UK Frontend's date input component which provides a space for an AM / PM select.

## What is the intent behind these changes?

To allow us to accept a time value from the user on the upcoming "edit action plan appointment" page.