### PR TITLE
IC-1436: Remove createActionPlanAppointment

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1797,45 +1797,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('createActionPlanAppointment', () => {
-    const actionPlanAppointment = {
-      sessionNumber: 1,
-      appointmentTime: '2021-05-13T13:30:00+01:00',
-      durationInMinutes: 120,
-    }
-
-    beforeEach(async () => {
-      await provider.addInteraction({
-        state: 'a draft action plan with ID ebe841a8-c33f-4772-8b01-ad58a16e5b6c exists and has no appointments',
-        uponReceiving:
-          'a POST request to create appointment for session 1 on action plan with ID ebe841a8-c33f-4772-8b01-ad58a16e5b6c',
-        withRequest: {
-          method: 'POST',
-          path: '/action-plan/ebe841a8-c33f-4772-8b01-ad58a16e5b6c/appointment',
-          body: actionPlanAppointment,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
-        },
-        willRespondWith: {
-          status: 201,
-          body: Matchers.like(actionPlanAppointment),
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        },
-      })
-    })
-
-    it('returns an action plan appointment', async () => {
-      expect(
-        await interventionsService.createActionPlanAppointment(
-          token,
-          'ebe841a8-c33f-4772-8b01-ad58a16e5b6c',
-          actionPlanAppointment
-        )
-      ).toMatchObject(actionPlanAppointment)
-    })
-  })
-
   describe('updateActionPlanAppointment', () => {
     describe('with non-null values', () => {
       it('returns an updated action plan appointment', async () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -446,19 +446,6 @@ export default class InterventionsService {
     )) as ActionPlanAppointment
   }
 
-  async createActionPlanAppointment(
-    token: string,
-    actionPlanId: string,
-    appointment: ActionPlanAppointment
-  ): Promise<ActionPlanAppointment> {
-    const restClient = this.createRestClient(token)
-    return (await restClient.post({
-      path: `/action-plan/${actionPlanId}/appointment`,
-      headers: { Accept: 'application/json' },
-      data: { ...appointment },
-    })) as ActionPlanAppointment
-  }
-
   async updateActionPlanAppointment(
     token: string,
     actionPlanId: string,


### PR DESCRIPTION
## What does this pull request do?

Removes API call to create an action plan appointment, and its contract test.

## What is the intent behind these changes?

Now that the Interventions Service creates appointments based on the
number of sessions specified, we no longer need to create this on the
frontend.
