### PR TITLE
Add Sentry exception monitoring

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
@@ -55,26 +55,10 @@ env:
         name: sentry
         key: ui_dsn
 
-  - name: REDIS_TLS_ENABLED
-    value: {{ .Values.env.REDIS_TLS_ENABLED | quote }}
-
-  - name: HMPPS_AUTH_URL
-    value: {{ .Values.env.HMPPS_AUTH_URL | quote }}
-
-  - name: COMMUNITY_API_URL
-    value: {{ .Values.env.COMMUNITY_API_URL | quote }}
-
-  - name: OFFENDER_ASSESSMENTS_API_URL
-    value: {{ .Values.env.OFFENDER_ASSESSMENTS_API_URL | quote }}
-
-  - name: INTERVENTIONS_SERVICE_URL
-    value: {{ .Values.env.INTERVENTIONS_SERVICE_URL | quote }}
-
-  - name: TOKEN_VERIFICATION_API_URL
-    value: {{ .Values.env.TOKEN_VERIFICATION_API_URL | quote }}
-
-  - name: TOKEN_VERIFICATION_ENABLED
-    value: {{ .Values.env.TOKEN_VERIFICATION_ENABLED | quote }}
+  {{ range $key, $value := .Values.env }}
+  - name: {{ $key }}
+    value: {{ $value | quote }}
+  {{ end }}
 
   - name: NODE_ENV
     value: production

--- a/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
@@ -49,6 +49,12 @@ env:
         name: elasticache-redis
         key: auth_token
 
+  - name: SENTRY_DSN
+    valueFrom:
+      secretKeyRef:
+        name: sentry
+        key: ui_dsn
+
   - name: REDIS_TLS_ENABLED
     value: {{ .Values.env.REDIS_TLS_ENABLED | quote }}
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,7 +15,7 @@ ingress:
   path: /
 
 env:
-  ENV: dev
+  DEPLOYMENT_ENV: dev
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,6 +15,7 @@ ingress:
   path: /
 
 env:
+  ENV: dev
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,6 +15,7 @@ ingress:
   path: /
 
 env:
+  ENV: preprod
   HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: https://offender-prprod.aks-live-1.studio-hosting.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,7 +15,7 @@ ingress:
   path: /
 
 env:
-  ENV: preprod
+  DEPLOYMENT_ENV: preprod
   HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: https://offender-prprod.aks-live-1.studio-hosting.service.justice.gov.uk

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -12,7 +12,7 @@ ingress:
   path: /
 
 env:
-  ENV: research
+  DEPLOYMENT_ENV: research
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -12,6 +12,7 @@ ingress:
   path: /
 
 env:
+  ENV: research
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/frontend": "0.0.21",
+        "@sentry/node": "^6.2.5",
         "@types/connect-flash": "0.0.35",
         "agentkeepalive": "^4.1.3",
         "applicationinsights": "^1.8.7",
@@ -2227,6 +2228,109 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/core": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.5.tgz",
+      "integrity": "sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==",
+      "dependencies": {
+        "@sentry/hub": "6.2.5",
+        "@sentry/minimal": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.5.tgz",
+      "integrity": "sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==",
+      "dependencies": {
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/minimal": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.5.tgz",
+      "integrity": "sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==",
+      "dependencies": {
+        "@sentry/hub": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.5.tgz",
+      "integrity": "sha512-/iM3khzGnUH713VFhZBAEYJhb/saEQSVz7Udogml+O7mFQ4rutnwJhgoGcB9YYrwMv2m7qOSszkdZbemDV6k2g==",
+      "dependencies": {
+        "@sentry/core": "6.2.5",
+        "@sentry/hub": "6.2.5",
+        "@sentry/tracing": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.5.tgz",
+      "integrity": "sha512-j/hM0BoHxfrNLxPeEJ5Vq4R34hO/TOHMEpLR3FdnunBXbsmjoKMMygIkPxnpML5XWtvukAehbwpDXldwMYz83w==",
+      "dependencies": {
+        "@sentry/hub": "6.2.5",
+        "@sentry/minimal": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.5.tgz",
+      "integrity": "sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.5.tgz",
+      "integrity": "sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==",
+      "dependencies": {
+        "@sentry/types": "6.2.5",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
@@ -3033,6 +3137,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/agentkeepalive": {
@@ -7137,7 +7252,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7906,6 +8020,18 @@
       "engines": {
         "node": ">=0.8",
         "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -11363,6 +11489,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -16526,8 +16657,7 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -19577,6 +19707,87 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sentry/core": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.5.tgz",
+      "integrity": "sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==",
+      "requires": {
+        "@sentry/hub": "6.2.5",
+        "@sentry/minimal": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.5.tgz",
+      "integrity": "sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==",
+      "requires": {
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.5.tgz",
+      "integrity": "sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==",
+      "requires": {
+        "@sentry/hub": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.5.tgz",
+      "integrity": "sha512-/iM3khzGnUH713VFhZBAEYJhb/saEQSVz7Udogml+O7mFQ4rutnwJhgoGcB9YYrwMv2m7qOSszkdZbemDV6k2g==",
+      "requires": {
+        "@sentry/core": "6.2.5",
+        "@sentry/hub": "6.2.5",
+        "@sentry/tracing": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
+    },
+    "@sentry/tracing": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.5.tgz",
+      "integrity": "sha512-j/hM0BoHxfrNLxPeEJ5Vq4R34hO/TOHMEpLR3FdnunBXbsmjoKMMygIkPxnpML5XWtvukAehbwpDXldwMYz83w==",
+      "requires": {
+        "@sentry/hub": "6.2.5",
+        "@sentry/minimal": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.5.tgz",
+      "integrity": "sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w=="
+    },
+    "@sentry/utils": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.5.tgz",
+      "integrity": "sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==",
+      "requires": {
+        "@sentry/types": "6.2.5",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sideway/address": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
@@ -20328,6 +20539,14 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "agentkeepalive": {
       "version": "4.1.3",
@@ -23728,7 +23947,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "dev": true,
       "optional": true
     },
     "fstream": {
@@ -24348,6 +24566,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "human-signals": {
@@ -27138,6 +27365,11 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -31262,8 +31494,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsscmp": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "0.0.21",
+    "@sentry/node": "^6.2.5",
     "@types/connect-flash": "0.0.35",
     "agentkeepalive": "^4.1.3",
     "applicationinsights": "^1.8.7",

--- a/server/app.ts
+++ b/server/app.ts
@@ -54,7 +54,7 @@ export default function createApp(
   app.set('port', config.port)
 
   // Reads config from SENTRY_DSN env variable, if exists
-  Sentry.init({ environment: config.sentry.environment })
+  Sentry.init({ environment: config.deploymentEnvironment })
 
   // The Sentry request handler must be the first middleware on the app
   app.use(Sentry.Handlers.requestHandler())

--- a/server/config.ts
+++ b/server/config.ts
@@ -40,6 +40,9 @@ export default {
   port: get('PORT', 3000),
   https: production,
   staticResourceCacheDuration: 20,
+  sentry: {
+    environment: get('ENV', 'local', requiredInProduction),
+  },
   redis: {
     host: process.env.REDIS_HOST,
     port: Number(process.env.REDIS_PORT) || 6379,

--- a/server/config.ts
+++ b/server/config.ts
@@ -40,9 +40,7 @@ export default {
   port: get('PORT', 3000),
   https: production,
   staticResourceCacheDuration: 20,
-  sentry: {
-    environment: get('ENV', 'local', requiredInProduction),
-  },
+  deploymentEnvironment: get('DEPLOYMENT_ENV', 'local', requiredInProduction),
   redis: {
     host: process.env.REDIS_HOST,
     port: Number(process.env.REDIS_PORT) || 6379,


### PR DESCRIPTION
## What does this pull request do?

Largely following the steps at https://docs.sentry.io/platforms/node/guides/express/

Sentry's configuration:
- the client key (called "DSN"), coming from `sentry.ui_dsn` secret from Kubernetes
- the environment, so it's correctly tagging where it happened, configured via `ENV` variable

The hardcoded environment variables are now replaced with ranging through the variables defined in `values-{env}.yml` -- similar to what the service does

## What is the intent behind these changes?

Enable exception monitoring on the UI side as well, following https://github.com/ministryofjustice/hmpps-interventions-service/pull/171