### PR TITLE
🐛 Set timezone to Europe/London (successfully, this time)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ FROM node:14-alpine3.13 as base
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ENV TZ=Europe/London
-RUN test -e "/usr/share/zoneinfo/$TZ" && \
+RUN apk add --no-cache tzdata && \
+      test -e "/usr/share/zoneinfo/$TZ" && \
       ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && \
       echo "$TZ" > /etc/timezone
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ FROM node:14-alpine3.13 as base
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ENV TZ=Europe/London
-RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
+RUN test -e "/usr/share/zoneinfo/$TZ" && \
+      ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && \
+      echo "$TZ" > /etc/timezone
 
 RUN addgroup --gid 2000 --system appgroup && \
     adduser --uid 2000 --system appuser && \


### PR DESCRIPTION
## What does this pull request do?

This PR fixes a 🐛 about setting the timezone to Europe/London in the Docker build.

As part of a set of conversations with @mahalrmoj we've discovered that the UI app is currently running on UTC:
```
$ k exec -ti hmpps-interventions-ui-5fc67cffcd-z4kgx --namespace=hmpps-interventions-dev -- date
Thu Apr  8 14:48:13 UTC 2021
``` 

### How?

- b6dc7cb adds a "build-time test" -- verifies that the timezone file in fact exists
- 774f922 then installs the package that provides that timezone file

Result:
```
$ docker build --tag=ui .
...<snip>...

$ docker run --rm -ti ui date
Thu Apr  8 15:47:44 BST 2021
```

## What is the intent behind these changes?

To make sure the service is running in Europe/London timezone. It has no material impact on our APIs, but it's the least surprising default :) -- At least it doesn't _look_ like we're setting the timezone when we aren't.