### PR TITLE
IC-1526 add service methods and contracts for submitting session feedback

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -32,25 +32,15 @@ describe('Probation Practitioner monitor journey', () => {
       })
 
       const appointments = [
-        actionPlanAppointmentFactory.build({
+        actionPlanAppointmentFactory.attended('yes').build({
           sessionNumber: 1,
           appointmentTime: '2021-03-24T09:02:02Z',
           durationInMinutes: 75,
-          sessionFeedback: {
-            attendance: {
-              attended: 'yes',
-            },
-          },
         }),
-        actionPlanAppointmentFactory.build({
+        actionPlanAppointmentFactory.attended('no').build({
           sessionNumber: 2,
           appointmentTime: '2021-04-30T09:02:02Z',
           durationInMinutes: 75,
-          sessionFeedback: {
-            attendance: {
-              attended: 'no',
-            },
-          },
         }),
         actionPlanAppointmentFactory.build({
           sessionNumber: 3,

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -128,5 +128,9 @@ module.exports = on => {
     stubUpdateActionPlanAppointment: arg => {
       return interventionsService.stubUpdateActionPlanAppointment(arg.id, arg.session, arg.responseJson)
     },
+
+    stubSubmitSessionFeedback: arg => {
+      return interventionsService.stubSubmitSessionFeedback(arg.actionPlanId, arg.session, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -85,3 +85,7 @@ Cypress.Commands.add('stubGetActionPlanAppointment', (id, session, responseJson)
 Cypress.Commands.add('stubUpdateActionPlanAppointment', (id, session, responseJson) => {
   cy.task('stubUpdateActionPlanAppointment', { id, session, responseJson })
 })
+
+Cypress.Commands.add('stubSubmitSessionFeedback', (actionPlanId, session, responseJson) => {
+  cy.task('stubSubmitSessionFeedback', { actionPlanId, session, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -348,4 +348,24 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubSubmitSessionFeedback = async (
+    actionPlanId: string,
+    session: number,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/action-plan/${actionPlanId}/appointment/${session}/submit`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -2,6 +2,7 @@ import InterventionProgressPresenter from './interventionProgressPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import serviceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 
 describe(InterventionProgressPresenter, () => {
   describe('sessionTableRows', () => {
@@ -15,16 +16,12 @@ describe(InterventionProgressPresenter, () => {
     })
 
     describe('when a session exists but an appointment has not yet been scheduled', () => {
-      it('populates the table with formatted session information, with the "Edit session details" link displayed', () => {
+      it('populates the table with formatted session information, with no link displayed', () => {
         const referral = sentReferralFactory.build()
         const serviceCategory = serviceCategoryFactory.build()
         const serviceUser = serviceUserFactory.build()
         const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [
-          {
-            sessionNumber: 1,
-            appointmentTime: null,
-            durationInMinutes: null,
-          },
+          actionPlanAppointmentFactory.newlyCreated().build(),
         ])
         expect(presenter.sessionTableRows).toEqual([
           {
@@ -46,11 +43,11 @@ describe(InterventionProgressPresenter, () => {
         const serviceCategory = serviceCategoryFactory.build()
         const serviceUser = serviceUserFactory.build()
         const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [
-          {
+          actionPlanAppointmentFactory.build({
             sessionNumber: 1,
             appointmentTime: '2020-12-07T13:00:00.000000Z',
             durationInMinutes: 120,
-          },
+          }),
         ])
         expect(presenter.sessionTableRows).toEqual([
           {
@@ -73,26 +70,8 @@ describe(InterventionProgressPresenter, () => {
           const serviceCategory = serviceCategoryFactory.build()
           const serviceUser = serviceUserFactory.build()
           const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [
-            {
-              sessionNumber: 1,
-              appointmentTime: null,
-              durationInMinutes: null,
-              sessionFeedback: {
-                attendance: {
-                  attended: 'yes',
-                },
-              },
-            },
-            {
-              sessionNumber: 2,
-              appointmentTime: null,
-              durationInMinutes: null,
-              sessionFeedback: {
-                attendance: {
-                  attended: 'late',
-                },
-              },
-            },
+            actionPlanAppointmentFactory.attended('yes').build({ sessionNumber: 1 }),
+            actionPlanAppointmentFactory.attended('late').build({ sessionNumber: 2 }),
           ])
           expect(presenter.sessionTableRows).toEqual([
             {
@@ -123,16 +102,7 @@ describe(InterventionProgressPresenter, () => {
           const serviceCategory = serviceCategoryFactory.build()
           const serviceUser = serviceUserFactory.build()
           const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [
-            {
-              sessionNumber: 1,
-              appointmentTime: null,
-              durationInMinutes: null,
-              sessionFeedback: {
-                attendance: {
-                  attended: 'no',
-                },
-              },
-            },
+            actionPlanAppointmentFactory.attended('no').build(),
           ])
           expect(presenter.sessionTableRows).toEqual([
             {

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -43,7 +43,7 @@ export default class InterventionProgressPresenter {
         sessionNumber: appointment.sessionNumber,
         appointmentTime: DateUtils.formatDateTimeOrEmptyString(appointment.appointmentTime),
         tagArgs: this.tagArgs(appointment),
-        linkHtml: appointment.sessionFeedback?.attendance ? `<a class="govuk-link" href="#">View</a>` : '',
+        linkHtml: appointment.sessionFeedback?.submitted ? `<a class="govuk-link" href="#">View</a>` : '',
       }
     })
   }

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -3,6 +3,7 @@ import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import serviceUserFactory from '../../../testutils/factories/deliusServiceUser'
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
+import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 
 describe(InterventionProgressPresenter, () => {
   describe('createActionPlanFormAction', () => {
@@ -33,11 +34,7 @@ describe(InterventionProgressPresenter, () => {
         const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
         const serviceUser = serviceUserFactory.build()
         const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [
-          {
-            sessionNumber: 1,
-            appointmentTime: null,
-            durationInMinutes: null,
-          },
+          actionPlanAppointmentFactory.newlyCreated().build(),
         ])
         expect(presenter.sessionTableRows).toEqual([
           {
@@ -61,11 +58,11 @@ describe(InterventionProgressPresenter, () => {
         const serviceCategory = serviceCategoryFactory.build()
         const serviceUser = serviceUserFactory.build()
         const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [
-          {
+          actionPlanAppointmentFactory.build({
             sessionNumber: 1,
             appointmentTime: '2020-12-07T13:00:00.000000Z',
             durationInMinutes: 120,
-          },
+          }),
         ])
         expect(presenter.sessionTableRows).toEqual([
           {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1936,6 +1936,51 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(appointment.sessionFeedback!.behaviour!.notifyProbationPractitioner).toEqual(false)
     })
   })
+
+  describe('submitSessionFeedback', () => {
+    it('submits attendance and behaviour feedback to the PP', async () => {
+      await provider.addInteraction({
+        state:
+          'an action plan with ID 0f5afe04-e323-4699-9423-fb6122580638 exists with 1 appointment with recorded attendance and behaviour',
+        uponReceiving:
+          'a POST request to submit the feedback for appointment 1 on action plan with ID 0f5afe04-e323-4699-9423-fb6122580638',
+        withRequest: {
+          method: 'POST',
+          path: '/action-plan/0f5afe04-e323-4699-9423-fb6122580638/appointment/1/submit',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            sessionNumber: 1,
+            appointmentTime: '2021-05-13T12:30:00Z',
+            durationInMinutes: 120,
+            sessionFeedback: {
+              attendance: {
+                attended: 'late',
+                additionalAttendanceInformation: 'Alex missed the bus',
+              },
+              behaviour: {
+                behaviourDescription: 'Alex was well behaved',
+                notifyProbationPractitioner: false,
+              },
+              submitted: true,
+            },
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const appointment = await interventionsService.submitSessionFeedback(
+        token,
+        '0f5afe04-e323-4699-9423-fb6122580638',
+        1
+      )
+      expect(appointment.sessionFeedback!.submitted).toEqual(true)
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -157,9 +157,10 @@ export interface ActionPlanAppointment {
   sessionNumber: number
   appointmentTime: string | null
   durationInMinutes: number | null
-  sessionFeedback?: {
-    attendance?: AppointmentAttendance
-    behaviour?: AppointmentBehaviour
+  sessionFeedback: {
+    attendance: AppointmentAttendance
+    behaviour: AppointmentBehaviour
+    submitted: boolean
   }
 }
 
@@ -168,14 +169,16 @@ export interface ActionPlanAppointmentUpdate {
   durationInMinutes: number | null
 }
 
+export type Attended = 'yes' | 'no' | 'late' | null
+
 export interface AppointmentAttendance {
-  attended: 'yes' | 'no' | 'late'
-  additionalAttendanceInformation?: string
+  attended: Attended
+  additionalAttendanceInformation: string | null
 }
 
 export interface AppointmentBehaviour {
-  behaviourDescription: string
-  notifyProbationPractitioner: boolean
+  behaviourDescription: string | null
+  notifyProbationPractitioner: boolean | null
 }
 
 export default class InterventionsService {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -500,4 +500,17 @@ export default class InterventionsService {
       data: appointmentBehaviourUpdate,
     })) as ActionPlanAppointment
   }
+
+  async submitSessionFeedback(
+    token: string,
+    actionPlanId: string,
+    sessionNumber: number
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}/submit`,
+      headers: { Accept: 'application/json' },
+    })) as ActionPlanAppointment
+  }
 }

--- a/testutils/factories/actionPlanAppointment.ts
+++ b/testutils/factories/actionPlanAppointment.ts
@@ -1,5 +1,5 @@
 import { Factory } from 'fishery'
-import { ActionPlanAppointment } from '../../server/services/interventionsService'
+import { ActionPlanAppointment, Attended } from '../../server/services/interventionsService'
 
 class ActionPlanAppointmentFactory extends Factory<ActionPlanAppointment> {
   newlyCreated() {
@@ -12,10 +12,37 @@ class ActionPlanAppointmentFactory extends Factory<ActionPlanAppointment> {
       durationInMinutes: 60,
     })
   }
+
+  attended(attendance: Attended) {
+    return this.params({
+      sessionFeedback: {
+        attendance: {
+          attended: attendance,
+          additionalAttendanceInformation: '',
+        },
+        behaviour: {
+          behaviourDescription: '',
+          notifyProbationPractitioner: false,
+        },
+        submitted: true,
+      },
+    })
+  }
 }
 
 export default ActionPlanAppointmentFactory.define(() => ({
   sessionNumber: 1,
   appointmentTime: null,
   durationInMinutes: null,
+  sessionFeedback: {
+    attendance: {
+      attended: null,
+      additionalAttendanceInformation: null,
+    },
+    behaviour: {
+      behaviourDescription: null,
+      notifyProbationPractitioner: null,
+    },
+    submitted: false,
+  },
 }))


### PR DESCRIPTION
## What does this pull request do?

adds contract for submitting session feedback

the contract is there, but the unit test part is commented out because it doesn't exist yet.

## What is the intent behind these changes?

validate the API endpoint for submitting session feedback.
