### PR TITLE
Add layout and presenter for end of service report form pages

### DIFF
--- a/server/routes/serviceProviderReferrals/endOfServiceReportFormPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFormPresenter.test.ts
@@ -1,0 +1,43 @@
+import EndOfServiceReportFormPresenter from './endOfServiceReportFormPresenter'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+
+describe(EndOfServiceReportFormPresenter, () => {
+  const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+  const referral = sentReferralFactory.build({ referral: { desiredOutcomesIds: ['1', '2', '3', '4', '5'] } })
+
+  describe('title', () => {
+    it('returns the title for all the form pages', () => {
+      const presenter = new EndOfServiceReportFormPresenter(serviceCategory, referral).checkAnswersPage
+      expect(presenter.text.title).toEqual('Social inclusion: End of service report')
+    })
+  })
+
+  describe('numberOfPages', () => {
+    it('returns the number of pages in the end of service report journey', () => {
+      const presenter = new EndOfServiceReportFormPresenter(serviceCategory, referral).checkAnswersPage
+      expect(presenter.text.numberOfPages).toEqual('7')
+    })
+  })
+
+  describe('.outcomePage', () => {
+    it('has the correct page number', () => {
+      const presenter = new EndOfServiceReportFormPresenter(serviceCategory, referral).desiredOutcomePage(2)
+      expect(presenter.text.pageNumber).toEqual('2')
+    })
+  })
+
+  describe('.furtherInformationPage', () => {
+    it('has the correct page number', () => {
+      const presenter = new EndOfServiceReportFormPresenter(serviceCategory, referral).furtherInformationPage
+      expect(presenter.text.pageNumber).toEqual('6')
+    })
+  })
+
+  describe('.checkAnswersPage', () => {
+    it('has the correct page number', () => {
+      const presenter = new EndOfServiceReportFormPresenter(serviceCategory, referral).checkAnswersPage
+      expect(presenter.text.pageNumber).toEqual('7')
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/endOfServiceReportFormPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFormPresenter.ts
@@ -1,0 +1,44 @@
+import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import utils from '../../utils/utils'
+
+interface EndOfServiceReportFormPagePresenter {
+  text: {
+    title: string
+    pageNumber: string
+    numberOfPages: string
+  }
+}
+
+export default class EndOfServiceReportFormPresenter {
+  constructor(private readonly serviceCategory: ServiceCategory, private readonly referral: SentReferral) {}
+
+  private get numberOfDesiredOutcomes(): number {
+    return this.referral.referral.desiredOutcomesIds.length
+  }
+
+  private get title(): string {
+    return `${utils.convertToProperCase(this.serviceCategory.name)}: End of service report`
+  }
+
+  private get numberOfPages(): string {
+    return String(this.numberOfDesiredOutcomes + 2)
+  }
+
+  desiredOutcomePage(desiredOutcomeNumber: number): EndOfServiceReportFormPagePresenter {
+    return { text: { title: this.title, pageNumber: String(desiredOutcomeNumber), numberOfPages: this.numberOfPages } }
+  }
+
+  get furtherInformationPage(): EndOfServiceReportFormPagePresenter {
+    return {
+      text: {
+        title: this.title,
+        pageNumber: String(this.numberOfDesiredOutcomes + 1),
+        numberOfPages: this.numberOfPages,
+      },
+    }
+  }
+
+  get checkAnswersPage(): EndOfServiceReportFormPagePresenter {
+    return { text: { title: this.title, pageNumber: this.numberOfPages, numberOfPages: this.numberOfPages } }
+  }
+}

--- a/server/views/serviceProviderReferrals/endOfServiceReport/formTemplate.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/formTemplate.njk
@@ -1,0 +1,27 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummaryArgs !== undefined and errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-xl">{{ presenter.formPagePresenter.text.title }}</h1>
+
+      {% if presenter.formPagePresenter.text.pageNumber %}
+        <p class="govuk-hint">Page {{ presenter.formPagePresenter.text.pageNumber }} of {{ presenter.formPagePresenter.text.numberOfPages }}</p>
+      {% endif %}
+
+      {% if presenter.text.subTitle %}
+        <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
+      {% endif %}
+
+      {% block formSection %}{% endblock %}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a page layout (and presenter used to drive it) which will provide the general structure used for every page on the upcoming "create end of service report" journey. The approach is similar to that taken by the action plan journey, except this time we have a dynamic number of pages (since it’s determined by the number of outcomes in the referral).

## What is the intent behind these changes?

To allow us to build the end of service report journey.