### PR TITLE
IC-1529: Update intervention progress statuses after feedback

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -85,25 +85,25 @@ describe('Probation Practitioner monitor journey', () => {
           {
             'Session details': 'Session 1',
             'Date and time': '24 Mar 2021, 09:02',
-            Status: 'COMPLETED',
-            Action: 'View',
+            Status: 'completed',
+            Action: 'View feedback form',
           },
           {
             'Session details': 'Session 2',
             'Date and time': '30 Apr 2021, 10:02',
-            Status: 'FAILURE TO ATTEND',
-            Action: 'View',
+            Status: 'did not attend',
+            Action: 'View feedback form',
           },
           {
             'Session details': 'Session 3',
             'Date and time': '31 May 2021, 10:02',
-            Status: 'SCHEDULED',
+            Status: 'scheduled',
             Action: '',
           },
           {
             'Session details': 'Session 4',
             'Date and time': '',
-            Status: 'NOT SCHEDULED',
+            Status: 'not scheduled',
             Action: '',
           },
         ])

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -496,6 +496,28 @@ describe('Service provider referrals dashboard', () => {
 
       cy.contains('Session feedback added and submitted to the probation practitioner')
       cy.contains('You can now deliver the next session scheduled for 31 Mar 2021.')
+
+      const updatedAppointments = [appointmentWithSubmittedFeedback, appointments[1]]
+      cy.stubGetActionPlanAppointments(actionPlan.id, updatedAppointments)
+
+      cy.contains('Return to service progress').click()
+
+      cy.get('table')
+        .getTable()
+        .should('deep.equal', [
+          {
+            'Session details': 'Session 1',
+            'Date and time': '24 Mar 2021, 09:02',
+            Status: 'completed',
+            Action: 'View feedback form',
+          },
+          {
+            'Session details': 'Session 2',
+            'Date and time': '31 Mar 2021, 10:02',
+            Status: 'scheduled',
+            Action: 'Reschedule sessionGive feedback',
+          },
+        ])
     })
 
     it('user records the Service User as having not attended, and skips behaviour screen', () => {
@@ -599,6 +621,28 @@ describe('Service provider referrals dashboard', () => {
 
       cy.contains('Session feedback added and submitted to the probation practitioner')
       cy.contains('You can now deliver the next session scheduled for 31 Mar 2021.')
+
+      const updatedAppointments = [appointmentWithSubmittedFeedback, appointments[1]]
+      cy.stubGetActionPlanAppointments(actionPlan.id, updatedAppointments)
+
+      cy.contains('Return to service progress').click()
+
+      cy.get('table')
+        .getTable()
+        .should('deep.equal', [
+          {
+            'Session details': 'Session 1',
+            'Date and time': '24 Mar 2021, 09:02',
+            Status: 'did not attend',
+            Action: 'View feedback form',
+          },
+          {
+            'Session details': 'Session 2',
+            'Date and time': '31 Mar 2021, 10:02',
+            Status: 'scheduled',
+            Action: 'Reschedule sessionGive feedback',
+          },
+        ])
     })
   })
 })

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -28,7 +28,7 @@ describe(InterventionProgressPresenter, () => {
             sessionNumber: 1,
             appointmentTime: '',
             tagArgs: {
-              text: 'NOT SCHEDULED',
+              text: 'not scheduled',
               classes: 'govuk-tag--grey',
             },
             linkHtml: '',
@@ -54,7 +54,7 @@ describe(InterventionProgressPresenter, () => {
             sessionNumber: 1,
             appointmentTime: '07 Dec 2020, 13:00',
             tagArgs: {
-              text: 'SCHEDULED',
+              text: 'scheduled',
               classes: 'govuk-tag--blue',
             },
             linkHtml: '',
@@ -63,7 +63,7 @@ describe(InterventionProgressPresenter, () => {
       })
     })
 
-    describe('after the scheduled appointment', () => {
+    describe('when session feedback has been recorded', () => {
       describe('when the service user attended the session or was late', () => {
         it('populates the table with the "completed" status against that session and a link to view it', () => {
           const referral = sentReferralFactory.build()
@@ -78,19 +78,19 @@ describe(InterventionProgressPresenter, () => {
               sessionNumber: 1,
               appointmentTime: '',
               tagArgs: {
-                text: 'COMPLETED',
+                text: 'completed',
                 classes: 'govuk-tag--green',
               },
-              linkHtml: '<a class="govuk-link" href="#">View</a>',
+              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
             },
             {
               sessionNumber: 2,
               appointmentTime: '',
               tagArgs: {
-                text: 'COMPLETED',
+                text: 'completed',
                 classes: 'govuk-tag--green',
               },
-              linkHtml: '<a class="govuk-link" href="#">View</a>',
+              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
             },
           ])
         })
@@ -109,10 +109,10 @@ describe(InterventionProgressPresenter, () => {
               sessionNumber: 1,
               appointmentTime: '',
               tagArgs: {
-                text: 'FAILURE TO ATTEND',
+                text: 'did not attend',
                 classes: 'govuk-tag--purple',
               },
-              linkHtml: '<a class="govuk-link" href="#">View</a>',
+              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
             },
           ])
         })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -41,7 +41,7 @@ describe(InterventionProgressPresenter, () => {
             sessionNumber: 1,
             appointmentTime: '',
             tagArgs: {
-              text: 'NOT SCHEDULED',
+              text: 'not scheduled',
               classes: 'govuk-tag--grey',
             },
             linkHtml:
@@ -69,12 +69,72 @@ describe(InterventionProgressPresenter, () => {
             sessionNumber: 1,
             appointmentTime: '07 Dec 2020, 13:00',
             tagArgs: {
-              text: 'SCHEDULED',
+              text: 'scheduled',
               classes: 'govuk-tag--blue',
             },
             linkHtml: `<a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/sessions/1/edit">Reschedule session</a><br><a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/1/post-session-feedback/attendance">Give feedback</a>`,
           },
         ])
+      })
+    })
+
+    describe('when the session feedback has been recorded', () => {
+      describe('when the service user attended the session or was late', () => {
+        it('populates the table with the "completed" status against that session and a link to view it', () => {
+          const referral = sentReferralFactory.build()
+          const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [
+            actionPlanAppointmentFactory.attended('yes').build({ sessionNumber: 1 }),
+            actionPlanAppointmentFactory.attended('late').build({ sessionNumber: 2 }),
+          ])
+
+          expect(presenter.sessionTableRows).toEqual([
+            {
+              sessionNumber: 1,
+              appointmentTime: '',
+              tagArgs: {
+                text: 'completed',
+                classes: 'govuk-tag--green',
+              },
+              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
+            },
+            {
+              sessionNumber: 2,
+              appointmentTime: '',
+              tagArgs: {
+                text: 'completed',
+                classes: 'govuk-tag--green',
+              },
+              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
+            },
+          ])
+        })
+      })
+
+      describe('when the service did not attend the session', () => {
+        it('populates the table with the "failure to attend" status against that session and a link to view it', () => {
+          const referral = sentReferralFactory.build()
+          const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [
+            actionPlanAppointmentFactory.attended('no').build(),
+          ])
+
+          expect(presenter.sessionTableRows).toEqual([
+            {
+              sessionNumber: 1,
+              appointmentTime: '',
+              tagArgs: {
+                text: 'did not attend',
+                classes: 'govuk-tag--purple',
+              },
+              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
+            },
+          ])
+        })
       })
     })
   })

--- a/server/routes/shared/sessionStatusPresenter.test.ts
+++ b/server/routes/shared/sessionStatusPresenter.test.ts
@@ -1,0 +1,32 @@
+import { SessionStatus } from '../../utils/sessionStatus'
+import SessionStatusPresenter from './sessionStatusPresenter'
+
+describe(SessionStatusPresenter, () => {
+  describe('text and tagClass', () => {
+    it.each([
+      {
+        status: SessionStatus.didNotAttend,
+        text: 'did not attend',
+        tagClass: 'govuk-tag--purple',
+      },
+      {
+        status: SessionStatus.scheduled,
+        text: 'scheduled',
+        tagClass: 'govuk-tag--blue',
+      },
+      {
+        status: SessionStatus.completed,
+        text: 'completed',
+        tagClass: 'govuk-tag--green',
+      },
+      {
+        status: SessionStatus.notScheduled,
+        text: 'not scheduled',
+        tagClass: 'govuk-tag--grey',
+      },
+    ])('returns the correct text and tag class for each status', ({ status, text, tagClass }) => {
+      expect(new SessionStatusPresenter(status).text).toEqual(text)
+      expect(new SessionStatusPresenter(status).tagClass).toEqual(tagClass)
+    })
+  })
+})

--- a/server/routes/shared/sessionStatusPresenter.ts
+++ b/server/routes/shared/sessionStatusPresenter.ts
@@ -1,0 +1,31 @@
+import { SessionStatus } from '../../utils/sessionStatus'
+
+export default class SessionStatusPresenter {
+  constructor(private readonly status: SessionStatus) {}
+
+  get text(): string {
+    switch (this.status) {
+      case SessionStatus.didNotAttend:
+        return 'did not attend'
+      case SessionStatus.scheduled:
+        return 'scheduled'
+      case SessionStatus.completed:
+        return 'completed'
+      default:
+        return 'not scheduled'
+    }
+  }
+
+  get tagClass(): string {
+    switch (this.status) {
+      case SessionStatus.didNotAttend:
+        return 'govuk-tag--purple'
+      case SessionStatus.scheduled:
+        return 'govuk-tag--blue'
+      case SessionStatus.completed:
+        return 'govuk-tag--green'
+      default:
+        return 'govuk-tag--grey'
+    }
+  }
+}

--- a/server/utils/sessionStatus.test.ts
+++ b/server/utils/sessionStatus.test.ts
@@ -1,0 +1,68 @@
+import actionPlanAppointmentFactory from '../../testutils/factories/actionPlanAppointment'
+import sessionStatus, { SessionStatus } from './sessionStatus'
+
+describe(sessionStatus.forAppointment, () => {
+  describe('when the appointment was not attended', () => {
+    const appointment = actionPlanAppointmentFactory.build({
+      sessionFeedback: {
+        attendance: {
+          attended: 'no',
+        },
+      },
+    })
+
+    it('returns "did not attend" status', () => {
+      expect(sessionStatus.forAppointment(appointment)).toEqual(SessionStatus.didNotAttend)
+    })
+  })
+
+  describe('when the appointment was attended or the user was late', () => {
+    const onTimeAppointment = actionPlanAppointmentFactory.build({
+      sessionFeedback: {
+        attendance: {
+          attended: 'yes',
+        },
+      },
+    })
+
+    const lateAppointment = actionPlanAppointmentFactory.build({
+      sessionFeedback: {
+        attendance: {
+          attended: 'yes',
+        },
+      },
+    })
+
+    it('returns "completed" status', () => {
+      expect(sessionStatus.forAppointment(onTimeAppointment)).toEqual(SessionStatus.completed)
+      expect(sessionStatus.forAppointment(lateAppointment)).toEqual(SessionStatus.completed)
+    })
+  })
+
+  describe('when the appointment does not have feedback, but has an appointment time set', () => {
+    const scheduledAppointment = actionPlanAppointmentFactory.scheduled().build({
+      sessionFeedback: {
+        attendance: {
+          attended: null,
+          additionalAttendanceInformation: null,
+        },
+        behaviour: {
+          behaviourDescription: null,
+          notifyProbationPractitioner: null,
+        },
+      },
+    })
+
+    it('returns "did not attend" status', () => {
+      expect(sessionStatus.forAppointment(scheduledAppointment)).toEqual(SessionStatus.scheduled)
+    })
+  })
+
+  describe('when the appointment has not yet been scheduled', () => {
+    const unscheduledAppointment = actionPlanAppointmentFactory.newlyCreated().build()
+
+    it('returns "did not attend" status', () => {
+      expect(sessionStatus.forAppointment(unscheduledAppointment)).toEqual(SessionStatus.notScheduled)
+    })
+  })
+})

--- a/server/utils/sessionStatus.ts
+++ b/server/utils/sessionStatus.ts
@@ -1,0 +1,28 @@
+import { ActionPlanAppointment } from '../services/interventionsService'
+
+export enum SessionStatus {
+  notScheduled,
+  scheduled,
+  completed,
+  didNotAttend,
+}
+
+export default {
+  forAppointment: (appointment: ActionPlanAppointment): SessionStatus => {
+    const sessionFeedbackAttendance = appointment.sessionFeedback.attendance
+
+    if (sessionFeedbackAttendance.attended === 'no') {
+      return SessionStatus.didNotAttend
+    }
+
+    if (sessionFeedbackAttendance.attended === 'yes' || sessionFeedbackAttendance.attended === 'late') {
+      return SessionStatus.completed
+    }
+
+    if (appointment.appointmentTime) {
+      return SessionStatus.scheduled
+    }
+
+    return SessionStatus.notScheduled
+  },
+}


### PR DESCRIPTION
## What does this pull request do?

Updates the PP and SP intervention progress pages with the right statuses once post session feedback has been submitted.

This currently doesn't display the red "awaiting feedback" status, or the green "today" ones, as I believe we were hesitant to start introducing statuses based on dates.

## What is the intent behind these changes?

To give the SP/PP a quick overview of the stage of each session.

Screenshots:

<img width="724" alt="image" src="https://user-images.githubusercontent.com/19826940/114899110-9749f480-9e0a-11eb-987a-780f99278f13.png">

<img width="963" alt="image" src="https://user-images.githubusercontent.com/19826940/114899181-a5981080-9e0a-11eb-9cfe-1b4b7c4580a9.png">



