### PR TITLE
Add duration input class

### DIFF
--- a/server/utils/forms/inputs/durationInput.test.ts
+++ b/server/utils/forms/inputs/durationInput.test.ts
@@ -1,0 +1,142 @@
+import DurationInput from './durationInput'
+import TestUtils from '../../../../testutils/testUtils'
+import Duration from '../../duration'
+
+describe(DurationInput, () => {
+  const messages = {
+    empty: 'Enter a session duration',
+    invalidDuration: 'The session duration must be a real duration',
+  }
+
+  describe('validate', () => {
+    describe('with valid data', () => {
+      it('returns a Duration value when hours and minutes are provided', async () => {
+        const request = TestUtils.createRequest({
+          'session-duration-hours': '1',
+          'session-duration-minutes': '30',
+        })
+
+        const result = await new DurationInput(request, 'session-duration', messages).validate()
+
+        expect(result.value).toEqual(Duration.fromUnits(1, 30, 0))
+      })
+
+      it('returns a Duration value when just hours are provided', async () => {
+        const request = TestUtils.createRequest({
+          'session-duration-hours': '1',
+          'session-duration-minutes': '',
+        })
+
+        const result = await new DurationInput(request, 'session-duration', messages).validate()
+
+        expect(result.value).toEqual(Duration.fromUnits(1, 0, 0))
+      })
+
+      it('returns a Duration value when just minutes are provided', async () => {
+        const request = TestUtils.createRequest({
+          'session-duration-hours': '',
+          'session-duration-minutes': '30',
+        })
+
+        const result = await new DurationInput(request, 'session-duration', messages).validate()
+
+        expect(result.value).toEqual(Duration.fromUnits(0, 30, 0))
+      })
+    })
+
+    it('returns an error when hours and minutes are both empty', async () => {
+      const request = TestUtils.createRequest({
+        'session-duration-hours': '',
+        'session-duration-minutes': '',
+      })
+
+      const result = await new DurationInput(request, 'session-duration', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'session-duration-hours',
+            formFields: ['session-duration-hours', 'session-duration-minutes'],
+            message: 'Enter a session duration',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when hours and minutes are both just whitespace', async () => {
+      const request = TestUtils.createRequest({
+        'session-duration-hours': '   ',
+        'session-duration-minutes': '     ',
+      })
+
+      const result = await new DurationInput(request, 'session-duration', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'session-duration-hours',
+            formFields: ['session-duration-hours', 'session-duration-minutes'],
+            message: 'Enter a session duration',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when a field is non-numeric', async () => {
+      const request = TestUtils.createRequest({
+        'session-duration-hours': '1',
+        'session-duration-minutes': 'hello',
+      })
+
+      const result = await new DurationInput(request, 'session-duration', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'session-duration-minutes',
+            formFields: ['session-duration-minutes'],
+            message: 'The session duration must be a real duration',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when a field is not an integer', async () => {
+      const request = TestUtils.createRequest({
+        'session-duration-hours': '1',
+        'session-duration-minutes': '30.5',
+      })
+
+      const result = await new DurationInput(request, 'session-duration', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'session-duration-minutes',
+            formFields: ['session-duration-minutes'],
+            message: 'The session duration must be a real duration',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when a field is negative', async () => {
+      const request = TestUtils.createRequest({
+        'session-duration-hours': '1',
+        'session-duration-minutes': '-30',
+      })
+
+      const result = await new DurationInput(request, 'session-duration', messages).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'session-duration-hours',
+            formFields: ['session-duration-hours', 'session-duration-minutes'],
+            message: 'The session duration must be a real duration',
+          },
+        ],
+      })
+    })
+  })
+})

--- a/server/utils/forms/inputs/durationInput.ts
+++ b/server/utils/forms/inputs/durationInput.ts
@@ -1,0 +1,100 @@
+import * as ExpressValidator from 'express-validator'
+import { Request } from 'express'
+import Duration from '../../duration'
+import { FormValidationError } from '../../formValidationError'
+import { FormValidationResult } from '../formValidationResult'
+import FormUtils from '../../formUtils'
+
+export interface DurationErrorMessages {
+  empty: string
+  invalidDuration: string
+}
+
+export default class DurationInput {
+  constructor(
+    private readonly request: Request,
+    private readonly key: string,
+    private readonly errorMessages: DurationErrorMessages
+  ) {}
+
+  private get keys() {
+    return { hours: `${this.key}-hours`, minutes: `${this.key}-minutes` }
+  }
+
+  async validate(): Promise<FormValidationResult<Duration>> {
+    const result = await FormUtils.runValidations({ request: this.request, validations: this.validations })
+
+    const error = this.error(result)
+    if (error) {
+      return { value: null, error }
+    }
+
+    return {
+      value: this.duration!,
+      error: null,
+    }
+  }
+
+  private error(result: ExpressValidator.Result): FormValidationError | null {
+    const formValidationError = FormUtils.validationErrorFromResult(result)
+    if (formValidationError !== null) {
+      formValidationError.errors = formValidationError.errors.map(anError => {
+        if (anError.message === this.errorMessages.empty) {
+          // express-validator doesn’t do multi-field validation rules, so
+          // we need to mark an empty duration as an error on all fields
+          return { ...anError, formFields: Object.values(this.keys) }
+        }
+        return anError
+      })
+
+      return formValidationError
+    }
+
+    if (this.duration === null) {
+      return {
+        errors: [
+          {
+            errorSummaryLinkedField: this.keys.hours,
+            formFields: [this.keys.hours, this.keys.minutes],
+            message: this.errorMessages.invalidDuration,
+          },
+        ],
+      }
+    }
+
+    return null
+  }
+
+  get validations(): ExpressValidator.ValidationChain[] {
+    const isEmptyOptions = { ignore_whitespace: true }
+
+    // TODO (IC-1504) Make sure we’re conforming to all GOV.UK Design System
+    // guidance for error messages
+    return [
+      // You need to provide at least one of hours or minutes
+      // It's a bit clunky; `oneOf` is what we want but it’s only a middleware
+      ExpressValidator.body(this.keys.hours)
+        .if(ExpressValidator.body(this.keys.minutes).isEmpty(isEmptyOptions))
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(this.errorMessages.empty),
+
+      // These two express that any provided component must be an integer
+      ExpressValidator.body(this.keys.hours)
+        .if(ExpressValidator.body(this.keys.hours).notEmpty(isEmptyOptions))
+        .isInt()
+        .withMessage(this.errorMessages.invalidDuration),
+      ExpressValidator.body(this.keys.minutes)
+        .if(ExpressValidator.body(this.keys.minutes).notEmpty(isEmptyOptions))
+        .isInt()
+        .withMessage(this.errorMessages.invalidDuration),
+    ]
+  }
+
+  get duration(): Duration | null {
+    return Duration.fromUnits(
+      Number(this.request.body[this.keys.hours]),
+      Number(this.request.body[this.keys.minutes]),
+      0
+    )
+  }
+}


### PR DESCRIPTION
**Dependency: This PR is dependent on #223 – please review that one first.**

## What does this pull request do?

Adds a class for validating and parsing a duration form input, continuing the pattern introduced in #223.

## What is the intent behind these changes?

To allow us to accept duration input on the upcoming "edit action plan appointment" page.