### PR TITLE
IC-1558 Improve auth error handling

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -25,6 +25,7 @@ import InterventionsService from './services/interventionsService'
 import OffenderAssessmentsApiService from './services/offenderAssessmentsApiService'
 import HmppsAuthClient from './data/hmppsAuthClient'
 import passportSetup from './authentication/passport'
+import authErrorHandler from './authentication/authErrorHandler'
 
 const RedisStore = connectRedis(session)
 
@@ -172,6 +173,7 @@ export default function createApp(
   )
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
+  app.use(authErrorHandler)
   app.use(errorHandler(config.production))
 
   return app

--- a/server/authentication/authErrorHandler.ts
+++ b/server/authentication/authErrorHandler.ts
@@ -1,0 +1,46 @@
+import type { Request, Response, NextFunction } from 'express'
+
+export enum ErrorType {
+  REQUIRES_SP_USER,
+  REQUIRES_PP_USER,
+  NO_SP_ORG,
+  INVALID_ROLES,
+}
+
+export class AuthError extends Error {
+  constructor(readonly type: ErrorType) {
+    super()
+  }
+}
+
+export default function authErrorHandler(err: Error, req: Request, res: Response, next: NextFunction): void {
+  if (res.headersSent) {
+    return next(err)
+  }
+
+  if (err instanceof AuthError) {
+    const { status, message } = {
+      [ErrorType.REQUIRES_SP_USER]: {
+        status: 403,
+        message: 'Only service providers can view this page.',
+      },
+      [ErrorType.REQUIRES_PP_USER]: {
+        status: 403,
+        message: 'Only probation practitioners can view this page.',
+      },
+      [ErrorType.NO_SP_ORG]: {
+        status: 403,
+        message: 'Your user account is not associated with a service provider organisation.',
+      },
+      [ErrorType.INVALID_ROLES]: {
+        status: 403,
+        message: 'You do not have the required permissions to view this page.',
+      },
+    }[err.type] ?? { status: 401, message: '' }
+
+    res.status(status)
+    return res.render('autherror', { message })
+  }
+
+  return next(err)
+}

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -13,6 +13,10 @@ export default function createErrorHandler(production: boolean) {
       'Error handling request'
     )
 
+    if (res.headersSent) {
+      return next(error)
+    }
+
     res.locals.message = production
       ? 'Something went wrong. The error has been logged. Please try again'
       : error.message

--- a/server/middleware/authorisationMiddleware.test.ts
+++ b/server/middleware/authorisationMiddleware.test.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 
 import authorisationMiddleware from './authorisationMiddleware'
+import { AuthError } from '../authentication/authErrorHandler'
 
 describe('authorisationMiddleware', () => {
   const next = jest.fn()
@@ -36,13 +37,13 @@ describe('authorisationMiddleware', () => {
     expect(authorisationResponse).toEqual(next())
   })
 
-  it('should redirect when user has no authorised roles', () => {
+  it('should throw AuthError when user has no authorised roles', () => {
     const req = createReqWithAuth(true)
     const res = createResWithToken(['SOME_OTHER_ROLES', 'THAT_ARENT_AUTHORISED'])
 
-    const authorisationResponse = authorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
-
-    expect(authorisationResponse).toEqual('authError')
+    expect(() => {
+      authorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
+    }).toThrow(AuthError)
   })
 
   it('should return next when user has authorised role', () => {

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express'
 import logger from '../../log'
+import { AuthError, ErrorType } from '../authentication/authErrorHandler'
 
 export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
   return (req, res, next) => {
@@ -9,8 +10,7 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
 
     if (authorisedRoles.length && !res.locals.user.token.roles.some((role: string) => authorisedRoles.includes(role))) {
       logger.error({ authorisedRoles }, 'user does not have the required role to access this page')
-      res.status(403)
-      return res.render('authError')
+      throw new AuthError(ErrorType.INVALID_ROLES)
     }
 
     return next()

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -49,7 +49,7 @@ export default class ServiceProviderReferralsController {
   ) {}
 
   async showDashboard(req: Request, res: Response): Promise<void> {
-    const serviceProvider = AuthUtils.getSPUserOrganization(res.locals.user)
+    const serviceProvider = AuthUtils.getServiceProviderUserOrganization(res.locals.user)
     const referrals = await this.interventionsService.getReferralsSentToServiceProvider(
       res.locals.user.token.accessToken,
       serviceProvider.id

--- a/server/utils/authUtils.ts
+++ b/server/utils/authUtils.ts
@@ -1,13 +1,15 @@
-import { ServiceProviderOrg, UserDetails } from '../services/userService'
+import { ServiceProviderOrg } from '../services/userService'
+import { AuthError, ErrorType } from '../authentication/authErrorHandler'
+import { User } from '../authentication/passport'
 
-function getSPUserOrganization(userDetails: UserDetails): ServiceProviderOrg {
-  const { organizations } = userDetails
+function getServiceProviderUserOrganization(user: User): ServiceProviderOrg {
+  const { organizations } = user
   if (organizations === undefined) {
-    throw new Error('user is not an SP user')
+    throw new AuthError(ErrorType.REQUIRES_SP_USER)
   }
 
   if (organizations.length === 0) {
-    throw new Error('user is not associated with a service provider organization')
+    throw new AuthError(ErrorType.NO_SP_ORG)
   }
 
   // for now we just take the first listed organization - this will change
@@ -16,5 +18,5 @@ function getSPUserOrganization(userDetails: UserDetails): ServiceProviderOrg {
 }
 
 export default {
-  getSPUserOrganization,
+  getServiceProviderUserOrganization,
 }

--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -6,5 +6,5 @@
 
 {% block content %}
   <h1 class="govuk-heading-l">Authorisation Error</h1>
-  <p>You do not have the required permissions to view this page.</p>
+  <p>{{ message }}</p>
 {% endblock %}


### PR DESCRIPTION
DEPENDS ON #245 so please only review latest commit

## What does this pull request do?

adds a new error subclass `AuthError` which can be used for dealing with a variety of auth error situations
adds a new error handler middleware specifically for errors of type `AuthError` which displays the auth error page with some detailed reason text.

## What is the intent behind these changes?

a) get rid of the generic 500 errors that get returned when `Error` is thrown
b) make the overall UX better for auth stuff