### PR TITLE
IC-1425: Add page for recording an SU's behaviour during a session

### DIFF
--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -70,6 +70,10 @@ Cypress.Commands.add('stubRecordAppointmentAttendance', (actionPlanId, sessionNu
   cy.task('stubRecordAppointmentAttendance', { actionPlanId, sessionNumber, responseJson })
 })
 
+Cypress.Commands.add('stubRecordAppointmentBehaviour', (actionPlanId, sessionNumber, responseJson) => {
+  cy.task('stubRecordAppointmentBehaviour', { actionPlanId, sessionNumber, responseJson })
+})
+
 Cypress.Commands.add('stubGetActionPlanAppointments', (id, responseJson) => {
   cy.task('stubGetActionPlanAppointments', { id, responseJson })
 })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -112,6 +112,14 @@ export default function routes(router: Router, services: Services): Router {
     (req, res) => serviceProviderReferralsController.recordPostSessionAttendanceFeedback(req, res)
   )
   get(
+    '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour',
+    (req, res) => serviceProviderReferralsController.addPostSessionBehaviourFeedback(req, res)
+  )
+  post(
+    '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour',
+    (req, res) => serviceProviderReferralsController.addPostSessionBehaviourFeedback(req, res)
+  )
+  get(
     '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation',
     (req, res) => serviceProviderReferralsController.showPostSessionFeedbackConfirmation(req, res)
   )

--- a/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackForm.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackForm.test.ts
@@ -1,0 +1,72 @@
+import TestUtils from '../../../testutils/testUtils'
+import PostSessionBehaviourFeedbackForm from './postSessionBehaviourFeedbackForm'
+
+describe(PostSessionBehaviourFeedbackForm, () => {
+  describe('data', () => {
+    describe('with valid data', () => {
+      it('returns a paramsForUpdate with the behaviour description and boolean value for whether to notify the PP', async () => {
+        const request = TestUtils.createRequest({
+          'behaviour-description': 'Alex was well-behaved',
+          'notify-probation-practitioner': 'no',
+        })
+
+        const data = await new PostSessionBehaviourFeedbackForm(request).data()
+
+        expect(data.paramsForUpdate?.behaviourDescription).toEqual('Alex was well-behaved')
+        expect(data.paramsForUpdate?.notifyProbationPractitioner).toEqual(false)
+      })
+    })
+
+    describe('invalid fields', () => {
+      it('returns errors when both required fields are not present', async () => {
+        const request = TestUtils.createRequest({})
+
+        const data = await new PostSessionBehaviourFeedbackForm(request).data()
+
+        expect(data.error?.errors).toContainEqual({
+          errorSummaryLinkedField: 'behaviour-description',
+          formFields: ['behaviour-description'],
+          message: "Enter a description of the service user's behaviour",
+        })
+        expect(data.error?.errors).toContainEqual({
+          errorSummaryLinkedField: 'notify-probation-practitioner',
+          formFields: ['notify-probation-practitioner'],
+          message: 'Select whether to notify the probation practitioner or not',
+        })
+      })
+
+      it('returns the error when behaviour description is invalid', async () => {
+        const request = TestUtils.createRequest({
+          'behaviour-description': '',
+          'notify-probation-practitioner': 'yes',
+        })
+
+        const data = await new PostSessionBehaviourFeedbackForm(request).data()
+
+        expect(data.error?.errors).toEqual([
+          {
+            errorSummaryLinkedField: 'behaviour-description',
+            formFields: ['behaviour-description'],
+            message: "Enter a description of the service user's behaviour",
+          },
+        ])
+      })
+
+      it('returns the error when notify probation practitioner value is missing', async () => {
+        const request = TestUtils.createRequest({
+          'behaviour-description': 'They did well',
+        })
+
+        const data = await new PostSessionBehaviourFeedbackForm(request).data()
+
+        expect(data.error?.errors).toEqual([
+          {
+            errorSummaryLinkedField: 'notify-probation-practitioner',
+            formFields: ['notify-probation-practitioner'],
+            message: 'Select whether to notify the probation practitioner or not',
+          },
+        ])
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackForm.ts
+++ b/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackForm.ts
@@ -1,0 +1,66 @@
+import { Request } from 'express'
+import { body, Result, ValidationChain, ValidationError } from 'express-validator'
+import { AppointmentBehaviour } from '../../services/interventionsService'
+import errorMessages from '../../utils/errorMessages'
+import FormUtils from '../../utils/formUtils'
+import { FormValidationError } from '../../utils/formValidationError'
+import { FormData } from '../../utils/forms/formData'
+
+export default class PostSessionBehaviourFeedbackForm {
+  constructor(private readonly request: Request) {}
+
+  async data(): Promise<FormData<Partial<AppointmentBehaviour>>> {
+    const validationResult = await FormUtils.runValidations({
+      request: this.request,
+      validations: PostSessionBehaviourFeedbackForm.validations,
+    })
+
+    const error = this.error(validationResult)
+
+    if (error) {
+      return {
+        paramsForUpdate: null,
+        error,
+      }
+    }
+
+    return {
+      paramsForUpdate: {
+        behaviourDescription: this.request.body['behaviour-description'],
+        notifyProbationPractitioner: this.notifyProbationPractitioner,
+      },
+      error: null,
+    }
+  }
+
+  static get validations(): ValidationChain[] {
+    return [
+      body('behaviour-description')
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(errorMessages.appointmentBehaviour.descriptionEmpty)
+        .bail()
+        .trim(),
+      body('notify-probation-practitioner')
+        .isIn(['yes', 'no'])
+        .withMessage(errorMessages.appointmentBehaviour.notifyProbationPractitionerNotSelected),
+    ]
+  }
+
+  private error(validationResult: Result<ValidationError>): FormValidationError | null {
+    if (validationResult.isEmpty()) {
+      return null
+    }
+
+    return {
+      errors: validationResult.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
+  }
+
+  private get notifyProbationPractitioner(): boolean {
+    return this.request.body['notify-probation-practitioner'] === 'yes'
+  }
+}

--- a/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackPresenter.test.ts
@@ -22,6 +22,68 @@ describe(PostSessionBehaviourFeedbackPresenter, () => {
         },
       })
     })
+
+    describe('when there are errors', () => {
+      it('populates the error messages for the fields with errors', () => {
+        const appointment = actionPlanAppointmentFactory.build()
+        const serviceUser = deliusServiceUserFactory.build()
+        const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser, {
+          errors: [
+            {
+              formFields: ['behaviour-description'],
+              errorSummaryLinkedField: 'behaviour-description',
+              message: 'behaviour msg',
+            },
+            {
+              formFields: ['notify-probation-practitioner'],
+              errorSummaryLinkedField: 'notify-probation-practitioner',
+              message: 'notify pp msg',
+            },
+          ],
+        })
+
+        expect(presenter.fields.behaviourDescription.errorMessage).toEqual('behaviour msg')
+        expect(presenter.fields.notifyProbationPractitioner.errorMessage).toEqual('notify pp msg')
+      })
+    })
+  })
+
+  describe('errorSummary', () => {
+    describe('when error is null', () => {
+      it('returns null', () => {
+        const appointment = actionPlanAppointmentFactory.build()
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+        const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when error is not null', () => {
+      it('returns a summary of the errors sorted into the order their fields appear on the page', () => {
+        const appointment = actionPlanAppointmentFactory.build()
+        const serviceUser = deliusServiceUserFactory.build()
+        const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser, {
+          errors: [
+            {
+              formFields: ['behaviour-description'],
+              errorSummaryLinkedField: 'behaviour-description',
+              message: 'behaviour msg',
+            },
+            {
+              formFields: ['notify-probation-practitioner'],
+              errorSummaryLinkedField: 'notify-probation-practitioner',
+              message: 'notify pp msg',
+            },
+          ],
+        })
+
+        expect(presenter.errorSummary).toEqual([
+          { field: 'behaviour-description', message: 'behaviour msg' },
+          { field: 'notify-probation-practitioner', message: 'notify pp msg' },
+        ])
+      })
+    })
   })
 
   describe('serviceUserBannerPresenter', () => {
@@ -47,7 +109,7 @@ describe(PostSessionBehaviourFeedbackPresenter, () => {
             const serviceUser = deliusServiceUserFactory.build()
             const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
 
-            expect(presenter.fields.behaviourDescriptionValue).toEqual('Alex was well behaved')
+            expect(presenter.fields.behaviourDescription.value).toEqual('Alex was well behaved')
           })
         })
 
@@ -61,7 +123,7 @@ describe(PostSessionBehaviourFeedbackPresenter, () => {
             const serviceUser = deliusServiceUserFactory.build()
             const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
 
-            expect(presenter.fields.behaviourDescriptionValue).toEqual('')
+            expect(presenter.fields.behaviourDescription.value).toEqual('')
           })
         })
       })
@@ -74,11 +136,11 @@ describe(PostSessionBehaviourFeedbackPresenter, () => {
             },
           })
           const serviceUser = deliusServiceUserFactory.build()
-          const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser, {
+          const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser, null, {
             'behaviour-description': 'Alex misbehaved during the session',
           })
 
-          expect(presenter.fields.behaviourDescriptionValue).toEqual('Alex misbehaved during the session')
+          expect(presenter.fields.behaviourDescription.value).toEqual('Alex misbehaved during the session')
         })
       })
     })
@@ -96,7 +158,7 @@ describe(PostSessionBehaviourFeedbackPresenter, () => {
             const serviceUser = deliusServiceUserFactory.build()
             const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
 
-            expect(presenter.fields.notifyProbationPractitioner).toEqual(false)
+            expect(presenter.fields.notifyProbationPractitioner.value).toEqual(false)
           })
         })
 
@@ -111,7 +173,7 @@ describe(PostSessionBehaviourFeedbackPresenter, () => {
             const serviceUser = deliusServiceUserFactory.build()
             const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
 
-            expect(presenter.fields.notifyProbationPractitioner).toEqual(null)
+            expect(presenter.fields.notifyProbationPractitioner.value).toEqual(null)
           })
         })
       })
@@ -124,12 +186,12 @@ describe(PostSessionBehaviourFeedbackPresenter, () => {
             },
           })
           const serviceUser = deliusServiceUserFactory.build()
-          const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser, {
+          const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser, null, {
             'behaviour-description': 'Alex misbehaved during the session',
             'notify-probation-practitioner': 'yes',
           })
 
-          expect(presenter.fields.notifyProbationPractitioner).toEqual(true)
+          expect(presenter.fields.notifyProbationPractitioner.value).toEqual(true)
         })
       })
     })

--- a/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackPresenter.test.ts
@@ -1,0 +1,137 @@
+import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
+import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import PostSessionBehaviourFeedbackPresenter from './postSessionBehaviourFeedbackPresenter'
+
+describe(PostSessionBehaviourFeedbackPresenter, () => {
+  describe('text', () => {
+    it('contains the text for the title and questions to be displayed on the page', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+      const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+
+      expect(presenter.text).toMatchObject({
+        title: 'Add behaviour feedback',
+        behaviourDescription: {
+          question: `Describe Alex's behaviour in this session`,
+          hint: 'For example, consider how well-engaged they were and what their body language was like.',
+        },
+        notifyProbationPractitioner: {
+          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+          explanation: 'If you select yes, the probation practitioner will be notified by email.',
+          hint: 'Select one option',
+        },
+      })
+    })
+  })
+
+  describe('serviceUserBannerPresenter', () => {
+    it('is instantiated with the service user', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+      const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+
+      expect(presenter.serviceUserBannerPresenter).toBeDefined()
+    })
+  })
+
+  describe('fields', () => {
+    describe('behaviourDescriptionValue', () => {
+      describe('when there is no user input data', () => {
+        describe('when the appointment already has behaviourDescription set', () => {
+          it('uses that value as the value attribute', () => {
+            const appointment = actionPlanAppointmentFactory.build({
+              sessionFeedback: {
+                behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+              },
+            })
+            const serviceUser = deliusServiceUserFactory.build()
+            const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+
+            expect(presenter.fields.behaviourDescriptionValue).toEqual('Alex was well behaved')
+          })
+        })
+
+        describe('when the appointment has no value for behaviourDescription', () => {
+          it('sets the value to an empty string', () => {
+            const appointment = actionPlanAppointmentFactory.build({
+              sessionFeedback: {
+                behaviour: { behaviourDescription: undefined },
+              },
+            })
+            const serviceUser = deliusServiceUserFactory.build()
+            const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+
+            expect(presenter.fields.behaviourDescriptionValue).toEqual('')
+          })
+        })
+      })
+
+      describe('when there is user input data', () => {
+        it('uses the user input data as the value attribute', () => {
+          const appointment = actionPlanAppointmentFactory.build({
+            sessionFeedback: {
+              behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+            },
+          })
+          const serviceUser = deliusServiceUserFactory.build()
+          const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser, {
+            'behaviour-description': 'Alex misbehaved during the session',
+          })
+
+          expect(presenter.fields.behaviourDescriptionValue).toEqual('Alex misbehaved during the session')
+        })
+      })
+    })
+
+    describe('notifyProbationPractitioner', () => {
+      describe('when there is no user input data', () => {
+        describe('when the appointment already has a value selected for notifying the probation practitioner', () => {
+          it('uses the pre-selected value', () => {
+            const appointment = actionPlanAppointmentFactory.build({
+              sessionFeedback: {
+                behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+              },
+            })
+
+            const serviceUser = deliusServiceUserFactory.build()
+            const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+
+            expect(presenter.fields.notifyProbationPractitioner).toEqual(false)
+          })
+        })
+
+        describe('when the appointment has no value for notifyProbationPractitioner', () => {
+          it('sets the value to null', () => {
+            const appointment = actionPlanAppointmentFactory.build({
+              sessionFeedback: {
+                behaviour: { behaviourDescription: undefined },
+              },
+            })
+
+            const serviceUser = deliusServiceUserFactory.build()
+            const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+
+            expect(presenter.fields.notifyProbationPractitioner).toEqual(null)
+          })
+        })
+      })
+
+      describe('when there is user input data', () => {
+        it('uses the user input data as the value attribute', () => {
+          const appointment = actionPlanAppointmentFactory.build({
+            sessionFeedback: {
+              behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+            },
+          })
+          const serviceUser = deliusServiceUserFactory.build()
+          const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser, {
+            'behaviour-description': 'Alex misbehaved during the session',
+            'notify-probation-practitioner': 'yes',
+          })
+
+          expect(presenter.fields.notifyProbationPractitioner).toEqual(true)
+        })
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackPresenter.ts
@@ -1,5 +1,6 @@
 import { DeliusServiceUser } from '../../services/communityApiService'
 import { ActionPlanAppointment } from '../../services/interventionsService'
+import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 import ServiceUserBannerPresenter from '../shared/serviceUserBannerPresenter'
 
@@ -7,8 +8,17 @@ export default class PostSessionBehaviourFeedbackPresenter {
   constructor(
     private readonly appointment: ActionPlanAppointment,
     private readonly serviceUser: DeliusServiceUser,
+    private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
+
+  private errorMessageForField(field: string): string | null {
+    return PresenterUtils.errorMessage(this.error, field)
+  }
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error, {
+    fieldOrder: ['behaviour-description', 'notify-probation-practitioner'],
+  })
 
   readonly text = {
     title: `Add behaviour feedback`,
@@ -28,13 +38,19 @@ export default class PostSessionBehaviourFeedbackPresenter {
   private readonly utils = new PresenterUtils(this.userInputData)
 
   readonly fields = {
-    behaviourDescriptionValue: new PresenterUtils(this.userInputData).stringValue(
-      this.appointment.sessionFeedback?.behaviour?.behaviourDescription || null,
-      'behaviour-description'
-    ),
-    notifyProbationPractitioner: this.utils.booleanValue(
-      this.appointment.sessionFeedback?.behaviour?.notifyProbationPractitioner ?? null,
-      'notify-probation-practitioner'
-    ),
+    behaviourDescription: {
+      value: new PresenterUtils(this.userInputData).stringValue(
+        this.appointment.sessionFeedback?.behaviour?.behaviourDescription || null,
+        'behaviour-description'
+      ),
+      errorMessage: this.errorMessageForField('behaviour-description'),
+    },
+    notifyProbationPractitioner: {
+      value: this.utils.booleanValue(
+        this.appointment.sessionFeedback?.behaviour?.notifyProbationPractitioner ?? null,
+        'notify-probation-practitioner'
+      ),
+      errorMessage: this.errorMessageForField('notify-probation-practitioner'),
+    },
   }
 }

--- a/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackPresenter.ts
@@ -1,0 +1,40 @@
+import { DeliusServiceUser } from '../../services/communityApiService'
+import { ActionPlanAppointment } from '../../services/interventionsService'
+import PresenterUtils from '../../utils/presenterUtils'
+import ServiceUserBannerPresenter from '../shared/serviceUserBannerPresenter'
+
+export default class PostSessionBehaviourFeedbackPresenter {
+  constructor(
+    private readonly appointment: ActionPlanAppointment,
+    private readonly serviceUser: DeliusServiceUser,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  readonly text = {
+    title: `Add behaviour feedback`,
+    behaviourDescription: {
+      question: `Describe ${this.serviceUser.firstName}'s behaviour in this session`,
+      hint: 'For example, consider how well-engaged they were and what their body language was like.',
+    },
+    notifyProbationPractitioner: {
+      question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+      explanation: 'If you select yes, the probation practitioner will be notified by email.',
+      hint: 'Select one option',
+    },
+  }
+
+  readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
+
+  private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly fields = {
+    behaviourDescriptionValue: new PresenterUtils(this.userInputData).stringValue(
+      this.appointment.sessionFeedback?.behaviour?.behaviourDescription || null,
+      'behaviour-description'
+    ),
+    notifyProbationPractitioner: this.utils.booleanValue(
+      this.appointment.sessionFeedback?.behaviour?.notifyProbationPractitioner ?? null,
+      'notify-probation-practitioner'
+    ),
+  }
+}

--- a/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackView.ts
+++ b/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackView.ts
@@ -5,6 +5,8 @@ import PostSessionBehaviourFeedbackPresenter from './postSessionBehaviourFeedbac
 export default class PostSessionBehaviourFeedbackView {
   constructor(private readonly presenter: PostSessionBehaviourFeedbackPresenter) {}
 
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+
   private get textAreaArgs(): TextareaArgs {
     return {
       name: 'behaviour-description',
@@ -17,7 +19,8 @@ export default class PostSessionBehaviourFeedbackView {
       hint: {
         text: this.presenter.text.behaviourDescription.hint,
       },
-      value: this.presenter.fields.behaviourDescriptionValue,
+      value: this.presenter.fields.behaviourDescription.value,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.behaviourDescription.errorMessage),
     }
   }
 
@@ -43,14 +46,15 @@ export default class PostSessionBehaviourFeedbackView {
         {
           value: 'yes',
           text: 'Yes',
-          checked: this.presenter.fields.notifyProbationPractitioner === true,
+          checked: this.presenter.fields.notifyProbationPractitioner.value === true,
         },
         {
           value: 'no',
           text: 'No',
-          checked: this.presenter.fields.notifyProbationPractitioner === false,
+          checked: this.presenter.fields.notifyProbationPractitioner.value === false,
         },
       ],
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.notifyProbationPractitioner.errorMessage),
     }
   }
 
@@ -62,6 +66,7 @@ export default class PostSessionBehaviourFeedbackView {
         serviceUserNotificationBannerArgs: this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs,
         textAreaArgs: this.textAreaArgs,
         radioButtonArgs: this.radioButtonArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackView.ts
+++ b/server/routes/serviceProviderReferrals/postSessionBehaviourFeedbackView.ts
@@ -1,0 +1,68 @@
+import { TextareaArgs } from '../../utils/govukFrontendTypes'
+import ViewUtils from '../../utils/viewUtils'
+import PostSessionBehaviourFeedbackPresenter from './postSessionBehaviourFeedbackPresenter'
+
+export default class PostSessionBehaviourFeedbackView {
+  constructor(private readonly presenter: PostSessionBehaviourFeedbackPresenter) {}
+
+  private get textAreaArgs(): TextareaArgs {
+    return {
+      name: 'behaviour-description',
+      id: 'behaviour-description',
+      label: {
+        text: this.presenter.text.behaviourDescription.question,
+        classes: 'govuk-label--m govuk-!-margin-bottom-4',
+        isPageHeading: false,
+      },
+      hint: {
+        text: this.presenter.text.behaviourDescription.hint,
+      },
+      value: this.presenter.fields.behaviourDescriptionValue,
+    }
+  }
+
+  private get radioButtonArgs(): Record<string, unknown> {
+    return {
+      classes: 'govuk-radios',
+      idPrefix: 'notify-probation-practitioner',
+      name: 'notify-probation-practitioner',
+      fieldset: {
+        legend: {
+          html: `<h2 class=govuk-fieldset__legend--m>${ViewUtils.escape(
+            this.presenter.text.notifyProbationPractitioner.question
+          )}</h2><p class="govuk-body--m">${ViewUtils.escape(
+            this.presenter.text.notifyProbationPractitioner.explanation
+          )}</p>`,
+          isPageHeading: false,
+        },
+      },
+      hint: {
+        text: this.presenter.text.notifyProbationPractitioner.hint,
+      },
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes',
+          checked: this.presenter.fields.notifyProbationPractitioner === true,
+        },
+        {
+          value: 'no',
+          text: 'No',
+          checked: this.presenter.fields.notifyProbationPractitioner === false,
+        },
+      ],
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/postSessionBehaviourFeedback',
+      {
+        presenter: this.presenter,
+        serviceUserNotificationBannerArgs: this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs,
+        textAreaArgs: this.textAreaArgs,
+        radioButtonArgs: this.radioButtonArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -676,35 +676,70 @@ describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNu
 })
 
 describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', () => {
-  it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the behaviour page', async () => {
-    const updatedAppointment = actionPlanAppointmentFactory.build({
-      sessionNumber: 1,
-      sessionFeedback: {
-        attendance: {
+  describe('when the Service Provider marks the Service User as having attended the session', () => {
+    it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the behaviour page', async () => {
+      const updatedAppointment = actionPlanAppointmentFactory.build({
+        sessionNumber: 1,
+        sessionFeedback: {
+          attendance: {
+            attended: 'yes',
+            additionalAttendanceInformation: 'Alex made the session on time',
+          },
+        },
+      })
+
+      const actionPlan = actionPlanFactory.build()
+
+      interventionsService.recordAppointmentAttendance.mockResolvedValue(updatedAppointment)
+
+      await request(app)
+        .post(
+          `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/attendance`
+        )
+        .type('form')
+        .send({
           attended: 'yes',
           additionalAttendanceInformation: 'Alex made the session on time',
-        },
-      },
+        })
+        .expect(302)
+        .expect(
+          'Location',
+          `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/behaviour`
+        )
     })
+  })
 
-    const actionPlan = actionPlanFactory.build()
-
-    interventionsService.recordAppointmentAttendance.mockResolvedValue(updatedAppointment)
-
-    await request(app)
-      .post(
-        `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/attendance`
-      )
-      .type('form')
-      .send({
-        attended: 'yes',
-        additionalAttendanceInformation: 'Alex made the session on time',
+  describe('when the Service Provider marks the Service User as not having attended the session', () => {
+    it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the confirmation page', async () => {
+      const updatedAppointment = actionPlanAppointmentFactory.build({
+        sessionNumber: 1,
+        sessionFeedback: {
+          attendance: {
+            attended: 'no',
+            additionalAttendanceInformation: "I haven't heard from Alex",
+          },
+        },
       })
-      .expect(302)
-      .expect(
-        'Location',
-        `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/behaviour`
-      )
+
+      const actionPlan = actionPlanFactory.build()
+
+      interventionsService.recordAppointmentAttendance.mockResolvedValue(updatedAppointment)
+
+      await request(app)
+        .post(
+          `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/attendance`
+        )
+        .type('form')
+        .send({
+          attended: 'no',
+          additionalAttendanceInformation: "I haven't heard from Alex",
+        })
+        .expect(302)
+        .expect(
+          'Location',
+          `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/confirmation`
+        )
+    })
   })
 })
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -676,7 +676,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNu
 })
 
 describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', () => {
-  it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the confirmation page', async () => {
+  it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the behaviour page', async () => {
     const updatedAppointment = actionPlanAppointmentFactory.build({
       sessionNumber: 1,
       sessionFeedback: {
@@ -699,6 +699,66 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
       .send({
         attended: 'yes',
         additionalAttendanceInformation: 'Alex made the session on time',
+      })
+      .expect(302)
+      .expect(
+        'Location',
+        `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/behaviour`
+      )
+  })
+})
+
+describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', () => {
+  it('renders a page with which the Service Provider can record the Service User‘s behaviour', async () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const serviceUser = deliusServiceUser.build()
+    const referral = sentReferralFactory.assigned().build()
+    const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+    const appointment = actionPlanAppointmentFactory.build({
+      appointmentTime: '2021-02-01T13:00:00Z',
+    })
+
+    communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+    interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
+
+    await request(app)
+      .get(
+        `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/behaviour`
+      )
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Add behaviour feedback')
+      })
+  })
+})
+
+describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', () => {
+  it('makes a request to the interventions service to record the Service User‘s behaviour and redirects to the confirmation page', async () => {
+    const updatedAppointment = actionPlanAppointmentFactory.build({
+      sessionNumber: 1,
+      sessionFeedback: {
+        behaviour: {
+          behaviourDescription: 'Alex was well-behaved',
+          notifyProbationPractitioner: false,
+        },
+      },
+    })
+
+    const actionPlan = actionPlanFactory.build()
+
+    interventionsService.recordAppointmentBehaviour.mockResolvedValue(updatedAppointment)
+
+    await request(app)
+      .post(
+        `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/behaviour`
+      )
+      .type('form')
+      .send({
+        'behaviour-description': 'Alex was well-behaved',
+        'notify-probation-practitioner': 'no',
       })
       .expect(302)
       .expect(

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -528,7 +528,7 @@ export default class ServiceProviderReferralsController {
     )
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser, userInputData)
+    const presenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser, formError, userInputData)
     const view = new PostSessionBehaviourFeedbackView(presenter)
 
     res.status(formError === null ? 200 : 400)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -462,15 +462,18 @@ export default class ServiceProviderReferralsController {
     formError = form.error
 
     if (form.isValid) {
-      await this.interventionsService.recordAppointmentAttendance(
+      const updatedAppointment = await this.interventionsService.recordAppointmentAttendance(
         res.locals.token,
         actionPlanId,
         Number(sessionNumber),
         form.attendanceParams
       )
 
+      const redirectPath =
+        updatedAppointment.sessionFeedback?.attendance?.attended === 'no' ? 'confirmation' : 'behaviour'
+
       return res.redirect(
-        `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/behaviour`
+        `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/${redirectPath}`
       )
     }
 

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -64,6 +64,10 @@ export default {
   attendedAppointment: {
     empty: 'Select whether the service user attended or not',
   },
+  appointmentBehaviour: {
+    descriptionEmpty: "Enter a description of the service user's behaviour",
+    notifyProbationPractitionerNotSelected: 'Select whether to notify the probation practitioner or not',
+  },
   editSession: {
     time: {
       calendarDay: {

--- a/server/views/serviceProviderReferrals/postSessionBehaviourFeedback.njk
+++ b/server/views/serviceProviderReferrals/postSessionBehaviourFeedback.njk
@@ -1,0 +1,17 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% extends "./actionPlan/actionPlanFormTemplate.njk" %}
+
+{% block formSection %}
+  <form method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {{ govukTextarea(textAreaArgs) }}
+
+    {{ govukRadios(radioButtonArgs) }}
+
+    {{ govukButton({ text: "Save and continue" }) }}
+  </form>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds page following attendance page where SP can record the SU's behaviour in a session.

This currently takes the user to the confirmation screen afterwards, but next up we'll be adding a "Check your answers" between these two pages.

If the SP marks the SU as "not attended", the user will go straight to the confirmation screen and skip this new behaviour page.

## What is the intent behind these changes?

To allow the SP to record the SU's behaviour in the session.

## Screenshot (composed of 2 separate screenshots due to size of image in E2E tests, apologies for slight wonkiness)

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/19826940/114211815-029e4d00-9959-11eb-840c-ea7403061fe1.png">
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/19826940/114211823-0500a700-9959-11eb-8f08-623446d1191c.png">

