### PR TITLE
IC-1298: Add PP session progress page

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -1,0 +1,118 @@
+import sentReferralFactory from '../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
+import deliusUserFactory from '../../testutils/factories/deliusUser'
+import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
+import actionPlanFactory from '../../testutils/factories/actionPlan'
+import actionPlanAppointmentFactory from '../../testutils/factories/actionPlanAppointment'
+
+describe('Probation Practitioner monitor journey', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubLogin')
+    cy.task('stubProbationPractitionerToken')
+    cy.task('stubProbationPractitionerAuthUser')
+  })
+
+  describe('viewing the progress of an intervention', () => {
+    it('displays the referral progress page with the status of each session', () => {
+      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const referralParams = {
+        id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
+        referral: { serviceCategoryId: serviceCategory.id },
+      }
+      const deliusServiceUser = deliusServiceUserFactory.build()
+      const probationPractitioner = deliusUserFactory.build({
+        firstName: 'John',
+        surname: 'Smith',
+        username: 'john.smith',
+      })
+      const actionPlan = actionPlanFactory.submitted().build({
+        referralId: referralParams.id,
+        numberOfSessions: 4,
+      })
+
+      const appointments = [
+        actionPlanAppointmentFactory.build({
+          sessionNumber: 1,
+          appointmentTime: '2021-03-24T09:02:02Z',
+          durationInMinutes: 75,
+          attendance: {
+            attended: 'yes',
+          },
+        }),
+        actionPlanAppointmentFactory.build({
+          sessionNumber: 2,
+          appointmentTime: '2021-04-30T09:02:02Z',
+          durationInMinutes: 75,
+          attendance: {
+            attended: 'no',
+          },
+        }),
+        actionPlanAppointmentFactory.build({
+          sessionNumber: 3,
+          appointmentTime: '2021-05-31T09:02:02Z',
+          durationInMinutes: 75,
+        }),
+        actionPlanAppointmentFactory.build({
+          sessionNumber: 4,
+          durationInMinutes: 75,
+        }),
+      ]
+
+      const assignedReferral = sentReferralFactory.assigned().build({
+        ...referralParams,
+        assignedTo: { username: probationPractitioner.username },
+        actionPlanId: actionPlan.id,
+      })
+
+      // Necessary until we add the Monitor dashboard
+      cy.stubGetDraftReferralsForUser([])
+
+      cy.stubGetSentReferrals([assignedReferral])
+      cy.stubGetActionPlan(actionPlan.id, actionPlan)
+      cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+      cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+      cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+      cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
+
+      cy.stubGetActionPlanAppointments(actionPlan.id, appointments)
+      cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointments[0])
+      cy.stubGetActionPlanAppointment(actionPlan.id, 2, appointments[1])
+
+      cy.login()
+
+      cy.visit(`/probation-practitioner/referrals/${assignedReferral.id}/progress`)
+
+      cy.get('h1').contains('Accommodation progress')
+
+      cy.get('table')
+        .getTable()
+        .should('deep.equal', [
+          {
+            'Session details': 'Session 1',
+            'Date and time': '24 Mar 2021, 09:02',
+            Status: 'COMPLETED',
+            Action: 'View',
+          },
+          {
+            'Session details': 'Session 2',
+            'Date and time': '30 Apr 2021, 10:02',
+            Status: 'FAILURE TO ATTEND',
+            Action: 'View',
+          },
+          {
+            'Session details': 'Session 3',
+            'Date and time': '31 May 2021, 10:02',
+            Status: 'SCHEDULED',
+            Action: '',
+          },
+          {
+            'Session details': 'Session 4',
+            'Date and time': '',
+            Status: 'NOT SCHEDULED',
+            Action: '',
+          },
+        ])
+    })
+  })
+})

--- a/integration_tests/support/commands.js
+++ b/integration_tests/support/commands.js
@@ -24,7 +24,7 @@ const getTable = (subject, options = {}) => {
   const headers = [...tableElement.querySelectorAll('thead th')].map(e => e.textContent)
 
   const rows = [...tableElement.querySelectorAll('tbody tr')].map(row => {
-    return [...row.querySelectorAll('td')].map(e => e.textContent)
+    return [...row.querySelectorAll('td')].map(e => e.textContent.trim())
   })
 
   return rows.map(row =>

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -33,7 +33,8 @@ export default function routes(router: Router, services: Services): Router {
   )
 
   const probationPractitionerReferralsController = new ProbationPractitionerReferralsController(
-    services.interventionsService
+    services.interventionsService,
+    services.communityApiService
   )
   const referralsController = new ReferralsController(services.interventionsService, services.communityApiService)
   const staticContentController = new StaticContentController()
@@ -124,6 +125,10 @@ export default function routes(router: Router, services: Services): Router {
 
   get('/probation-practitioner/dashboard', (req, res) =>
     probationPractitionerReferralsController.showDashboard(req, res)
+  )
+
+  get('/probation-practitioner/referrals/:id/progress', (req, res) =>
+    probationPractitionerReferralsController.showInterventionProgress(req, res)
   )
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -1,0 +1,180 @@
+import InterventionProgressPresenter from './interventionProgressPresenter'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import serviceUserFactory from '../../../testutils/factories/deliusServiceUser'
+
+describe(InterventionProgressPresenter, () => {
+  describe('sessionTableRows', () => {
+    it('returns an empty list if there are no appointments', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [])
+
+      expect(presenter.sessionTableRows).toEqual([])
+    })
+
+    describe('when a session exists but an appointment has not yet been scheduled', () => {
+      it('populates the table with formatted session information, with the "Edit session details" link displayed', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [
+          {
+            sessionNumber: 1,
+            appointmentTime: null,
+            durationInMinutes: null,
+          },
+        ])
+        expect(presenter.sessionTableRows).toEqual([
+          {
+            sessionNumber: 1,
+            appointmentTime: '',
+            tagArgs: {
+              text: 'NOT SCHEDULED',
+              classes: 'govuk-tag--grey',
+            },
+            linkHtml: '',
+          },
+        ])
+      })
+    })
+
+    describe('when an appointment has been scheduled', () => {
+      it('populates the table with formatted session information, with the "Reschedule session" and "Give feedback" links displayed', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [
+          {
+            sessionNumber: 1,
+            appointmentTime: '2020-12-07T13:00:00.000000Z',
+            durationInMinutes: 120,
+          },
+        ])
+        expect(presenter.sessionTableRows).toEqual([
+          {
+            sessionNumber: 1,
+            appointmentTime: '07 Dec 2020, 13:00',
+            tagArgs: {
+              text: 'SCHEDULED',
+              classes: 'govuk-tag--blue',
+            },
+            linkHtml: '',
+          },
+        ])
+      })
+    })
+
+    describe('after the scheduled appointment', () => {
+      describe('when the service user attended the session or was late', () => {
+        it('populates the table with the "completed" status against that session and a link to view it', () => {
+          const referral = sentReferralFactory.build()
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [
+            {
+              sessionNumber: 1,
+              appointmentTime: null,
+              durationInMinutes: null,
+              attendance: {
+                attended: 'yes',
+              },
+            },
+            {
+              sessionNumber: 2,
+              appointmentTime: null,
+              durationInMinutes: null,
+              attendance: {
+                attended: 'late',
+              },
+            },
+          ])
+          expect(presenter.sessionTableRows).toEqual([
+            {
+              sessionNumber: 1,
+              appointmentTime: '',
+              tagArgs: {
+                text: 'COMPLETED',
+                classes: 'govuk-tag--green',
+              },
+              linkHtml: '<a class="govuk-link" href="#">View</a>',
+            },
+            {
+              sessionNumber: 2,
+              appointmentTime: '',
+              tagArgs: {
+                text: 'COMPLETED',
+                classes: 'govuk-tag--green',
+              },
+              linkHtml: '<a class="govuk-link" href="#">View</a>',
+            },
+          ])
+        })
+      })
+
+      describe('when the service did not attend the session', () => {
+        it('populates the table with the "failure to attend" status against that session and a link to view it', () => {
+          const referral = sentReferralFactory.build()
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [
+            {
+              sessionNumber: 1,
+              appointmentTime: null,
+              durationInMinutes: null,
+              attendance: {
+                attended: 'no',
+              },
+            },
+          ])
+          expect(presenter.sessionTableRows).toEqual([
+            {
+              sessionNumber: 1,
+              appointmentTime: '',
+              tagArgs: {
+                text: 'FAILURE TO ATTEND',
+                classes: 'govuk-tag--purple',
+              },
+              linkHtml: '<a class="govuk-link" href="#">View</a>',
+            },
+          ])
+        })
+      })
+    })
+  })
+
+  describe('text', () => {
+    describe('title', () => {
+      it('returns a title to be displayed', () => {
+        const referral = sentReferralFactory.build()
+        const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [])
+
+        expect(presenter.text).toMatchObject({
+          title: 'Accommodation progress',
+        })
+      })
+    })
+  })
+
+  describe('referralAssigned', () => {
+    it('returns false when the referral has no assignee', () => {
+      const referral = sentReferralFactory.unassigned().build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [])
+
+      expect(presenter.referralAssigned).toEqual(false)
+    })
+    it('returns true when the referral has an assignee', () => {
+      const referral = sentReferralFactory.assigned().build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [])
+
+      expect(presenter.referralAssigned).toEqual(true)
+    })
+  })
+})

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -26,7 +26,7 @@ export default class InterventionProgressPresenter {
   }
 
   readonly text = {
-    title: utils.convertToTitleCase(this.serviceCategory.name),
+    title: `${utils.convertToTitleCase(this.serviceCategory.name)} progress`,
   }
 
   readonly hasSessions = this.actionPlanAppointments.length !== 0

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -1,0 +1,66 @@
+import { ActionPlanAppointment, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import utils from '../../utils/utils'
+import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from '../shared/referralOverviewPagePresenter'
+import { DeliusServiceUser } from '../../services/communityApiService'
+import DateUtils from '../../utils/dateUtils'
+
+export default class InterventionProgressPresenter {
+  referralOverviewPagePresenter: ReferralOverviewPagePresenter
+
+  constructor(
+    private readonly referral: SentReferral,
+    private readonly serviceCategory: ServiceCategory,
+    serviceUser: DeliusServiceUser,
+    private readonly actionPlanAppointments: ActionPlanAppointment[]
+  ) {
+    this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
+      ReferralOverviewPageSection.Progress,
+      referral,
+      serviceUser,
+      'probation-practitioner'
+    )
+  }
+
+  get referralAssigned(): boolean {
+    return this.referral.assignedTo !== null
+  }
+
+  readonly text = {
+    title: utils.convertToTitleCase(this.serviceCategory.name),
+  }
+
+  readonly hasSessions = this.actionPlanAppointments.length !== 0
+
+  readonly sessionTableHeaders = ['Session details', 'Date and time', 'Status', 'Action']
+
+  get sessionTableRows(): Record<string, unknown>[] {
+    if (!this.hasSessions) {
+      return []
+    }
+
+    return this.actionPlanAppointments.map(appointment => {
+      return {
+        sessionNumber: appointment.sessionNumber,
+        appointmentTime: DateUtils.formatDateTimeOrEmptyString(appointment.appointmentTime),
+        tagArgs: this.tagArgs(appointment),
+        linkHtml: appointment.attendance ? `<a class="govuk-link" href="#">View</a>` : '',
+      }
+    })
+  }
+
+  private tagArgs(appointment: ActionPlanAppointment): Record<string, unknown> {
+    if (appointment.attendance?.attended === 'no') {
+      return { text: 'FAILURE TO ATTEND', classes: 'govuk-tag--purple' }
+    }
+
+    if (appointment.attendance?.attended === 'yes' || appointment.attendance?.attended === 'late') {
+      return { text: 'COMPLETED', classes: 'govuk-tag--green' }
+    }
+
+    if (appointment.appointmentTime) {
+      return { text: 'SCHEDULED', classes: 'govuk-tag--blue' }
+    }
+
+    return { text: 'NOT SCHEDULED', classes: 'govuk-tag--grey' }
+  }
+}

--- a/server/routes/probationPractitionerReferrals/interventionProgressView.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressView.ts
@@ -1,0 +1,41 @@
+import { TagArgs, TableArgs } from '../../utils/govukFrontendTypes'
+
+import InterventionProgressPresenter from './interventionProgressPresenter'
+
+export default class InterventionProgressView {
+  constructor(private readonly presenter: InterventionProgressPresenter) {}
+
+  private sessionTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
+    return {
+      head: this.presenter.sessionTableHeaders.map((header: string) => {
+        return { text: header }
+      }),
+      rows: this.presenter.sessionTableRows.map(row => {
+        return [
+          { text: `Session ${row.sessionNumber}` },
+          { text: `${row.appointmentTime}` },
+          { text: tagMacro(row.tagArgs as TagArgs) },
+          { html: `${row.linkHtml}` },
+        ]
+      }),
+    }
+  }
+
+  private readonly backLinkArgs = {
+    text: 'Back',
+    href: '/probation-practitioner/dashboard',
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'probationPractitionerReferrals/interventionProgress',
+      {
+        presenter: this.presenter,
+        backLinkArgs: this.backLinkArgs,
+        subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
+        serviceUserBannerArgs: this.presenter.referralOverviewPagePresenter.serviceUserBannerArgs,
+        sessionTableArgs: this.sessionTableArgs.bind(this),
+      },
+    ]
+  }
+}

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -4,6 +4,9 @@ import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import InterventionsService from '../../services/interventionsService'
 import apiConfig from '../../config'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
 
 import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
 import CommunityApiService from '../../services/communityApiService'
@@ -52,6 +55,28 @@ describe('GET /probation-practitioner/dashboard', () => {
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Alex River')
+      })
+  })
+})
+
+describe('GET /probation-practitioner/referrals/:id/progress', () => {
+  it('displays information about the intervention progress', async () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const serviceUser = deliusServiceUserFactory.build()
+    const sentReferral = sentReferralFactory.assigned().build({
+      referral: { serviceCategoryId: serviceCategory.id },
+    })
+
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getSentReferral.mockResolvedValue(sentReferral)
+    communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+
+    await request(app)
+      .get(`/probation-practitioner/referrals/${sentReferral.id}/progress`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Intervention sessions')
+        expect(res.text).toContain('These show the progress of each intervention session')
       })
   })
 })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -1,10 +1,16 @@
 import { Request, Response } from 'express'
-import InterventionsService from '../../services/interventionsService'
+import CommunityApiService from '../../services/communityApiService'
+import InterventionsService, { ActionPlanAppointment } from '../../services/interventionsService'
+import InterventionProgressPresenter from './interventionProgressPresenter'
+import InterventionProgressView from './interventionProgressView'
 import DashboardPresenter from './dashboardPresenter'
 import DashboardView from './dashboardView'
 
 export default class ProbationPractitionerReferralsController {
-  constructor(private readonly interventionsService: InterventionsService) {}
+  constructor(
+    private readonly interventionsService: InterventionsService,
+    private readonly communityApiService: CommunityApiService
+  ) {}
 
   async showDashboard(req: Request, res: Response): Promise<void> {
     const { token, userId } = res.locals.user
@@ -12,6 +18,46 @@ export default class ProbationPractitionerReferralsController {
     const existingDraftReferrals = await this.interventionsService.getDraftReferralsForUser(token.accessToken, userId)
     const presenter = new DashboardPresenter(existingDraftReferrals)
     const view = new DashboardView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async showInterventionProgress(req: Request, res: Response): Promise<void> {
+    const sentReferral = await this.interventionsService.getSentReferral(
+      res.locals.user.token.accessToken,
+      req.params.id
+    )
+    const serviceUserPromise = this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
+    const serviceCategoryPromise = this.interventionsService.getServiceCategory(
+      res.locals.user.token.accessToken,
+      sentReferral.referral.serviceCategoryId
+    )
+    const actionPlanPromise =
+      sentReferral.actionPlanId === null
+        ? Promise.resolve(null)
+        : this.interventionsService.getActionPlan(res.locals.user.token.accessToken, sentReferral.actionPlanId)
+
+    const [serviceCategory, actionPlan, serviceUser] = await Promise.all([
+      serviceCategoryPromise,
+      actionPlanPromise,
+      serviceUserPromise,
+    ])
+
+    let actionPlanAppointments: ActionPlanAppointment[] = []
+    if (actionPlan !== null && actionPlan.submittedAt !== null) {
+      actionPlanAppointments = await this.interventionsService.getActionPlanAppointments(
+        res.locals.user.token.accessToken,
+        actionPlan.id
+      )
+    }
+
+    const presenter = new InterventionProgressPresenter(
+      sentReferral,
+      serviceCategory,
+      serviceUser,
+      actionPlanAppointments
+    )
+    const view = new InterventionProgressView(presenter)
 
     res.render(...view.renderArgs)
   }

--- a/server/views/partials/referralNavigationTemplate.njk
+++ b/server/views/partials/referralNavigationTemplate.njk
@@ -16,7 +16,7 @@
 
       {{ govukBackLink(backLinkArgs) }}
 
-      <h1 class="govuk-heading-l">Referral overview</h1>
+      <h1 class="govuk-heading-l">{{ presenter.text.title }}</h1>
 
       {{ mojSubNavigation(subNavArgs) }}
 

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -1,0 +1,24 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% extends "../partials/referralNavigationTemplate.njk" %}
+
+{% block referralPageSection %}
+
+  <h2 class="govuk-heading-m">Intervention sessions</h2>
+  <p class="govuk-body">
+    These show the progress of each intervention session.
+  </p>
+
+  {% if presenter.hasSessions %}
+    {{ govukTable(sessionTableArgs(govukTag)) }}
+  {% else %}
+    <p class="govuk-body">
+      Sessions will appear here when the action plan is ready.
+    </p>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  {% endif %}
+
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds PP session progress page with various appointment states.

This depends on a few of the refactoring changes in #218 that make various components in the SP journey re-usable.

## What is the intent behind these changes?

To give the PP an overview of how the intervention is progressing.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/113747020-de473400-96fe-11eb-9268-7145958b634c.png)

