### PR TITLE
Make Duration.fromUnits validate the values

### DIFF
--- a/server/utils/duration.test.ts
+++ b/server/utils/duration.test.ts
@@ -3,8 +3,14 @@ import Duration from './duration'
 describe(Duration, () => {
   describe('.fromUnits', () => {
     it('converts hours, minutes and seconds to seconds', () => {
-      expect(Duration.fromUnits(10, 5, 32).seconds).toEqual(36332)
-      expect(Duration.fromUnits(0, 500, 0).seconds).toEqual(30000)
+      expect(Duration.fromUnits(10, 5, 32)!.seconds).toEqual(36332)
+      expect(Duration.fromUnits(0, 500, 0)!.seconds).toEqual(30000)
+    })
+
+    it('returns null with invalid input', () => {
+      expect(Duration.fromUnits(-1, 1, 1)).toBeNull()
+      expect(Duration.fromUnits(1, -1, 1)).toBeNull()
+      expect(Duration.fromUnits(1, 1, -1)).toBeNull()
     })
   })
 

--- a/server/utils/duration.ts
+++ b/server/utils/duration.ts
@@ -1,7 +1,16 @@
 export default class Duration {
   constructor(readonly seconds: number) {}
 
-  static fromUnits(hours: number, minutes: number, seconds: number): Duration {
+  /*
+   * hours ≥ 0
+   * minutes ≥ 0
+   * seconds ≥ 0
+   */
+  static fromUnits(hours: number, minutes: number, seconds: number): Duration | null {
+    if (hours < 0 || minutes < 0 || seconds < 0) {
+      return null
+    }
+
     return new Duration(hours * 3600 + minutes * 60 + seconds)
   }
 


### PR DESCRIPTION

## What does this pull request do?

Makes `Duration.fromUnits` validate that its arguments are all non-negative.

## What is the intent behind these changes?

To make it consistent with `CalendarDay` and `ClockTime`, and to allow us to validate the duration on the upcoming "edit action plan appointment" page.
