### PR TITLE
Add method to get a Date from (CalendarDay, ClockTime)

### DIFF
--- a/server/utils/calendarDay.test.ts
+++ b/server/utils/calendarDay.test.ts
@@ -1,4 +1,5 @@
 import CalendarDay from './calendarDay'
+import ClockTime from './clockTime'
 
 describe('CalendarDay', () => {
   describe('iso8601', () => {
@@ -79,6 +80,26 @@ describe('CalendarDay', () => {
 
     it('handles daylight saving time', () => {
       expect(CalendarDay.britishDayForDate(new Date('2021-08-25T23:30:00Z'))).toEqual({ day: 26, month: 8, year: 2021 })
+    })
+  })
+
+  describe('atTimeInBritain', () => {
+    it('returns a Date for that day and time in Britain', () => {
+      const date = CalendarDay.fromComponents(30, 1, 2021)!.atTimeInBritain(ClockTime.fromComponents(12, 5, 6)!)
+
+      expect(date).toEqual(new Date('2021-01-30T12:05:06Z'))
+    })
+
+    it('handles daylight saving time', () => {
+      const date = CalendarDay.fromComponents(30, 3, 2021)!.atTimeInBritain(ClockTime.fromComponents(12, 5, 6)!)
+
+      expect(date).toEqual(new Date('2021-03-30T11:05:06Z'))
+    })
+
+    it('returns null when the time doesn’t exist on that day in Britain', () => {
+      const date = CalendarDay.fromComponents(28, 3, 2021)!.atTimeInBritain(ClockTime.fromComponents(1, 30, 0)!)
+
+      expect(date).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## What does this pull request do?

Adds a method to answer questions like "If I’m in Britain, and the clock says 2pm and the calendar says 23rd March 2021, then what moment in time is it?"

## What is the intent behind these changes?

To allow us to convert the user input on the upcoming "edit action plan appointment details" into an ISO 8601 timestamp to send as the `appointmentTime` value to the interventions service.