### PR TITLE
Add a class for representing a duration, and then the ability to present it as form input fields

### DIFF
--- a/server/utils/duration.test.ts
+++ b/server/utils/duration.test.ts
@@ -1,0 +1,20 @@
+import Duration from './duration'
+
+describe(Duration, () => {
+  describe('.fromUnits', () => {
+    it('converts hours, minutes and seconds to seconds', () => {
+      expect(Duration.fromUnits(10, 5, 32).seconds).toEqual(36332)
+      expect(Duration.fromUnits(0, 500, 0).seconds).toEqual(30000)
+    })
+  })
+
+  describe('stopwatch values', () => {
+    it('returns the correct values', () => {
+      const duration = new Duration(10 * 3600 + 5 * 60 + 32.5)
+
+      expect(duration.stopwatchHours).toEqual(10)
+      expect(duration.stopwatchMinutes).toEqual(5)
+      expect(duration.stopwatchSeconds).toEqual(32.5)
+    })
+  })
+})

--- a/server/utils/duration.ts
+++ b/server/utils/duration.ts
@@ -1,0 +1,25 @@
+export default class Duration {
+  constructor(readonly seconds: number) {}
+
+  static fromUnits(hours: number, minutes: number, seconds: number): Duration {
+    return new Duration(hours * 3600 + minutes * 60 + seconds)
+  }
+
+  // The hours value displayed for this duration on a stopwatch
+  // that displays durations in hours, minutes, and seconds.
+  get stopwatchHours(): number {
+    return Math.floor(this.seconds / 3600)
+  }
+
+  // The minutes value displayed for this duration on a stopwatch
+  // that displays durations in hours, minutes, and seconds.
+  get stopwatchMinutes(): number {
+    return Math.floor((this.seconds % 3600) / 60)
+  }
+
+  // The seconds value displayed for this duration on a stopwatch
+  // that displays durations in hours, minutes, and seconds.
+  get stopwatchSeconds(): number {
+    return this.seconds % 60
+  }
+}

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -1,6 +1,7 @@
 import PresenterUtils from './presenterUtils'
 import draftReferralFactory from '../../testutils/factories/draftReferral'
 import CalendarDay from './calendarDay'
+import Duration from './duration'
 
 describe(PresenterUtils, () => {
   describe('stringValue', () => {
@@ -303,6 +304,82 @@ describe(PresenterUtils, () => {
           expect(value.day.hasError).toEqual(false)
           expect(value.month.hasError).toEqual(true)
           expect(value.year.hasError).toEqual(true)
+        })
+      })
+    })
+  })
+
+  describe('durationValue', () => {
+    describe('hours, minutes values', () => {
+      describe('when the model has a null value for the property', () => {
+        describe('and there is no user input data', () => {
+          it('returns empty strings', () => {
+            const utils = new PresenterUtils(null)
+            const value = utils.durationValue(null, 'duration', null)
+
+            expect(value).toMatchObject({ hours: { value: '' }, minutes: { value: '' } })
+          })
+        })
+      })
+
+      describe('when the model has a non-null value for the property', () => {
+        describe('and there is no user input data', () => {
+          it('returns the corresponding values from the model', () => {
+            const utils = new PresenterUtils(null)
+            const value = utils.durationValue(Duration.fromUnits(0, 75, 0), 'duration', null)
+
+            expect(value).toMatchObject({ hours: { value: '1' }, minutes: { value: '15' } })
+          })
+        })
+      })
+
+      describe('when there is user input data', () => {
+        it('returns the user input data', () => {
+          const utils = new PresenterUtils({ 'duration-hours': 'egg', 'duration-minutes': 7 })
+          const value = utils.durationValue(Duration.fromUnits(0, 75, 0), 'duration', null)
+
+          expect(value.hours.value).toBe('egg')
+          expect(value.minutes.value).toBe('7')
+        })
+
+        it('returns an empty string if a field is missing', () => {
+          const utils = new PresenterUtils({ 'duration-hours': 7 })
+          const value = utils.durationValue(Duration.fromUnits(0, 75, 0), 'duration', null)
+
+          expect(value.hours.value).toBe('7')
+          expect(value.minutes.value).toBe('')
+        })
+      })
+    })
+
+    describe('error information', () => {
+      describe('when a null error is passed in', () => {
+        it('returns no errors', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.durationValue(null, 'duration', null)
+
+          expect(value.errorMessage).toBeNull()
+          expect(value.hours.hasError).toEqual(false)
+          expect(value.minutes.hasError).toEqual(false)
+        })
+      })
+
+      describe('when a non-null error is passed in', () => {
+        it('returns error information', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.durationValue(null, 'duration', {
+            errors: [
+              {
+                errorSummaryLinkedField: 'duration-minutes',
+                formFields: ['duration-minutes'],
+                message: 'Please enter a number of minutes',
+              },
+            ],
+          })
+
+          expect(value.errorMessage).toBe('Please enter a number of minutes')
+          expect(value.hours.hasError).toEqual(false)
+          expect(value.minutes.hasError).toEqual(true)
         })
       })
     })

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -2,18 +2,25 @@ import { AuthUser } from '../data/hmppsAuthClient'
 import { ServiceUser } from '../services/interventionsService'
 import CalendarDay from './calendarDay'
 import { FormValidationError } from './formValidationError'
+import Duration from './duration'
 import utils from './utils'
 
-interface DateComponentInputPresenter {
+interface DateTimeComponentInputPresenter {
   value: string
   hasError: boolean
 }
 
 export interface DateInputPresenter {
   errorMessage: string | null
-  day: DateComponentInputPresenter
-  month: DateComponentInputPresenter
-  year: DateComponentInputPresenter
+  day: DateTimeComponentInputPresenter
+  month: DateTimeComponentInputPresenter
+  year: DateTimeComponentInputPresenter
+}
+
+interface DurationInputPresenter {
+  errorMessage: string | null
+  hours: DateTimeComponentInputPresenter
+  minutes: DateTimeComponentInputPresenter
 }
 
 export default class PresenterUtils {
@@ -80,6 +87,41 @@ export default class PresenterUtils {
       year: {
         value: yearValue,
         hasError: PresenterUtils.hasError(error, yearKey),
+      },
+    }
+  }
+
+  durationValue(
+    modelValue: Duration | null,
+    userInputKey: string,
+    error: FormValidationError | null
+  ): DurationInputPresenter {
+    const [hoursKey, minutesKey] = ['hours', 'minutes'].map(suffix => `${userInputKey}-${suffix}`)
+
+    const errorMessage = PresenterUtils.errorMessage(error, hoursKey) ?? PresenterUtils.errorMessage(error, minutesKey)
+
+    let hoursValue = ''
+    let minutesValue = ''
+
+    if (this.userInputData === null) {
+      if (modelValue !== null) {
+        hoursValue = String(modelValue?.stopwatchHours ?? '')
+        minutesValue = String(modelValue?.stopwatchMinutes ?? '')
+      }
+    } else {
+      hoursValue = String(this.userInputData[hoursKey] || '')
+      minutesValue = String(this.userInputData[minutesKey] || '')
+    }
+
+    return {
+      errorMessage,
+      hours: {
+        value: hoursValue,
+        hasError: PresenterUtils.hasError(error, hoursKey),
+      },
+      minutes: {
+        value: minutesValue,
+        hasError: PresenterUtils.hasError(error, minutesKey),
       },
     }
   }


### PR DESCRIPTION
## What does this pull request do?

Adds a `Duration` class which represents a quantity of time. It provides convenience methods for getting stopwatch values.

It then adds a presenter utility method that will allow us to display a form input backed by a `Duration` object.

## What is the intent behind these changes?

To allow us to build the "duration" input on the upcoming "edit action plan appointment details" form.