### PR TITLE
Add a class for representing a clock time, and then the ability to present it as form input fields

### DIFF
--- a/server/utils/clockTime.test.ts
+++ b/server/utils/clockTime.test.ts
@@ -1,0 +1,78 @@
+import ClockTime from './clockTime'
+
+describe(ClockTime, () => {
+  describe('fromComponents', () => {
+    describe('with valid input', () => {
+      it('returns a time object', () => {
+        expect(ClockTime.fromComponents(0, 0, 0)).not.toBeNull()
+        expect(ClockTime.fromComponents(23, 59, 59)).not.toBeNull()
+      })
+    })
+
+    describe('with invalid input', () => {
+      it('returns null', () => {
+        expect(ClockTime.fromComponents(24, 0, 0)).toBeNull()
+        expect(ClockTime.fromComponents(0, 61, 0)).toBeNull()
+        expect(ClockTime.fromComponents(0, 0, 61)).toBeNull()
+
+        expect(ClockTime.fromComponents(-1, 0, 0)).toBeNull()
+        expect(ClockTime.fromComponents(0, -1, 0)).toBeNull()
+        expect(ClockTime.fromComponents(0, 0, -1)).toBeNull()
+      })
+    })
+  })
+
+  describe('britishTimeForDate', () => {
+    it('returns the time that the date occurs at in Britain', () => {
+      expect(ClockTime.britishTimeForDate(new Date('2021-02-25T23:30:05Z'))).toEqual({
+        hour: 23,
+        minute: 30,
+        second: 5,
+      })
+    })
+
+    it('handles daylight saving time', () => {
+      expect(ClockTime.britishTimeForDate(new Date('2021-08-25T23:30:05Z'))).toEqual({
+        hour: 0,
+        minute: 30,
+        second: 5,
+      })
+    })
+  })
+
+  describe('twelveHourClockHour', () => {
+    it('returns the correct hour for morning times', () => {
+      expect(ClockTime.fromComponents(10, 0, 0)!.twelveHourClockHour).toEqual(10)
+    })
+
+    it('returns 0 for midnight', () => {
+      expect(ClockTime.fromComponents(0, 0, 0)!.twelveHourClockHour).toEqual(0)
+    })
+
+    it('returns 12 for midday', () => {
+      expect(ClockTime.fromComponents(12, 0, 0)!.twelveHourClockHour).toEqual(12)
+    })
+
+    it('returns the correct hour for afternoon times', () => {
+      expect(ClockTime.fromComponents(22, 0, 0)!.twelveHourClockHour).toEqual(10)
+    })
+  })
+
+  describe('partOfDay', () => {
+    it("returns 'am' for morning times", () => {
+      expect(ClockTime.fromComponents(10, 0, 0)!.partOfDay).toEqual('am')
+    })
+
+    it("returns 'am' for midnight", () => {
+      expect(ClockTime.fromComponents(0, 0, 0)!.partOfDay).toEqual('am')
+    })
+
+    it("returns 'pm' for midday", () => {
+      expect(ClockTime.fromComponents(12, 0, 0)!.partOfDay).toEqual('pm')
+    })
+
+    it("returns 'pm' for afternoon times", () => {
+      expect(ClockTime.fromComponents(22, 0, 0)!.partOfDay).toEqual('pm')
+    })
+  })
+})

--- a/server/utils/clockTime.ts
+++ b/server/utils/clockTime.ts
@@ -1,0 +1,62 @@
+export default class ClockTime {
+  /*
+   * 0 ≤ hour ≤ 23
+   * 0 ≤ minute ≤ 59
+   * 0 ≤ second ≤ 59
+   */
+  private constructor(readonly hour: number, readonly minute: number, readonly second: number) {}
+
+  static fromComponents(hour: number, minute: number, second: number): ClockTime | null {
+    return ClockTime.isValid(hour, minute, second) ? new ClockTime(hour, minute, second) : null
+  }
+
+  static isValid(hour: number, minute: number, second: number): boolean {
+    return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 && second >= 0 && second <= 59
+  }
+
+  private static timeForDate(date: Date, ianaTimeZoneIdentifier: string): ClockTime {
+    /*
+    We take the same approach here as in CalendarDay.dayForDate; see the comment 
+    there.
+    */
+
+    const format = Intl.DateTimeFormat('en-US', {
+      timeZone: ianaTimeZoneIdentifier,
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      hour12: false,
+    })
+
+    const parts = format.formatToParts(date)
+    const componentStrings = ['hour', 'minute', 'second'].map(
+      component => parts.find(part => part.type === component)?.value
+    )
+    const components = componentStrings.map(componentString => {
+      if (componentString === undefined) {
+        throw new Error('Failed to extract component from date')
+      }
+
+      return Number.parseInt(componentString, 10)
+    })
+
+    if (components[0] === 24) {
+      // I don’t know why midnight gets formatted as 24 hours, but let’s normalise it
+      components[0] = 0
+    }
+
+    return new ClockTime(components[0], components[1], components[2])
+  }
+
+  static britishTimeForDate(date: Date): ClockTime {
+    return this.timeForDate(date, 'Europe/London')
+  }
+
+  get twelveHourClockHour(): number {
+    return this.hour > 12 ? this.hour % 12 : this.hour
+  }
+
+  get partOfDay(): 'am' | 'pm' {
+    return this.hour < 12 ? 'am' : 'pm'
+  }
+}

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -1,6 +1,7 @@
 import { AuthUser } from '../data/hmppsAuthClient'
 import { ServiceUser } from '../services/interventionsService'
 import CalendarDay from './calendarDay'
+import ClockTime from './clockTime'
 import { FormValidationError } from './formValidationError'
 import Duration from './duration'
 import utils from './utils'
@@ -21,6 +22,18 @@ interface DurationInputPresenter {
   errorMessage: string | null
   hours: DateTimeComponentInputPresenter
   minutes: DateTimeComponentInputPresenter
+}
+
+interface PartOfDayInputPresenter {
+  value: 'am' | 'pm' | null
+  hasError: boolean
+}
+
+interface TwelveHourTimeInputPresenter {
+  errorMessage: string | null
+  hour: DateTimeComponentInputPresenter
+  minute: DateTimeComponentInputPresenter
+  partOfDay: PartOfDayInputPresenter
 }
 
 export default class PresenterUtils {
@@ -122,6 +135,58 @@ export default class PresenterUtils {
       minutes: {
         value: minutesValue,
         hasError: PresenterUtils.hasError(error, minutesKey),
+      },
+    }
+  }
+
+  twelveHourTimeValue(
+    modelValue: ClockTime | null,
+    userInputKey: string,
+    error: FormValidationError | null
+  ): TwelveHourTimeInputPresenter {
+    const [hourKey, minuteKey, partOfDayKey] = ['hour', 'minute', 'part-of-day'].map(
+      suffix => `${userInputKey}-${suffix}`
+    )
+
+    const errorMessage =
+      PresenterUtils.errorMessage(error, hourKey) ??
+      PresenterUtils.errorMessage(error, minuteKey) ??
+      PresenterUtils.errorMessage(error, partOfDayKey)
+
+    let hourValue = ''
+    let minuteValue = ''
+    let partOfDayValue: 'am' | 'pm' | null = null
+
+    if (this.userInputData === null) {
+      if (modelValue !== null) {
+        hourValue = String(modelValue?.twelveHourClockHour ?? '')
+        minuteValue = modelValue ? String(modelValue.minute).padStart(2, '0') : ''
+        partOfDayValue = modelValue?.partOfDay ?? null
+      }
+    } else {
+      hourValue = String(this.userInputData[hourKey] || '')
+      minuteValue = String(this.userInputData[minuteKey] || '')
+
+      if (this.userInputData[partOfDayKey] === 'am' || this.userInputData[partOfDayKey] === 'pm') {
+        partOfDayValue = this.userInputData[partOfDayKey] as 'am' | 'pm'
+      } else {
+        partOfDayValue = null
+      }
+    }
+
+    return {
+      errorMessage,
+      partOfDay: {
+        value: partOfDayValue,
+        hasError: PresenterUtils.hasError(error, partOfDayKey),
+      },
+      hour: {
+        value: hourValue,
+        hasError: PresenterUtils.hasError(error, hourKey),
+      },
+      minute: {
+        value: minuteValue,
+        hasError: PresenterUtils.hasError(error, minuteKey),
       },
     }
   }


### PR DESCRIPTION
## What does this pull request do?

Adds a `ClockTime` class which represents the values displayed on a clock, analogous to our existing `CalendarDay` class. It provides convenience methods for getting 12-hour values.

It then adds a presenter utility method that will allow us to display a form input backed by a `ClockTime` object.

## What is the intent behind these changes?

To allow us to build the "time" input on the upcoming "edit action plan appointment details" form.