### PR TITLE
Add method to get minutes from a Duration

### DIFF
--- a/server/utils/duration.test.ts
+++ b/server/utils/duration.test.ts
@@ -8,6 +8,16 @@ describe(Duration, () => {
     })
   })
 
+  describe('minutes', () => {
+    it('returns the number of minutes when the duration is a full number of minutes', () => {
+      expect(new Duration(120).minutes).toEqual(2)
+    })
+
+    it('returns null when the duration is not a full number of minutes', () => {
+      expect(new Duration(121).minutes).toBeNull()
+    })
+  })
+
   describe('stopwatch values', () => {
     it('returns the correct values', () => {
       const duration = new Duration(10 * 3600 + 5 * 60 + 32.5)

--- a/server/utils/duration.ts
+++ b/server/utils/duration.ts
@@ -5,6 +5,16 @@ export default class Duration {
     return new Duration(hours * 3600 + minutes * 60 + seconds)
   }
 
+  // If the duration represents a whole number of minutes, then this
+  // returns the number of minutes. Else, it returns null.
+  get minutes(): number | null {
+    if (this.seconds % 60 === 0) {
+      return this.seconds / 60
+    }
+
+    return null
+  }
+
   // The hours value displayed for this duration on a stopwatch
   // that displays durations in hours, minutes, and seconds.
   get stopwatchHours(): number {


### PR DESCRIPTION
## What does this pull request do?

Adds a method to get the number of minutes that a `Duration` instance represents.

## What is the intent behind these changes?

To allow us to convert the user input on the upcoming "edit action plan appointment details" into an number of minutes to send as the `durationInMinutes` value to the interventions service.
