### PR TITLE
Extract calendar day input

### DIFF
--- a/server/routes/referrals/completionDeadlineForm.test.ts
+++ b/server/routes/referrals/completionDeadlineForm.test.ts
@@ -1,160 +1,42 @@
-import { Request } from 'express'
 import CompletionDeadlineForm from './completionDeadlineForm'
+import TestUtils from '../../../testutils/testUtils'
 
 describe('CompletionDeadlineForm', () => {
-  describe('createForm', () => {
-    it('returns a form and sanitizes the request body', async () => {
-      const req = {
-        body: {
+  describe('data', () => {
+    describe('with valid data', () => {
+      it('returns a paramsForUpdate with the completionDeadline key and an ISO-formatted date', async () => {
+        const request = TestUtils.createRequest({
           'completion-deadline-year': '2021',
           'completion-deadline-month': '09',
           'completion-deadline-day': '12',
-        },
-      } as Request
+        })
 
-      await CompletionDeadlineForm.createForm(req)
+        const data = await new CompletionDeadlineForm(request).data()
 
-      expect(req.body['completion-deadline-year']).toBe(2021)
-      expect(req.body['completion-deadline-month']).toBe(9)
-      expect(req.body['completion-deadline-day']).toBe(12)
+        expect(data.paramsForUpdate).toEqual({ completionDeadline: '2021-09-12' })
+      })
     })
 
     describe('with invalid data', () => {
-      it('does not modify the invalid fields', async () => {
-        const req = {
-          body: {
-            'completion-deadline-year': '2021',
-            'completion-deadline-month': '09',
-            'completion-deadline-day': 'hello',
-          },
-        } as Request
-
-        await CompletionDeadlineForm.createForm(req)
-
-        expect(req.body['completion-deadline-year']).toBe(2021)
-        expect(req.body['completion-deadline-month']).toBe(9)
-        expect(req.body['completion-deadline-day']).toBe('hello')
-      })
-    })
-  })
-
-  describe('errors', () => {
-    it('returns null with valid data', async () => {
-      const req = {
-        body: {
+      it('returns an error', async () => {
+        const request = TestUtils.createRequest({
           'completion-deadline-year': '2021',
           'completion-deadline-month': '09',
-          'completion-deadline-day': '12',
-        },
-      } as Request
+          'completion-deadline-day': '',
+        })
 
-      const form = await CompletionDeadlineForm.createForm(req)
+        const data = await new CompletionDeadlineForm(request).data()
 
-      expect(form.error).toBeNull()
-    })
-
-    it('returns an error when a field is empty', async () => {
-      const req = {
-        body: {
-          'completion-deadline-year': '',
-          'completion-deadline-month': '09',
-          'completion-deadline-day': '12',
-        },
-      } as Request
-
-      const form = await CompletionDeadlineForm.createForm(req)
-
-      expect(form.error).toEqual({
-        errors: [
-          {
-            errorSummaryLinkedField: 'completion-deadline-day',
-            formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
-            message: 'The date by which the service needs to be completed must be a real date',
-          },
-        ],
+        expect(data.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'completion-deadline-day',
+              formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
+              message: 'The date by which the service needs to be completed must be a real date',
+            },
+          ],
+        })
       })
-    })
-
-    it('returns an error when a field is just whitespace', async () => {
-      const req = {
-        body: {
-          'completion-deadline-year': '2021',
-          'completion-deadline-month': '     ',
-          'completion-deadline-day': '12',
-        },
-      } as Request
-
-      const form = await CompletionDeadlineForm.createForm(req)
-
-      expect(form.error).toEqual({
-        errors: [
-          {
-            errorSummaryLinkedField: 'completion-deadline-day',
-            formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
-            message: 'The date by which the service needs to be completed must be a real date',
-          },
-        ],
-      })
-    })
-
-    it('returns an error when a field is non-numeric', async () => {
-      const req = {
-        body: {
-          'completion-deadline-year': '2021',
-          'completion-deadline-month': '09',
-          'completion-deadline-day': 'hello',
-        },
-      } as Request
-
-      const form = await CompletionDeadlineForm.createForm(req)
-
-      expect(form.error).toEqual({
-        errors: [
-          {
-            errorSummaryLinkedField: 'completion-deadline-day',
-            formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
-            message: 'The date by which the service needs to be completed must be a real date',
-          },
-        ],
-      })
-    })
-
-    it('returns an error when the date specified does not exist', async () => {
-      const req = {
-        body: {
-          'completion-deadline-year': '2011',
-          'completion-deadline-month': '02',
-          'completion-deadline-day': '31',
-        },
-      } as Request
-
-      const form = await CompletionDeadlineForm.createForm(req)
-
-      expect(form.error).toEqual({
-        errors: [
-          {
-            errorSummaryLinkedField: 'completion-deadline-day',
-            formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
-            message: 'The date by which the service needs to be completed must be a real date',
-          },
-        ],
-      })
-    })
-  })
-
-  describe('paramsForUpdate', () => {
-    it('returns an object with the completionDeadline key and an ISO-formatted date', async () => {
-      const req = {
-        body: {
-          'completion-deadline-year': '2021',
-          'completion-deadline-month': '09',
-          'completion-deadline-day': '12',
-        },
-      } as Request
-
-      const form = await CompletionDeadlineForm.createForm(req)
-
-      expect(form.paramsForUpdate).toEqual({ completionDeadline: '2021-09-12' })
     })
   })
 })

--- a/server/routes/referrals/completionDeadlineForm.test.ts
+++ b/server/routes/referrals/completionDeadlineForm.test.ts
@@ -31,8 +31,8 @@ describe('CompletionDeadlineForm', () => {
           errors: [
             {
               errorSummaryLinkedField: 'completion-deadline-day',
-              formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
-              message: 'The date by which the service needs to be completed must be a real date',
+              formFields: ['completion-deadline-day'],
+              message: 'The date by which the service needs to be completed must include a day',
             },
           ],
         })

--- a/server/routes/referrals/completionDeadlineForm.ts
+++ b/server/routes/referrals/completionDeadlineForm.ts
@@ -1,87 +1,20 @@
 import { Request } from 'express'
-import { body, Result, SanitizationChain, ValidationError, validationResult } from 'express-validator'
 import { DraftReferral } from '../../services/interventionsService'
-import CalendarDay from '../../utils/calendarDay'
 import errorMessages from '../../utils/errorMessages'
-import { FormValidationError } from '../../utils/formValidationError'
+import CalendarDayInput from '../../utils/forms/inputs/calendarDayInput'
+import { FormData } from '../../utils/forms/formData'
 
 export default class CompletionDeadlineForm {
-  private constructor(private readonly request: Request, private readonly result: Result<ValidationError>) {}
+  constructor(private readonly request: Request) {}
 
-  static async createForm(request: Request): Promise<CompletionDeadlineForm> {
-    await Promise.all(this.validations.map(validation => validation.run(request)))
+  async data(): Promise<FormData<Partial<DraftReferral>>> {
+    const input = new CalendarDayInput(this.request, 'completion-deadline', errorMessages.completionDeadline)
+    const result = await input.validate()
 
-    const result = validationResult(request)
-
-    return new CompletionDeadlineForm(request, result)
-  }
-
-  static get validations(): SanitizationChain[] {
-    return [
-      // TODO decide whether we like the fact that express-validator is mutating the request?
-      // e.g. the `bail` before toInt() is so that we don’t end up replaying NaN back to the user
-      // if they enter a blank input
-      body('completion-deadline-day')
-        .notEmpty({ ignore_whitespace: true })
-        .withMessage(errorMessages.completionDeadline.dayEmpty)
-        .isInt()
-        .withMessage(errorMessages.completionDeadline.invalidDate)
-        .bail()
-        .toInt(),
-      body('completion-deadline-month')
-        .notEmpty({ ignore_whitespace: true })
-        .withMessage(errorMessages.completionDeadline.monthEmpty)
-        .isInt()
-        .withMessage(errorMessages.completionDeadline.invalidDate)
-        .bail()
-        .toInt(),
-      body('completion-deadline-year')
-        .notEmpty({ ignore_whitespace: true })
-        .withMessage(errorMessages.completionDeadline.yearEmpty)
-        .isInt()
-        .withMessage(errorMessages.completionDeadline.invalidDate)
-        .bail()
-        .toInt(),
-    ]
-  }
-
-  get paramsForUpdate(): Partial<DraftReferral> {
-    if (this.completionDeadline === null) {
-      return {}
+    if (result.value) {
+      return { error: null, paramsForUpdate: { completionDeadline: result.value.iso8601 } }
     }
 
-    return {
-      completionDeadline: this.completionDeadline.iso8601,
-    }
-  }
-
-  get isValid(): boolean {
-    return this.error === null
-  }
-
-  get error(): FormValidationError | null {
-    if (this.result.isEmpty() && this.completionDeadline) {
-      return null
-    }
-
-    // TODO (IC-706) use `result`, implement all the rules of the GOV.UK Design
-    // System date input component error handling
-    return {
-      errors: [
-        {
-          errorSummaryLinkedField: 'completion-deadline-day',
-          formFields: ['completion-deadline-day', 'completion-deadline-month', 'completion-deadline-year'],
-          message: errorMessages.completionDeadline.invalidDate,
-        },
-      ],
-    }
-  }
-
-  private get completionDeadline(): CalendarDay | null {
-    return CalendarDay.fromComponents(
-      this.request.body['completion-deadline-day'],
-      this.request.body['completion-deadline-month'],
-      this.request.body['completion-deadline-year']
-    )
+    return { error: result.error, paramsForUpdate: null }
   }
 }

--- a/server/routes/referrals/completionDeadlinePresenter.test.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.test.ts
@@ -39,7 +39,7 @@ describe('CompletionDeadlinePresenter', () => {
           .build()
         const presenter = new CompletionDeadlinePresenter(referral, serviceCategory, null, {
           'completion-deadline-day': 'egg',
-          'completion-deadline-month': 7,
+          'completion-deadline-month': '7',
         })
 
         expect(presenter.fields.completionDeadline.day.value).toBe('egg')

--- a/server/routes/referrals/rarDaysForm.ts
+++ b/server/routes/referrals/rarDaysForm.ts
@@ -52,16 +52,6 @@ export default class RarDaysForm {
   }
 
   get error(): FormValidationError | null {
-    if (this.result.isEmpty()) {
-      return null
-    }
-
-    return {
-      errors: this.result.array().map(validationError => ({
-        formFields: [validationError.param],
-        errorSummaryLinkedField: validationError.param,
-        message: validationError.msg,
-      })),
-    }
+    return FormUtils.validationErrorFromResult(this.result)
   }
 }

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -303,22 +303,22 @@ export default class ReferralsController {
   }
 
   async updateCompletionDeadline(req: Request, res: Response): Promise<void> {
-    const form = await CompletionDeadlineForm.createForm(req)
+    const data = await new CompletionDeadlineForm(req).data()
 
     let error: FormValidationError | null = null
 
-    if (form.isValid) {
+    if (data.paramsForUpdate) {
       try {
         await this.interventionsService.patchDraftReferral(
           res.locals.user.token.accessToken,
           req.params.id,
-          form.paramsForUpdate
+          data.paramsForUpdate
         )
       } catch (e) {
         error = createFormValidationErrorOrRethrow(e)
       }
     } else {
-      error = form.error
+      error = data.error
     }
 
     if (error === null) {

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,5 +1,6 @@
 import { body, Result, ValidationChain, ValidationError, validationResult } from 'express-validator'
 import { Request } from 'express'
+import { FormValidationError } from './formValidationError'
 
 export default class FormUtils {
   static yesNoRadioWithConditionalInputValidationChain({
@@ -28,5 +29,19 @@ export default class FormUtils {
   }): Promise<Result<ValidationError>> {
     await Promise.all(validations.map(validation => validation.run(request)))
     return validationResult(request)
+  }
+
+  static validationErrorFromResult(result: Result): FormValidationError | null {
+    if (result.isEmpty()) {
+      return null
+    }
+
+    return {
+      errors: result.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
   }
 }

--- a/server/utils/forms/formData.ts
+++ b/server/utils/forms/formData.ts
@@ -1,0 +1,5 @@
+import { FormValidationError } from '../formValidationError'
+
+export type FormData<ParamsType> =
+  | { paramsForUpdate: ParamsType; error: null }
+  | { paramsForUpdate: null; error: FormValidationError }

--- a/server/utils/forms/formValidationResult.ts
+++ b/server/utils/forms/formValidationResult.ts
@@ -1,0 +1,13 @@
+import { FormValidationError } from '../formValidationError'
+
+interface FormValidationErrorResult {
+  value: null
+  error: FormValidationError
+}
+
+interface FormValidationSuccessResult<Value> {
+  value: Value
+  error: null
+}
+
+export type FormValidationResult<Value> = FormValidationErrorResult | FormValidationSuccessResult<Value>

--- a/server/utils/forms/inputs/calendarDayInput.test.ts
+++ b/server/utils/forms/inputs/calendarDayInput.test.ts
@@ -37,9 +37,9 @@ describe(CalendarDayInput, () => {
       expect(result.error).toEqual({
         errors: [
           {
-            errorSummaryLinkedField: 'deadline-day',
-            formFields: ['deadline-day', 'deadline-month', 'deadline-year'],
-            message: 'The deadline must be a real date',
+            errorSummaryLinkedField: 'deadline-year',
+            formFields: ['deadline-year'],
+            message: 'The deadline must include a year',
           },
         ],
       })
@@ -57,9 +57,9 @@ describe(CalendarDayInput, () => {
       expect(result.error).toEqual({
         errors: [
           {
-            errorSummaryLinkedField: 'deadline-day',
-            formFields: ['deadline-day', 'deadline-month', 'deadline-year'],
-            message: 'The deadline must be a real date',
+            errorSummaryLinkedField: 'deadline-month',
+            formFields: ['deadline-month'],
+            message: 'The deadline must include a month',
           },
         ],
       })
@@ -78,7 +78,7 @@ describe(CalendarDayInput, () => {
         errors: [
           {
             errorSummaryLinkedField: 'deadline-day',
-            formFields: ['deadline-day', 'deadline-month', 'deadline-year'],
+            formFields: ['deadline-day'],
             message: 'The deadline must be a real date',
           },
         ],

--- a/server/utils/forms/inputs/calendarDayInput.test.ts
+++ b/server/utils/forms/inputs/calendarDayInput.test.ts
@@ -105,6 +105,26 @@ describe(CalendarDayInput, () => {
       })
     })
 
+    it('returns an error when a field is not an integer', async () => {
+      const request = TestUtils.createRequest({
+        'deadline-year': '2021',
+        'deadline-month': '09',
+        'deadline-day': '12.1',
+      })
+
+      const result = await new CalendarDayInput(request, 'deadline', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-day',
+            formFields: ['deadline-day'],
+            message: 'The deadline must be a real date',
+          },
+        ],
+      })
+    })
+
     it('returns an error when the date specified does not exist', async () => {
       const request = TestUtils.createRequest({
         'deadline-year': '2011',

--- a/server/utils/forms/inputs/calendarDayInput.test.ts
+++ b/server/utils/forms/inputs/calendarDayInput.test.ts
@@ -45,6 +45,26 @@ describe(CalendarDayInput, () => {
       })
     })
 
+    it('returns an error when multiple fields are empty', async () => {
+      const request = TestUtils.createRequest({
+        'deadline-year': '',
+        'deadline-month': '',
+        'deadline-day': '12',
+      })
+
+      const result = await new CalendarDayInput(request, 'deadline', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-month',
+            formFields: ['deadline-month'],
+            message: 'The deadline must include a month',
+          },
+        ],
+      })
+    })
+
     it('returns an error when a field is just whitespace', async () => {
       const request = TestUtils.createRequest({
         'deadline-year': '2021',

--- a/server/utils/forms/inputs/calendarDayInput.test.ts
+++ b/server/utils/forms/inputs/calendarDayInput.test.ts
@@ -1,0 +1,108 @@
+import CalendarDayInput from './calendarDayInput'
+import TestUtils from '../../../../testutils/testUtils'
+import CalendarDay from '../../calendarDay'
+
+describe(CalendarDayInput, () => {
+  const messages = {
+    dayEmpty: 'The deadline must include a day',
+    monthEmpty: 'The deadline must include a month',
+    yearEmpty: 'The deadline must include a year',
+    invalidDate: 'The deadline must be a real date',
+  }
+
+  describe('validate', () => {
+    describe('with valid data', () => {
+      it('returns a CalendarDay value', async () => {
+        const request = TestUtils.createRequest({
+          'deadline-year': '2021',
+          'deadline-month': '09',
+          'deadline-day': '12',
+        })
+
+        const result = await new CalendarDayInput(request, 'deadline', messages).validate()
+
+        expect(result.value).toEqual(CalendarDay.fromComponents(12, 9, 2021))
+      })
+    })
+
+    it('returns an error when a field is empty', async () => {
+      const request = TestUtils.createRequest({
+        'deadline-year': '',
+        'deadline-month': '09',
+        'deadline-day': '12',
+      })
+
+      const result = await new CalendarDayInput(request, 'deadline', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-day',
+            formFields: ['deadline-day', 'deadline-month', 'deadline-year'],
+            message: 'The deadline must be a real date',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when a field is just whitespace', async () => {
+      const request = TestUtils.createRequest({
+        'deadline-year': '2021',
+        'deadline-month': '     ',
+        'deadline-day': '12',
+      })
+
+      const result = await new CalendarDayInput(request, 'deadline', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-day',
+            formFields: ['deadline-day', 'deadline-month', 'deadline-year'],
+            message: 'The deadline must be a real date',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when a field is non-numeric', async () => {
+      const request = TestUtils.createRequest({
+        'deadline-year': '2021',
+        'deadline-month': '09',
+        'deadline-day': 'hello',
+      })
+
+      const result = await new CalendarDayInput(request, 'deadline', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-day',
+            formFields: ['deadline-day', 'deadline-month', 'deadline-year'],
+            message: 'The deadline must be a real date',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when the date specified does not exist', async () => {
+      const request = TestUtils.createRequest({
+        'deadline-year': '2011',
+        'deadline-month': '02',
+        'deadline-day': '31',
+      })
+
+      const result = await new CalendarDayInput(request, 'deadline', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-day',
+            formFields: ['deadline-day', 'deadline-month', 'deadline-year'],
+            message: 'The deadline must be a real date',
+          },
+        ],
+      })
+    })
+  })
+})

--- a/server/utils/forms/inputs/calendarDayInput.ts
+++ b/server/utils/forms/inputs/calendarDayInput.ts
@@ -40,7 +40,7 @@ export default class CalendarDayInput {
   private error(result: ExpressValidator.Result): FormValidationError | null {
     const error = FormUtils.validationErrorFromResult(result)
     if (error !== null) {
-      return error
+      return this.convertToSingleError(error)
     }
 
     if (this.calendarDay === null) {
@@ -56,6 +56,10 @@ export default class CalendarDayInput {
     }
 
     return null
+  }
+
+  private convertToSingleError(error: FormValidationError): FormValidationError {
+    return { errors: [error.errors[0]] }
   }
 
   private get validations() {

--- a/server/utils/forms/inputs/calendarDayInput.ts
+++ b/server/utils/forms/inputs/calendarDayInput.ts
@@ -1,0 +1,89 @@
+import * as ExpressValidator from 'express-validator'
+import { Request } from 'express'
+import CalendarDay from '../../calendarDay'
+import { FormValidationError } from '../../formValidationError'
+import { FormValidationResult } from '../formValidationResult'
+import FormUtils from '../../formUtils'
+
+export interface CalendarDayErrorMessages {
+  dayEmpty: string
+  monthEmpty: string
+  yearEmpty: string
+  invalidDate: string
+}
+
+export default class CalendarDayInput {
+  constructor(
+    private readonly request: Request,
+    private readonly key: string,
+    private readonly errorMessages: CalendarDayErrorMessages
+  ) {}
+
+  private get keys() {
+    return { day: `${this.key}-day`, month: `${this.key}-month`, year: `${this.key}-year` }
+  }
+
+  async validate(): Promise<FormValidationResult<CalendarDay>> {
+    const result = await FormUtils.runValidations({ request: this.request, validations: this.validations })
+
+    const error = this.error(result)
+    if (error) {
+      return { value: null, error }
+    }
+
+    return {
+      value: this.calendarDay!,
+      error: null,
+    }
+  }
+
+  private error(result: ExpressValidator.Result): FormValidationError | null {
+    const isValidDate = this.calendarDay !== null
+
+    if (result.isEmpty() && isValidDate) {
+      return null
+    }
+
+    // TODO (IC-706) use `result`, implement all the rules of the GOV.UK Design
+    // System date input component error handling
+    return {
+      errors: [
+        {
+          errorSummaryLinkedField: this.keys.day,
+          formFields: [this.keys.day, this.keys.month, this.keys.year],
+          message: this.errorMessages.invalidDate,
+        },
+      ],
+    }
+  }
+
+  private get validations() {
+    // TODO (IC-706) Make sure we’re conforming to all GOV.UK Design System
+    // guidance for error messages
+    return [
+      ExpressValidator.body(this.keys.day)
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(this.errorMessages.dayEmpty)
+        .isInt()
+        .withMessage(this.errorMessages.invalidDate),
+      ExpressValidator.body(this.keys.month)
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(this.errorMessages.monthEmpty)
+        .isInt()
+        .withMessage(this.errorMessages.invalidDate),
+      ExpressValidator.body(this.keys.year)
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(this.errorMessages.yearEmpty)
+        .isInt()
+        .withMessage(this.errorMessages.invalidDate),
+    ]
+  }
+
+  private get calendarDay(): CalendarDay | null {
+    return CalendarDay.fromComponents(
+      Number(this.request.body[this.keys.day]),
+      Number(this.request.body[this.keys.month]),
+      Number(this.request.body[this.keys.year])
+    )
+  }
+}

--- a/server/utils/forms/inputs/calendarDayInput.ts
+++ b/server/utils/forms/inputs/calendarDayInput.ts
@@ -38,23 +38,24 @@ export default class CalendarDayInput {
   }
 
   private error(result: ExpressValidator.Result): FormValidationError | null {
-    const isValidDate = this.calendarDay !== null
-
-    if (result.isEmpty() && isValidDate) {
-      return null
+    const error = FormUtils.validationErrorFromResult(result)
+    if (error !== null) {
+      return error
     }
 
-    // TODO (IC-706) use `result`, implement all the rules of the GOV.UK Design
-    // System date input component error handling
-    return {
-      errors: [
-        {
-          errorSummaryLinkedField: this.keys.day,
-          formFields: [this.keys.day, this.keys.month, this.keys.year],
-          message: this.errorMessages.invalidDate,
-        },
-      ],
+    if (this.calendarDay === null) {
+      return {
+        errors: [
+          {
+            errorSummaryLinkedField: this.keys.day,
+            formFields: [this.keys.day, this.keys.month, this.keys.year],
+            message: this.errorMessages.invalidDate,
+          },
+        ],
+      }
     }
+
+    return null
   }
 
   private get validations() {
@@ -64,16 +65,19 @@ export default class CalendarDayInput {
       ExpressValidator.body(this.keys.day)
         .notEmpty({ ignore_whitespace: true })
         .withMessage(this.errorMessages.dayEmpty)
+        .bail()
         .isInt()
         .withMessage(this.errorMessages.invalidDate),
       ExpressValidator.body(this.keys.month)
         .notEmpty({ ignore_whitespace: true })
         .withMessage(this.errorMessages.monthEmpty)
+        .bail()
         .isInt()
         .withMessage(this.errorMessages.invalidDate),
       ExpressValidator.body(this.keys.year)
         .notEmpty({ ignore_whitespace: true })
         .withMessage(this.errorMessages.yearEmpty)
+        .bail()
         .isInt()
         .withMessage(this.errorMessages.invalidDate),
     ]

--- a/testutils/testUtils.ts
+++ b/testutils/testUtils.ts
@@ -1,3 +1,4 @@
+import { Request } from 'express'
 import { SummaryListItem } from '../server/utils/summaryList'
 
 export default class TestUtils {
@@ -5,5 +6,9 @@ export default class TestUtils {
     const items = list()
     const item = items.find(anItem => anItem.key === key)
     return item?.lines ?? null
+  }
+
+  static createRequest = (body: Record<string, unknown>): Request => {
+    return { body } as Request
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Extracts the code for validating and parsing a calendar day form input, which is currently all contained within the completion deadline form. It then makes some improvemens to this validator, to return more detailed error messages.

## What is the intent behind these changes?

To be able to reuse the calendar day input logic for the upcoming "edit action plan appointment" page.