### PR TITLE
Add 12 hour datetime input class

### DIFF
--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -81,5 +81,18 @@ describe('FormUtils', () => {
         { location: 'body', msg: 'field3 is empty', param: 'field3', value: '' },
       ])
     })
+
+    it('can be used multiple times on the same request with different validations', async () => {
+      const validations = [body('field2').notEmpty().withMessage('field2 is empty')]
+      const secondValidations = [body('field3').notEmpty().withMessage('field3 is empty')]
+
+      const request = { body: { field1: 'Hello', field2: '', field3: '' } } as Request
+
+      const result = await FormUtils.runValidations({ request, validations })
+      const secondResult = await FormUtils.runValidations({ request, validations: secondValidations })
+
+      expect(result.array()).toEqual([{ location: 'body', msg: 'field2 is empty', param: 'field2', value: '' }])
+      expect(secondResult.array()).toEqual([{ location: 'body', msg: 'field3 is empty', param: 'field3', value: '' }])
+    })
   })
 })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -27,8 +27,9 @@ export default class FormUtils {
     request: Request
     validations: ValidationChain[]
   }): Promise<Result<ValidationError>> {
-    await Promise.all(validations.map(validation => validation.run(request)))
-    return validationResult(request)
+    const clonedRequest = { ...request }
+    await Promise.all(validations.map(validation => validation.run(clonedRequest)))
+    return validationResult(clonedRequest)
   }
 
   static validationErrorFromResult(result: Result): FormValidationError | null {

--- a/server/utils/forms/inputs/twelveHourBritishDateTimeInput.test.ts
+++ b/server/utils/forms/inputs/twelveHourBritishDateTimeInput.test.ts
@@ -1,0 +1,161 @@
+import TestUtils from '../../../../testutils/testUtils'
+import TwelveHourBritishDateTimeInput from './twelveHourBritishDateTimeInput'
+
+describe(TwelveHourBritishDateTimeInput, () => {
+  const messages = {
+    calendarDay: {
+      dayEmpty: 'The deadline must include a day',
+      monthEmpty: 'The deadline must include a month',
+      yearEmpty: 'The deadline must include a year',
+      invalidDate: 'The deadline date must be a real date',
+    },
+    clockTime: {
+      hourEmpty: 'The deadline must include an hour',
+      minuteEmpty: 'The deadline must include a minute',
+      partOfDayEmpty: 'Select whether the deadline is AM or PM',
+      invalidTime: 'The deadline time must be a real time',
+    },
+    invalidTime: 'The deadline time must exist on the deadline day',
+  }
+
+  describe('validate', () => {
+    describe('with valid data', () => {
+      it('returns the date that the day and time occur in Britain', async () => {
+        const request = TestUtils.createRequest({
+          'deadline-date-year': '2021',
+          'deadline-date-month': '09',
+          'deadline-date-day': '12',
+          'deadline-time-hour': '1',
+          'deadline-time-minute': '05',
+          'deadline-time-part-of-day': 'pm',
+        })
+
+        const result = await new TwelveHourBritishDateTimeInput(
+          request,
+          'deadline-date',
+          'deadline-time',
+          messages
+        ).validate()
+
+        expect(result.value).toEqual(new Date('2021-09-12T12:05:00Z'))
+      })
+    })
+
+    it('returns an error when the date is invalid', async () => {
+      const request = TestUtils.createRequest({
+        'deadline-date-year': '2021',
+        'deadline-date-month': '09',
+        'deadline-date-day': '',
+        'deadline-time-hour': '1',
+        'deadline-time-minute': '05',
+        'deadline-time-part-of-day': 'pm',
+      })
+
+      const result = await new TwelveHourBritishDateTimeInput(
+        request,
+        'deadline-date',
+        'deadline-time',
+        messages
+      ).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-date-day',
+            formFields: ['deadline-date-day'],
+            message: 'The deadline must include a day',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when the time is invalid', async () => {
+      const request = TestUtils.createRequest({
+        'deadline-date-year': '2021',
+        'deadline-date-month': '09',
+        'deadline-date-day': '12',
+        'deadline-time-hour': '',
+        'deadline-time-minute': '05',
+        'deadline-time-part-of-day': 'pm',
+      })
+
+      const result = await new TwelveHourBritishDateTimeInput(
+        request,
+        'deadline-date',
+        'deadline-time',
+        messages
+      ).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-time-hour',
+            formFields: ['deadline-time-hour'],
+            message: 'The deadline must include an hour',
+          },
+        ],
+      })
+    })
+
+    it('returns multiple errors when both the date and time are invalid', async () => {
+      const request = TestUtils.createRequest({
+        'deadline-date-year': '2021',
+        'deadline-date-month': '09',
+        'deadline-date-day': '',
+        'deadline-time-hour': '',
+        'deadline-time-minute': '05',
+        'deadline-time-part-of-day': 'pm',
+      })
+
+      const result = await new TwelveHourBritishDateTimeInput(
+        request,
+        'deadline-date',
+        'deadline-time',
+        messages
+      ).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-date-day',
+            formFields: ['deadline-date-day'],
+            message: 'The deadline must include a day',
+          },
+          {
+            errorSummaryLinkedField: 'deadline-time-hour',
+            formFields: ['deadline-time-hour'],
+            message: 'The deadline must include an hour',
+          },
+        ],
+      })
+    })
+
+    it('returns an error when the date / time combination doesn’t exist in Britain', async () => {
+      const request = TestUtils.createRequest({
+        'deadline-date-year': '2021',
+        'deadline-date-month': '03',
+        'deadline-date-day': '28',
+        'deadline-time-hour': '1',
+        'deadline-time-minute': '30',
+        'deadline-time-part-of-day': 'am',
+      })
+
+      const result = await new TwelveHourBritishDateTimeInput(
+        request,
+        'deadline-date',
+        'deadline-time',
+        messages
+      ).validate()
+
+      expect(result.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-time-hour',
+            formFields: ['deadline-time-hour', 'deadline-time-minute', 'deadline-time-part-of-day'],
+            message: 'The deadline time must exist on the deadline day',
+          },
+        ],
+      })
+    })
+  })
+})

--- a/server/utils/forms/inputs/twelveHourBritishDateTimeInput.ts
+++ b/server/utils/forms/inputs/twelveHourBritishDateTimeInput.ts
@@ -1,0 +1,71 @@
+import { Request } from 'express'
+import CalendarDay from '../../calendarDay'
+import ClockTime from '../../clockTime'
+import { FormValidationError } from '../../formValidationError'
+import { FormValidationResult } from '../formValidationResult'
+import CalendarDayInput, { CalendarDayErrorMessages } from './calendarDayInput'
+import TwelveHourClockTimeInput, { TwelveHourClockTimeErrorMessages } from './twelveHourClockTimeInput'
+
+export interface TwelveHourBritishDateTimeErrorMessages {
+  calendarDay: CalendarDayErrorMessages
+  clockTime: TwelveHourClockTimeErrorMessages
+  invalidTime: string
+}
+
+export default class TwelveHourBritishDateTimeInput {
+  constructor(
+    private readonly request: Request,
+    private readonly dayKey: string,
+    private readonly timeKey: string,
+    private readonly errorMessages: TwelveHourBritishDateTimeErrorMessages
+  ) {}
+
+  async validate(): Promise<FormValidationResult<Date>> {
+    const [dayResult, timeResult] = await Promise.all([
+      new CalendarDayInput(this.request, this.dayKey, this.errorMessages.calendarDay).validate(),
+      new TwelveHourClockTimeInput(this.request, this.timeKey, this.errorMessages.clockTime).validate(),
+    ])
+
+    const error = this.error(dayResult, timeResult)
+    if (error) {
+      return { value: null, error }
+    }
+
+    return {
+      value: this.date(dayResult, timeResult)!,
+      error: null,
+    }
+  }
+
+  private error(
+    dayResult: FormValidationResult<CalendarDay>,
+    timeResult: FormValidationResult<ClockTime>
+  ): FormValidationError | null {
+    if (dayResult.error || timeResult.error) {
+      return { errors: [...(dayResult.error?.errors ?? []), ...(timeResult.error?.errors ?? [])] }
+    }
+
+    if (this.date(dayResult, timeResult) === null) {
+      return {
+        errors: [
+          {
+            errorSummaryLinkedField: `${this.timeKey}-hour`,
+            formFields: [`${this.timeKey}-hour`, `${this.timeKey}-minute`, `${this.timeKey}-part-of-day`],
+            message: this.errorMessages.invalidTime,
+          },
+        ],
+      }
+    }
+
+    return null
+  }
+
+  private date(dayResult: FormValidationResult<CalendarDay>, timeResult: FormValidationResult<ClockTime>): Date | null {
+    if (dayResult.value === null || timeResult.value === null) {
+      return null
+    }
+
+    const date = dayResult.value.atTimeInBritain(timeResult.value)
+    return date
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Combines the calendar day input of #223 and the 12-hour time input of #224 to create a class that takes date / time inputs, validates them, and returns a JavaScript `Date`.

In addition to validating the individual date / time, it also checks that the date and time combination is valid (daylight savings time edge case but best to be safe).

## What is the intent behind these changes?

To allow us to create a timestamp to send for the `appointmentTime` value on the upcoming "edit action plan appointment" page.
