### PR TITLE
IC-1322: Add a route for creating a draft end of service report

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -132,5 +132,21 @@ module.exports = on => {
     stubSubmitSessionFeedback: arg => {
       return interventionsService.stubSubmitSessionFeedback(arg.actionPlanId, arg.session, arg.responseJson)
     },
+
+    stubGetEndOfServiceReport: arg => {
+      return interventionsService.stubGetEndOfServiceReport(arg.id, arg.responseJson)
+    },
+
+    stubCreateDraftEndOfServiceReport: arg => {
+      return interventionsService.stubCreateDraftEndOfServiceReport(arg.responseJson)
+    },
+
+    stubUpdateDraftEndOfServiceReport: arg => {
+      return interventionsService.stubUpdateDraftEndOfServiceReport(arg.id, arg.responseJson)
+    },
+
+    stubSubmitEndOfServiceReport: arg => {
+      return interventionsService.stubSubmitEndOfServiceReport(arg.id, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -89,3 +89,19 @@ Cypress.Commands.add('stubUpdateActionPlanAppointment', (id, session, responseJs
 Cypress.Commands.add('stubSubmitSessionFeedback', (actionPlanId, session, responseJson) => {
   cy.task('stubSubmitSessionFeedback', { actionPlanId, session, responseJson })
 })
+
+Cypress.Commands.add('stubGetEndOfServiceReport', (id, responseJson) => {
+  cy.task('stubGetEndOfServiceReport', { id, responseJson })
+})
+
+Cypress.Commands.add('stubCreateDraftEndOfServiceReport', responseJson => {
+  cy.task('stubCreateDraftEndOfServiceReport', { responseJson })
+})
+
+Cypress.Commands.add('stubUpdateDraftEndOfServiceReport', (id, responseJson) => {
+  cy.task('stubUpdateDraftEndOfServiceReport', { id, responseJson })
+})
+
+Cypress.Commands.add('stubSubmitEndOfServiceReport', (id, responseJson) => {
+  cy.task('stubSubmitEndOfServiceReport', { id, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -368,4 +368,68 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubCreateDraftEndOfServiceReport = async (responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/draft-end-of-service-report`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  stubUpdateDraftEndOfServiceReport = async (id: string, responseJson: Record<string, unknown>): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/draft-end-of-service-report/${id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  stubSubmitEndOfServiceReport = async (id: string, responseJson: Record<string, unknown>): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/draft-end-of-service-report/${id}/submit`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  stubGetEndOfServiceReport = async (id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/end-of-service-report/${id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -131,6 +131,10 @@ export default function routes(router: Router, services: Services): Router {
     '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation',
     (req, res) => serviceProviderReferralsController.showPostSessionFeedbackConfirmation(req, res)
   )
+  post('/service-provider/referrals/:id/end-of-service-report', (req, res) =>
+    serviceProviderReferralsController.createDraftEndOfServiceReport(req, res)
+  )
+
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {
       return staticContentController.index(req, res)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -14,6 +14,7 @@ import MockedHmppsAuthClient from '../../data/testutils/hmppsAuthClientSetup'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
+import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -927,5 +928,19 @@ describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNu
           expect(res.text).toContain('The probation practitioner has been sent a copy of the session feedback form.')
         })
     })
+  })
+})
+
+describe('POST /service-provider/referrals/:id/end-of-service-report', () => {
+  it('creates an end of service report for that referral on the interventions service, and redirects to the first page of the service provider end of service report journey', async () => {
+    const endOfServiceReport = endOfServiceReportFactory.build()
+    interventionsService.createDraftEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+
+    await request(app)
+      .post(`/service-provider/referrals/19/end-of-service-report`)
+      .expect(303)
+      .expect('Location', `/service-provider/end-of-service-report/${endOfServiceReport.id}/outcomes/1`)
+
+    expect(interventionsService.createDraftEndOfServiceReport).toHaveBeenCalledWith('token', '19')
   })
 })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -596,4 +596,13 @@ export default class ServiceProviderReferralsController {
 
     res.render(...view.renderArgs)
   }
+
+  async createDraftEndOfServiceReport(req: Request, res: Response): Promise<void> {
+    const draftEndOfServiceReport = await this.interventionsService.createDraftEndOfServiceReport(
+      res.locals.user.token.accessToken,
+      req.params.id
+    )
+
+    res.redirect(303, `/service-provider/end-of-service-report/${draftEndOfServiceReport.id}/outcomes/1`)
+  }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -49,6 +49,7 @@ export interface SentReferral {
   sentBy: AuthUser
   assignedTo: AuthUser | null
   actionPlanId: string | null
+  endOfServiceReport: EndOfServiceReport | null
 }
 
 export interface ServiceCategory {
@@ -179,6 +180,35 @@ export interface AppointmentAttendance {
 export interface AppointmentBehaviour {
   behaviourDescription: string | null
   notifyProbationPractitioner: boolean | null
+}
+
+export interface EndOfServiceReport {
+  id: string
+  referralId: string
+  submittedAt: string | null
+  furtherInformation: string | null
+  outcomes: EndOfServiceReportOutcome[]
+}
+
+export type AchievementLevel = 'ACHIEVED' | 'PARTIALLY_ACHIEVED' | 'NOT_ACHIEVED'
+
+export interface EndOfServiceReportOutcome {
+  desiredOutcome: DesiredOutcome
+  achievementLevel: AchievementLevel
+  progressionComments: string
+  additionalTaskComments: string
+}
+
+export interface CreateEndOfServiceReportOutcome {
+  desiredOutcomeId: string
+  achievementLevel: AchievementLevel
+  progressionComments: string
+  additionalTaskComments: string
+}
+
+export interface UpdateDraftEndOfServiceReportParams {
+  furtherInformation: string | null
+  outcome: CreateEndOfServiceReportOutcome | null
 }
 
 export default class InterventionsService {
@@ -523,5 +553,55 @@ export default class InterventionsService {
       path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}/submit`,
       headers: { Accept: 'application/json' },
     })) as ActionPlanAppointment
+  }
+
+  async createDraftEndOfServiceReport(token: string, referralId: string): Promise<EndOfServiceReport> {
+    const restClient = this.createRestClient(token)
+
+    try {
+      return (await restClient.post({
+        path: '/draft-end-of-service-report',
+        headers: { Accept: 'application/json' },
+        data: { referralId },
+      })) as EndOfServiceReport
+    } catch (e) {
+      throw this.createServiceError(e)
+    }
+  }
+
+  async getEndOfServiceReport(token: string, id: string): Promise<EndOfServiceReport> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/end-of-service-report/${id}`,
+      headers: { Accept: 'application/json' },
+    })) as EndOfServiceReport
+  }
+
+  async updateDraftEndOfServiceReport(
+    token: string,
+    id: string,
+    patch: Partial<UpdateDraftEndOfServiceReportParams>
+  ): Promise<EndOfServiceReport> {
+    const restClient = this.createRestClient(token)
+
+    try {
+      return (await restClient.patch({
+        path: `/draft-end-of-service-report/${id}`,
+        headers: { Accept: 'application/json' },
+        data: patch,
+      })) as EndOfServiceReport
+    } catch (e) {
+      throw this.createServiceError(e)
+    }
+  }
+
+  async submitEndOfServiceReport(token: string, id: string): Promise<EndOfServiceReport> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/draft-end-of-service-report/${id}/submit`,
+      headers: { Accept: 'application/json' },
+    })) as EndOfServiceReport
   }
 }

--- a/testutils/factories/endOfServiceReport.ts
+++ b/testutils/factories/endOfServiceReport.ts
@@ -1,0 +1,24 @@
+import { Factory } from 'fishery'
+import { EndOfServiceReport } from '../../server/services/interventionsService'
+
+class EndOfServiceReportFactory extends Factory<EndOfServiceReport> {
+  justCreated() {
+    return this
+  }
+
+  notSubmitted() {
+    return this
+  }
+
+  submitted() {
+    return this.params({ submittedAt: new Date().toISOString() })
+  }
+}
+
+export default EndOfServiceReportFactory.define(({ sequence }) => ({
+  id: sequence.toString(),
+  referralId: '81d754aa-d868-4347-9c0f-50690773014e',
+  submittedAt: null,
+  furtherInformation: null,
+  outcomes: [],
+}))

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -78,4 +78,5 @@ export default SentReferralFactory.define(({ sequence }) => ({
   referral: exampleReferralFields(),
   assignedTo: null,
   actionPlanId: null,
+  endOfServiceReport: null,
 }))


### PR DESCRIPTION
<strong>This is dependent on https://github.com/ministryofjustice/hmpps-interventions-ui/pull/249 — please only review the final commit here.</strong>

## What does this pull request do?

Adds a route that creates a draft end of service report. This will be the first part of the end of service report journey.

This is one of many bite-sized PRs to come. I'll add the integration test once I've built the whole journey.

## What is the intent behind these changes?

To build the end of service report journey.