### PR TITLE
IC-1412 Get all sessions for an action plan at once

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -210,6 +210,12 @@ describe('Service provider referrals dashboard', () => {
       .assigned()
       .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username } })
     const draftActionPlan = actionPlanFactory.justCreated(assignedReferral.id).build()
+    const actionPlanAppointments = [
+      actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 1 }),
+      actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 2 }),
+      actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 3 }),
+      actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 4 }),
+    ]
 
     cy.stubGetSentReferrals([assignedReferral])
 
@@ -220,6 +226,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+    cy.stubGetActionPlanAppointments(draftActionPlan.id, actionPlanAppointments)
 
     cy.login()
 
@@ -355,11 +362,18 @@ describe('Service provider referrals dashboard', () => {
       numberOfSessions: 4,
     })
 
-    const appointment = actionPlanAppointmentFactory.build({
-      sessionNumber: 1,
-      appointmentTime: '2021-03-24T09:02:02Z',
-      durationInMinutes: 75,
-    })
+    const appointments = [
+      actionPlanAppointmentFactory.build({
+        sessionNumber: 1,
+        appointmentTime: '2021-03-24T09:02:02Z',
+        durationInMinutes: 75,
+      }),
+      actionPlanAppointmentFactory.build({
+        sessionNumber: 2,
+        appointmentTime: '2021-03-31T09:02:02Z',
+        durationInMinutes: 75,
+      }),
+    ]
 
     const assignedReferral = sentReferralFactory.assigned().build({
       ...referralParams,
@@ -369,14 +383,17 @@ describe('Service provider referrals dashboard', () => {
 
     cy.stubGetSentReferrals([assignedReferral])
     cy.stubGetActionPlan(actionPlan.id, actionPlan)
-    cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointment)
     cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
     cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
     cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
     cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
 
+    cy.stubGetActionPlanAppointments(actionPlan.id, appointments)
+    cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointments[0])
+    cy.stubGetActionPlanAppointment(actionPlan.id, 2, appointments[1])
+
     const appointmentWithAttendanceRecorded = {
-      ...appointment,
+      ...appointments[0],
       attendance: {
         attended: 'yes',
         additionalAttendanceInformation: 'Alex attended the session',
@@ -393,14 +410,6 @@ describe('Service provider referrals dashboard', () => {
     cy.contains("Add additional information about Alex's attendance").type('Alex attended the session')
 
     cy.stubRecordAppointmentAttendance(actionPlan.id, 1, appointmentWithAttendanceRecorded)
-
-    const subsequentAppointment = actionPlanAppointmentFactory.build({
-      sessionNumber: 2,
-      appointmentTime: '2021-03-31T09:02:02Z',
-      durationInMinutes: 75,
-    })
-
-    cy.stubGetActionPlanAppointment(actionPlan.id, 2, subsequentAppointment)
 
     cy.contains('Submit for approval').click()
     cy.contains('Session feedback added and submitted to the probation practitioner')

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -125,32 +125,11 @@ export default class ServiceProviderReferralsController {
     ])
 
     let actionPlanAppointments: ActionPlanAppointment[] = []
-
-    // this code is horribly inefficient and results in a lot of unnecessary log messages from the client.
-    // we are going to change the backend so that all the appointments exist for a submitted action plan,
-    // which will allow us to use the `getActionPlanAppointments` method and clean up this code.
     if (actionPlan !== null && actionPlan.submittedAt !== null) {
-      const appointmentPromises: Promise<ActionPlanAppointment>[] = []
-
-      // submitted action plans cannot have numberOfSessions === null
-      for (let session = 1; session <= actionPlan.numberOfSessions!; session += 1) {
-        appointmentPromises.push(
-          this.interventionsService
-            .getActionPlanAppointment(res.locals.user.token.accessToken, actionPlan.id, session)
-            .then(
-              appointment => Promise.resolve(appointment),
-              e =>
-                e.status === 404
-                  ? {
-                      sessionNumber: session,
-                      appointmentTime: null,
-                      durationInMinutes: null,
-                    }
-                  : Promise.reject(e)
-            )
-        )
-      }
-      actionPlanAppointments = await Promise.all(appointmentPromises)
+      actionPlanAppointments = await this.interventionsService.getActionPlanAppointments(
+        res.locals.user.token.accessToken,
+        actionPlan.id
+      )
     }
 
     const presenter = new InterventionProgressPresenter(

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1697,7 +1697,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
     beforeEach(async () => {
       await provider.addInteraction({
-        state: 'a draft action plan with ID e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d exists and has some appointments',
+        state: 'an action plan with ID e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d exists and it has 3 scheduled appointments',
         uponReceiving: 'a GET request for the appointments on action plan with ID e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d',
         withRequest: {
           method: 'GET',
@@ -1731,7 +1731,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     beforeEach(async () => {
       await provider.addInteraction({
         state:
-          'a draft action plan with ID e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d exists and has an appointment for session 1',
+          'an action plan with ID e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d exists and has an appointment for session 1',
         uponReceiving:
           'a GET request for the appointment for session 1 on action plan with ID e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d',
         withRequest: {
@@ -1797,45 +1797,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('createActionPlanAppointment', () => {
-    const actionPlanAppointment = {
-      sessionNumber: 1,
-      appointmentTime: '2021-05-13T13:30:00+01:00',
-      durationInMinutes: 120,
-    }
-
-    beforeEach(async () => {
-      await provider.addInteraction({
-        state: 'a draft action plan with ID ebe841a8-c33f-4772-8b01-ad58a16e5b6c exists and has no appointments',
-        uponReceiving:
-          'a POST request to create appointment for session 1 on action plan with ID ebe841a8-c33f-4772-8b01-ad58a16e5b6c',
-        withRequest: {
-          method: 'POST',
-          path: '/action-plan/ebe841a8-c33f-4772-8b01-ad58a16e5b6c/appointment',
-          body: actionPlanAppointment,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
-        },
-        willRespondWith: {
-          status: 201,
-          body: Matchers.like(actionPlanAppointment),
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        },
-      })
-    })
-
-    it('returns an action plan appointment', async () => {
-      expect(
-        await interventionsService.createActionPlanAppointment(
-          token,
-          'ebe841a8-c33f-4772-8b01-ad58a16e5b6c',
-          actionPlanAppointment
-        )
-      ).toMatchObject(actionPlanAppointment)
-    })
-  })
-
   describe('updateActionPlanAppointment', () => {
     describe('with non-null values', () => {
       it('returns an updated action plan appointment', async () => {
@@ -1847,7 +1808,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
         await provider.addInteraction({
           state:
-            'a draft action plan with ID 345059d4-1697-467b-8914-fedec9957279 exists and has 2 2-hour appointments already',
+            'an action plan with ID 345059d4-1697-467b-8914-fedec9957279 exists and has 2 2-hour appointments already',
           uponReceiving:
             'a PATCH request to update the appointment for session 2 to change the duration to an hour on action plan with ID 345059d4-1697-467b-8914-fedec9957279',
           withRequest: {
@@ -1886,7 +1847,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
         await provider.addInteraction({
           state:
-            'a draft action plan with ID a065a681-57a0-4ffc-9681-b00455df462b exists and has 2 2-hour appointments already',
+            'an action plan with ID a065a681-57a0-4ffc-9681-b00455df462b exists and has 2 2-hour appointments already',
           uponReceiving:
             'a PATCH request to update the appointment for session 2 to change the duration to an hour on action plan with ID a065a681-57a0-4ffc-9681-b00455df462b',
           withRequest: {
@@ -1921,7 +1882,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   describe('recordAppointmentAttendance', () => {
     it('returns an updated action plan appointment with the service user‘s attendance', async () => {
       await provider.addInteraction({
-        state: 'a draft action plan with ID 345059d4-1697-467b-8914-fedec9957279 exists',
+        state:
+          'an action plan with ID 345059d4-1697-467b-8914-fedec9957279 exists and has 2 2-hour appointments already',
         uponReceiving:
           'a POST request to set the attendance for session 2 on action plan with ID 345059d4-1697-467b-8914-fedec9957279',
         withRequest: {


### PR DESCRIPTION
## What does this pull request do?

This pulls out some nasty code which created empty sessions for
missing appointments on action plans. This has been changed on the
backend now so that an action plan that has been submitted always
has the correct number of appointments automatically created.

There is no longer a need for a 'create appointment' endpoint so the
contracts for this have been removed.

## What is the intent behind these changes?

improve the code behind action plan sessions
