### PR TITLE
IC-1530: Make answers components reusable

### DIFF
--- a/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.test.ts
@@ -31,239 +31,27 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
     })
   })
 
-  describe('attendedAnswers', () => {
-    const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
-
-    it('returns an object with the question and answer given', () => {
+  describe('sessionDetailsSummary', () => {
+    it('extracts the date and time from the appointmentTime and puts it in a SummaryList format', () => {
+      const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
+      const serviceUser = deliusServiceUserFactory.build()
       const appointment = actionPlanAppointmentFactory.build({
-        sessionFeedback: {
-          attendance: {
-            attended: 'yes',
-          },
-          behaviour: {
-            behaviourDescription: null,
-            notifyProbationPractitioner: null,
-          },
-        },
+        appointmentTime: '2021-02-01T13:00:00Z',
       })
-      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
       const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
 
-      expect(presenter.attendedAnswers).toEqual({
-        question: 'Did Alex attend this session?',
-        answer: 'Yes, they were on time',
-      })
-    })
-
-    describe('when there is no value for attended', () => {
-      it('returns null', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
-              attended: null,
-            },
-            behaviour: {
-              behaviourDescription: null,
-              notifyProbationPractitioner: null,
-            },
-          },
-        })
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
-        expect(presenter.attendedAnswers).toBeNull()
-      })
-    })
-  })
-
-  describe('additionalAttendanceAnswers', () => {
-    const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
-
-    describe('when there is an answer for AdditionalAttendanceInformation', () => {
-      it('returns an object with the question and answer given', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
-              attended: 'late',
-              additionalAttendanceInformation: 'Alex missed the bus',
-            },
-            behaviour: {
-              behaviourDescription: null,
-              notifyProbationPractitioner: null,
-            },
-          },
-        })
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
-
-        expect(presenter.additionalAttendanceAnswers).toEqual({
-          question: "Add additional information about Alex's attendance:",
-          answer: 'Alex missed the bus',
-        })
-      })
-    })
-
-    describe('when there is no answer for AdditionalAttendanceInformation', () => {
-      it('returns an object with "None" as the answer', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
-              attended: 'late',
-              additionalAttendanceInformation: '',
-            },
-            behaviour: {
-              behaviourDescription: null,
-              notifyProbationPractitioner: null,
-            },
-          },
-        })
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
-
-        expect(presenter.additionalAttendanceAnswers).toEqual({
-          question: "Add additional information about Alex's attendance:",
-          answer: 'None',
-        })
-      })
-    })
-
-    describe('when there is a null value for AdditionalAttendanceInformation', () => {
-      it('returns null', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
-              attended: 'late',
-              additionalAttendanceInformation: null,
-            },
-            behaviour: {
-              behaviourDescription: null,
-              notifyProbationPractitioner: null,
-            },
-          },
-        })
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
-        expect(presenter.additionalAttendanceAnswers).toBeNull()
-      })
-    })
-  })
-
-  describe('behaviourDescriptionAnswers', () => {
-    const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
-
-    describe('if the behaviour question was answered', () => {
-      it('returns an object with the question and answer given', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
-              attended: 'yes',
-            },
-            behaviour: {
-              behaviourDescription: 'Alex had a bad attitude',
-              notifyProbationPractitioner: true,
-            },
-          },
-        })
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
-
-        expect(presenter.behaviourDescriptionAnswers).toEqual({
-          question: "Describe Alex's behaviour in this session",
-          answer: 'Alex had a bad attitude',
-        })
-      })
-    })
-
-    describe('if the behaviour question was not answered', () => {
-      it('returns null', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
-              attended: 'yes',
-            },
-            behaviour: {
-              behaviourDescription: null,
-              notifyProbationPractitioner: null,
-            },
-          },
-        })
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
-
-        expect(presenter.behaviourDescriptionAnswers).toBeNull()
-      })
-    })
-  })
-
-  describe('notifyProbationPractitionerAnswers', () => {
-    const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
-
-    describe('if the behaviour question was answered with yes', () => {
-      it('returns an object with the question and answer given, converting the boolean value into a "yes"', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            behaviour: {
-              behaviourDescription: 'Alex had a bad attitude',
-              notifyProbationPractitioner: true,
-            },
-          },
-        })
-
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
-
-        expect(presenter.notifyProbationPractitionerAnswers).toEqual({
-          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-          answer: 'Yes',
-        })
-      })
-    })
-
-    describe('if the behaviour question was answered with no', () => {
-      it('returns an object with the question and answer given, converting the boolean value into a "no"', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            behaviour: {
-              behaviourDescription: 'Alex had a good attitude',
-              notifyProbationPractitioner: false,
-            },
-          },
-        })
-
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
-
-        expect(presenter.notifyProbationPractitionerAnswers).toEqual({
-          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-          answer: 'No',
-        })
-      })
-    })
-
-    describe('if the behaviour question was not answered', () => {
-      it('returns null', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            behaviour: {
-              behaviourDescription: null,
-              notifyProbationPractitioner: null,
-            },
-          },
-        })
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new PostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
-
-        expect(presenter.notifyProbationPractitionerAnswers).toBeNull()
-      })
+      expect(presenter.sessionDetailsSummary).toEqual([
+        {
+          key: 'Date',
+          lines: ['01 Feb 2021'],
+          isList: false,
+        },
+        {
+          key: 'Time',
+          lines: ['13:00'],
+          isList: false,
+        },
+      ])
     })
   })
 

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.ts
@@ -1,22 +1,19 @@
 import { DeliusServiceUser } from '../../services/communityApiService'
 import { ActionPlanAppointment } from '../../services/interventionsService'
+import DateUtils from '../../utils/dateUtils'
 import { SummaryListItem } from '../../utils/summaryList'
+import FeedbackAnswersPresenter from '../shared/feedbackAnswersPresenter'
 import ServiceUserBannerPresenter from '../shared/serviceUserBannerPresenter'
-import PostSessionAttendanceFeedbackPresenter from './postSessionAttendanceFeedbackPresenter'
-import PostSessionBehaviourFeedbackPresenter from './postSessionBehaviourFeedbackPresenter'
 
 export default class PostSessionFeedbackCheckAnswersPresenter {
-  private readonly attendancePresenter: PostSessionAttendanceFeedbackPresenter
-
-  private readonly behaviourPresenter: PostSessionBehaviourFeedbackPresenter
+  readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
 
   constructor(
     private readonly appointment: ActionPlanAppointment,
     private readonly serviceUser: DeliusServiceUser,
     private readonly actionPlanId: string
   ) {
-    this.attendancePresenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
-    this.behaviourPresenter = new PostSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+    this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(this.appointment, this.serviceUser)
   }
 
   readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
@@ -27,57 +24,16 @@ export default class PostSessionFeedbackCheckAnswersPresenter {
     title: `Confirm feedback`,
   }
 
-  get attendedAnswers(): { question: string; answer: string } | null {
-    if (this.appointment.sessionFeedback.attendance.attended === null) {
-      return null
-    }
-
-    const selectedRadio = this.attendancePresenter.attendanceResponses.find(response => response.checked)
-
-    if (!selectedRadio) {
-      return null
-    }
-
-    return {
-      question: this.attendancePresenter.text.attendanceQuestion,
-      answer: selectedRadio.text,
-    }
-  }
-
-  get additionalAttendanceAnswers(): { question: string; answer: string } | null {
-    if (this.appointment.sessionFeedback.attendance.additionalAttendanceInformation === null) {
-      return null
-    }
-
-    return {
-      question: this.attendancePresenter.text.additionalAttendanceInformationLabel,
-      answer: this.appointment.sessionFeedback.attendance.additionalAttendanceInformation || 'None',
-    }
-  }
-
-  get behaviourDescriptionAnswers(): { question: string; answer: string } | null {
-    if (this.appointment.sessionFeedback.behaviour.behaviourDescription === null) {
-      return null
-    }
-
-    return {
-      question: this.behaviourPresenter.text.behaviourDescription.question,
-      answer: this.appointment.sessionFeedback.behaviour.behaviourDescription,
-    }
-  }
-
-  get notifyProbationPractitionerAnswers(): { question: string; answer: string } | null {
-    if (this.appointment.sessionFeedback.behaviour.notifyProbationPractitioner === null) {
-      return null
-    }
-
-    return {
-      question: this.behaviourPresenter.text.notifyProbationPractitioner.question,
-      answer: this.appointment.sessionFeedback.behaviour.notifyProbationPractitioner ? 'Yes' : 'No',
-    }
-  }
-
-  get sessionDetailsSummary(): SummaryListItem[] {
-    return this.attendancePresenter.sessionDetailsSummary
-  }
+  readonly sessionDetailsSummary: SummaryListItem[] = [
+    {
+      key: 'Date',
+      lines: [DateUtils.getDateStringFromDateTimeString(this.appointment.appointmentTime)],
+      isList: false,
+    },
+    {
+      key: 'Time',
+      lines: [DateUtils.getTimeStringFromDateTimeString(this.appointment.appointmentTime)],
+      isList: false,
+    },
+  ]
 }

--- a/server/routes/shared/feedbackAnswersPresenter.test.ts
+++ b/server/routes/shared/feedbackAnswersPresenter.test.ts
@@ -1,0 +1,233 @@
+import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
+import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import FeedbackAnswersPresenter from './feedbackAnswersPresenter'
+
+describe(FeedbackAnswersPresenter, () => {
+  describe('attendedAnswers', () => {
+    it('returns an object with the question and answer given', () => {
+      const appointment = actionPlanAppointmentFactory.build({
+        sessionFeedback: {
+          attendance: {
+            attended: 'yes',
+          },
+          behaviour: {
+            behaviourDescription: null,
+            notifyProbationPractitioner: null,
+          },
+        },
+      })
+      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+      const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
+
+      expect(presenter.attendedAnswers).toEqual({
+        question: 'Did Alex attend this session?',
+        answer: 'Yes, they were on time',
+      })
+    })
+
+    describe('when there is no value for attended', () => {
+      it('returns null', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: null,
+            },
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
+        expect(presenter.attendedAnswers).toBeNull()
+      })
+    })
+  })
+
+  describe('additionalAttendanceAnswers', () => {
+    describe('when there is an answer for AdditionalAttendanceInformation', () => {
+      it('returns an object with the question and answer given', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: 'late',
+              additionalAttendanceInformation: 'Alex missed the bus',
+            },
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.additionalAttendanceAnswers).toEqual({
+          question: "Add additional information about Alex's attendance:",
+          answer: 'Alex missed the bus',
+        })
+      })
+    })
+
+    describe('when there is no answer for AdditionalAttendanceInformation', () => {
+      it('returns an object with "None" as the answer', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: 'late',
+              additionalAttendanceInformation: '',
+            },
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.additionalAttendanceAnswers).toEqual({
+          question: "Add additional information about Alex's attendance:",
+          answer: 'None',
+        })
+      })
+    })
+
+    describe('when there is a null value for AdditionalAttendanceInformation', () => {
+      it('returns null', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: 'late',
+              additionalAttendanceInformation: null,
+            },
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
+        expect(presenter.additionalAttendanceAnswers).toBeNull()
+      })
+    })
+  })
+
+  describe('behaviourDescriptionAnswers', () => {
+    describe('if the behaviour question was answered', () => {
+      it('returns an object with the question and answer given', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: 'yes',
+            },
+            behaviour: {
+              behaviourDescription: 'Alex had a bad attitude',
+              notifyProbationPractitioner: true,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.behaviourDescriptionAnswers).toEqual({
+          question: "Describe Alex's behaviour in this session",
+          answer: 'Alex had a bad attitude',
+        })
+      })
+    })
+
+    describe('if the behaviour question was not answered', () => {
+      it('returns null', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            attendance: {
+              attended: 'yes',
+            },
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.behaviourDescriptionAnswers).toBeNull()
+      })
+    })
+  })
+
+  describe('notifyProbationPractitionerAnswers', () => {
+    describe('if the behaviour question was answered with yes', () => {
+      it('returns an object with the question and answer given, converting the boolean value into a "yes"', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            behaviour: {
+              behaviourDescription: 'Alex had a bad attitude',
+              notifyProbationPractitioner: true,
+            },
+          },
+        })
+
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.notifyProbationPractitionerAnswers).toEqual({
+          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+          answer: 'Yes',
+        })
+      })
+    })
+
+    describe('if the behaviour question was answered with no', () => {
+      it('returns an object with the question and answer given, converting the boolean value into a "no"', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            behaviour: {
+              behaviourDescription: 'Alex had a good attitude',
+              notifyProbationPractitioner: false,
+            },
+          },
+        })
+
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.notifyProbationPractitionerAnswers).toEqual({
+          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+          answer: 'No',
+        })
+      })
+    })
+
+    describe('if the behaviour question was not answered', () => {
+      it('returns null', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          sessionFeedback: {
+            behaviour: {
+              behaviourDescription: null,
+              notifyProbationPractitioner: null,
+            },
+          },
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
+
+        expect(presenter.notifyProbationPractitionerAnswers).toBeNull()
+      })
+    })
+  })
+})

--- a/server/routes/shared/feedbackAnswersPresenter.ts
+++ b/server/routes/shared/feedbackAnswersPresenter.ts
@@ -1,0 +1,65 @@
+import { DeliusServiceUser } from '../../services/communityApiService'
+import { ActionPlanAppointment } from '../../services/interventionsService'
+import PostSessionAttendanceFeedbackPresenter from '../serviceProviderReferrals/postSessionAttendanceFeedbackPresenter'
+import PostSessionBehaviourFeedbackPresenter from '../serviceProviderReferrals/postSessionBehaviourFeedbackPresenter'
+
+export default class FeedbackAnswersPresenter {
+  private readonly attendancePresenter: PostSessionAttendanceFeedbackPresenter
+
+  private readonly behaviourPresenter: PostSessionBehaviourFeedbackPresenter
+
+  constructor(private readonly appointment: ActionPlanAppointment, private readonly serviceUser: DeliusServiceUser) {
+    this.attendancePresenter = new PostSessionAttendanceFeedbackPresenter(this.appointment, this.serviceUser)
+    this.behaviourPresenter = new PostSessionBehaviourFeedbackPresenter(this.appointment, this.serviceUser)
+  }
+
+  get attendedAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.sessionFeedback.attendance.attended === null) {
+      return null
+    }
+
+    const selectedRadio = this.attendancePresenter.attendanceResponses.find(response => response.checked)
+
+    if (!selectedRadio) {
+      return null
+    }
+
+    return {
+      question: this.attendancePresenter.text.attendanceQuestion,
+      answer: selectedRadio.text,
+    }
+  }
+
+  get additionalAttendanceAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.sessionFeedback.attendance.additionalAttendanceInformation === null) {
+      return null
+    }
+
+    return {
+      question: this.attendancePresenter.text.additionalAttendanceInformationLabel,
+      answer: this.appointment.sessionFeedback.attendance.additionalAttendanceInformation || 'None',
+    }
+  }
+
+  get behaviourDescriptionAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.sessionFeedback.behaviour.behaviourDescription === null) {
+      return null
+    }
+
+    return {
+      question: this.behaviourPresenter.text.behaviourDescription.question,
+      answer: this.appointment.sessionFeedback.behaviour.behaviourDescription,
+    }
+  }
+
+  get notifyProbationPractitionerAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.sessionFeedback.behaviour.notifyProbationPractitioner === null) {
+      return null
+    }
+
+    return {
+      question: this.behaviourPresenter.text.notifyProbationPractitioner.question,
+      answer: this.appointment.sessionFeedback.behaviour.notifyProbationPractitioner ? 'Yes' : 'No',
+    }
+  }
+}

--- a/server/views/partials/postSessionFeedbackResponses.njk
+++ b/server/views/partials/postSessionFeedbackResponses.njk
@@ -1,19 +1,21 @@
-{% if presenter.attendedAnswers %}
-  <h3 class="govuk-heading-s">{{ presenter.attendedAnswers.question }}</h3>
-  <p>{{ presenter.attendedAnswers.answer }}</p>
+{% set feedbackAnswersPresenter = presenter.feedbackAnswersPresenter %}
+
+{% if feedbackAnswersPresenter.attendedAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.attendedAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.attendedAnswers.answer }}</p>
 {% endif %}
 
-{% if presenter.additionalAttendanceAnswers %}
-  <h3 class="govuk-heading-s">{{ presenter.additionalAttendanceAnswers.question }}</h3>
-  <p>{{ presenter.additionalAttendanceAnswers.answer }}</p>
+{% if feedbackAnswersPresenter.additionalAttendanceAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.additionalAttendanceAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.additionalAttendanceAnswers.answer }}</p>
 {% endif %}
 
-{% if presenter.behaviourDescriptionAnswers %}
-  <h3 class="govuk-heading-s">{{ presenter.behaviourDescriptionAnswers.question }}</h3>
-  <p>{{ presenter.behaviourDescriptionAnswers.answer }}</p>
+{% if feedbackAnswersPresenter.behaviourDescriptionAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.behaviourDescriptionAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.behaviourDescriptionAnswers.answer }}</p>
 {% endif %}
 
-{% if presenter.notifyProbationPractitionerAnswers %}
-  <h3 class="govuk-heading-s">{{ presenter.notifyProbationPractitionerAnswers.question }}</h3>
-  <p>{{ presenter.notifyProbationPractitionerAnswers.answer }}</p>
+{% if feedbackAnswersPresenter.notifyProbationPractitionerAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.notifyProbationPractitionerAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.notifyProbationPractitionerAnswers.answer }}</p>
 {% endif %}

--- a/server/views/partials/postSessionFeedbackResponses.njk
+++ b/server/views/partials/postSessionFeedbackResponses.njk
@@ -1,0 +1,19 @@
+{% if presenter.attendedAnswers %}
+  <h3 class="govuk-heading-s">{{ presenter.attendedAnswers.question }}</h3>
+  <p>{{ presenter.attendedAnswers.answer }}</p>
+{% endif %}
+
+{% if presenter.additionalAttendanceAnswers %}
+  <h3 class="govuk-heading-s">{{ presenter.additionalAttendanceAnswers.question }}</h3>
+  <p>{{ presenter.additionalAttendanceAnswers.answer }}</p>
+{% endif %}
+
+{% if presenter.behaviourDescriptionAnswers %}
+  <h3 class="govuk-heading-s">{{ presenter.behaviourDescriptionAnswers.question }}</h3>
+  <p>{{ presenter.behaviourDescriptionAnswers.answer }}</p>
+{% endif %}
+
+{% if presenter.notifyProbationPractitionerAnswers %}
+  <h3 class="govuk-heading-s">{{ presenter.notifyProbationPractitionerAnswers.question }}</h3>
+  <p>{{ presenter.notifyProbationPractitionerAnswers.answer }}</p>
+{% endif %}

--- a/server/views/serviceProviderReferrals/postSessionFeedbackCheckAnswers.njk
+++ b/server/views/serviceProviderReferrals/postSessionFeedbackCheckAnswers.njk
@@ -1,7 +1,5 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% extends "./actionPlan/actionPlanFormTemplate.njk" %}
 
@@ -10,25 +8,7 @@
 
   <br>
 
-  {% if presenter.attendedAnswers %}
-    <h3 class="govuk-heading-s">{{ presenter.attendedAnswers.question }}</h3>
-    <p>{{ presenter.attendedAnswers.answer }}</p>
-  {% endif %}
-
-  {% if presenter.additionalAttendanceAnswers %}
-    <h3 class="govuk-heading-s">{{ presenter.additionalAttendanceAnswers.question }}</h3>
-    <p>{{ presenter.additionalAttendanceAnswers.answer }}</p>
-  {% endif %}
-
-  {% if presenter.behaviourDescriptionAnswers %}
-    <h3 class="govuk-heading-s">{{ presenter.behaviourDescriptionAnswers.question }}</h3>
-    <p>{{ presenter.behaviourDescriptionAnswers.answer }}</p>
-  {% endif %}
-
-  {% if presenter.notifyProbationPractitionerAnswers %}
-    <h3 class="govuk-heading-s">{{ presenter.notifyProbationPractitionerAnswers.question }}</h3>
-    <p>{{ presenter.notifyProbationPractitionerAnswers.answer }}</p>
-  {% endif %}
+  {% include "../partials/postSessionFeedbackResponses.njk" %}
 
   <form method="post" action="{{ presenter.submitHref }}">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">


### PR DESCRIPTION
## What does this pull request do?

- Creates new session feedback partial that can be used on the "Check your Answers" page and the soon-to-be-added "View Feedback" page.
- Extracts answers that we want to render across both pages into a "FeedbackAnswersPresenter" that can be used on both screens.

## What is the intent behind these changes?

To create re-usable components that we can use in the upcoming "View Feedback" page.
