### PR TITLE
Extract the ability to present a calendar day as form input fields

### DIFF
--- a/server/routes/referrals/completionDeadlinePresenter.test.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.test.ts
@@ -10,9 +10,9 @@ describe('CompletionDeadlinePresenter', () => {
         const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
         const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
 
-        expect(presenter.day).toBe('')
-        expect(presenter.month).toBe('')
-        expect(presenter.year).toBe('')
+        expect(presenter.fields.completionDeadline.day.value).toBe('')
+        expect(presenter.fields.completionDeadline.month.value).toBe('')
+        expect(presenter.fields.completionDeadline.year.value).toBe('')
       })
     })
 
@@ -24,9 +24,9 @@ describe('CompletionDeadlinePresenter', () => {
           .build({ completionDeadline: '2021-09-12' })
         const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
 
-        expect(presenter.day).toBe('12')
-        expect(presenter.month).toBe('9')
-        expect(presenter.year).toBe('2021')
+        expect(presenter.fields.completionDeadline.day.value).toBe('12')
+        expect(presenter.fields.completionDeadline.month.value).toBe('9')
+        expect(presenter.fields.completionDeadline.year.value).toBe('2021')
       })
     })
 
@@ -42,9 +42,9 @@ describe('CompletionDeadlinePresenter', () => {
           'completion-deadline-month': 7,
         })
 
-        expect(presenter.day).toBe('egg')
-        expect(presenter.month).toBe('7')
-        expect(presenter.year).toBe('')
+        expect(presenter.fields.completionDeadline.day.value).toBe('egg')
+        expect(presenter.fields.completionDeadline.month.value).toBe('7')
+        expect(presenter.fields.completionDeadline.year.value).toBe('')
       })
     })
   })
@@ -56,10 +56,10 @@ describe('CompletionDeadlinePresenter', () => {
         const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
         const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
 
-        expect(presenter.errorMessage).toBeNull()
-        expect(presenter.hasDayError).toEqual(false)
-        expect(presenter.hasMonthError).toEqual(false)
-        expect(presenter.hasYearError).toEqual(false)
+        expect(presenter.fields.completionDeadline.errorMessage).toBeNull()
+        expect(presenter.fields.completionDeadline.day.hasError).toEqual(false)
+        expect(presenter.fields.completionDeadline.month.hasError).toEqual(false)
+        expect(presenter.fields.completionDeadline.year.hasError).toEqual(false)
         expect(presenter.errorSummary).toBeNull()
       })
     })
@@ -78,10 +78,10 @@ describe('CompletionDeadlinePresenter', () => {
           ],
         })
 
-        expect(presenter.errorMessage).toBe('Please enter a month and a year')
-        expect(presenter.hasDayError).toEqual(false)
-        expect(presenter.hasMonthError).toEqual(true)
-        expect(presenter.hasYearError).toEqual(true)
+        expect(presenter.fields.completionDeadline.errorMessage).toBe('Please enter a month and a year')
+        expect(presenter.fields.completionDeadline.day.hasError).toEqual(false)
+        expect(presenter.fields.completionDeadline.month.hasError).toEqual(true)
+        expect(presenter.fields.completionDeadline.year.hasError).toEqual(true)
         expect(presenter.errorSummary).toEqual([
           { message: 'Please enter a month and a year', field: 'completion-deadline-month' },
         ])

--- a/server/routes/referrals/completionDeadlinePresenter.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.ts
@@ -17,48 +17,13 @@ export default class CompletionDeadlinePresenter {
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
-  fields = (() => {
-    const errorMessage =
-      PresenterUtils.errorMessage(this.error, 'completion-deadline-day') ??
-      PresenterUtils.errorMessage(this.error, 'completion-deadline-month') ??
-      PresenterUtils.errorMessage(this.error, 'completion-deadline-year')
+  private readonly utils = new PresenterUtils(this.userInputData)
 
-    let dayValue = ''
-    let monthValue = ''
-    let yearValue = ''
-
-    if (this.userInputData === null) {
-      const calendarDay = this.referral.completionDeadline
-        ? CalendarDay.parseIso8601(this.referral.completionDeadline)
-        : null
-
-      if (calendarDay !== null) {
-        dayValue = String(calendarDay?.day ?? '')
-        monthValue = String(calendarDay?.month ?? '')
-        yearValue = String(calendarDay?.year ?? '')
-      }
-    } else {
-      dayValue = String(this.userInputData['completion-deadline-day'] || '')
-      monthValue = String(this.userInputData['completion-deadline-month'] || '')
-      yearValue = String(this.userInputData['completion-deadline-year'] || '')
-    }
-
-    return {
-      completionDeadline: {
-        errorMessage,
-        day: {
-          value: dayValue,
-          hasError: PresenterUtils.hasError(this.error, 'completion-deadline-day'),
-        },
-        month: {
-          value: monthValue,
-          hasError: PresenterUtils.hasError(this.error, 'completion-deadline-month'),
-        },
-        year: {
-          value: yearValue,
-          hasError: PresenterUtils.hasError(this.error, 'completion-deadline-year'),
-        },
-      },
-    }
-  })()
+  fields = {
+    completionDeadline: this.utils.dateValue(
+      this.referral.completionDeadline === null ? null : CalendarDay.parseIso8601Date(this.referral.completionDeadline),
+      'completion-deadline',
+      this.error
+    ),
+  }
 }

--- a/server/routes/referrals/completionDeadlinePresenter.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.ts
@@ -4,21 +4,7 @@ import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class CompletionDeadlinePresenter {
-  readonly day: string
-
-  readonly month: string
-
-  readonly year: string
-
-  readonly errorMessage: string | null
-
-  readonly hasMonthError: boolean
-
-  readonly hasDayError: boolean
-
-  readonly hasYearError: boolean
-
-  readonly errorSummary: { field: string; message: string }[] | null
+  readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
   readonly title = `What date does the ${this.serviceCategory.name} service need to be completed by?`
 
@@ -27,37 +13,52 @@ export default class CompletionDeadlinePresenter {
   constructor(
     private readonly referral: DraftReferral,
     private readonly serviceCategory: ServiceCategory,
-    error: FormValidationError | null = null,
-    userInputData: Record<string, unknown> | null = null
-  ) {
-    if (!userInputData) {
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  fields = (() => {
+    const errorMessage =
+      PresenterUtils.errorMessage(this.error, 'completion-deadline-day') ??
+      PresenterUtils.errorMessage(this.error, 'completion-deadline-month') ??
+      PresenterUtils.errorMessage(this.error, 'completion-deadline-year')
+
+    let dayValue = ''
+    let monthValue = ''
+    let yearValue = ''
+
+    if (this.userInputData === null) {
       const calendarDay = this.referral.completionDeadline
         ? CalendarDay.parseIso8601(this.referral.completionDeadline)
         : null
 
-      if (!calendarDay) {
-        this.day = ''
-        this.month = ''
-        this.year = ''
-      } else {
-        this.day = String(calendarDay.day)
-        this.month = String(calendarDay.month)
-        this.year = String(calendarDay.year)
+      if (calendarDay !== null) {
+        dayValue = String(calendarDay?.day ?? '')
+        monthValue = String(calendarDay?.month ?? '')
+        yearValue = String(calendarDay?.year ?? '')
       }
     } else {
-      this.day = String(userInputData['completion-deadline-day'] || '')
-      this.month = String(userInputData['completion-deadline-month'] || '')
-      this.year = String(userInputData['completion-deadline-year'] || '')
+      dayValue = String(this.userInputData['completion-deadline-day'] || '')
+      monthValue = String(this.userInputData['completion-deadline-month'] || '')
+      yearValue = String(this.userInputData['completion-deadline-year'] || '')
     }
 
-    this.errorSummary = PresenterUtils.errorSummary(error)
-    this.errorMessage =
-      PresenterUtils.errorMessage(error, 'completion-deadline-day') ??
-      PresenterUtils.errorMessage(error, 'completion-deadline-month') ??
-      PresenterUtils.errorMessage(error, 'completion-deadline-year')
-
-    this.hasDayError = PresenterUtils.hasError(error, 'completion-deadline-day')
-    this.hasMonthError = PresenterUtils.hasError(error, 'completion-deadline-month')
-    this.hasYearError = PresenterUtils.hasError(error, 'completion-deadline-year')
-  }
+    return {
+      completionDeadline: {
+        errorMessage,
+        day: {
+          value: dayValue,
+          hasError: PresenterUtils.hasError(this.error, 'completion-deadline-day'),
+        },
+        month: {
+          value: monthValue,
+          hasError: PresenterUtils.hasError(this.error, 'completion-deadline-month'),
+        },
+        year: {
+          value: yearValue,
+          hasError: PresenterUtils.hasError(this.error, 'completion-deadline-year'),
+        },
+      },
+    }
+  })()
 }

--- a/server/routes/referrals/completionDeadlineView.ts
+++ b/server/routes/referrals/completionDeadlineView.ts
@@ -19,22 +19,28 @@ export default class CompletionDeadlineView {
       hint: {
         text: this.presenter.hint,
       },
-      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.completionDeadline.errorMessage),
       items: [
         {
-          classes: `govuk-input--width-2${this.presenter.hasDayError ? ' govuk-input--error' : ''}`,
+          classes: `govuk-input--width-2${
+            this.presenter.fields.completionDeadline.day.hasError ? ' govuk-input--error' : ''
+          }`,
           name: 'day',
-          value: this.presenter.day,
+          value: this.presenter.fields.completionDeadline.day.value,
         },
         {
-          classes: `govuk-input--width-2${this.presenter.hasMonthError ? ' govuk-input--error' : ''}`,
+          classes: `govuk-input--width-2${
+            this.presenter.fields.completionDeadline.month.hasError ? ' govuk-input--error' : ''
+          }`,
           name: 'month',
-          value: this.presenter.month,
+          value: this.presenter.fields.completionDeadline.month.value,
         },
         {
-          classes: `govuk-input--width-4${this.presenter.hasYearError ? ' govuk-input--error' : ''}`,
+          classes: `govuk-input--width-4${
+            this.presenter.fields.completionDeadline.year.hasError ? ' govuk-input--error' : ''
+          }`,
           name: 'year',
-          value: this.presenter.year,
+          value: this.presenter.fields.completionDeadline.year.value,
         },
       ],
     }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -207,7 +207,7 @@ export default class InterventionsService {
       : null
 
     const iso8601DateOfBirth = deliusServiceUser.dateOfBirth
-      ? CalendarDay.parseIso8601(deliusServiceUser.dateOfBirth)?.iso8601 || null
+      ? CalendarDay.parseIso8601Date(deliusServiceUser.dateOfBirth)?.iso8601 || null
       : null
 
     return {

--- a/server/utils/calendarDay.test.ts
+++ b/server/utils/calendarDay.test.ts
@@ -35,33 +35,33 @@ describe('CalendarDay', () => {
 
   describe('.parseIso8601', () => {
     it('returns a calendar day when given a valid ISO 8601 formatted date', () => {
-      expect(CalendarDay.parseIso8601('1992-09-15')).toEqual(CalendarDay.fromComponents(15, 9, 1992))
+      expect(CalendarDay.parseIso8601Date('1992-09-15')).toEqual(CalendarDay.fromComponents(15, 9, 1992))
     })
 
     // This is intentional - a moment in time can’t be mapped
     // to a calendar day without also specifying a time zone.
     it('returns null when given an ISO 8601 formatted date and time', () => {
-      expect(CalendarDay.parseIso8601('1992-09-15T12:49:50Z')).toBeNull()
+      expect(CalendarDay.parseIso8601Date('1992-09-15T12:49:50Z')).toBeNull()
     })
 
     it('returns null when given something other than an ISO 8601 formatted date', () => {
-      expect(CalendarDay.parseIso8601('19920915')).toBeNull()
+      expect(CalendarDay.parseIso8601Date('19920915')).toBeNull()
     })
 
     it('returns null when given 31st February in a non-leap year', () => {
-      expect(CalendarDay.parseIso8601('2011-02-31')).toBeNull()
+      expect(CalendarDay.parseIso8601Date('2011-02-31')).toBeNull()
     })
 
     it('returns null when given a month out of bounds', () => {
-      expect(CalendarDay.parseIso8601('2011-13-01')).toBeNull()
+      expect(CalendarDay.parseIso8601Date('2011-13-01')).toBeNull()
     })
 
     it('returns null when given a day out of bounds for any month', () => {
-      expect(CalendarDay.parseIso8601('2011-01-32')).toBeNull()
+      expect(CalendarDay.parseIso8601Date('2011-01-32')).toBeNull()
     })
 
     it('returns null when given a day out of bounds for the month', () => {
-      expect(CalendarDay.parseIso8601('2011-06-31')).toBeNull()
+      expect(CalendarDay.parseIso8601Date('2011-06-31')).toBeNull()
     })
   })
 

--- a/server/utils/calendarDay.ts
+++ b/server/utils/calendarDay.ts
@@ -5,7 +5,7 @@ export default class CalendarDay {
     return isValidDate(day, month, year) ? new CalendarDay(day, month, year) : null
   }
 
-  static parseIso8601(val: string): CalendarDay | null {
+  static parseIso8601Date(val: string): CalendarDay | null {
     const result = /^(\d{4})-(\d{2})-(\d{2})$/.exec(val)
 
     if (result === null) {

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -237,6 +237,77 @@ describe(PresenterUtils, () => {
     })
   })
 
+  describe('dateValue', () => {
+    describe('day, month, year values', () => {
+      describe('when the model has a null value for the property', () => {
+        describe('and there is no user input data', () => {
+          it('returns empty strings', () => {
+            const utils = new PresenterUtils(null)
+            const value = utils.dateValue(null, 'completion-deadline', null)
+
+            expect(value).toMatchObject({ day: { value: '' }, month: { value: '' }, year: { value: '' } })
+          })
+        })
+      })
+
+      describe('when the model has a non-null value for the property', () => {
+        describe('and there is no user input data', () => {
+          it('returns the corresponding values from the model', () => {
+            const utils = new PresenterUtils(null)
+            const value = utils.dateValue(CalendarDay.fromComponents(12, 9, 2021), 'completion-deadline', null)
+
+            expect(value).toMatchObject({ day: { value: '12' }, month: { value: '9' }, year: { value: '2021' } })
+          })
+        })
+      })
+
+      describe('when there is user input data', () => {
+        it('returns the user input data, or an empty string if a field is missing', () => {
+          const utils = new PresenterUtils({ 'completion-deadline-day': 'egg', 'completion-deadline-month': 7 })
+          const value = utils.dateValue(CalendarDay.fromComponents(12, 9, 2021), 'completion-deadline', null)
+
+          expect(value.day.value).toBe('egg')
+          expect(value.month.value).toBe('7')
+          expect(value.year.value).toBe('')
+        })
+      })
+    })
+
+    describe('error information', () => {
+      describe('when a null error is passed in', () => {
+        it('returns no errors', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.dateValue(null, 'completion-deadline', null)
+
+          expect(value.errorMessage).toBeNull()
+          expect(value.day.hasError).toEqual(false)
+          expect(value.month.hasError).toEqual(false)
+          expect(value.year.hasError).toEqual(false)
+        })
+      })
+
+      describe('when a non-null error is passed in', () => {
+        it('returns error information', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.dateValue(null, 'completion-deadline', {
+            errors: [
+              {
+                errorSummaryLinkedField: 'completion-deadline-month',
+                formFields: ['completion-deadline-month', 'completion-deadline-year'],
+                message: 'Please enter a month and a year',
+              },
+            ],
+          })
+
+          expect(value.errorMessage).toBe('Please enter a month and a year')
+          expect(value.day.hasError).toEqual(false)
+          expect(value.month.hasError).toEqual(true)
+          expect(value.year.hasError).toEqual(true)
+        })
+      })
+    })
+  })
+
   describe('.errorSummary', () => {
     describe('with null error', () => {
       it('returns null', () => {

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -170,7 +170,7 @@ export default class PresenterUtils {
     const notFoundMessage = 'Not found'
 
     if (date) {
-      const iso8601date = CalendarDay.parseIso8601(date)
+      const iso8601date = CalendarDay.parseIso8601Date(date)
 
       return iso8601date ? this.govukFormattedDate(iso8601date) : notFoundMessage
     }

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -1,7 +1,20 @@
 import { AuthUser } from '../data/hmppsAuthClient'
 import { ServiceUser } from '../services/interventionsService'
 import CalendarDay from './calendarDay'
+import { FormValidationError } from './formValidationError'
 import utils from './utils'
+
+interface DateComponentInputPresenter {
+  value: string
+  hasError: boolean
+}
+
+export interface DateInputPresenter {
+  errorMessage: string | null
+  day: DateComponentInputPresenter
+  month: DateComponentInputPresenter
+  year: DateComponentInputPresenter
+}
 
 export default class PresenterUtils {
   constructor(private readonly userInputData: Record<string, unknown> | null = null) {}
@@ -24,6 +37,51 @@ export default class PresenterUtils {
       return false
     }
     return null
+  }
+
+  dateValue(
+    modelValue: CalendarDay | null,
+    userInputKey: string,
+    error: FormValidationError | null
+  ): DateInputPresenter {
+    const [dayKey, monthKey, yearKey] = ['day', 'month', 'year'].map(suffix => `${userInputKey}-${suffix}`)
+
+    const errorMessage =
+      PresenterUtils.errorMessage(error, dayKey) ??
+      PresenterUtils.errorMessage(error, monthKey) ??
+      PresenterUtils.errorMessage(error, yearKey)
+
+    let dayValue = ''
+    let monthValue = ''
+    let yearValue = ''
+
+    if (this.userInputData === null) {
+      if (modelValue !== null) {
+        dayValue = String(modelValue?.day ?? '')
+        monthValue = String(modelValue?.month ?? '')
+        yearValue = String(modelValue?.year ?? '')
+      }
+    } else {
+      dayValue = String(this.userInputData[dayKey] || '')
+      monthValue = String(this.userInputData[monthKey] || '')
+      yearValue = String(this.userInputData[yearKey] || '')
+    }
+
+    return {
+      errorMessage,
+      day: {
+        value: dayValue,
+        hasError: PresenterUtils.hasError(error, dayKey),
+      },
+      month: {
+        value: monthValue,
+        hasError: PresenterUtils.hasError(error, monthKey),
+      },
+      year: {
+        value: yearValue,
+        hasError: PresenterUtils.hasError(error, yearKey),
+      },
+    }
   }
 
   private static sortedErrors<T extends { errorSummaryLinkedField: string }>(errors: T[], fieldOrder: string[]): T[] {


### PR DESCRIPTION
## What does this pull request do?

Adds a presenter utility method that will allow us to display a form input backed by a `CalendarDay` object. This is extracted from the existing `CompletionDeadlinePresenter`.

It also makes a slight renaming to a `CalendarDay` method for clarity.

## What is the intent behind these changes?

To allow us to build the "date" input on the upcoming "edit action plan appointment" form.
