### PR TITLE
Add method to create ClockTime from 12-hour components

### DIFF
--- a/server/utils/clockTime.test.ts
+++ b/server/utils/clockTime.test.ts
@@ -4,20 +4,20 @@ describe(ClockTime, () => {
   describe('fromComponents', () => {
     describe('with valid input', () => {
       it('returns a time object', () => {
-        expect(ClockTime.fromComponents(0, 0, 0)).not.toBeNull()
-        expect(ClockTime.fromComponents(23, 59, 59)).not.toBeNull()
+        expect(ClockTime.fromTwentyFourHourComponents(0, 0, 0)).not.toBeNull()
+        expect(ClockTime.fromTwentyFourHourComponents(23, 59, 59)).not.toBeNull()
       })
     })
 
     describe('with invalid input', () => {
       it('returns null', () => {
-        expect(ClockTime.fromComponents(24, 0, 0)).toBeNull()
-        expect(ClockTime.fromComponents(0, 61, 0)).toBeNull()
-        expect(ClockTime.fromComponents(0, 0, 61)).toBeNull()
+        expect(ClockTime.fromTwentyFourHourComponents(24, 0, 0)).toBeNull()
+        expect(ClockTime.fromTwentyFourHourComponents(0, 61, 0)).toBeNull()
+        expect(ClockTime.fromTwentyFourHourComponents(0, 0, 61)).toBeNull()
 
-        expect(ClockTime.fromComponents(-1, 0, 0)).toBeNull()
-        expect(ClockTime.fromComponents(0, -1, 0)).toBeNull()
-        expect(ClockTime.fromComponents(0, 0, -1)).toBeNull()
+        expect(ClockTime.fromTwentyFourHourComponents(-1, 0, 0)).toBeNull()
+        expect(ClockTime.fromTwentyFourHourComponents(0, -1, 0)).toBeNull()
+        expect(ClockTime.fromTwentyFourHourComponents(0, 0, -1)).toBeNull()
       })
     })
   })
@@ -70,37 +70,37 @@ describe(ClockTime, () => {
 
   describe('twelveHourClockHour', () => {
     it('returns the correct hour for morning times', () => {
-      expect(ClockTime.fromComponents(10, 0, 0)!.twelveHourClockHour).toEqual(10)
+      expect(ClockTime.fromTwentyFourHourComponents(10, 0, 0)!.twelveHourClockHour).toEqual(10)
     })
 
     it('returns 0 for midnight', () => {
-      expect(ClockTime.fromComponents(0, 0, 0)!.twelveHourClockHour).toEqual(0)
+      expect(ClockTime.fromTwentyFourHourComponents(0, 0, 0)!.twelveHourClockHour).toEqual(0)
     })
 
     it('returns 12 for midday', () => {
-      expect(ClockTime.fromComponents(12, 0, 0)!.twelveHourClockHour).toEqual(12)
+      expect(ClockTime.fromTwentyFourHourComponents(12, 0, 0)!.twelveHourClockHour).toEqual(12)
     })
 
     it('returns the correct hour for afternoon times', () => {
-      expect(ClockTime.fromComponents(22, 0, 0)!.twelveHourClockHour).toEqual(10)
+      expect(ClockTime.fromTwentyFourHourComponents(22, 0, 0)!.twelveHourClockHour).toEqual(10)
     })
   })
 
   describe('partOfDay', () => {
     it("returns 'am' for morning times", () => {
-      expect(ClockTime.fromComponents(10, 0, 0)!.partOfDay).toEqual('am')
+      expect(ClockTime.fromTwentyFourHourComponents(10, 0, 0)!.partOfDay).toEqual('am')
     })
 
     it("returns 'am' for midnight", () => {
-      expect(ClockTime.fromComponents(0, 0, 0)!.partOfDay).toEqual('am')
+      expect(ClockTime.fromTwentyFourHourComponents(0, 0, 0)!.partOfDay).toEqual('am')
     })
 
     it("returns 'pm' for midday", () => {
-      expect(ClockTime.fromComponents(12, 0, 0)!.partOfDay).toEqual('pm')
+      expect(ClockTime.fromTwentyFourHourComponents(12, 0, 0)!.partOfDay).toEqual('pm')
     })
 
     it("returns 'pm' for afternoon times", () => {
-      expect(ClockTime.fromComponents(22, 0, 0)!.partOfDay).toEqual('pm')
+      expect(ClockTime.fromTwentyFourHourComponents(22, 0, 0)!.partOfDay).toEqual('pm')
     })
   })
 })

--- a/server/utils/clockTime.test.ts
+++ b/server/utils/clockTime.test.ts
@@ -22,6 +22,34 @@ describe(ClockTime, () => {
     })
   })
 
+  describe('fromTwelveHourComponents', () => {
+    describe('with valid input', () => {
+      it('returns a time object', () => {
+        expect(ClockTime.fromTwelveHourComponents(0, 0, 0, 'am')).toEqual({ hour: 0, minute: 0, second: 0 })
+        expect(ClockTime.fromTwelveHourComponents(9, 30, 20, 'am')).toEqual({ hour: 9, minute: 30, second: 20 })
+        expect(ClockTime.fromTwelveHourComponents(12, 0, 0, 'pm')).toEqual({ hour: 12, minute: 0, second: 0 })
+        expect(ClockTime.fromTwelveHourComponents(12, 30, 20, 'pm')).toEqual({ hour: 12, minute: 30, second: 20 })
+        expect(ClockTime.fromTwelveHourComponents(11, 59, 59, 'pm')).toEqual({ hour: 23, minute: 59, second: 59 })
+        expect(ClockTime.fromTwelveHourComponents(9, 30, 20, 'pm')).toEqual({ hour: 21, minute: 30, second: 20 })
+      })
+    })
+
+    describe('with invalid input', () => {
+      it('returns null', () => {
+        expect(ClockTime.fromTwelveHourComponents(13, 0, 0, 'am')).toBeNull()
+        expect(ClockTime.fromTwelveHourComponents(0, 61, 0, 'am')).toBeNull()
+        expect(ClockTime.fromTwelveHourComponents(0, 0, 61, 'am')).toBeNull()
+
+        expect(ClockTime.fromTwelveHourComponents(-1, 0, 0, 'am')).toBeNull()
+        expect(ClockTime.fromTwelveHourComponents(-1, 0, 0, 'pm')).toBeNull()
+        expect(ClockTime.fromTwelveHourComponents(12, 0, 0, 'am')).toBeNull()
+        expect(ClockTime.fromTwelveHourComponents(0, 0, 0, 'pm')).toBeNull()
+        expect(ClockTime.fromTwelveHourComponents(0, -1, 0, 'am')).toBeNull()
+        expect(ClockTime.fromTwelveHourComponents(0, 0, -1, 'am')).toBeNull()
+      })
+    })
+  })
+
   describe('britishTimeForDate', () => {
     it('returns the time that the date occurs at in Britain', () => {
       expect(ClockTime.britishTimeForDate(new Date('2021-02-25T23:30:05Z'))).toEqual({

--- a/server/utils/clockTime.ts
+++ b/server/utils/clockTime.ts
@@ -8,7 +8,7 @@ export default class ClockTime {
    */
   private constructor(readonly hour: number, readonly minute: number, readonly second: number) {}
 
-  static fromComponents(hour: number, minute: number, second: number): ClockTime | null {
+  static fromTwentyFourHourComponents(hour: number, minute: number, second: number): ClockTime | null {
     return ClockTime.isValid(hour, minute, second) ? new ClockTime(hour, minute, second) : null
   }
 
@@ -24,7 +24,7 @@ export default class ClockTime {
 
     const hour = partOfDay === 'pm' && twelveHourClockHour < 12 ? twelveHourClockHour + 12 : twelveHourClockHour
 
-    return this.fromComponents(hour, minute, second)
+    return this.fromTwentyFourHourComponents(hour, minute, second)
   }
 
   static isValid(hour: number, minute: number, second: number): boolean {

--- a/server/utils/clockTime.ts
+++ b/server/utils/clockTime.ts
@@ -1,3 +1,5 @@
+type PartOfDay = 'am' | 'pm'
+
 export default class ClockTime {
   /*
    * 0 ≤ hour ≤ 23
@@ -8,6 +10,21 @@ export default class ClockTime {
 
   static fromComponents(hour: number, minute: number, second: number): ClockTime | null {
     return ClockTime.isValid(hour, minute, second) ? new ClockTime(hour, minute, second) : null
+  }
+
+  static fromTwelveHourComponents(
+    twelveHourClockHour: number,
+    minute: number,
+    second: number,
+    partOfDay: PartOfDay
+  ): ClockTime | null {
+    if (twelveHourClockHour < (partOfDay === 'pm' ? 1 : 0) || twelveHourClockHour > (partOfDay === 'am' ? 11 : 12)) {
+      return null
+    }
+
+    const hour = partOfDay === 'pm' && twelveHourClockHour < 12 ? twelveHourClockHour + 12 : twelveHourClockHour
+
+    return this.fromComponents(hour, minute, second)
   }
 
   static isValid(hour: number, minute: number, second: number): boolean {
@@ -56,7 +73,7 @@ export default class ClockTime {
     return this.hour > 12 ? this.hour % 12 : this.hour
   }
 
-  get partOfDay(): 'am' | 'pm' {
+  get partOfDay(): PartOfDay {
     return this.hour < 12 ? 'am' : 'pm'
   }
 }

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -403,21 +403,33 @@ describe(PresenterUtils, () => {
         describe('and there is no user input data', () => {
           it('returns the corresponding values from the model', () => {
             const utils = new PresenterUtils(null)
-            const value = utils.twelveHourTimeValue(ClockTime.fromComponents(10, 15, 23), 'start-time', null)
+            const value = utils.twelveHourTimeValue(
+              ClockTime.fromTwentyFourHourComponents(10, 15, 23),
+              'start-time',
+              null
+            )
 
             expect(value).toMatchObject({ hour: { value: '10' }, minute: { value: '15' } })
           })
 
           it('returns the correct 12-hour clock hour value', () => {
             const utils = new PresenterUtils(null)
-            const value = utils.twelveHourTimeValue(ClockTime.fromComponents(22, 15, 23), 'start-time', null)
+            const value = utils.twelveHourTimeValue(
+              ClockTime.fromTwentyFourHourComponents(22, 15, 23),
+              'start-time',
+              null
+            )
 
             expect(value).toMatchObject({ hour: { value: '10' }, minute: { value: '15' } })
           })
 
           it('pads the minute value to 2 digits', () => {
             const utils = new PresenterUtils(null)
-            const value = utils.twelveHourTimeValue(ClockTime.fromComponents(10, 5, 23), 'start-time', null)
+            const value = utils.twelveHourTimeValue(
+              ClockTime.fromTwentyFourHourComponents(10, 5, 23),
+              'start-time',
+              null
+            )
 
             expect(value).toMatchObject({ hour: { value: '10' }, minute: { value: '05' } })
           })
@@ -427,7 +439,7 @@ describe(PresenterUtils, () => {
       describe('when there is user input data', () => {
         it('returns the user input data', () => {
           const utils = new PresenterUtils({ 'start-time-hour': 'egg', 'start-time-minute': 7 })
-          const value = utils.twelveHourTimeValue(ClockTime.fromComponents(10, 5, 23), 'start-time', null)
+          const value = utils.twelveHourTimeValue(ClockTime.fromTwentyFourHourComponents(10, 5, 23), 'start-time', null)
 
           expect(value.hour.value).toBe('egg')
           expect(value.minute.value).toBe('7')
@@ -435,7 +447,7 @@ describe(PresenterUtils, () => {
 
         it('returns an empty string if a field is missing', () => {
           const utils = new PresenterUtils({ 'start-time-hour': 7 })
-          const value = utils.twelveHourTimeValue(ClockTime.fromComponents(10, 5, 23), 'start-time', null)
+          const value = utils.twelveHourTimeValue(ClockTime.fromTwentyFourHourComponents(10, 5, 23), 'start-time', null)
 
           expect(value.hour.value).toBe('7')
           expect(value.minute.value).toBe('')
@@ -459,14 +471,22 @@ describe(PresenterUtils, () => {
         describe('and there is no user input data', () => {
           it('returns "am" when the time from the model is before midday', () => {
             const utils = new PresenterUtils(null)
-            const value = utils.twelveHourTimeValue(ClockTime.fromComponents(10, 15, 23), 'start-time', null)
+            const value = utils.twelveHourTimeValue(
+              ClockTime.fromTwentyFourHourComponents(10, 15, 23),
+              'start-time',
+              null
+            )
 
             expect(value).toMatchObject({ partOfDay: { value: 'am' } })
           })
 
           it('returns "pm" when the time from the model is after midday', () => {
             const utils = new PresenterUtils(null)
-            const value = utils.twelveHourTimeValue(ClockTime.fromComponents(22, 15, 23), 'start-time', null)
+            const value = utils.twelveHourTimeValue(
+              ClockTime.fromTwentyFourHourComponents(22, 15, 23),
+              'start-time',
+              null
+            )
 
             expect(value).toMatchObject({ partOfDay: { value: 'pm' } })
           })
@@ -475,7 +495,7 @@ describe(PresenterUtils, () => {
 
       describe('when there is user input data', () => {
         it('returns the user input data if a valid option was chosen', () => {
-          const modelValue = ClockTime.fromComponents(10, 5, 23)
+          const modelValue = ClockTime.fromTwentyFourHourComponents(10, 5, 23)
 
           expect(
             new PresenterUtils({ 'start-time-part-of-day': 'am' }).twelveHourTimeValue(modelValue, 'start-time', null)
@@ -489,7 +509,7 @@ describe(PresenterUtils, () => {
         })
 
         it('returns null if an invalid option was chosen', () => {
-          const modelValue = ClockTime.fromComponents(10, 5, 23)
+          const modelValue = ClockTime.fromTwentyFourHourComponents(10, 5, 23)
 
           expect(
             new PresenterUtils({ 'start-time-part-of-day': 'egg' }).twelveHourTimeValue(modelValue, 'start-time', null)
@@ -498,7 +518,7 @@ describe(PresenterUtils, () => {
         })
 
         it('returns null if the field is missing', () => {
-          const modelValue = ClockTime.fromComponents(10, 5, 23)
+          const modelValue = ClockTime.fromTwentyFourHourComponents(10, 5, 23)
 
           expect(new PresenterUtils({}).twelveHourTimeValue(modelValue, 'start-time', null).partOfDay.value).toBeNull()
         })


### PR DESCRIPTION
## What does this pull request do?

Adds a method to create a `ClockTime` instance from 12-hour clock components.

## What is the intent behind these changes?

To allow us to convert the user input on the upcoming "edit action plan appointment" page into a `ClockTime`.
