### PR TITLE
Switch test logging to `warn` level

### DIFF
--- a/log.ts
+++ b/log.ts
@@ -2,7 +2,7 @@ import Logger from 'bunyan'
 import type { ResponseError } from 'superagent'
 import config from './server/config'
 
-const level = config.production ? 'warn' : 'debug'
+const level = config.production || config.testMode ? 'warn' : 'debug'
 
 function responseErrorSerializer(err: ResponseError) {
   const baseErr = Logger.stdSerializers.err(err)


### PR DESCRIPTION
## What does this pull request do?

Switches log level to "warn" for test environment.

## What is the intent behind these changes?

Since switching to structured logging, the output has become a little
verbose and there's way too much noise. I'm tempted to turn off logging
on tests completely, but there might be some value in having the logs
for debugging.

There's still some logging going on when running tests now, but it's a
lot less.
