### PR TITLE
Add missing action plan appointment contract for /appointments/:sessionNumber

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1719,6 +1719,46 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('getActionPlanAppointment', () => {
+    const actionPlanAppointment = {
+      sessionNumber: 1,
+      appointmentTime: '2021-05-13T13:30:00+01:00',
+      durationInMinutes: 120,
+    }
+
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state:
+          'a draft action plan with ID e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d exists and has an appointment for session 1',
+        uponReceiving:
+          'a GET request for the appointment for session 1 on action plan with ID e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d',
+        withRequest: {
+          method: 'GET',
+          path: '/action-plan/e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d/appointments/1',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(actionPlanAppointment),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns the requested action plan appointment', async () => {
+      const appointment = await interventionsService.getActionPlanAppointment(
+        token,
+        'e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d',
+        1
+      )
+      expect(appointment.sessionNumber).toEqual(1)
+      expect(appointment.appointmentTime).toEqual('2021-05-13T13:30:00+01:00')
+      expect(appointment.durationInMinutes).toEqual(120)
+    })
+  })
+
   describe('createActionPlanAppointment', () => {
     const actionPlanAppointment = {
       sessionNumber: 1,


### PR DESCRIPTION
## What does this pull request do?

Adds missing contract for `getActionPlanAppointment`.

## What is the intent behind these changes?

It looks like we were missing a contract for fetching an individual
appointment. I'm using this endpoint to fetch appointments for the Post
Session Feedback page, so want to make sure it's covered.
