### PR TITLE
IC-1424: Add check your answers page to post session feedback journey

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -445,6 +445,20 @@ describe('Service provider referrals dashboard', () => {
           },
         },
       }
+      const appointmentWithSubmittedFeedback = {
+        ...appointmentWithBehaviourRecorded,
+        sessionFeedback: {
+          attendance: {
+            attended: 'yes',
+            additionalAttendanceInformation: 'Alex attended the session',
+          },
+          behaviour: {
+            behaviourDescription: 'Alex was well-behaved',
+            notifyProbationPractitioner: false,
+          },
+          submitted: true,
+        },
+      }
 
       cy.login()
 
@@ -466,7 +480,19 @@ describe('Service provider referrals dashboard', () => {
 
       cy.stubRecordAppointmentBehaviour(actionPlan.id, 1, appointmentWithBehaviourRecorded)
 
+      cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointmentWithBehaviourRecorded)
+
       cy.contains('Save and continue').click()
+
+      cy.contains('Confirm feedback')
+      cy.contains('Alex attended the session')
+      cy.contains('Yes, they were on time')
+      cy.contains('Alex was well-behaved')
+      cy.contains('No')
+
+      cy.stubSubmitSessionFeedback(actionPlan.id, 1, appointmentWithSubmittedFeedback)
+
+      cy.get('form').contains('Confirm').click()
 
       cy.contains('Session feedback added and submitted to the probation practitioner')
       cy.contains('You can now deliver the next session scheduled for 31 Mar 2021.')
@@ -526,6 +552,25 @@ describe('Service provider referrals dashboard', () => {
             attended: 'no',
             additionalAttendanceInformation: "Alex didn't attend",
           },
+          behaviour: {
+            behaviourDescription: null,
+            notifyProbationPractitioner: null,
+          },
+        },
+      }
+
+      const appointmentWithSubmittedFeedback = {
+        ...appointmentWithAttendanceRecorded,
+        sessionFeedback: {
+          attendance: {
+            attended: 'no',
+            additionalAttendanceInformation: "Alex didn't attend",
+          },
+          behaviour: {
+            behaviourDescription: null,
+            notifyProbationPractitioner: null,
+          },
+          submitted: true,
         },
       }
 
@@ -535,12 +580,22 @@ describe('Service provider referrals dashboard', () => {
 
       cy.contains('Give feedback').click()
 
-      cy.contains('Yes').click()
-      cy.contains("Add additional information about Alex's attendance").type('Alex attended the session')
+      cy.contains('No').click()
+      cy.contains("Add additional information about Alex's attendance").type("Alex didn't attend")
 
       cy.stubRecordAppointmentAttendance(actionPlan.id, 1, appointmentWithAttendanceRecorded)
 
+      cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointmentWithAttendanceRecorded)
+
       cy.contains('Save and continue').click()
+
+      cy.contains('Confirm feedback')
+      cy.contains('No')
+      cy.contains("Alex didn't attend")
+
+      cy.stubSubmitSessionFeedback(actionPlan.id, 1, appointmentWithSubmittedFeedback)
+
+      cy.get('form').contains('Confirm').click()
 
       cy.contains('Session feedback added and submitted to the probation practitioner')
       cy.contains('You can now deliver the next session scheduled for 31 Mar 2021.')

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -123,6 +123,10 @@ export default function routes(router: Router, services: Services): Router {
     '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/check-your-answers',
     (req, res) => serviceProviderReferralsController.checkPostSessionFeedbackAnswers(req, res)
   )
+  post(
+    '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/submit',
+    (req, res) => serviceProviderReferralsController.submitPostSessionFeedback(req, res)
+  )
   get(
     '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation',
     (req, res) => serviceProviderReferralsController.showPostSessionFeedbackConfirmation(req, res)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -120,10 +120,13 @@ export default function routes(router: Router, services: Services): Router {
     (req, res) => serviceProviderReferralsController.addPostSessionBehaviourFeedback(req, res)
   )
   get(
+    '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/check-your-answers',
+    (req, res) => serviceProviderReferralsController.checkPostSessionFeedbackAnswers(req, res)
+  )
+  get(
     '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation',
     (req, res) => serviceProviderReferralsController.showPostSessionFeedbackConfirmation(req, res)
   )
-
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {
       return staticContentController.index(req, res)

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.test.ts
@@ -7,8 +7,9 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
     it('includes the title of the page', () => {
       const appointment = actionPlanAppointmentFactory.build()
       const serviceUser = deliusServiceUserFactory.build()
+      const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
 
-      const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+      const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
       expect(presenter.text).toMatchObject({
         title: 'Confirm feedback',
@@ -16,7 +17,23 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
     })
   })
 
+  describe('submitHref', () => {
+    it('includes the action plan id and session number', () => {
+      const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 1 })
+      const serviceUser = deliusServiceUserFactory.build()
+      const actionPlanId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
+
+      const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
+
+      expect(presenter.submitHref).toEqual(
+        '/service-provider/action-plan/77f0d8fc-9443-492c-b352-4cab66acbf3c/appointment/1/post-session-feedback/submit'
+      )
+    })
+  })
+
   describe('attendedAnswers', () => {
+    const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
+
     it('returns an object with the question and answer given', () => {
       const appointment = actionPlanAppointmentFactory.build({
         sessionFeedback: {
@@ -31,7 +48,7 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
       })
       const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-      const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+      const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
       expect(presenter.attendedAnswers).toEqual({
         question: 'Did Alex attend this session?',
@@ -54,13 +71,15 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
         expect(presenter.attendedAnswers).toBeNull()
       })
     })
   })
 
   describe('additionalAttendanceAnswers', () => {
+    const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
+
     describe('when there is an answer for AdditionalAttendanceInformation', () => {
       it('returns an object with the question and answer given', () => {
         const appointment = actionPlanAppointmentFactory.build({
@@ -77,7 +96,7 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
         expect(presenter.additionalAttendanceAnswers).toEqual({
           question: "Add additional information about Alex's attendance:",
@@ -102,7 +121,7 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
         expect(presenter.additionalAttendanceAnswers).toEqual({
           question: "Add additional information about Alex's attendance:",
@@ -127,13 +146,15 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
         expect(presenter.additionalAttendanceAnswers).toBeNull()
       })
     })
   })
 
   describe('behaviourDescriptionAnswers', () => {
+    const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
+
     describe('if the behaviour question was answered', () => {
       it('returns an object with the question and answer given', () => {
         const appointment = actionPlanAppointmentFactory.build({
@@ -149,7 +170,7 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
         expect(presenter.behaviourDescriptionAnswers).toEqual({
           question: "Describe Alex's behaviour in this session",
@@ -173,7 +194,7 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
         expect(presenter.behaviourDescriptionAnswers).toBeNull()
       })
@@ -181,6 +202,8 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
   })
 
   describe('notifyProbationPractitionerAnswers', () => {
+    const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
+
     describe('if the behaviour question was answered with yes', () => {
       it('returns an object with the question and answer given, converting the boolean value into a "yes"', () => {
         const appointment = actionPlanAppointmentFactory.build({
@@ -194,7 +217,7 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
 
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
         expect(presenter.notifyProbationPractitionerAnswers).toEqual({
           question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
@@ -216,7 +239,7 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
 
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
         expect(presenter.notifyProbationPractitionerAnswers).toEqual({
           question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
@@ -237,7 +260,7 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
         expect(presenter.notifyProbationPractitionerAnswers).toBeNull()
       })
@@ -248,7 +271,8 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
     it('is instantiated with the service user', () => {
       const appointment = actionPlanAppointmentFactory.build()
       const serviceUser = deliusServiceUserFactory.build()
-      const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+      const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
+      const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
       expect(presenter.serviceUserBannerPresenter).toBeDefined()
     })

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.test.ts
@@ -1,0 +1,256 @@
+import PostSessionFeedbackCheckAnswersPresenter from './postSessionFeedbackCheckAnswersPresenter'
+import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
+import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+
+describe(PostSessionFeedbackCheckAnswersPresenter, () => {
+  describe('text', () => {
+    it('includes the title of the page', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+
+      const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+
+      expect(presenter.text).toMatchObject({
+        title: 'Confirm feedback',
+      })
+    })
+  })
+
+  describe('attendedAnswers', () => {
+    it('returns an object with the question and answer given', () => {
+      const appointment = actionPlanAppointmentFactory.build({
+        sessionFeedback: {
+          attendance: {
+            attended: 'yes',
+          },
+          behaviour: {
+            behaviourDescription: null,
+            notifyProbationPractitioner: null,
+          },
+        },
+      })
+      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+      const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+
+      expect(presenter.attendedAnswers).toEqual({
+        question: 'Did Alex attend this session?',
+        answer: 'Yes, they were on time',
+      })
+    })
+
+    describe('when there is no value for attended', () => {
+      it('returns null', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: null,
+            },
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        expect(presenter.attendedAnswers).toBeNull()
+      })
+    })
+  })
+
+  describe('additionalAttendanceAnswers', () => {
+    describe('when there is an answer for AdditionalAttendanceInformation', () => {
+      it('returns an object with the question and answer given', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: 'late',
+              additionalAttendanceInformation: 'Alex missed the bus',
+            },
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.additionalAttendanceAnswers).toEqual({
+          question: "Add additional information about Alex's attendance:",
+          answer: 'Alex missed the bus',
+        })
+      })
+    })
+
+    describe('when there is no answer for AdditionalAttendanceInformation', () => {
+      it('returns an object with "None" as the answer', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: 'late',
+              additionalAttendanceInformation: '',
+            },
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.additionalAttendanceAnswers).toEqual({
+          question: "Add additional information about Alex's attendance:",
+          answer: 'None',
+        })
+      })
+    })
+
+    describe('when there is a null value for AdditionalAttendanceInformation', () => {
+      it('returns null', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: 'late',
+              additionalAttendanceInformation: null,
+            },
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+        expect(presenter.additionalAttendanceAnswers).toBeNull()
+      })
+    })
+  })
+
+  describe('behaviourDescriptionAnswers', () => {
+    describe('if the behaviour question was answered', () => {
+      it('returns an object with the question and answer given', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: 'yes',
+            },
+            behaviour: {
+              behaviourDescription: 'Alex had a bad attitude',
+              notifyProbationPractitioner: true,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.behaviourDescriptionAnswers).toEqual({
+          question: "Describe Alex's behaviour in this session",
+          answer: 'Alex had a bad attitude',
+        })
+      })
+    })
+
+    describe('if the behaviour question was not answered', () => {
+      it('returns null', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: 'yes',
+            },
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.behaviourDescriptionAnswers).toBeNull()
+      })
+    })
+  })
+
+  describe('notifyProbationPractitionerAnswers', () => {
+    describe('if the behaviour question was answered with yes', () => {
+      it('returns an object with the question and answer given, converting the boolean value into a "yes"', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            behaviour: {
+              behaviourDescription: 'Alex had a bad attitude',
+              notifyProbationPractitioner: true,
+            },
+          },
+        })
+
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.notifyProbationPractitionerAnswers).toEqual({
+          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+          answer: 'Yes',
+        })
+      })
+    })
+
+    describe('if the behaviour question was answered with no', () => {
+      it('returns an object with the question and answer given, converting the boolean value into a "no"', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            behaviour: {
+              behaviourDescription: 'Alex had a good attitude',
+              notifyProbationPractitioner: false,
+            },
+          },
+        })
+
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.notifyProbationPractitionerAnswers).toEqual({
+          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+          answer: 'No',
+        })
+      })
+    })
+
+    describe('if the behaviour question was not answered', () => {
+      it('returns null', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.notifyProbationPractitionerAnswers).toBeNull()
+      })
+    })
+  })
+
+  describe('serviceUserBannerPresenter', () => {
+    it('is instantiated with the service user', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+      const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser)
+
+      expect(presenter.serviceUserBannerPresenter).toBeDefined()
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.ts
@@ -10,12 +10,18 @@ export default class PostSessionFeedbackCheckAnswersPresenter {
 
   private readonly behaviourPresenter: PostSessionBehaviourFeedbackPresenter
 
-  constructor(private readonly appointment: ActionPlanAppointment, private readonly serviceUser: DeliusServiceUser) {
+  constructor(
+    private readonly appointment: ActionPlanAppointment,
+    private readonly serviceUser: DeliusServiceUser,
+    private readonly actionPlanId: string
+  ) {
     this.attendancePresenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
     this.behaviourPresenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
   }
 
   readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
+
+  readonly submitHref = `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.appointment.sessionNumber}/post-session-feedback/submit`
 
   readonly text = {
     title: `Confirm feedback`,

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.ts
@@ -1,0 +1,77 @@
+import { DeliusServiceUser } from '../../services/communityApiService'
+import { ActionPlanAppointment } from '../../services/interventionsService'
+import { SummaryListItem } from '../../utils/summaryList'
+import ServiceUserBannerPresenter from '../shared/serviceUserBannerPresenter'
+import PostSessionAttendanceFeedbackPresenter from './postSessionAttendanceFeedbackPresenter'
+import PostSessionBehaviourFeedbackPresenter from './postSessionBehaviourFeedbackPresenter'
+
+export default class PostSessionFeedbackCheckAnswersPresenter {
+  private readonly attendancePresenter: PostSessionAttendanceFeedbackPresenter
+
+  private readonly behaviourPresenter: PostSessionBehaviourFeedbackPresenter
+
+  constructor(private readonly appointment: ActionPlanAppointment, private readonly serviceUser: DeliusServiceUser) {
+    this.attendancePresenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+    this.behaviourPresenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+  }
+
+  readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
+
+  readonly text = {
+    title: `Confirm feedback`,
+  }
+
+  get attendedAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.sessionFeedback.attendance.attended === null) {
+      return null
+    }
+
+    const selectedRadio = this.attendancePresenter.attendanceResponses.find(response => response.checked)
+
+    if (!selectedRadio) {
+      return null
+    }
+
+    return {
+      question: this.attendancePresenter.text.attendanceQuestion,
+      answer: selectedRadio.text,
+    }
+  }
+
+  get additionalAttendanceAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.sessionFeedback.attendance.additionalAttendanceInformation === null) {
+      return null
+    }
+
+    return {
+      question: this.attendancePresenter.text.additionalAttendanceInformationLabel,
+      answer: this.appointment.sessionFeedback.attendance.additionalAttendanceInformation || 'None',
+    }
+  }
+
+  get behaviourDescriptionAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.sessionFeedback.behaviour.behaviourDescription === null) {
+      return null
+    }
+
+    return {
+      question: this.behaviourPresenter.text.behaviourDescription.question,
+      answer: this.appointment.sessionFeedback.behaviour.behaviourDescription,
+    }
+  }
+
+  get notifyProbationPractitionerAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.sessionFeedback.behaviour.notifyProbationPractitioner === null) {
+      return null
+    }
+
+    return {
+      question: this.behaviourPresenter.text.notifyProbationPractitioner.question,
+      answer: this.appointment.sessionFeedback.behaviour.notifyProbationPractitioner ? 'Yes' : 'No',
+    }
+  }
+
+  get sessionDetailsSummary(): SummaryListItem[] {
+    return this.attendancePresenter.sessionDetailsSummary
+  }
+}

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersView.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersView.ts
@@ -1,0 +1,19 @@
+import ViewUtils from '../../utils/viewUtils'
+import PostSessionFeedbackCheckAnswersPresenter from './postSessionFeedbackCheckAnswersPresenter'
+
+export default class PostSessionFeedbackCheckAnswersView {
+  constructor(private readonly presenter: PostSessionFeedbackCheckAnswersPresenter) {}
+
+  private readonly summaryListArgs = ViewUtils.summaryListArgs(this.presenter.sessionDetailsSummary)
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/postSessionFeedbackCheckAnswers',
+      {
+        presenter: this.presenter,
+        serviceUserNotificationBannerArgs: this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs,
+        summaryListArgs: this.summaryListArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -803,6 +803,33 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
   })
 })
 
+describe('GET /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/check-your-answers', () => {
+  it('renders a page with answers the user has so far selected', async () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const serviceUser = deliusServiceUser.build()
+    const referral = sentReferralFactory.assigned().build()
+    const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+    const appointment = actionPlanAppointmentFactory.build({
+      appointmentTime: '2021-02-01T13:00:00Z',
+    })
+
+    communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+    interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
+
+    await request(app)
+      .get(
+        `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/check-your-answers`
+      )
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Confirm feedback')
+      })
+  })
+})
+
 describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation', () => {
   describe('when final appointment attendance has been recorded', () => {
     it('renders a page confirming that the action plan has been submitted', async () => {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -710,7 +710,7 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
   })
 
   describe('when the Service Provider marks the Service User as not having attended the session', () => {
-    it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the confirmation page', async () => {
+    it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the check-your-answers page', async () => {
       const updatedAppointment = actionPlanAppointmentFactory.build({
         sessionNumber: 1,
         sessionFeedback: {
@@ -737,7 +737,7 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
         .expect(302)
         .expect(
           'Location',
-          `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/confirmation`
+          `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/check-your-answers`
         )
     })
   })
@@ -771,7 +771,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNu
 })
 
 describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', () => {
-  it('makes a request to the interventions service to record the Service User‘s behaviour and redirects to the confirmation page', async () => {
+  it('makes a request to the interventions service to record the Service User‘s behaviour and redirects to the check your answers page', async () => {
     const updatedAppointment = actionPlanAppointmentFactory.build({
       sessionNumber: 1,
       sessionFeedback: {
@@ -798,7 +798,7 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
       .expect(302)
       .expect(
         'Location',
-        `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/confirmation`
+        `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/check-your-answers`
       )
   })
 })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -830,6 +830,23 @@ describe('GET /service-provider/action-plan:actionPlanId/appointment/:sessionNum
   })
 })
 
+describe('POST /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/submit', () => {
+  it('marks the appointment as submitted and redirects to the confirmation page', async () => {
+    const actionPlanId = '91e7ceab-74fd-45d8-97c8-ec58844618dd'
+    const sessionNumber = 2
+
+    await request(app)
+      .post(`/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/submit`)
+      .expect(302)
+      .expect(
+        'Location',
+        `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/confirmation`
+      )
+
+    expect(interventionsService.submitSessionFeedback).toHaveBeenCalledWith('token', actionPlanId, sessionNumber)
+  })
+})
+
 describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation', () => {
   describe('when final appointment attendance has been recorded', () => {
     it('renders a page confirming that the action plan has been submitted', async () => {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -37,6 +37,8 @@ import PostSessionFeedbackConfirmationView from './postSessionFeedbackConfirmati
 import PostSessionBehaviourFeedbackPresenter from './postSessionBehaviourFeedbackPresenter'
 import PostSessionBehaviourFeedbackView from './postSessionBehaviourFeedbackView'
 import PostSessionBehaviourFeedbackForm from './postSessionBehaviourFeedbackForm'
+import PostSessionFeedbackCheckAnswersView from './postSessionFeedbackCheckAnswersView'
+import PostSessionFeedbackCheckAnswersPresenter from './postSessionFeedbackCheckAnswersPresenter'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -525,6 +527,28 @@ export default class ServiceProviderReferralsController {
     const view = new PostSessionBehaviourFeedbackView(presenter)
 
     res.status(formError === null ? 200 : 400)
+    return res.render(...view.renderArgs)
+  }
+
+  async checkPostSessionFeedbackAnswers(req: Request, res: Response): Promise<void> {
+    const { user } = res.locals
+    const { accessToken } = user.token
+    const { actionPlanId, sessionNumber } = req.params
+
+    const actionPlan = await this.interventionsService.getActionPlan(accessToken, actionPlanId)
+    const referral = await this.interventionsService.getSentReferral(accessToken, actionPlan.referralId)
+
+    const currentAppointment = await this.interventionsService.getActionPlanAppointment(
+      accessToken,
+      actionPlanId,
+      Number(sessionNumber)
+    )
+
+    const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
+
+    const presenter = new PostSessionFeedbackCheckAnswersPresenter(currentAppointment, serviceUser)
+    const view = new PostSessionFeedbackCheckAnswersView(presenter)
+
     return res.render(...view.renderArgs)
   }
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -459,7 +459,7 @@ export default class ServiceProviderReferralsController {
         )
 
         const redirectPath =
-          updatedAppointment.sessionFeedback?.attendance?.attended === 'no' ? 'confirmation' : 'behaviour'
+          updatedAppointment.sessionFeedback?.attendance?.attended === 'no' ? 'check-your-answers' : 'behaviour'
 
         return res.redirect(
           `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/${redirectPath}`
@@ -508,7 +508,7 @@ export default class ServiceProviderReferralsController {
         )
 
         return res.redirect(
-          `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/confirmation`
+          `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/check-your-answers`
         )
       }
     }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -546,10 +546,22 @@ export default class ServiceProviderReferralsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new PostSessionFeedbackCheckAnswersPresenter(currentAppointment, serviceUser)
+    const presenter = new PostSessionFeedbackCheckAnswersPresenter(currentAppointment, serviceUser, actionPlanId)
     const view = new PostSessionFeedbackCheckAnswersView(presenter)
 
     return res.render(...view.renderArgs)
+  }
+
+  async submitPostSessionFeedback(req: Request, res: Response): Promise<void> {
+    const { user } = res.locals
+    const { accessToken } = user.token
+    const { actionPlanId, sessionNumber } = req.params
+
+    await this.interventionsService.submitSessionFeedback(accessToken, actionPlanId, Number(sessionNumber))
+
+    return res.redirect(
+      `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/confirmation`
+    )
   }
 
   async showPostSessionFeedbackConfirmation(req: Request, res: Response): Promise<void> {

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
@@ -18,7 +18,9 @@
       {% endif %}
 
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
-      <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
+      {% if presenter.text.subTitle %}
+        <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
+      {% endif %}
 
       {% if presenter.text.pageNumber %}
         <p class="govuk-hint">Page {{ presenter.text.pageNumber }} of 3</p>

--- a/server/views/serviceProviderReferrals/postSessionFeedbackCheckAnswers.njk
+++ b/server/views/serviceProviderReferrals/postSessionFeedbackCheckAnswers.njk
@@ -1,0 +1,37 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% extends "./actionPlan/actionPlanFormTemplate.njk" %}
+
+{% block formSection %}
+  {{ govukSummaryList(summaryListArgs) }}
+
+  <br>
+
+  {% if presenter.attendedAnswers %}
+    <h3 class="govuk-heading-s">{{ presenter.attendedAnswers.question }}</h3>
+    <p>{{ presenter.attendedAnswers.answer }}</p>
+  {% endif %}
+
+  {% if presenter.additionalAttendanceAnswers %}
+    <h3 class="govuk-heading-s">{{ presenter.additionalAttendanceAnswers.question }}</h3>
+    <p>{{ presenter.additionalAttendanceAnswers.answer }}</p>
+  {% endif %}
+
+  {% if presenter.behaviourDescriptionAnswers %}
+    <h3 class="govuk-heading-s">{{ presenter.behaviourDescriptionAnswers.question }}</h3>
+    <p>{{ presenter.behaviourDescriptionAnswers.answer }}</p>
+  {% endif %}
+
+  {% if presenter.notifyProbationPractitionerAnswers %}
+    <h3 class="govuk-heading-s">{{ presenter.notifyProbationPractitionerAnswers.question }}</h3>
+    <p>{{ presenter.notifyProbationPractitionerAnswers.answer }}</p>
+  {% endif %}
+
+  <form method="post" action="#">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {{ govukButton({ text: "Confirm" }) }}
+  </form>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/postSessionFeedbackCheckAnswers.njk
+++ b/server/views/serviceProviderReferrals/postSessionFeedbackCheckAnswers.njk
@@ -30,7 +30,7 @@
     <p>{{ presenter.notifyProbationPractitionerAnswers.answer }}</p>
   {% endif %}
 
-  <form method="post" action="#">
+  <form method="post" action="{{ presenter.submitHref }}">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukButton({ text: "Confirm" }) }}
   </form>


### PR DESCRIPTION
## What does this pull request do?

Adds check your answers page to post session feedback journey.

If the SP marks the SU as having not attended, they'll skip the behaviour question and go straight to the check your answers page (and won't see the behaviour questions on that page).

Clicking "confirm" on the check your answers page marks the referral as `submitted` on the backend.

## What is the intent behind these changes?

To allow users to check their answers before submitting attendance/behaviour feedback.

## Screenshots

### Service user did not attend

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/19826940/114884380-a24a5800-9dfd-11eb-85ca-50f906535e64.png">

### Service user attended

<img width="996" alt="image" src="https://user-images.githubusercontent.com/19826940/114884409-a6767580-9dfd-11eb-9c3b-81fd7e4e45f2.png">


