### PR TITLE
IC-1425: Attendance form refactor

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -105,11 +105,11 @@ export default function routes(router: Router, services: Services): Router {
   )
   get(
     '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance',
-    (req, res) => serviceProviderReferralsController.showPostSessionAttendanceFeedbackForm(req, res)
+    (req, res) => serviceProviderReferralsController.addPostSessionAttendanceFeedback(req, res)
   )
   post(
     '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance',
-    (req, res) => serviceProviderReferralsController.recordPostSessionAttendanceFeedback(req, res)
+    (req, res) => serviceProviderReferralsController.addPostSessionAttendanceFeedback(req, res)
   )
   get(
     '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour',

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackForm.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackForm.test.ts
@@ -10,7 +10,7 @@ describe(PostSessionAttendanceFeedbackForm, () => {
         it('returns a paramsForUpdate with the attended property and optional further information', async () => {
           const request = TestUtils.createRequest({
             attended: validAttendedValue,
-            additionalAttendanceInformation: 'Alex missed the bus',
+            'additional-attendance-information': 'Alex missed the bus',
           })
           const data = await new PostSessionAttendanceFeedbackForm(request).data()
 

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackForm.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackForm.test.ts
@@ -1,84 +1,36 @@
-import { Request } from 'express'
+import TestUtils from '../../../testutils/testUtils'
 import PostSessionAttendanceFeedbackForm from './postSessionAttendanceFeedbackForm'
 
 describe(PostSessionAttendanceFeedbackForm, () => {
-  describe('isValid', () => {
-    it('returns true when the attendance property is present in the body', async () => {
-      const form = await PostSessionAttendanceFeedbackForm.createForm({
-        body: { attended: 'yes' },
-      } as Request)
+  describe('data', () => {
+    describe('with valid data', () => {
+      const validAttendedValues = ['yes', 'late', 'no']
 
-      expect(form.isValid).toBe(true)
-    })
+      validAttendedValues.forEach(validAttendedValue => {
+        it('returns a paramsForUpdate with the attended property and optional further information', async () => {
+          const request = TestUtils.createRequest({
+            attended: validAttendedValue,
+            additionalAttendanceInformation: 'Alex missed the bus',
+          })
+          const data = await new PostSessionAttendanceFeedbackForm(request).data()
 
-    it('returns false when the attendance property is absent in the body', async () => {
-      const form = await PostSessionAttendanceFeedbackForm.createForm({
-        body: {},
-      } as Request)
-
-      expect(form.isValid).toBe(false)
-    })
-
-    it('returns false when the attendance property is null in the body', async () => {
-      const form = await PostSessionAttendanceFeedbackForm.createForm({
-        body: { attended: null },
-      } as Request)
-
-      expect(form.isValid).toBe(false)
-    })
-  })
-
-  describe('error', () => {
-    it('returns null when the attendance property is present in the body', async () => {
-      const form = await PostSessionAttendanceFeedbackForm.createForm({
-        body: { attended: 'yes' },
-      } as Request)
-
-      expect(form.error).toBe(null)
-    })
-
-    it('returns an error object when the attendance property is absent in the body', async () => {
-      const form = await PostSessionAttendanceFeedbackForm.createForm({
-        body: {},
-      } as Request)
-
-      expect(form.error).toEqual({
-        errors: [
-          {
-            errorSummaryLinkedField: 'attended',
-            formFields: ['attended'],
-            message: 'Select whether the service user attended or not',
-          },
-        ],
+          expect(data.paramsForUpdate?.attended).toEqual(validAttendedValue)
+          expect(data.paramsForUpdate?.additionalAttendanceInformation).toEqual('Alex missed the bus')
+        })
       })
     })
 
-    it('returns an error object when the attendance property is null in the body', async () => {
-      const form = await PostSessionAttendanceFeedbackForm.createForm({
-        body: { attended: null },
-      } as Request)
+    describe('invalid fields', () => {
+      it('returns an error when the attended property is not present', async () => {
+        const request = TestUtils.createRequest({})
 
-      expect(form.error).toEqual({
-        errors: [
-          {
-            errorSummaryLinkedField: 'attended',
-            formFields: ['attended'],
-            message: 'Select whether the service user attended or not',
-          },
-        ],
-      })
-    })
-  })
+        const data = await new PostSessionAttendanceFeedbackForm(request).data()
 
-  describe('attendanceParams', () => {
-    it('returns the params to be sent to the backend, when the data in the body is valid', async () => {
-      const form = await PostSessionAttendanceFeedbackForm.createForm({
-        body: { attended: 'yes', additionalAttendanceInformation: 'Alex attended the session' },
-      } as Request)
-
-      expect(form.attendanceParams).toEqual({
-        attended: 'yes',
-        additionalAttendanceInformation: 'Alex attended the session',
+        expect(data.error?.errors).toContainEqual({
+          errorSummaryLinkedField: 'attended',
+          formFields: ['attended'],
+          message: 'Select whether the service user attended or not',
+        })
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackForm.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackForm.ts
@@ -27,7 +27,7 @@ export default class PostSessionAttendanceFeedbackForm {
     return {
       paramsForUpdate: {
         attended: this.request.body.attended,
-        additionalAttendanceInformation: this.request.body.additionalAttendanceInformation,
+        additionalAttendanceInformation: this.request.body['additional-attendance-information'],
       },
       error: null,
     }

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackForm.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackForm.ts
@@ -1,39 +1,53 @@
 import { Request } from 'express'
+import { body, Result, ValidationChain, ValidationError } from 'express-validator'
 import { AppointmentAttendance } from '../../services/interventionsService'
 import errorMessages from '../../utils/errorMessages'
 import { FormValidationError } from '../../utils/formValidationError'
+import { FormData } from '../../utils/forms/formData'
+import FormUtils from '../../utils/formUtils'
 
 export default class PostSessionAttendanceFeedbackForm {
-  private constructor(private readonly request: Request) {}
+  constructor(private readonly request: Request) {}
 
-  static async createForm(request: Request): Promise<PostSessionAttendanceFeedbackForm> {
-    return new PostSessionAttendanceFeedbackForm(request)
-  }
+  async data(): Promise<FormData<Partial<AppointmentAttendance>>> {
+    const validationResult = await FormUtils.runValidations({
+      request: this.request,
+      validations: PostSessionAttendanceFeedbackForm.validations,
+    })
 
-  get attendanceParams(): Partial<AppointmentAttendance> {
+    const error = this.error(validationResult)
+
+    if (error) {
+      return {
+        paramsForUpdate: null,
+        error,
+      }
+    }
+
     return {
-      attended: this.request.body.attended,
-      additionalAttendanceInformation: this.request.body.additionalAttendanceInformation,
+      paramsForUpdate: {
+        attended: this.request.body.attended,
+        additionalAttendanceInformation: this.request.body.additionalAttendanceInformation,
+      },
+      error: null,
     }
   }
 
-  get isValid(): boolean {
-    return this.request.body.attended !== null && this.request.body.attended !== undefined
+  static get validations(): ValidationChain[] {
+    return [body('attended').isIn(['yes', 'late', 'no']).withMessage(errorMessages.attendedAppointment.empty)]
   }
 
-  get error(): FormValidationError | null {
-    if (this.isValid) {
+  private error(validationResult: Result<ValidationError>): FormValidationError | null {
+    if (validationResult.isEmpty()) {
       return null
     }
 
     return {
-      errors: [
-        {
-          formFields: ['attended'],
-          errorSummaryLinkedField: 'attended',
-          message: errorMessages.attendedAppointment.empty,
-        },
-      ],
+      errors: validationResult.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
     }
   }
 }

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.test.ts
@@ -99,7 +99,7 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
           ],
         })
 
-        expect(presenter.errorMessage).toEqual('Select whether the service user attended or not')
+        expect(presenter.fields.attended.errorMessage).toEqual('Select whether the service user attended or not')
       })
     })
 
@@ -107,7 +107,7 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
       it('returns null', () => {
         const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
 
-        expect(presenter.errorMessage).toBeNull()
+        expect(presenter.fields.attended.errorMessage).toBeNull()
       })
     })
   })
@@ -189,7 +189,7 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
           const serviceUser = deliusServiceUserFactory.build()
           const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
 
-          expect(presenter.fields.additionalAttendanceInformationValue).toEqual('Alex missed the bus')
+          expect(presenter.fields.additionalAttendanceInformation.value).toEqual('Alex missed the bus')
         })
       })
 
@@ -203,7 +203,7 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
           const serviceUser = deliusServiceUserFactory.build()
           const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
 
-          expect(presenter.fields.additionalAttendanceInformationValue).toEqual('')
+          expect(presenter.fields.additionalAttendanceInformation.value).toEqual('')
         })
       })
     })
@@ -217,10 +217,12 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build()
         const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser, null, {
+          attended: 'no',
           'additional-attendance-information': "Alex's car broke down en route",
         })
 
-        expect(presenter.fields.additionalAttendanceInformationValue).toEqual("Alex's car broke down en route")
+        expect(presenter.fields.attended.value).toEqual('no')
+        expect(presenter.fields.additionalAttendanceInformation.value).toEqual("Alex's car broke down en route")
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.ts
@@ -22,27 +22,7 @@ export default class PostSessionAttendanceFeedbackPresenter {
     additionalAttendanceInformationLabel: `Add additional information about ${this.serviceUser.firstName}'s attendance:`,
   }
 
-  readonly errorMessage = PresenterUtils.errorMessage(this.error, 'attended')
-
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
-
-  readonly attendanceResponses = [
-    {
-      value: 'yes',
-      text: 'Yes, they were on time',
-      checked: this.appointment.sessionFeedback?.attendance?.attended === 'yes',
-    },
-    {
-      value: 'late',
-      text: 'They were late',
-      checked: this.appointment.sessionFeedback?.attendance?.attended === 'late',
-    },
-    {
-      value: 'no',
-      text: 'No',
-      checked: this.appointment.sessionFeedback?.attendance?.attended === 'no',
-    },
-  ]
 
   readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
 
@@ -60,9 +40,36 @@ export default class PostSessionAttendanceFeedbackPresenter {
   ]
 
   readonly fields = {
-    additionalAttendanceInformationValue: new PresenterUtils(this.userInputData).stringValue(
-      this.appointment.sessionFeedback?.attendance?.additionalAttendanceInformation || null,
-      'additional-attendance-information'
-    ),
+    attended: {
+      value: new PresenterUtils(this.userInputData).stringValue(
+        this.appointment.sessionFeedback?.attendance?.attended ?? null,
+        'attended'
+      ),
+      errorMessage: PresenterUtils.errorMessage(this.error, 'attended'),
+    },
+    additionalAttendanceInformation: {
+      value: new PresenterUtils(this.userInputData).stringValue(
+        this.appointment.sessionFeedback?.attendance?.additionalAttendanceInformation ?? null,
+        'additional-attendance-information'
+      ),
+    },
   }
+
+  readonly attendanceResponses = [
+    {
+      value: 'yes',
+      text: 'Yes, they were on time',
+      checked: this.fields.attended.value === 'yes',
+    },
+    {
+      value: 'late',
+      text: 'They were late',
+      checked: this.fields.attended.value === 'late',
+    },
+    {
+      value: 'no',
+      text: 'No',
+      checked: this.fields.attended.value === 'no',
+    },
+  ]
 }

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackView.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackView.ts
@@ -22,7 +22,7 @@ export default class PostSessionAttendanceFeedbackView {
       hint: {
         text: this.presenter.text.attendanceQuestionHint,
       },
-      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.attended.errorMessage),
       items: this.presenter.attendanceResponses.map(response => {
         return {
           value: response.value,
@@ -44,7 +44,7 @@ export default class PostSessionAttendanceFeedbackView {
         classes: 'govuk-label--s govuk-!-margin-bottom-4',
         isPageHeading: false,
       },
-      value: this.presenter.fields.additionalAttendanceInformationValue,
+      value: this.presenter.fields.additionalAttendanceInformation.value,
     }
   }
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -699,7 +699,7 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
         .type('form')
         .send({
           attended: 'yes',
-          additionalAttendanceInformation: 'Alex made the session on time',
+          'additional-attendance-information': 'Alex made the session on time',
         })
         .expect(302)
         .expect(
@@ -732,7 +732,7 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
         .type('form')
         .send({
           attended: 'no',
-          additionalAttendanceInformation: "I haven't heard from Alex",
+          'additional-attendance-information': "I haven't heard from Alex",
         })
         .expect(302)
         .expect(

--- a/server/views/serviceProviderReferrals/postSessionAttendanceFeedback.njk
+++ b/server/views/serviceProviderReferrals/postSessionAttendanceFeedback.njk
@@ -8,7 +8,7 @@
 {% block formSection %}
   {{ govukSummaryList(summaryListArgs) }}
 
-  <form method="post" action="#">
+  <form method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukRadios(radioButtonArgs) }}
 


### PR DESCRIPTION
## What does this pull request do?

- Refactors the Post Session attendance form to more closely match the way we've structured our Form objects in recent feature branches.
- Refactors the `serviceProviderReferralsController` to use this new structure
- DRYs up controller code to only use one function for POST and GET (as we've done in other recent tasks).

## What is the intent behind these changes?

- To encapsulate the validation behaviour in a `validate` function whose result we can query for errors or the data value.
- To DRY up code before working on the next feature (check your answers page)
