### PR TITLE
Turn on verbose logging in Wiremock

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -18,6 +18,7 @@ services:
     restart: always
     ports:
       - "9091:8080"
+    command: '--verbose'
 
 networks:
   hmpps_int:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,7 @@ services:
       - "9092:8080"
     volumes:
       - ./wiremock_mappings:/home/wiremock/mappings
+    command: '--verbose'
 
 networks:
   hmpps:


### PR DESCRIPTION
## What does this pull request do?

It causes Wiremock to log every request it receives and every response
it sends. This is particularly useful in the integration tests, for
debugging misconfigured mocks.

## What is the intent behind these changes?

To make it easier to debug mocks in the local development environment.