### PR TITLE
IC-1424: Clarify entire Appointment (including null values) present in every response

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1675,21 +1675,21 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
   describe('getActionPlanAppointments', () => {
     const actionPlanAppointments = [
-      {
+      actionPlanAppointmentFactory.build({
         sessionNumber: 1,
         appointmentTime: '2021-05-13T12:30:00Z',
         durationInMinutes: 120,
-      },
-      {
+      }),
+      actionPlanAppointmentFactory.build({
         sessionNumber: 2,
         appointmentTime: '2021-05-20T12:30:00Z',
         durationInMinutes: 120,
-      },
-      {
+      }),
+      actionPlanAppointmentFactory.build({
         sessionNumber: 3,
         appointmentTime: '2021-05-27T12:30:00Z',
         durationInMinutes: 120,
-      },
+      }),
     ]
 
     beforeEach(async () => {
@@ -1719,11 +1719,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   })
 
   describe('getActionPlanAppointment', () => {
-    const actionPlanAppointment = {
+    const actionPlanAppointment = actionPlanAppointmentFactory.build({
       sessionNumber: 1,
       appointmentTime: '2021-05-13T12:30:00Z',
       durationInMinutes: 120,
-    }
+    })
 
     beforeEach(async () => {
       await provider.addInteraction({
@@ -1797,11 +1797,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   describe('updateActionPlanAppointment', () => {
     describe('with non-null values', () => {
       it('returns an updated action plan appointment', async () => {
-        const actionPlanAppointment = {
+        const actionPlanAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 2,
           appointmentTime: '2021-05-13T12:30:00Z',
           durationInMinutes: 60,
-        }
+        })
 
         await provider.addInteraction({
           state:
@@ -1862,6 +1862,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
                 attended: 'late',
                 additionalAttendanceInformation: 'Alex missed the bus',
               },
+              behaviour: {
+                behaviourDescription: null,
+                notifyProbationPractitioner: null,
+              },
+              submitted: false,
             },
           }),
           headers: {
@@ -1916,6 +1921,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
                 notifyProbationPractitioner: false,
               },
             },
+            submitted: false,
           }),
           headers: {
             'Content-Type': 'application/json',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1839,7 +1839,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     it('returns an updated action plan appointment with the service user‘s attendance', async () => {
       await provider.addInteraction({
         state:
-          'an action plan with ID 345059d4-1697-467b-8914-fedec9957279 exists and has 2 2-hour appointments already',
+          'an action plan with ID 345059d4-1697-467b-8914-fedec9957279 exists and has an appointment for which no session feedback has been recorded',
         uponReceiving:
           'a POST request to set the attendance for session 2 on action plan with ID 345059d4-1697-467b-8914-fedec9957279',
         withRequest: {


### PR DESCRIPTION
## What does this pull request do?

Adds whole response for Appointment for each contract test, including `null` values to make it clear what we actually receive from each response.

## What is the intent behind these changes?

When developing the "check your answers page" and relying on these fields, I found it
difficult to determine whether the session feedback fields (attendance
and behaviour) would be present in the response from the API or not,
particularly before they'd been sent vs if they had been skipped as an
optional answer.

By ensuring we use the `actionPlanAppointmentFactory` in this step, we
know that the fields will be `null` but present on the response object
by default, as that's how they're configured in the factory.

I've also added the missing parts of the response to make sure they're
in every contract test to be totally clear what's coming back from every
request.
