### PR TITLE
IC-1323: Add end of service report contracts

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -132,5 +132,21 @@ module.exports = on => {
     stubSubmitSessionFeedback: arg => {
       return interventionsService.stubSubmitSessionFeedback(arg.actionPlanId, arg.session, arg.responseJson)
     },
+
+    stubGetEndOfServiceReport: arg => {
+      return interventionsService.stubGetEndOfServiceReport(arg.id, arg.responseJson)
+    },
+
+    stubCreateDraftEndOfServiceReport: arg => {
+      return interventionsService.stubCreateDraftEndOfServiceReport(arg.responseJson)
+    },
+
+    stubUpdateDraftEndOfServiceReport: arg => {
+      return interventionsService.stubUpdateDraftEndOfServiceReport(arg.id, arg.responseJson)
+    },
+
+    stubSubmitEndOfServiceReport: arg => {
+      return interventionsService.stubSubmitEndOfServiceReport(arg.id, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -89,3 +89,19 @@ Cypress.Commands.add('stubUpdateActionPlanAppointment', (id, session, responseJs
 Cypress.Commands.add('stubSubmitSessionFeedback', (actionPlanId, session, responseJson) => {
   cy.task('stubSubmitSessionFeedback', { actionPlanId, session, responseJson })
 })
+
+Cypress.Commands.add('stubGetEndOfServiceReport', (id, responseJson) => {
+  cy.task('stubGetEndOfServiceReport', { id, responseJson })
+})
+
+Cypress.Commands.add('stubCreateDraftEndOfServiceReport', responseJson => {
+  cy.task('stubCreateDraftEndOfServiceReport', { responseJson })
+})
+
+Cypress.Commands.add('stubUpdateDraftEndOfServiceReport', (id, responseJson) => {
+  cy.task('stubUpdateDraftEndOfServiceReport', { id, responseJson })
+})
+
+Cypress.Commands.add('stubSubmitEndOfServiceReport', (id, responseJson) => {
+  cy.task('stubSubmitEndOfServiceReport', { id, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -368,4 +368,68 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubCreateDraftEndOfServiceReport = async (responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/draft-end-of-service-report`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  stubUpdateDraftEndOfServiceReport = async (id: string, responseJson: Record<string, unknown>): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/draft-end-of-service-report/${id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  stubSubmitEndOfServiceReport = async (id: string, responseJson: Record<string, unknown>): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/draft-end-of-service-report/${id}/submit`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  stubGetEndOfServiceReport = async (id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/end-of-service-report/${id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -49,6 +49,7 @@ export interface SentReferral {
   sentBy: AuthUser
   assignedTo: AuthUser | null
   actionPlanId: string | null
+  endOfServiceReport: EndOfServiceReport | null
 }
 
 export interface ServiceCategory {
@@ -179,6 +180,35 @@ export interface AppointmentAttendance {
 export interface AppointmentBehaviour {
   behaviourDescription: string | null
   notifyProbationPractitioner: boolean | null
+}
+
+export interface EndOfServiceReport {
+  id: string
+  referralId: string
+  submittedAt: string | null
+  furtherInformation: string | null
+  outcomes: EndOfServiceReportOutcome[]
+}
+
+export type AchievementLevel = 'ACHIEVED' | 'PARTIALLY_ACHIEVED' | 'NOT_ACHIEVED'
+
+export interface EndOfServiceReportOutcome {
+  desiredOutcome: DesiredOutcome
+  achievementLevel: AchievementLevel
+  progressionComments: string
+  additionalTaskComments: string
+}
+
+export interface CreateEndOfServiceReportOutcome {
+  desiredOutcomeId: string
+  achievementLevel: AchievementLevel
+  progressionComments: string
+  additionalTaskComments: string
+}
+
+export interface UpdateDraftEndOfServiceReportParams {
+  furtherInformation: string | null
+  outcome: CreateEndOfServiceReportOutcome | null
 }
 
 export default class InterventionsService {
@@ -523,5 +553,55 @@ export default class InterventionsService {
       path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}/submit`,
       headers: { Accept: 'application/json' },
     })) as ActionPlanAppointment
+  }
+
+  async createDraftEndOfServiceReport(token: string, referralId: string): Promise<EndOfServiceReport> {
+    const restClient = this.createRestClient(token)
+
+    try {
+      return (await restClient.post({
+        path: '/draft-end-of-service-report',
+        headers: { Accept: 'application/json' },
+        data: { referralId },
+      })) as EndOfServiceReport
+    } catch (e) {
+      throw this.createServiceError(e)
+    }
+  }
+
+  async getEndOfServiceReport(token: string, id: string): Promise<EndOfServiceReport> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/end-of-service-report/${id}`,
+      headers: { Accept: 'application/json' },
+    })) as EndOfServiceReport
+  }
+
+  async updateDraftEndOfServiceReport(
+    token: string,
+    id: string,
+    patch: Partial<UpdateDraftEndOfServiceReportParams>
+  ): Promise<EndOfServiceReport> {
+    const restClient = this.createRestClient(token)
+
+    try {
+      return (await restClient.patch({
+        path: `/draft-end-of-service-report/${id}`,
+        headers: { Accept: 'application/json' },
+        data: patch,
+      })) as EndOfServiceReport
+    } catch (e) {
+      throw this.createServiceError(e)
+    }
+  }
+
+  async submitEndOfServiceReport(token: string, id: string): Promise<EndOfServiceReport> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/draft-end-of-service-report/${id}/submit`,
+      headers: { Accept: 'application/json' },
+    })) as EndOfServiceReport
   }
 }

--- a/testutils/factories/endOfServiceReport.ts
+++ b/testutils/factories/endOfServiceReport.ts
@@ -1,0 +1,24 @@
+import { Factory } from 'fishery'
+import { EndOfServiceReport } from '../../server/services/interventionsService'
+
+class EndOfServiceReportFactory extends Factory<EndOfServiceReport> {
+  justCreated() {
+    return this
+  }
+
+  notSubmitted() {
+    return this
+  }
+
+  submitted() {
+    return this.params({ submittedAt: new Date().toISOString() })
+  }
+}
+
+export default EndOfServiceReportFactory.define(({ sequence }) => ({
+  id: sequence.toString(),
+  referralId: '81d754aa-d868-4347-9c0f-50690773014e',
+  submittedAt: null,
+  furtherInformation: null,
+  outcomes: [],
+}))

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -78,4 +78,5 @@ export default SentReferralFactory.define(({ sequence }) => ({
   referral: exampleReferralFields(),
   assignedTo: null,
   actionPlanId: null,
+  endOfServiceReport: null,
 }))


### PR DESCRIPTION
## What does this pull request do?

Adds contracts for the end of service report. These are mainly based on the implementation already written in the interventions service, with one exception (see commit message re `referralId` please, @ministryofjustice/interventions-service).

## What is the intent behind these changes?

To allow us to build the end of service report journey.
