### PR TITLE
IC-1530: Add SP and PP pages for viewing submitted post session feedback

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -169,6 +169,7 @@ describe('Probation Practitioner monitor journey', () => {
 
       cy.contains('View feedback form').click()
 
+      cy.contains('john.smith')
       cy.contains('Alex attended the session')
       cy.contains('Yes, they were on time')
       cy.contains('Alex was well-behaved')

--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -109,4 +109,70 @@ describe('Probation Practitioner monitor journey', () => {
         ])
     })
   })
+
+  describe('Viewing session feedback', () => {
+    it('allows users to click through to a page to view session feedback', () => {
+      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const referralParams = {
+        id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
+        referral: { serviceCategoryId: serviceCategory.id },
+      }
+      const deliusServiceUser = deliusServiceUserFactory.build()
+      const probationPractitioner = deliusUserFactory.build({
+        firstName: 'John',
+        surname: 'Smith',
+        username: 'john.smith',
+      })
+      const actionPlan = actionPlanFactory.submitted().build({
+        referralId: referralParams.id,
+        numberOfSessions: 4,
+      })
+
+      const assignedReferral = sentReferralFactory.assigned().build({
+        ...referralParams,
+        assignedTo: { username: probationPractitioner.username },
+        actionPlanId: actionPlan.id,
+      })
+
+      cy.stubGetDraftReferralsForUser([])
+
+      cy.stubGetSentReferrals([assignedReferral])
+      cy.stubGetActionPlan(actionPlan.id, actionPlan)
+      cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+      cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+      cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+      cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
+
+      const appointmentsWithSubmittedFeedback = [
+        actionPlanAppointmentFactory.scheduled().build({
+          sessionNumber: 1,
+          sessionFeedback: {
+            attendance: {
+              attended: 'yes',
+              additionalAttendanceInformation: 'Alex attended the session',
+            },
+            behaviour: {
+              behaviourDescription: 'Alex was well-behaved',
+              notifyProbationPractitioner: false,
+            },
+            submitted: true,
+          },
+        }),
+      ]
+
+      cy.stubGetActionPlanAppointments(actionPlan.id, appointmentsWithSubmittedFeedback)
+      cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointmentsWithSubmittedFeedback[0])
+
+      cy.login()
+
+      cy.visit(`/probation-practitioner/referrals/${assignedReferral.id}/progress`)
+
+      cy.contains('View feedback form').click()
+
+      cy.contains('Alex attended the session')
+      cy.contains('Yes, they were on time')
+      cy.contains('Alex was well-behaved')
+      cy.contains('No')
+    })
+  })
 })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -157,6 +157,10 @@ export default function routes(router: Router, services: Services): Router {
   get('/probation-practitioner/referrals/:id/progress', (req, res) =>
     probationPractitionerReferralsController.showInterventionProgress(req, res)
   )
+  get(
+    '/probation-practitioner/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback',
+    (req, res) => probationPractitionerReferralsController.viewSubmittedPostSessionFeedback(req, res)
+  )
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
   get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -131,6 +131,9 @@ export default function routes(router: Router, services: Services): Router {
     '/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation',
     (req, res) => serviceProviderReferralsController.showPostSessionFeedbackConfirmation(req, res)
   )
+  get('/service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', (req, res) =>
+    serviceProviderReferralsController.viewSubmittedPostSessionFeedback(req, res)
+  )
   post('/service-provider/referrals/:id/end-of-service-report', (req, res) =>
     serviceProviderReferralsController.createDraftEndOfServiceReport(req, res)
   )

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -81,7 +81,7 @@ describe(InterventionProgressPresenter, () => {
                 text: 'completed',
                 classes: 'govuk-tag--green',
               },
-              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
+              linkHtml: `<a class="govuk-link" href="/probation-practitioner/action-plan/${referral.actionPlanId}/appointment/1/post-session-feedback">View feedback form</a>`,
             },
             {
               sessionNumber: 2,
@@ -90,7 +90,7 @@ describe(InterventionProgressPresenter, () => {
                 text: 'completed',
                 classes: 'govuk-tag--green',
               },
-              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
+              linkHtml: `<a class="govuk-link" href="/probation-practitioner/action-plan/${referral.actionPlanId}/appointment/2/post-session-feedback">View feedback form</a>`,
             },
           ])
         })
@@ -112,7 +112,7 @@ describe(InterventionProgressPresenter, () => {
                 text: 'did not attend',
                 classes: 'govuk-tag--purple',
               },
-              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
+              linkHtml: `<a class="govuk-link" href="/probation-practitioner/action-plan/${referral.actionPlanId}/appointment/1/post-session-feedback">View feedback form</a>`,
             },
           ])
         })

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -61,13 +61,13 @@ export default class InterventionProgressPresenter {
         return {
           text: presenter.text,
           tagClass: presenter.tagClass,
-          linkHTML: `<a class="govuk-link" href="#">View feedback form</a>`,
+          linkHTML: `<a class="govuk-link" href="/probation-practitioner/action-plan/${this.referral.actionPlanId}/appointment/${appointment.sessionNumber}/post-session-feedback">View feedback form</a>`,
         }
       case SessionStatus.completed:
         return {
           text: presenter.text,
           tagClass: presenter.tagClass,
-          linkHTML: `<a class="govuk-link" href="#">View feedback form</a>`,
+          linkHTML: `<a class="govuk-link" href="/probation-practitioner/action-plan/${this.referral.actionPlanId}/appointment/${appointment.sessionNumber}/post-session-feedback">View feedback form</a>`,
         }
       case SessionStatus.scheduled:
         return {

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -86,7 +86,7 @@ describe('GET /probation-practitioner/referrals/:id/progress', () => {
 describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', () => {
   it('renders a page displaying feedback answers', async () => {
     const actionPlanId = '05f39e99-b5c7-4a9b-a857-bec04a28eb34'
-    const referral = sentReferralFactory.assigned().build({ actionPlanId })
+    const referral = sentReferralFactory.assigned().build({ actionPlanId, assignedTo: { username: 'Kay.Swerker' } })
     const submittedActionPlan = actionPlanFactory
       .submitted()
       .build({ id: actionPlanId, referralId: referral.id, numberOfSessions: 1 })
@@ -119,6 +119,7 @@ describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:ses
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('View feedback')
+        expect(res.text).toContain('Kay.Swerker')
         expect(res.text).toContain('They were early to the session')
         expect(res.text).toContain('Yes, they were on time')
         expect(res.text).toContain('Alex was well-behaved')

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -7,6 +7,8 @@ import apiConfig from '../../config'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import actionPlanFactory from '../../../testutils/factories/actionPlan'
+import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 
 import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
 import CommunityApiService from '../../services/communityApiService'
@@ -77,6 +79,50 @@ describe('GET /probation-practitioner/referrals/:id/progress', () => {
       .expect(res => {
         expect(res.text).toContain('Intervention sessions')
         expect(res.text).toContain('These show the progress of each intervention session')
+      })
+  })
+})
+
+describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', () => {
+  it('renders a page displaying feedback answers', async () => {
+    const actionPlanId = '05f39e99-b5c7-4a9b-a857-bec04a28eb34'
+    const referral = sentReferralFactory.assigned().build({ actionPlanId })
+    const submittedActionPlan = actionPlanFactory
+      .submitted()
+      .build({ id: actionPlanId, referralId: referral.id, numberOfSessions: 1 })
+    const serviceUser = deliusServiceUserFactory.build()
+
+    const appointmentWithSubmittedFeedback = actionPlanAppointmentFactory.build({
+      sessionNumber: 1,
+      sessionFeedback: {
+        attendance: {
+          attended: 'yes',
+          additionalAttendanceInformation: 'They were early to the session',
+        },
+        behaviour: {
+          behaviourDescription: 'Alex was well-behaved',
+          notifyProbationPractitioner: false,
+        },
+        submitted: true,
+      },
+    })
+
+    communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+    interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
+
+    await request(app)
+      .get(
+        `/probation-practitioner/action-plan/${actionPlanId}/appointment/${appointmentWithSubmittedFeedback.sessionNumber}/post-session-feedback`
+      )
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('View feedback')
+        expect(res.text).toContain('They were early to the session')
+        expect(res.text).toContain('Yes, they were on time')
+        expect(res.text).toContain('Alex was well-behaved')
+        expect(res.text).toContain('No')
       })
   })
 })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -102,7 +102,11 @@ export default class ProbationPractitionerReferralsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new SubmittedPostSessionFeedbackPresenter(currentAppointment, serviceUser)
+    if (!referral.assignedTo) {
+      throw new Error('Referral has not yet been assigned to a caseworker')
+    }
+
+    const presenter = new SubmittedPostSessionFeedbackPresenter(currentAppointment, serviceUser, referral.assignedTo)
     const view = new SubmittedPostSessionFeedbackView(presenter)
 
     return res.render(...view.renderArgs)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -8,6 +8,8 @@ import MyCasesView from './myCasesView'
 import MyCasesPresenter from './myCasesPresenter'
 import FindStartView from './findStartView'
 import AuthUtils from '../../utils/authUtils'
+import SubmittedPostSessionFeedbackPresenter from '../shared/submittedPostSessionFeedbackPresenter'
+import SubmittedPostSessionFeedbackView from '../shared/submittedPostSessionFeedbackView'
 
 export default class ProbationPractitionerReferralsController {
   constructor(
@@ -82,5 +84,27 @@ export default class ProbationPractitionerReferralsController {
     const view = new InterventionProgressView(presenter)
 
     res.render(...view.renderArgs)
+  }
+
+  async viewSubmittedPostSessionFeedback(req: Request, res: Response): Promise<void> {
+    const { user } = res.locals
+    const { accessToken } = user.token
+    const { actionPlanId, sessionNumber } = req.params
+
+    const actionPlan = await this.interventionsService.getActionPlan(accessToken, actionPlanId)
+    const referral = await this.interventionsService.getSentReferral(accessToken, actionPlan.referralId)
+
+    const currentAppointment = await this.interventionsService.getActionPlanAppointment(
+      accessToken,
+      actionPlanId,
+      Number(sessionNumber)
+    )
+
+    const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
+
+    const presenter = new SubmittedPostSessionFeedbackPresenter(currentAppointment, serviceUser)
+    const view = new SubmittedPostSessionFeedbackView(presenter)
+
+    return res.render(...view.renderArgs)
   }
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -98,7 +98,8 @@ describe(InterventionProgressPresenter, () => {
                 text: 'completed',
                 classes: 'govuk-tag--green',
               },
-              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
+              linkHtml:
+                '<a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/1/post-session-feedback">View feedback form</a>',
             },
             {
               sessionNumber: 2,
@@ -107,7 +108,8 @@ describe(InterventionProgressPresenter, () => {
                 text: 'completed',
                 classes: 'govuk-tag--green',
               },
-              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
+              linkHtml:
+                '<a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/2/post-session-feedback">View feedback form</a>',
             },
           ])
         })
@@ -131,7 +133,8 @@ describe(InterventionProgressPresenter, () => {
                 text: 'did not attend',
                 classes: 'govuk-tag--purple',
               },
-              linkHtml: '<a class="govuk-link" href="#">View feedback form</a>',
+              linkHtml:
+                '<a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/1/post-session-feedback">View feedback form</a>',
             },
           ])
         })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -77,13 +77,17 @@ export default class InterventionProgressPresenter {
         return {
           text: presenter.text,
           tagClass: presenter.tagClass,
-          linkHTML: `<a class="govuk-link" href="#">View feedback form</a>`,
+          linkHTML: `<a class="govuk-link" href="/service-provider/action-plan/${this.actionPlan!.id}/appointment/${
+            appointment.sessionNumber
+          }/post-session-feedback">View feedback form</a>`,
         }
       case SessionStatus.completed:
         return {
           text: presenter.text,
           tagClass: presenter.tagClass,
-          linkHTML: `<a class="govuk-link" href="#">View feedback form</a>`,
+          linkHTML: `<a class="govuk-link" href="/service-provider/action-plan/${this.actionPlan!.id}/appointment/${
+            appointment.sessionNumber
+          }/post-session-feedback">View feedback form</a>`,
         }
       case SessionStatus.scheduled:
         return {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -931,6 +931,45 @@ describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNu
   })
 })
 
+describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', () => {
+  it('renders a page displaying feedback answers', async () => {
+    const referral = sentReferralFactory.assigned().build()
+    const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id, numberOfSessions: 1 })
+    const serviceUser = deliusServiceUser.build()
+
+    const appointmentWithSubmittedFeedback = actionPlanAppointmentFactory.build({
+      sessionNumber: 1,
+      sessionFeedback: {
+        attendance: {
+          attended: 'yes',
+          additionalAttendanceInformation: 'They were early to the session',
+        },
+        behaviour: {
+          behaviourDescription: 'Alex was well-behaved',
+          notifyProbationPractitioner: false,
+        },
+        submitted: true,
+      },
+    })
+
+    communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+    interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
+
+    await request(app)
+      .get(`/service-provider/action-plan/${submittedActionPlan.id}/appointment/1/post-session-feedback`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('View feedback')
+        expect(res.text).toContain('They were early to the session')
+        expect(res.text).toContain('Yes, they were on time')
+        expect(res.text).toContain('Alex was well-behaved')
+        expect(res.text).toContain('No')
+      })
+  })
+})
+
 describe('POST /service-provider/referrals/:id/end-of-service-report', () => {
   it('creates an end of service report for that referral on the interventions service, and redirects to the first page of the service provider end of service report journey', async () => {
     const endOfServiceReport = endOfServiceReportFactory.build()

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -40,6 +40,8 @@ import PostSessionBehaviourFeedbackForm from './postSessionBehaviourFeedbackForm
 import PostSessionFeedbackCheckAnswersView from './postSessionFeedbackCheckAnswersView'
 import PostSessionFeedbackCheckAnswersPresenter from './postSessionFeedbackCheckAnswersPresenter'
 import AuthUtils from '../../utils/authUtils'
+import SubmittedPostSessionFeedbackView from '../shared/submittedPostSessionFeedbackView'
+import SubmittedPostSessionFeedbackPresenter from '../shared/submittedPostSessionFeedbackPresenter'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -567,6 +569,28 @@ export default class ServiceProviderReferralsController {
     return res.redirect(
       `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/confirmation`
     )
+  }
+
+  async viewSubmittedPostSessionFeedback(req: Request, res: Response): Promise<void> {
+    const { user } = res.locals
+    const { accessToken } = user.token
+    const { actionPlanId, sessionNumber } = req.params
+
+    const actionPlan = await this.interventionsService.getActionPlan(accessToken, actionPlanId)
+    const referral = await this.interventionsService.getSentReferral(accessToken, actionPlan.referralId)
+
+    const currentAppointment = await this.interventionsService.getActionPlanAppointment(
+      accessToken,
+      actionPlanId,
+      Number(sessionNumber)
+    )
+
+    const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
+
+    const presenter = new SubmittedPostSessionFeedbackPresenter(currentAppointment, serviceUser)
+    const view = new SubmittedPostSessionFeedbackView(presenter)
+
+    return res.render(...view.renderArgs)
   }
 
   async showPostSessionFeedbackConfirmation(req: Request, res: Response): Promise<void> {

--- a/server/routes/shared/submittedPostSessionFeedbackPresenter.test.ts
+++ b/server/routes/shared/submittedPostSessionFeedbackPresenter.test.ts
@@ -1,0 +1,52 @@
+import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
+import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import SubmittedPostSessionFeedbackPresenter from './submittedPostSessionFeedbackPresenter'
+
+describe(SubmittedPostSessionFeedbackPresenter, () => {
+  describe('text', () => {
+    it('includes the title of the page', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+
+      const presenter = new SubmittedPostSessionFeedbackPresenter(appointment, serviceUser)
+
+      expect(presenter.text).toMatchObject({
+        title: 'View feedback',
+      })
+    })
+  })
+
+  describe('serviceUserBannerPresenter', () => {
+    it('is instantiated with the service user', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+
+      const presenter = new SubmittedPostSessionFeedbackPresenter(appointment, serviceUser)
+
+      expect(presenter.serviceUserBannerPresenter).toBeDefined()
+    })
+  })
+
+  describe('sessionDetailsSummary', () => {
+    it('extracts the date and time from the appointmentTime and puts it in a SummaryList format', () => {
+      const serviceUser = deliusServiceUserFactory.build()
+      const appointment = actionPlanAppointmentFactory.build({
+        appointmentTime: '2021-02-01T13:00:00Z',
+      })
+      const presenter = new SubmittedPostSessionFeedbackPresenter(appointment, serviceUser)
+
+      expect(presenter.sessionDetailsSummary).toEqual([
+        {
+          key: 'Date',
+          lines: ['01 Feb 2021'],
+          isList: false,
+        },
+        {
+          key: 'Time',
+          lines: ['13:00'],
+          isList: false,
+        },
+      ])
+    })
+  })
+})

--- a/server/routes/shared/submittedPostSessionFeedbackPresenter.test.ts
+++ b/server/routes/shared/submittedPostSessionFeedbackPresenter.test.ts
@@ -1,5 +1,6 @@
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import { AuthUser } from '../../services/interventionsService'
 import SubmittedPostSessionFeedbackPresenter from './submittedPostSessionFeedbackPresenter'
 
 describe(SubmittedPostSessionFeedbackPresenter, () => {
@@ -28,25 +29,61 @@ describe(SubmittedPostSessionFeedbackPresenter, () => {
   })
 
   describe('sessionDetailsSummary', () => {
-    it('extracts the date and time from the appointmentTime and puts it in a SummaryList format', () => {
-      const serviceUser = deliusServiceUserFactory.build()
-      const appointment = actionPlanAppointmentFactory.build({
-        appointmentTime: '2021-02-01T13:00:00Z',
-      })
-      const presenter = new SubmittedPostSessionFeedbackPresenter(appointment, serviceUser)
+    describe('when a caseworker is passed in', () => {
+      it('extracts the date and time from the appointmentTime and puts it in a SummaryList format alongside the caseworker name', () => {
+        const caseworker: AuthUser = {
+          username: 'Kay.Swerker',
+          authSource: 'Delius',
+          userId: '91229a16-b5f4-4784-942e-a484a97ac865',
+        }
 
-      expect(presenter.sessionDetailsSummary).toEqual([
-        {
-          key: 'Date',
-          lines: ['01 Feb 2021'],
-          isList: false,
-        },
-        {
-          key: 'Time',
-          lines: ['13:00'],
-          isList: false,
-        },
-      ])
+        const serviceUser = deliusServiceUserFactory.build()
+        const appointment = actionPlanAppointmentFactory.build({
+          appointmentTime: '2021-02-01T13:00:00Z',
+        })
+        const presenter = new SubmittedPostSessionFeedbackPresenter(appointment, serviceUser, caseworker)
+
+        expect(presenter.sessionDetailsSummary).toEqual([
+          {
+            key: 'Caseworker',
+            lines: ['Kay.Swerker'],
+            isList: false,
+          },
+          {
+            key: 'Date',
+            lines: ['01 Feb 2021'],
+            isList: false,
+          },
+          {
+            key: 'Time',
+            lines: ['13:00'],
+            isList: false,
+          },
+        ])
+      })
+    })
+
+    describe('when a caseworker is not passed in', () => {
+      it('extracts the date and time from the appointmentTime and puts it in a SummaryList format', () => {
+        const serviceUser = deliusServiceUserFactory.build()
+        const appointment = actionPlanAppointmentFactory.build({
+          appointmentTime: '2021-02-01T13:00:00Z',
+        })
+        const presenter = new SubmittedPostSessionFeedbackPresenter(appointment, serviceUser)
+
+        expect(presenter.sessionDetailsSummary).toEqual([
+          {
+            key: 'Date',
+            lines: ['01 Feb 2021'],
+            isList: false,
+          },
+          {
+            key: 'Time',
+            lines: ['13:00'],
+            isList: false,
+          },
+        ])
+      })
     })
   })
 })

--- a/server/routes/shared/submittedPostSessionFeedbackPresenter.ts
+++ b/server/routes/shared/submittedPostSessionFeedbackPresenter.ts
@@ -1,0 +1,33 @@
+import { DeliusServiceUser } from '../../services/communityApiService'
+import { ActionPlanAppointment } from '../../services/interventionsService'
+import DateUtils from '../../utils/dateUtils'
+import { SummaryListItem } from '../../utils/summaryList'
+import FeedbackAnswersPresenter from './feedbackAnswersPresenter'
+import ServiceUserBannerPresenter from './serviceUserBannerPresenter'
+
+export default class SubmittedPostSessionFeedbackPresenter {
+  readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
+
+  constructor(private readonly appointment: ActionPlanAppointment, private readonly serviceUser: DeliusServiceUser) {
+    this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(this.appointment, this.serviceUser)
+  }
+
+  readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
+
+  readonly text = {
+    title: `View feedback`,
+  }
+
+  readonly sessionDetailsSummary: SummaryListItem[] = [
+    {
+      key: 'Date',
+      lines: [DateUtils.getDateStringFromDateTimeString(this.appointment.appointmentTime)],
+      isList: false,
+    },
+    {
+      key: 'Time',
+      lines: [DateUtils.getTimeStringFromDateTimeString(this.appointment.appointmentTime)],
+      isList: false,
+    },
+  ]
+}

--- a/server/routes/shared/submittedPostSessionFeedbackPresenter.ts
+++ b/server/routes/shared/submittedPostSessionFeedbackPresenter.ts
@@ -1,5 +1,5 @@
 import { DeliusServiceUser } from '../../services/communityApiService'
-import { ActionPlanAppointment } from '../../services/interventionsService'
+import { ActionPlanAppointment, AuthUser } from '../../services/interventionsService'
 import DateUtils from '../../utils/dateUtils'
 import { SummaryListItem } from '../../utils/summaryList'
 import FeedbackAnswersPresenter from './feedbackAnswersPresenter'
@@ -8,7 +8,11 @@ import ServiceUserBannerPresenter from './serviceUserBannerPresenter'
 export default class SubmittedPostSessionFeedbackPresenter {
   readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
 
-  constructor(private readonly appointment: ActionPlanAppointment, private readonly serviceUser: DeliusServiceUser) {
+  constructor(
+    private readonly appointment: ActionPlanAppointment,
+    private readonly serviceUser: DeliusServiceUser,
+    private readonly assignedCaseworker: AuthUser | null = null
+  ) {
     this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(this.appointment, this.serviceUser)
   }
 
@@ -18,16 +22,31 @@ export default class SubmittedPostSessionFeedbackPresenter {
     title: `View feedback`,
   }
 
-  readonly sessionDetailsSummary: SummaryListItem[] = [
-    {
-      key: 'Date',
-      lines: [DateUtils.getDateStringFromDateTimeString(this.appointment.appointmentTime)],
-      isList: false,
-    },
-    {
-      key: 'Time',
-      lines: [DateUtils.getTimeStringFromDateTimeString(this.appointment.appointmentTime)],
-      isList: false,
-    },
-  ]
+  get sessionDetailsSummary(): SummaryListItem[] {
+    const dateAndTimeSummary = [
+      {
+        key: 'Date',
+        lines: [DateUtils.getDateStringFromDateTimeString(this.appointment.appointmentTime)],
+        isList: false,
+      },
+      {
+        key: 'Time',
+        lines: [DateUtils.getTimeStringFromDateTimeString(this.appointment.appointmentTime)],
+        isList: false,
+      },
+    ]
+
+    if (this.assignedCaseworker) {
+      return [
+        {
+          key: 'Caseworker',
+          lines: [this.assignedCaseworker.username],
+          isList: false,
+        },
+        ...dateAndTimeSummary,
+      ]
+    }
+
+    return dateAndTimeSummary
+  }
 }

--- a/server/routes/shared/submittedPostSessionFeedbackView.ts
+++ b/server/routes/shared/submittedPostSessionFeedbackView.ts
@@ -1,0 +1,19 @@
+import ViewUtils from '../../utils/viewUtils'
+import SubmittedPostSessionFeedbackPresenter from './submittedPostSessionFeedbackPresenter'
+
+export default class SubmittedPostSessionFeedbackView {
+  constructor(private readonly presenter: SubmittedPostSessionFeedbackPresenter) {}
+
+  private readonly summaryListArgs = ViewUtils.summaryListArgs(this.presenter.sessionDetailsSummary)
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'shared/viewSubmittedPostSessionFeedback',
+      {
+        presenter: this.presenter,
+        serviceUserNotificationBannerArgs: this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs,
+        summaryListArgs: this.summaryListArgs,
+      },
+    ]
+  }
+}

--- a/server/views/shared/viewSubmittedPostSessionFeedback.njk
+++ b/server/views/shared/viewSubmittedPostSessionFeedback.njk
@@ -1,0 +1,11 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "../serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk" %}
+
+{% block formSection %}
+  {{ govukSummaryList(summaryListArgs) }}
+
+  <br>
+
+  {% include "../partials/postSessionFeedbackResponses.njk" %}
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds SP and PP pages for viewing submitted post-session feedback.

The PP version currently displays the caseworker's username, rather than their First and Lastname, as is specified in the designs, as we don't currently display that anywhere else with assigned users. This will be addressed in https://dsdmoj.atlassian.net/browse/IC-1183

## What is the intent behind these changes?

To allow SPs and PPs to view session feedback once it's been submitted.

## Screenshots:

### PP:

<img width="985" alt="image" src="https://user-images.githubusercontent.com/19826940/115576102-16cc3d80-a2bb-11eb-9a2d-07bdc5ddd6c5.png">

### SP (no caseworker name):
<img width="972" alt="image" src="https://user-images.githubusercontent.com/19826940/115576155-251a5980-a2bb-11eb-9691-c7dd251c4014.png">

