### PR TITLE
Add mock for updateActionPlanAppointment

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -120,5 +120,9 @@ module.exports = on => {
     stubGetActionPlanAppointment: arg => {
       return interventionsService.stubGetActionPlanAppointment(arg.id, arg.session, arg.responseJson)
     },
+
+    stubUpdateActionPlanAppointment: arg => {
+      return interventionsService.stubUpdateActionPlanAppointment(arg.id, arg.session, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -77,3 +77,7 @@ Cypress.Commands.add('stubGetActionPlanAppointments', (id, responseJson) => {
 Cypress.Commands.add('stubGetActionPlanAppointment', (id, session, responseJson) => {
   cy.task('stubGetActionPlanAppointment', { id, session, responseJson })
 })
+
+Cypress.Commands.add('stubUpdateActionPlanAppointment', (id, session, responseJson) => {
+  cy.task('stubUpdateActionPlanAppointment', { id, session, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -312,4 +312,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubUpdateActionPlanAppointment = async (id: string, session: number, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/action-plan/${id}/appointment/${session}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds a missing mock method for `updateActionPlanAppointment`.

## What is the intent behind these changes?

To be able to write integration tests for the upcoming "edit action plan appointment" page.