### PR TITLE
IC-1423: Add record behaviour function and contract test

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -36,16 +36,20 @@ describe('Probation Practitioner monitor journey', () => {
           sessionNumber: 1,
           appointmentTime: '2021-03-24T09:02:02Z',
           durationInMinutes: 75,
-          attendance: {
-            attended: 'yes',
+          sessionFeedback: {
+            attendance: {
+              attended: 'yes',
+            },
           },
         }),
         actionPlanAppointmentFactory.build({
           sessionNumber: 2,
           appointmentTime: '2021-04-30T09:02:02Z',
           durationInMinutes: 75,
-          attendance: {
-            attended: 'no',
+          sessionFeedback: {
+            attendance: {
+              attended: 'no',
+            },
           },
         }),
         actionPlanAppointmentFactory.build({

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -423,9 +423,11 @@ describe('Service provider referrals dashboard', () => {
 
     const appointmentWithAttendanceRecorded = {
       ...appointments[0],
-      attendance: {
-        attended: 'yes',
-        additionalAttendanceInformation: 'Alex attended the session',
+      sessionFeedback: {
+        attendance: {
+          attended: 'yes',
+          additionalAttendanceInformation: 'Alex attended the session',
+        },
       },
     }
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -113,6 +113,10 @@ module.exports = on => {
       return interventionsService.stubRecordAppointmentAttendance(arg.actionPlanId, arg.sessionNumber, arg.responseJson)
     },
 
+    stubRecordAppointmentBehaviour: arg => {
+      return interventionsService.stubRecordAppointmentBehaviour(arg.actionPlanId, arg.sessionNumber, arg.responseJson)
+    },
+
     stubGetActionPlanAppointments: arg => {
       return interventionsService.stubGetActionPlanAppointments(arg.id, arg.responseJson)
     },

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -281,6 +281,26 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubRecordAppointmentBehaviour = async (
+    actionPlanId: string,
+    sessionNumber: string,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/action-plan/${actionPlanId}/appointment/${sessionNumber}/record-behaviour`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
   stubGetActionPlanAppointments = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -77,16 +77,20 @@ describe(InterventionProgressPresenter, () => {
               sessionNumber: 1,
               appointmentTime: null,
               durationInMinutes: null,
-              attendance: {
-                attended: 'yes',
+              sessionFeedback: {
+                attendance: {
+                  attended: 'yes',
+                },
               },
             },
             {
               sessionNumber: 2,
               appointmentTime: null,
               durationInMinutes: null,
-              attendance: {
-                attended: 'late',
+              sessionFeedback: {
+                attendance: {
+                  attended: 'late',
+                },
               },
             },
           ])
@@ -123,8 +127,10 @@ describe(InterventionProgressPresenter, () => {
               sessionNumber: 1,
               appointmentTime: null,
               durationInMinutes: null,
-              attendance: {
-                attended: 'no',
+              sessionFeedback: {
+                attendance: {
+                  attended: 'no',
+                },
               },
             },
           ])

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -43,17 +43,19 @@ export default class InterventionProgressPresenter {
         sessionNumber: appointment.sessionNumber,
         appointmentTime: DateUtils.formatDateTimeOrEmptyString(appointment.appointmentTime),
         tagArgs: this.tagArgs(appointment),
-        linkHtml: appointment.attendance ? `<a class="govuk-link" href="#">View</a>` : '',
+        linkHtml: appointment.sessionFeedback?.attendance ? `<a class="govuk-link" href="#">View</a>` : '',
       }
     })
   }
 
   private tagArgs(appointment: ActionPlanAppointment): Record<string, unknown> {
-    if (appointment.attendance?.attended === 'no') {
+    const sessionFeedbackAttendance = appointment.sessionFeedback?.attendance
+
+    if (sessionFeedbackAttendance?.attended === 'no') {
       return { text: 'FAILURE TO ATTEND', classes: 'govuk-tag--purple' }
     }
 
-    if (appointment.attendance?.attended === 'yes' || appointment.attendance?.attended === 'late') {
+    if (sessionFeedbackAttendance?.attended === 'yes' || sessionFeedbackAttendance?.attended === 'late') {
       return { text: 'COMPLETED', classes: 'govuk-tag--green' }
     }
 

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.test.ts
@@ -144,7 +144,9 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
 
       responseValues.forEach(responseValue => {
         const appointment = actionPlanAppointmentFactory.build({
-          attendance: { attended: responseValue },
+          sessionFeedback: {
+            attendance: { attended: responseValue },
+          },
         })
 
         describe(`service provider has selected ${responseValue}`, () => {
@@ -180,7 +182,9 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
       describe('when the appointment already has additionalAttendanceInformation set', () => {
         it('uses that value as the value attribute', () => {
           const appointment = actionPlanAppointmentFactory.build({
-            attendance: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
+            sessionFeedback: {
+              attendance: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
+            },
           })
           const serviceUser = deliusServiceUserFactory.build()
           const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
@@ -192,7 +196,9 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
       describe('when the appointment has no value for additionalAttendanceInformation', () => {
         it('uses sets the value to an empty string', () => {
           const appointment = actionPlanAppointmentFactory.build({
-            attendance: { attended: 'late' },
+            sessionFeedback: {
+              attendance: { attended: 'late' },
+            },
           })
           const serviceUser = deliusServiceUserFactory.build()
           const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
@@ -205,7 +211,9 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
     describe('when there is user input data', () => {
       it('uses the user input data as the value attribute', () => {
         const appointment = actionPlanAppointmentFactory.build({
-          attendance: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
+          sessionFeedback: {
+            attendance: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
+          },
         })
         const serviceUser = deliusServiceUserFactory.build()
         const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser, null, {

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.ts
@@ -30,17 +30,17 @@ export default class PostSessionAttendanceFeedbackPresenter {
     {
       value: 'yes',
       text: 'Yes, they were on time',
-      checked: this.appointment.attendance?.attended === 'yes',
+      checked: this.appointment.sessionFeedback?.attendance?.attended === 'yes',
     },
     {
       value: 'late',
       text: 'They were late',
-      checked: this.appointment.attendance?.attended === 'late',
+      checked: this.appointment.sessionFeedback?.attendance?.attended === 'late',
     },
     {
       value: 'no',
       text: 'No',
-      checked: this.appointment.attendance?.attended === 'no',
+      checked: this.appointment.sessionFeedback?.attendance?.attended === 'no',
     },
   ]
 
@@ -61,7 +61,7 @@ export default class PostSessionAttendanceFeedbackPresenter {
 
   readonly fields = {
     additionalAttendanceInformationValue: new PresenterUtils(this.userInputData).stringValue(
-      this.appointment.attendance?.additionalAttendanceInformation || null,
+      this.appointment.sessionFeedback?.attendance?.additionalAttendanceInformation || null,
       'additional-attendance-information'
     ),
   }

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackConfirmationPresenter.test.ts
@@ -8,8 +8,10 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
       const actionPlan = actionPlanFactory.build({ referralId: '9c84b308-2ebb-427a-9b9f-c4da06f5e7c3' })
       const appointment = actionPlanAppointment.build({
         sessionNumber: 1,
-        attendance: {
-          attended: 'yes',
+        sessionFeedback: {
+          attendance: {
+            attended: 'yes',
+          },
         },
       })
       const presenter = new PostSessionFeedbackConfirmationPresenter(actionPlan, appointment)
@@ -26,8 +28,10 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
           const appointments = [
             actionPlanAppointment.build({
               sessionNumber: 1,
-              attendance: {
-                attended: 'yes',
+              sessionFeedback: {
+                attendance: {
+                  attended: 'yes',
+                },
               },
             }),
             actionPlanAppointment.build({
@@ -49,8 +53,10 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
         it('informs the service provider that the probation practitioner has been sent a copy of the session feedback form', () => {
           const appointment = actionPlanAppointment.build({
             sessionNumber: 1,
-            attendance: {
-              attended: 'yes',
+            sessionFeedback: {
+              attendance: {
+                attended: 'yes',
+              },
             },
           })
 
@@ -67,8 +73,10 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
         it('reminds the service provider to submit their end of service report within 5 days', () => {
           const appointment = actionPlanAppointment.build({
             sessionNumber: 2,
-            attendance: {
-              attended: 'yes',
+            sessionFeedback: {
+              attendance: {
+                attended: 'yes',
+              },
             },
           })
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -679,9 +679,11 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
   it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the confirmation page', async () => {
     const updatedAppointment = actionPlanAppointmentFactory.build({
       sessionNumber: 1,
-      attendance: {
-        attended: 'yes',
-        additionalAttendanceInformation: 'Alex made the session on time',
+      sessionFeedback: {
+        attendance: {
+          attended: 'yes',
+          additionalAttendanceInformation: 'Alex made the session on time',
+        },
       },
     })
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1901,9 +1901,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             sessionNumber: 2,
             appointmentTime: '2021-05-13T13:30:00+01:00',
             durationInMinutes: 60,
-            attendance: {
-              attended: 'late',
-              additionalAttendanceInformation: 'Alex missed the bus',
+            sessionFeedback: {
+              attendance: {
+                attended: 'late',
+                additionalAttendanceInformation: 'Alex missed the bus',
+              },
             },
           }),
           headers: {
@@ -1921,8 +1923,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           additionalAttendanceInformation: 'Alex missed the bus',
         }
       )
-      expect(appointment.attendance!.attended).toEqual('late')
-      expect(appointment.attendance!.additionalAttendanceInformation).toEqual('Alex missed the bus')
+      expect(appointment.sessionFeedback!.attendance!.attended).toEqual('late')
+      expect(appointment.sessionFeedback!.attendance!.additionalAttendanceInformation).toEqual('Alex missed the bus')
     })
   })
 })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1927,6 +1927,59 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(appointment.sessionFeedback!.attendance!.additionalAttendanceInformation).toEqual('Alex missed the bus')
     })
   })
+
+  describe('recordAppointmentBehaviour', () => {
+    it('returns an updated action plan appointment with the service user‘s behaviour', async () => {
+      await provider.addInteraction({
+        state:
+          'an action plan with ID 345059d4-1697-467b-8914-fedec9957279 exists and has 2 2-hour appointments already',
+        uponReceiving:
+          'a POST request to set the behaviour for session 2 on action plan with ID 345059d4-1697-467b-8914-fedec9957279',
+        withRequest: {
+          method: 'POST',
+          path: '/action-plan/345059d4-1697-467b-8914-fedec9957279/appointment/2/record-behaviour',
+          body: {
+            behaviourDescription: 'Alex was well behaved',
+            notifyProbationPractitioner: false,
+          },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            sessionNumber: 2,
+            appointmentTime: '2021-05-13T13:30:00+01:00',
+            durationInMinutes: 60,
+            sessionFeedback: {
+              attendance: {
+                attended: 'late',
+                additionalAttendanceInformation: 'Alex missed the bus',
+              },
+              behaviour: {
+                behaviourDescription: 'Alex was well behaved',
+                notifyProbationPractitioner: false,
+              },
+            },
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const appointment = await interventionsService.recordAppointmentBehaviour(
+        token,
+        '345059d4-1697-467b-8914-fedec9957279',
+        2,
+        {
+          behaviourDescription: 'Alex was well behaved',
+          notifyProbationPractitioner: false,
+        }
+      )
+      expect(appointment.sessionFeedback!.behaviour!.behaviourDescription).toEqual('Alex was well behaved')
+      expect(appointment.sessionFeedback!.behaviour!.notifyProbationPractitioner).toEqual(false)
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -157,7 +157,9 @@ export interface ActionPlanAppointment {
   sessionNumber: number
   appointmentTime: string | null
   durationInMinutes: number | null
-  attendance?: AppointmentAttendance
+  sessionFeedback?: {
+    attendance?: AppointmentAttendance
+  }
 }
 
 export interface ActionPlanAppointmentUpdate {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -159,6 +159,7 @@ export interface ActionPlanAppointment {
   durationInMinutes: number | null
   sessionFeedback?: {
     attendance?: AppointmentAttendance
+    behaviour?: AppointmentBehaviour
   }
 }
 
@@ -170,6 +171,11 @@ export interface ActionPlanAppointmentUpdate {
 export interface AppointmentAttendance {
   attended: 'yes' | 'no' | 'late'
   additionalAttendanceInformation?: string
+}
+
+export interface AppointmentBehaviour {
+  behaviourDescription: string
+  notifyProbationPractitioner: boolean
 }
 
 export default class InterventionsService {
@@ -474,6 +480,21 @@ export default class InterventionsService {
       path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}/record-attendance`,
       headers: { Accept: 'application/json' },
       data: appointmentAttendanceUpdate,
+    })) as ActionPlanAppointment
+  }
+
+  async recordAppointmentBehaviour(
+    token: string,
+    actionPlanId: string,
+    sessionNumber: number,
+    appointmentBehaviourUpdate: Partial<AppointmentBehaviour>
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}/record-behaviour`,
+      headers: { Accept: 'application/json' },
+      data: appointmentBehaviourUpdate,
     })) as ActionPlanAppointment
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds Interventions Service function to record a Service User's behaviour after a session, as well as mocks and stubs for integration tests.

## What is the intent behind these changes?

To allow the Service Provider to record the SU's behaviour and notify the PP if there is anything noteworthy.
