### PR TITLE
IC-1557 Changes to sent referrals endpoints

### DIFF
--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -120,7 +120,7 @@ export default class InterventionsServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `${this.mockPrefix}/sent-referrals`,
+        urlPathPattern: `${this.mockPrefix}/sent-referrals`,
       },
       response: {
         status: 200,

--- a/server/authentication/passport.ts
+++ b/server/authentication/passport.ts
@@ -17,6 +17,7 @@ interface HmmpsAuthUser {
   }
   username: string
   userId: string
+  authSource: string
 }
 export type User = HmmpsAuthUser & UserDetails
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -59,7 +59,7 @@ describe('GET /service-provider/dashboard', () => {
       }),
     ]
 
-    interventionsService.getSentReferrals.mockResolvedValue(sentReferrals)
+    interventionsService.getReferralsSentToServiceProvider.mockResolvedValue(sentReferrals)
     interventionsService.getServiceCategory.mockImplementation(async (token, id) => {
       const result = [accommodationServiceCategory, socialInclusionServiceCategory].find(category => category.id === id)
       return result!

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -39,6 +39,7 @@ import PostSessionBehaviourFeedbackView from './postSessionBehaviourFeedbackView
 import PostSessionBehaviourFeedbackForm from './postSessionBehaviourFeedbackForm'
 import PostSessionFeedbackCheckAnswersView from './postSessionFeedbackCheckAnswersView'
 import PostSessionFeedbackCheckAnswersPresenter from './postSessionFeedbackCheckAnswersPresenter'
+import AuthUtils from '../../utils/authUtils'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -48,7 +49,11 @@ export default class ServiceProviderReferralsController {
   ) {}
 
   async showDashboard(req: Request, res: Response): Promise<void> {
-    const referrals = await this.interventionsService.getSentReferrals(res.locals.user.token.accessToken)
+    const serviceProvider = AuthUtils.getSPUserOrganization(res.locals.user)
+    const referrals = await this.interventionsService.getReferralsSentToServiceProvider(
+      res.locals.user.token.accessToken,
+      serviceProvider.id
+    )
 
     const dedupedServiceCategoryIds = Array.from(
       new Set(referrals.map(referral => referral.referral.serviceCategoryId))

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -27,6 +27,9 @@ function appSetup(route: Router, production: boolean, userType: AppSetupUserType
   nunjucksSetup(app, path)
 
   user.authSource = userType
+  if (userType === AppSetupUserType.serviceProvider) {
+    user.organizations = [{ id: 'HARMONY_LIVING', name: 'Harmony Living' }]
+  }
 
   app.use((req, res, next) => {
     req.user = user

--- a/server/routes/testutils/mocks/mockUserService.ts
+++ b/server/routes/testutils/mocks/mockUserService.ts
@@ -1,10 +1,9 @@
 import UserService, { UserDetails } from '../../../services/userService'
 import MockedHmppsAuthClient from '../../../data/testutils/hmppsAuthClientSetup'
+import { User } from '../../../authentication/passport'
 
-export const user = {
+export const user: User = {
   name: 'john smith',
-  firstName: 'john',
-  lastName: 'smith',
   username: 'user1',
   displayName: 'J. Smith',
   token: {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1112,14 +1112,15 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('getSentReferrals', () => {
-    it('returns a list of all sent referrals', async () => {
+  describe('getReferralsSentToServiceProvider', () => {
+    it('returns a list of all sent referrals for the SP user', async () => {
       await provider.addInteraction({
-        state: 'There are some existing sent referrals',
-        uponReceiving: 'a request for all sent referrals',
+        state: 'There are some existing sent referrals sent to HARMONY_LIVING',
+        uponReceiving: "a request for all sent referrals for the SP user's organization",
         withRequest: {
           method: 'GET',
           path: '/sent-referrals',
+          query: { sentTo: 'HARMONY_LIVING' },
           headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
         },
         willRespondWith: {
@@ -1129,7 +1130,35 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      expect(await interventionsService.getSentReferrals(token)).toEqual([sentReferral, sentReferral])
+      expect(await interventionsService.getReferralsSentToServiceProvider(token, 'HARMONY_LIVING')).toEqual([
+        sentReferral,
+        sentReferral,
+      ])
+    })
+  })
+
+  describe('getReferralsSentByProbationPractitioner', () => {
+    it('returns a list of all referrals sent by the PP user', async () => {
+      await provider.addInteraction({
+        state: "There are some existing sent referrals sent by user with id 'bernard.beaks'",
+        uponReceiving: "a request for all sent referrals for the SP user's organization",
+        withRequest: {
+          method: 'GET',
+          path: '/sent-referrals',
+          query: { sentBy: 'bernard.beaks' },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like([sentReferral, sentReferral]),
+          headers: { 'Content-Type': 'application/json' },
+        },
+      })
+
+      expect(await interventionsService.getReferralsSentByProbationPractitioner(token, 'bernard.beaks')).toEqual([
+        sentReferral,
+        sentReferral,
+      ])
     })
   })
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -319,11 +319,22 @@ export default class InterventionsService {
     })) as SentReferral
   }
 
-  async getSentReferrals(token: string): Promise<SentReferral[]> {
+  async getReferralsSentByProbationPractitioner(token: string, userId: string): Promise<SentReferral[]> {
     const restClient = this.createRestClient(token)
 
     return (await restClient.get({
       path: `/sent-referrals`,
+      query: { sentBy: userId },
+      headers: { Accept: 'application/json' },
+    })) as SentReferral[]
+  }
+
+  async getReferralsSentToServiceProvider(token: string, providerId: string): Promise<SentReferral[]> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/sent-referrals`,
+      query: { sentTo: providerId },
       headers: { Accept: 'application/json' },
     })) as SentReferral[]
   }

--- a/server/utils/authUtils.ts
+++ b/server/utils/authUtils.ts
@@ -1,0 +1,20 @@
+import { ServiceProviderOrg, UserDetails } from '../services/userService'
+
+function getSPUserOrganization(userDetails: UserDetails): ServiceProviderOrg {
+  const { organizations } = userDetails
+  if (organizations === undefined) {
+    throw new Error('user is not an SP user')
+  }
+
+  if (organizations.length === 0) {
+    throw new Error('user is not associated with a service provider organization')
+  }
+
+  // for now we just take the first listed organization - this will change
+  // when we implement the prime/subcontractor authorization work.
+  return organizations[0]
+}
+
+export default {
+  getSPUserOrganization,
+}


### PR DESCRIPTION
## What does this pull request do?

uses the new and improved API endpoint for getting sent referrals. 

there are a couple of necessary changes here too, the first is updating the user objects to accurately reflect what we are storing in `res.locals.user` - it's kind of annoying we don't get proper type checking on this thing. the second is that we now must validate the SP user is associated with an organization on the UI side. this is a taste of things to come with regards to the bigger auth stories being planned out, but for now is quite simple. i've abstracted the logic to a helper function so it's clear how the organization is being parsed out. 

finally, the contracts are updated to validate the new API expectations.

## What is the intent behind these changes?

ground work for PP dashboard
