### PR TITLE
IC-1286: Service provider caseworker can schedule an appointment

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -100,6 +100,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/service-provider/action-plan/:id/sessions/:sessionNumber/edit', (req, res) =>
     serviceProviderReferralsController.editSession(req, res)
   )
+  post('/service-provider/action-plan/:id/sessions/:sessionNumber/edit', (req, res) =>
+    serviceProviderReferralsController.editSession(req, res)
+  )
   get(
     '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance',
     (req, res) => serviceProviderReferralsController.showPostSessionAttendanceFeedbackForm(req, res)

--- a/server/routes/serviceProviderReferrals/editSessionForm.test.ts
+++ b/server/routes/serviceProviderReferrals/editSessionForm.test.ts
@@ -1,0 +1,62 @@
+import EditSessionForm from './editSessionForm'
+import TestUtils from '../../../testutils/testUtils'
+
+describe('EditSessionForm', () => {
+  describe('data', () => {
+    describe('with valid data', () => {
+      it('returns a paramsForUpdate with the completionDeadline key and an ISO-formatted date', async () => {
+        const request = TestUtils.createRequest({
+          'date-year': '2021',
+          'date-month': '09',
+          'date-day': '12',
+          'time-hour': '1',
+          'time-minute': '05',
+          'time-part-of-day': 'pm',
+          'duration-hours': '1',
+          'duration-minutes': '30',
+        })
+
+        const data = await new EditSessionForm(request).data()
+
+        expect(data.paramsForUpdate).toEqual({ appointmentTime: '2021-09-12T12:05:00.000Z', durationInMinutes: 90 })
+      })
+    })
+
+    describe('with invalid data', () => {
+      it('returns an error', async () => {
+        const request = TestUtils.createRequest({
+          'date-year': '2021',
+          'date-month': '09',
+          'date-day': '',
+          'time-hour': '1',
+          'time-minute': '09',
+          'time-part-of-day': '',
+          'duration-hours': '',
+          'duration-minutes': '',
+        })
+
+        const data = await new EditSessionForm(request).data()
+
+        expect(data.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'date-day',
+              formFields: ['date-day'],
+              message: 'The session date must include a day',
+            },
+            {
+              errorSummaryLinkedField: 'time-part-of-day',
+              formFields: ['time-part-of-day'],
+              message: 'Select whether the session time is AM or PM',
+            },
+            {
+              errorSummaryLinkedField: 'duration-hours',
+              formFields: ['duration-hours', 'duration-minutes'],
+              message: 'Enter a duration',
+            },
+          ],
+        })
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/editSessionForm.ts
+++ b/server/routes/serviceProviderReferrals/editSessionForm.ts
@@ -1,0 +1,32 @@
+import { Request } from 'express'
+import { ActionPlanAppointmentUpdate } from '../../services/interventionsService'
+import TwelveHourBritishDateTimeInput from '../../utils/forms/inputs/twelveHourBritishDateTimeInput'
+import { FormData } from '../../utils/forms/formData'
+import DurationInput from '../../utils/forms/inputs/durationInput'
+import errorMessages from '../../utils/errorMessages'
+
+export default class EditSessionForm {
+  constructor(private readonly request: Request) {}
+
+  async data(): Promise<FormData<Partial<ActionPlanAppointmentUpdate>>> {
+    const [dateResult, durationResult] = await Promise.all([
+      new TwelveHourBritishDateTimeInput(this.request, 'date', 'time', errorMessages.editSession.time).validate(),
+      new DurationInput(this.request, 'duration', errorMessages.editSession.duration).validate(),
+    ])
+
+    if (dateResult.error || durationResult.error) {
+      return {
+        paramsForUpdate: null,
+        error: { errors: [...(dateResult.error?.errors ?? []), ...(durationResult.error?.errors ?? [])] },
+      }
+    }
+
+    return {
+      error: null,
+      paramsForUpdate: {
+        appointmentTime: dateResult.value.toISOString() ?? null,
+        durationInMinutes: durationResult.value.minutes ?? null,
+      },
+    }
+  }
+}

--- a/server/routes/serviceProviderReferrals/editSessionPresenter.ts
+++ b/server/routes/serviceProviderReferrals/editSessionPresenter.ts
@@ -3,35 +3,42 @@ import CalendarDay from '../../utils/calendarDay'
 import Duration from '../../utils/duration'
 import PresenterUtils from '../../utils/presenterUtils'
 import ClockTime from '../../utils/clockTime'
+import { FormValidationError } from '../../utils/formValidationError'
 
 export default class EditSessionPresenter {
-  constructor(private readonly appointment: ActionPlanAppointment) {}
+  constructor(
+    private readonly appointment: ActionPlanAppointment,
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
 
   readonly text = {
     title: `Add session ${this.appointment.sessionNumber} details`,
   }
 
-  private readonly utils = new PresenterUtils(null)
+  private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
   readonly fields = {
     date: this.utils.dateValue(
       this.appointment.appointmentTime === null
         ? null
         : CalendarDay.britishDayForDate(new Date(this.appointment.appointmentTime)),
-      '',
-      null
+      'date',
+      this.error
     ),
     time: this.utils.twelveHourTimeValue(
       this.appointment.appointmentTime === null
         ? null
         : ClockTime.britishTimeForDate(new Date(this.appointment.appointmentTime)),
-      '',
-      null
+      'time',
+      this.error
     ),
     duration: this.utils.durationValue(
       this.appointment.durationInMinutes === null ? null : Duration.fromUnits(0, this.appointment.durationInMinutes, 0),
-      '',
-      null
+      'duration',
+      this.error
     ),
   }
 }

--- a/server/routes/serviceProviderReferrals/editSessionView.ts
+++ b/server/routes/serviceProviderReferrals/editSessionView.ts
@@ -84,6 +84,7 @@ export default class EditSessionView {
         label: {
           text: 'AM or PM',
         },
+        classes: this.presenter.fields.time.partOfDay.hasError ? 'govuk-select--error' : '',
       },
     }
   }

--- a/server/routes/serviceProviderReferrals/editSessionView.ts
+++ b/server/routes/serviceProviderReferrals/editSessionView.ts
@@ -13,9 +13,12 @@ export default class EditSessionView {
         dateInputArgs: this.dateInputArgs,
         timeInputArgs: this.timeInputArgs,
         durationDateInputArgs: this.durationDateInputArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
       },
     ]
   }
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   get dateInputArgs(): DateInputArgs {
     return {
@@ -23,7 +26,7 @@ export default class EditSessionView {
       namePrefix: 'date',
       fieldset: {
         legend: {
-          text: 'Date (optional)',
+          text: 'Date',
           isPageHeading: false,
           classes: 'govuk-fieldset__legend--m',
         },
@@ -55,7 +58,7 @@ export default class EditSessionView {
       namePrefix: 'time',
       fieldset: {
         legend: {
-          text: 'Time (optional)',
+          text: 'Time',
           isPageHeading: false,
           classes: 'govuk-fieldset__legend--m',
         },
@@ -97,7 +100,7 @@ export default class EditSessionView {
       namePrefix: 'duration',
       fieldset: {
         legend: {
-          text: 'Duration of the session (optional)',
+          text: 'Duration of the session',
           isPageHeading: false,
           classes: 'govuk-fieldset__legend--m',
         },

--- a/server/routes/serviceProviderReferrals/editSessionView.ts
+++ b/server/routes/serviceProviderReferrals/editSessionView.ts
@@ -41,7 +41,7 @@ export default class EditSessionView {
           value: this.presenter.fields.date.month.value,
         },
         {
-          classes: `govuk-input--width-4${this.presenter.fields.date.month.hasError ? ' govuk-input--error' : ''}`,
+          classes: `govuk-input--width-4${this.presenter.fields.date.year.hasError ? ' govuk-input--error' : ''}`,
           name: 'year',
           value: this.presenter.fields.date.year.value,
         },
@@ -68,7 +68,7 @@ export default class EditSessionView {
           value: this.presenter.fields.time.hour.value,
         },
         {
-          classes: `govuk-input--width-2${this.presenter.fields.time.hour.hasError ? ' govuk-input--error' : ''}`,
+          classes: `govuk-input--width-2${this.presenter.fields.time.minute.hasError ? ' govuk-input--error' : ''}`,
           name: 'minute',
           value: this.presenter.fields.time.minute.value,
         },
@@ -109,7 +109,9 @@ export default class EditSessionView {
           value: this.presenter.fields.duration.hours.value,
         },
         {
-          classes: `govuk-input--width-2${this.presenter.fields.duration.hours.hasError ? ' govuk-input--error' : ''}`,
+          classes: `govuk-input--width-2${
+            this.presenter.fields.duration.minutes.hasError ? ' govuk-input--error' : ''
+          }`,
           name: 'minutes',
           value: this.presenter.fields.duration.minutes.value,
         },

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -64,4 +64,25 @@ export default {
   attendedAppointment: {
     empty: 'Select whether the service user attended or not',
   },
+  editSession: {
+    time: {
+      calendarDay: {
+        dayEmpty: 'The session date must include a day',
+        monthEmpty: 'The session date must include a month',
+        yearEmpty: 'The session date must include a year',
+        invalidDate: 'The session date must be a real date',
+      },
+      clockTime: {
+        hourEmpty: 'The session time must include an hour',
+        minuteEmpty: 'The session time must include a minute',
+        partOfDayEmpty: 'Select whether the session time is AM or PM',
+        invalidTime: 'The session time must be a real time',
+      },
+      invalidTime: 'The session time must exist on the session date',
+    },
+    duration: {
+      empty: 'Enter a duration',
+      invalidDuration: 'The session duration must be a real duration',
+    },
+  },
 }

--- a/server/views/serviceProviderReferrals/editSession.njk
+++ b/server/views/serviceProviderReferrals/editSession.njk
@@ -15,6 +15,10 @@
       <form method="post" novalidate>
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
+        {% if errorSummaryArgs !== null %}
+          {{ govukErrorSummary(errorSummaryArgs) }}
+        {% endif %}
+
         <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
 
         {{ govukDateInput(dateInputArgs) }}


### PR DESCRIPTION
## What does this pull request do?

Allows a service provider caseworker to schedule an action plan appointment.

Specifically, adds the ability to actually update the appointment to the "edit action plan appointment" page originally introduced in #194, which currently only allows the user to view details that have already been set.

## What is the intent behind these changes?

To allow a service provider to record the details of an appointment.

## Screenshot

![image](https://user-images.githubusercontent.com/53756884/113994151-0d6bbb80-984d-11eb-933b-7e587e8af2d6.png)
