### PR TITLE
IC-1322: Service provider caseworker can create, fill in, and submit an end of service report

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -152,6 +152,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/service-provider/end-of-service-report/:id/check-answers', (req, res) =>
     serviceProviderReferralsController.endOfServiceReportCheckAnswers(req, res)
   )
+  post('/service-provider/end-of-service-report/:id/submit', (req, res) =>
+    serviceProviderReferralsController.submitEndOfServiceReport(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -155,6 +155,9 @@ export default function routes(router: Router, services: Services): Router {
   post('/service-provider/end-of-service-report/:id/submit', (req, res) =>
     serviceProviderReferralsController.submitEndOfServiceReport(req, res)
   )
+  get('/service-provider/end-of-service-report/:id/confirmation', (req, res) =>
+    serviceProviderReferralsController.showEndOfServiceReportConfirmation(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -149,6 +149,9 @@ export default function routes(router: Router, services: Services): Router {
   post('/service-provider/end-of-service-report/:id/further-information', (req, res) =>
     serviceProviderReferralsController.editEndOfServiceReportFurtherInformation(req, res)
   )
+  get('/service-provider/end-of-service-report/:id/check-answers', (req, res) =>
+    serviceProviderReferralsController.endOfServiceReportCheckAnswers(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -143,6 +143,12 @@ export default function routes(router: Router, services: Services): Router {
   post('/service-provider/end-of-service-report/:id/outcomes/:number', (req, res) =>
     serviceProviderReferralsController.editEndOfServiceReportOutcome(req, res)
   )
+  get('/service-provider/end-of-service-report/:id/further-information', (req, res) =>
+    serviceProviderReferralsController.editEndOfServiceReportFurtherInformation(req, res)
+  )
+  post('/service-provider/end-of-service-report/:id/further-information', (req, res) =>
+    serviceProviderReferralsController.editEndOfServiceReportFurtherInformation(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -137,6 +137,12 @@ export default function routes(router: Router, services: Services): Router {
   post('/service-provider/referrals/:id/end-of-service-report', (req, res) =>
     serviceProviderReferralsController.createDraftEndOfServiceReport(req, res)
   )
+  get('/service-provider/end-of-service-report/:id/outcomes/:number', (req, res) =>
+    serviceProviderReferralsController.editEndOfServiceReportOutcome(req, res)
+  )
+  post('/service-provider/end-of-service-report/:id/outcomes/:number', (req, res) =>
+    serviceProviderReferralsController.editEndOfServiceReportOutcome(req, res)
+  )
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.test.ts
@@ -1,0 +1,144 @@
+import EndOfServiceReportCheckAnswersPresenter from './endOfServiceReportCheckAnswersPresenter'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
+
+describe(EndOfServiceReportCheckAnswersPresenter, () => {
+  const referral = sentReferralFactory.build({
+    referral: { desiredOutcomesIds: ['1', '3'], serviceUser: { firstName: 'Alex', lastName: 'River' } },
+  })
+  const serviceCategory = serviceCategoryFactory.build({
+    name: 'social inclusion',
+    desiredOutcomes: [
+      { id: '1', description: 'Description of desired outcome 1' },
+      { id: '2', description: 'Description of desired outcome 2' },
+      { id: '3', description: 'Description of desired outcome 3' },
+    ],
+  })
+  const buildEndOfServiceReport = () =>
+    endOfServiceReportFactory.build({
+      outcomes: [
+        {
+          desiredOutcome: serviceCategory.desiredOutcomes[0],
+          achievementLevel: 'ACHIEVED',
+          progressionComments: 'Example progression comments 1',
+          additionalTaskComments: 'Example task comments 1',
+        },
+        {
+          desiredOutcome: serviceCategory.desiredOutcomes[2],
+          achievementLevel: 'PARTIALLY_ACHIEVED',
+          progressionComments: 'Example progression comments 2',
+          additionalTaskComments: 'Example task comments 2',
+        },
+      ],
+    })
+
+  describe('text', () => {
+    it('returns text to be displayed', () => {
+      const presenter = new EndOfServiceReportCheckAnswersPresenter(
+        referral,
+        buildEndOfServiceReport(),
+        serviceCategory
+      )
+
+      expect(presenter.text).toEqual({
+        subTitle: 'Review the end of service report',
+      })
+    })
+  })
+
+  describe('interventionSummary', () => {
+    it('returns a summary of the intervention', () => {
+      const presenter = new EndOfServiceReportCheckAnswersPresenter(
+        referral,
+        buildEndOfServiceReport(),
+        serviceCategory
+      )
+
+      expect(presenter.interventionSummary).toEqual([
+        {
+          isList: false,
+          key: 'Service user’s name',
+          lines: ['Alex River'],
+        },
+      ])
+    })
+  })
+
+  describe('outcomes', () => {
+    it('replays the user’s outcome answers from the draft end of service report, with a link for changing the answer', () => {
+      const presenter = new EndOfServiceReportCheckAnswersPresenter(
+        referral,
+        buildEndOfServiceReport(),
+        serviceCategory
+      )
+
+      expect(presenter.outcomes).toEqual([
+        {
+          achievementLevelStyle: 'ACHIEVED',
+          achievementLevelText: 'Achieved',
+          additionalTaskComments: 'Example task comments 1',
+          changeHref: '/service-provider/end-of-service-report/3/outcomes/1',
+          progressionComments: 'Example progression comments 1',
+          subtitle: 'Description of desired outcome 1',
+          title: 'Outcome 1',
+        },
+        {
+          achievementLevelStyle: 'PARTIALLY_ACHIEVED',
+          achievementLevelText: 'Partially achieved',
+          additionalTaskComments: 'Example task comments 2',
+          changeHref: '/service-provider/end-of-service-report/3/outcomes/2',
+          progressionComments: 'Example progression comments 2',
+          subtitle: 'Description of desired outcome 3',
+          title: 'Outcome 2',
+        },
+      ])
+    })
+
+    describe('progressionComments', () => {
+      it('returns “None” when there are no comments', () => {
+        const endOfServiceReport = buildEndOfServiceReport()
+        endOfServiceReport.outcomes[0].progressionComments = ''
+
+        const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+
+        expect(presenter.outcomes[0].progressionComments).toEqual('None')
+      })
+    })
+
+    describe('additionalTaskComments', () => {
+      it('returns “None” when there are no comments', () => {
+        const endOfServiceReport = buildEndOfServiceReport()
+        endOfServiceReport.outcomes[0].additionalTaskComments = ''
+
+        const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+
+        expect(presenter.outcomes[0].additionalTaskComments).toEqual('None')
+      })
+    })
+  })
+
+  describe('furtherInformation', () => {
+    it('replays the user’s further information answer from the draft end of service report, with a link for changing the answer', () => {
+      const presenter = new EndOfServiceReportCheckAnswersPresenter(
+        referral,
+        buildEndOfServiceReport(),
+        serviceCategory
+      )
+
+      expect(presenter.furtherInformation).toEqual({
+        changeHref: '/service-provider/end-of-service-report/6/further-information',
+        text: 'None',
+      })
+    })
+
+    it('returns “None” for the text when there are no comments', () => {
+      const endOfServiceReport = buildEndOfServiceReport()
+      endOfServiceReport.furtherInformation = ''
+
+      const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+
+      expect(presenter.furtherInformation.text).toEqual('None')
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.ts
@@ -1,0 +1,87 @@
+import {
+  EndOfServiceReport,
+  EndOfServiceReportOutcome,
+  SentReferral,
+  ServiceCategory,
+} from '../../services/interventionsService'
+import PresenterUtils from '../../utils/presenterUtils'
+import { SummaryListItem } from '../../utils/summaryList'
+import EndOfServiceReportFormPresenter from './endOfServiceReportFormPresenter'
+
+export type EndOfServiceReportAchievementLevelStyle = 'ACHIEVED' | 'PARTIALLY_ACHIEVED' | 'NOT_ACHIEVED'
+
+interface OutcomePresenter {
+  title: string
+  subtitle: string
+  progressionComments: string
+  additionalTaskComments: string
+  changeHref: string
+  achievementLevelText: string
+  achievementLevelStyle: EndOfServiceReportAchievementLevelStyle
+}
+
+export default class EndOfServiceReportCheckAnswersPresenter {
+  constructor(
+    private readonly referral: SentReferral,
+    private readonly endOfServiceReport: EndOfServiceReport,
+    private readonly serviceCategory: ServiceCategory
+  ) {}
+
+  readonly formAction = `/service-provider/end-of-service-report/${this.endOfServiceReport.id}/submit`
+
+  readonly text = {
+    subTitle: 'Review the end of service report',
+  }
+
+  readonly formPagePresenter = new EndOfServiceReportFormPresenter(this.serviceCategory, this.referral).checkAnswersPage
+
+  readonly interventionSummary: SummaryListItem[] = [
+    // TODO IC-1322 Populate this fully
+    { key: 'Service user’s name', lines: [PresenterUtils.fullName(this.referral.referral.serviceUser)], isList: false },
+  ]
+
+  readonly outcomes: OutcomePresenter[] = this.referral.referral.desiredOutcomesIds.map((desiredOutcomeId, index) => {
+    const number = index + 1
+    const outcome = this.endOfServiceReport.outcomes.find(anOutcome => anOutcome.desiredOutcome.id === desiredOutcomeId)
+
+    if (!outcome) {
+      throw new Error(`Outcome not found for desired outcome ${desiredOutcomeId}`)
+    }
+
+    const desiredOutcome = this.serviceCategory.desiredOutcomes.find(
+      aDesiredOutcome => aDesiredOutcome.id === desiredOutcomeId
+    )
+
+    if (!desiredOutcome) {
+      throw new Error(`Desired outcome ${desiredOutcomeId} not found`)
+    }
+
+    return {
+      title: `Outcome ${number}`,
+      subtitle: desiredOutcome.description,
+      progressionComments: outcome.progressionComments?.length ? outcome.progressionComments : 'None',
+      additionalTaskComments: outcome.additionalTaskComments?.length ? outcome.additionalTaskComments : 'None',
+      changeHref: `/service-provider/end-of-service-report/${this.endOfServiceReport.id}/outcomes/${number}`,
+      achievementLevelText: this.achievementLevelText(outcome),
+      achievementLevelStyle: outcome.achievementLevel,
+    }
+  })
+
+  private achievementLevelText(outcome: EndOfServiceReportOutcome): string {
+    switch (outcome.achievementLevel) {
+      case 'ACHIEVED':
+        return 'Achieved'
+      case 'NOT_ACHIEVED':
+        return 'Not achieved'
+      case 'PARTIALLY_ACHIEVED':
+        return 'Partially achieved'
+      default:
+        return ''
+    }
+  }
+
+  readonly furtherInformation = {
+    text: this.endOfServiceReport.furtherInformation?.length ? this.endOfServiceReport.furtherInformation : 'None',
+    changeHref: `/service-provider/end-of-service-report/${this.endOfServiceReport.id}/further-information`,
+  }
+}

--- a/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersView.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersView.ts
@@ -1,0 +1,32 @@
+import ViewUtils from '../../utils/viewUtils'
+import EndOfServiceReportCheckAnswersPresenter, {
+  EndOfServiceReportAchievementLevelStyle,
+} from './endOfServiceReportCheckAnswersPresenter'
+
+export default class EndOfServiceReportCheckAnswersView {
+  constructor(private readonly presenter: EndOfServiceReportCheckAnswersPresenter) {}
+
+  private readonly interventionSummarySummaryListArgs = ViewUtils.summaryListArgs(this.presenter.interventionSummary)
+
+  private readonly achievementLevelTagClass = (style: EndOfServiceReportAchievementLevelStyle) => {
+    switch (style) {
+      case 'ACHIEVED':
+        return 'govuk-tag--green'
+      case 'PARTIALLY_ACHIEVED':
+        return 'govuk-tag--blue'
+      case 'NOT_ACHIEVED':
+        return 'govuk-tag--red'
+      default:
+        return ''
+    }
+  }
+
+  readonly renderArgs: [string, Record<string, unknown>] = [
+    'serviceProviderReferrals/endOfServiceReport/checkAnswers',
+    {
+      presenter: this.presenter,
+      interventionSummarySummaryListArgs: this.interventionSummarySummaryListArgs,
+      achievementLevelTagClass: this.achievementLevelTagClass,
+    },
+  ]
+}

--- a/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.test.ts
@@ -1,0 +1,40 @@
+import EndOfServiceReportConfirmationPresenter from './endOfServiceReportConfirmationPresenter'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+
+describe(EndOfServiceReportConfirmationPresenter, () => {
+  describe('progressHref', () => {
+    it('returns the relative URL of the service provider referral progress page', () => {
+      const sentReferral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const presenter = new EndOfServiceReportConfirmationPresenter(sentReferral, serviceCategory)
+
+      expect(presenter.progressHref).toEqual(`/service-provider/referrals/${sentReferral.id}/progress`)
+    })
+  })
+
+  describe('summary', () => {
+    it('returns a summary of the referral', () => {
+      const sentReferral = sentReferralFactory.build({
+        referenceNumber: 'CEF345',
+        referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
+      })
+      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+      const presenter = new EndOfServiceReportConfirmationPresenter(sentReferral, serviceCategory)
+
+      expect(presenter.summary).toEqual([
+        { key: 'Name', lines: ['Johnny Davis'], isList: false },
+        {
+          key: 'Referral number',
+          lines: ['CEF345'],
+          isList: false,
+        },
+        {
+          key: 'Service type',
+          lines: ['Social inclusion'],
+          isList: false,
+        },
+      ])
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.ts
@@ -1,0 +1,28 @@
+import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import PresenterUtils from '../../utils/presenterUtils'
+import { SummaryListItem } from '../../utils/summaryList'
+import utils from '../../utils/utils'
+
+export default class EndOfServiceReportConfirmationPresenter {
+  constructor(private readonly referral: SentReferral, private readonly serviceCategory: ServiceCategory) {}
+
+  progressHref = `/service-provider/referrals/${this.referral.id}/progress`
+
+  readonly summary: SummaryListItem[] = [
+    {
+      key: 'Name',
+      lines: [PresenterUtils.fullName(this.referral.referral.serviceUser)],
+      isList: false,
+    },
+    {
+      key: 'Referral number',
+      lines: [this.referral.referenceNumber],
+      isList: false,
+    },
+    {
+      key: 'Service type',
+      lines: [utils.convertToProperCase(this.serviceCategory.name)],
+      isList: false,
+    },
+  ]
+}

--- a/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationView.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationView.ts
@@ -1,0 +1,18 @@
+import ViewUtils from '../../utils/viewUtils'
+import EndOfServiceReportConfirmationPresenter from './endOfServiceReportConfirmationPresenter'
+
+export default class EndOfServiceReportConfirmationView {
+  constructor(private readonly presenter: EndOfServiceReportConfirmationPresenter) {}
+
+  private readonly summaryListArgs = ViewUtils.summaryListArgs(this.presenter.summary)
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/endOfServiceReport/confirmation',
+      {
+        presenter: this.presenter,
+        summaryListArgs: this.summaryListArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationForm.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationForm.test.ts
@@ -1,0 +1,14 @@
+import TestUtils from '../../../testutils/testUtils'
+import EndOfServiceReportFurtherInformationForm from './endOfServiceReportFurtherInformationForm'
+
+describe(EndOfServiceReportFurtherInformationForm, () => {
+  describe('paramsForUpdate', () => {
+    it('returns params to be used to update the appointment on the interventions service', () => {
+      const form = new EndOfServiceReportFurtherInformationForm(
+        TestUtils.createRequest({ 'further-information': 'Some further information' })
+      )
+
+      expect(form.paramsForUpdate).toEqual({ furtherInformation: 'Some further information' })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationForm.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationForm.ts
@@ -1,0 +1,10 @@
+import { Request } from 'express'
+import { UpdateDraftEndOfServiceReportParams } from '../../services/interventionsService'
+
+export default class EndOfServiceReportFurtherInformationForm {
+  constructor(private readonly request: Request) {}
+
+  readonly paramsForUpdate: Partial<UpdateDraftEndOfServiceReportParams> = {
+    furtherInformation: this.request.body['further-information'] ?? '',
+  }
+}

--- a/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationPresenter.test.ts
@@ -1,0 +1,52 @@
+import EndOfServiceReportFurtherInformationPresenter from './endOfServiceReportFurtherInformationPresenter'
+import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+
+describe(EndOfServiceReportFurtherInformationPresenter, () => {
+  const endOfServiceReport = endOfServiceReportFactory.build({ furtherInformation: 'Some further information' })
+  const serviceCategory = serviceCategoryFactory.build()
+  const referral = sentReferralFactory.build()
+
+  describe('text', () => {
+    it('returns text to be displayed', () => {
+      const presenter = new EndOfServiceReportFurtherInformationPresenter(endOfServiceReport, serviceCategory, referral)
+
+      expect(presenter.text).toEqual({
+        subTitle: 'Would you like to give any additional information about this intervention (optional)?',
+      })
+    })
+  })
+
+  describe('fields', () => {
+    describe('furtherInformation', () => {
+      describe('when there is no user input data', () => {
+        it('returns the value from the model', () => {
+          const presenter = new EndOfServiceReportFurtherInformationPresenter(
+            endOfServiceReport,
+            serviceCategory,
+            referral,
+            null
+          )
+
+          expect(presenter.fields).toEqual({ furtherInformation: { value: 'Some further information' } })
+        })
+      })
+
+      describe('when there is user input data', () => {
+        it('returns the user input value', () => {
+          const presenter = new EndOfServiceReportFurtherInformationPresenter(
+            endOfServiceReport,
+            serviceCategory,
+            referral,
+            {
+              'further-information': 'Some user input further information',
+            }
+          )
+
+          expect(presenter.fields).toEqual({ furtherInformation: { value: 'Some user input further information' } })
+        })
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationPresenter.ts
@@ -1,0 +1,27 @@
+import { EndOfServiceReport, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import PresenterUtils from '../../utils/presenterUtils'
+import EndOfServiceReportFormPresenter from './endOfServiceReportFormPresenter'
+
+export default class EndOfServiceReportFurtherInformationPresenter {
+  constructor(
+    private readonly endOfServiceReport: EndOfServiceReport,
+    private readonly serviceCategory: ServiceCategory,
+    private readonly referral: SentReferral,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  readonly text = {
+    subTitle: 'Would you like to give any additional information about this intervention (optional)?',
+  }
+
+  readonly formPagePresenter = new EndOfServiceReportFormPresenter(this.serviceCategory, this.referral)
+    .furtherInformationPage
+
+  private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly fields = {
+    furtherInformation: {
+      value: this.utils.stringValue(this.endOfServiceReport.furtherInformation, 'further-information'),
+    },
+  }
+}

--- a/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationView.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationView.ts
@@ -1,0 +1,23 @@
+import { TextareaArgs } from '../../utils/govukFrontendTypes'
+import EndOfServiceReportFurtherInformationPresenter from './endOfServiceReportFurtherInformationPresenter'
+
+export default class EndOfServiceReportFurtherInformationView {
+  constructor(private readonly presenter: EndOfServiceReportFurtherInformationPresenter) {}
+
+  private readonly furtherInformationTextareaArgs: TextareaArgs = {
+    id: 'further-information',
+    name: 'further-information',
+    value: this.presenter.fields.furtherInformation.value,
+    label: {
+      text: 'Provide any further information that you believe is important for the probation practitioner to know.',
+    },
+  }
+
+  readonly renderArgs: [string, Record<string, unknown>] = [
+    'serviceProviderReferrals/endOfServiceReport/furtherInformation',
+    {
+      presenter: this.presenter,
+      furtherInformationTextareaArgs: this.furtherInformationTextareaArgs,
+    },
+  ]
+}

--- a/server/routes/serviceProviderReferrals/endOfServiceReportOutcomeForm.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportOutcomeForm.test.ts
@@ -1,0 +1,91 @@
+import EndOfServiceReportOutcomeForm from './endOfServiceReportOutcomeForm'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import TestUtils from '../../../testutils/testUtils'
+
+describe(EndOfServiceReportOutcomeForm, () => {
+  const { serviceUser } = sentReferralFactory.build({ referral: { serviceUser: { firstName: 'Alex' } } }).referral
+
+  describe('data', () => {
+    describe('with an empty achievement-level', () => {
+      it('returns an error', async () => {
+        const body = {
+          'achievement-level': '',
+        }
+        const data = await new EndOfServiceReportOutcomeForm(
+          TestUtils.createRequest(body),
+          'abc123',
+          serviceUser
+        ).data()
+
+        expect(data).toEqual({
+          paramsForUpdate: null,
+          error: {
+            errors: [
+              {
+                errorSummaryLinkedField: 'achievement-level',
+                formFields: ['achievement-level'],
+                message: 'Select whether Alex achieved the desired outcome',
+              },
+            ],
+          },
+        })
+      })
+    })
+
+    describe('with valid data', () => {
+      describe('with all fields populated', () => {
+        it('returns params for updating the outcome', async () => {
+          const body = {
+            'achievement-level': 'ACHIEVED',
+            'progression-comments': 'Some progression comments',
+            'additional-task-comments': 'Some task comments',
+          }
+          const data = await new EndOfServiceReportOutcomeForm(
+            TestUtils.createRequest(body),
+            'abc123',
+            serviceUser
+          ).data()
+
+          expect(data).toEqual({
+            error: null,
+            paramsForUpdate: {
+              outcome: {
+                desiredOutcomeId: 'abc123',
+                achievementLevel: 'ACHIEVED',
+                progressionComments: 'Some progression comments',
+                additionalTaskComments: 'Some task comments',
+              },
+            },
+          })
+        })
+      })
+
+      describe('with optional fields empty', () => {
+        it('returns params for updating the outcome', async () => {
+          const body = {
+            'achievement-level': 'ACHIEVED',
+            'progression-comments': '',
+            'additional-task-comments': '',
+          }
+          const data = await new EndOfServiceReportOutcomeForm(
+            TestUtils.createRequest(body),
+            'abc123',
+            serviceUser
+          ).data()
+
+          expect(data).toEqual({
+            error: null,
+            paramsForUpdate: {
+              outcome: {
+                desiredOutcomeId: 'abc123',
+                achievementLevel: 'ACHIEVED',
+                progressionComments: '',
+                additionalTaskComments: '',
+              },
+            },
+          })
+        })
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/endOfServiceReportOutcomeForm.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportOutcomeForm.ts
@@ -1,0 +1,43 @@
+import * as ExpressValidator from 'express-validator'
+import { Request } from 'express'
+import { FormData } from '../../utils/forms/formData'
+import errorMessages from '../../utils/errorMessages'
+import { ServiceUser, UpdateDraftEndOfServiceReportParams } from '../../services/interventionsService'
+import FormUtils from '../../utils/formUtils'
+
+export default class EndOfServiceReportOutcomeForm {
+  constructor(
+    private readonly request: Request,
+    private readonly desiredOutcomeId: string,
+    private readonly serviceUser: ServiceUser
+  ) {}
+
+  async data(): Promise<FormData<Partial<UpdateDraftEndOfServiceReportParams>>> {
+    const result = await FormUtils.runValidations({ request: this.request, validations: this.validations })
+
+    const error = FormUtils.validationErrorFromResult(result)
+    if (error) {
+      return { paramsForUpdate: null, error }
+    }
+
+    return {
+      paramsForUpdate: {
+        outcome: {
+          desiredOutcomeId: this.desiredOutcomeId,
+          achievementLevel: this.request.body['achievement-level'],
+          progressionComments: this.request.body['progression-comments'],
+          additionalTaskComments: this.request.body['additional-task-comments'],
+        },
+      },
+      error: null,
+    }
+  }
+
+  private get validations() {
+    return [
+      ExpressValidator.body('achievement-level')
+        .notEmpty()
+        .withMessage(errorMessages.endOfServiceReportOutcome.achievementLevel.empty(this.serviceUser.firstName ?? '')),
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/endOfServiceReportOutcomePresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportOutcomePresenter.test.ts
@@ -1,0 +1,291 @@
+import EndOfServiceReportOutcomePresenter from './endOfServiceReportOutcomePresenter'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import { EndOfServiceReportOutcome } from '../../services/interventionsService'
+
+describe(EndOfServiceReportOutcomePresenter, () => {
+  const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+  const desiredOutcome = serviceCategory.desiredOutcomes[0]
+  const desiredOutcomeNumber = 1
+  const referral = sentReferralFactory.build({ referral: { serviceUser: { firstName: 'Alex' } } })
+  const endOfServiceReport = endOfServiceReportFactory.build()
+
+  describe('text', () => {
+    it('returns text to be displayed', () => {
+      const presenter = new EndOfServiceReportOutcomePresenter(
+        referral,
+        endOfServiceReport,
+        serviceCategory,
+        desiredOutcome,
+        desiredOutcomeNumber,
+        null
+      )
+
+      expect(presenter.text).toEqual({
+        subTitle: `About desired outcome 1`,
+        desiredOutcomeNumberDescription: `Desired outcome 1`,
+        desiredOutcomeDescription: desiredOutcome.description,
+        achievementLevel: {
+          label: `Overall, did Alex achieve desired outcome 1?`,
+        },
+      })
+    })
+  })
+
+  describe('fields', () => {
+    describe('when there is no existing outcome', () => {
+      it('returns blank values and an empty radio button selection', () => {
+        const presenter = new EndOfServiceReportOutcomePresenter(
+          referral,
+          endOfServiceReport,
+          serviceCategory,
+          desiredOutcome,
+          desiredOutcomeNumber,
+          null
+        )
+
+        expect(presenter.fields).toEqual({
+          achievementLevel: {
+            errorMessage: null,
+            values: [
+              {
+                selected: false,
+                text: 'Achieved',
+                value: 'ACHIEVED',
+              },
+              {
+                selected: false,
+                text: 'Partially achieved',
+                value: 'PARTIALLY_ACHIEVED',
+              },
+              {
+                selected: false,
+                text: 'Not achieved',
+                value: 'NOT_ACHIEVED',
+              },
+            ],
+          },
+          additionalTaskComments: { value: '' },
+          progressionComments: { value: '' },
+        })
+      })
+    })
+
+    describe('when there is an existing outcome', () => {
+      describe('and there is no user input data', () => {
+        it('returns the values from the outcome', () => {
+          const outcome: EndOfServiceReportOutcome = {
+            desiredOutcome,
+            achievementLevel: 'PARTIALLY_ACHIEVED',
+            progressionComments: 'Some progression comments',
+            additionalTaskComments: 'Some task comments',
+          }
+
+          const presenter = new EndOfServiceReportOutcomePresenter(
+            referral,
+            endOfServiceReport,
+            serviceCategory,
+            desiredOutcome,
+            desiredOutcomeNumber,
+            outcome
+          )
+
+          expect(presenter.fields).toEqual({
+            achievementLevel: {
+              errorMessage: null,
+              values: [
+                {
+                  selected: false,
+                  text: 'Achieved',
+                  value: 'ACHIEVED',
+                },
+                {
+                  selected: true,
+                  text: 'Partially achieved',
+                  value: 'PARTIALLY_ACHIEVED',
+                },
+                {
+                  selected: false,
+                  text: 'Not achieved',
+                  value: 'NOT_ACHIEVED',
+                },
+              ],
+            },
+            additionalTaskComments: { value: 'Some task comments' },
+            progressionComments: { value: 'Some progression comments' },
+          })
+        })
+      })
+
+      describe('and there is user input data', () => {
+        it('returns the values from the user input data', () => {
+          const outcome: EndOfServiceReportOutcome = {
+            desiredOutcome,
+            achievementLevel: 'PARTIALLY_ACHIEVED',
+            progressionComments: 'Some progression comments',
+            additionalTaskComments: 'Some task comments',
+          }
+          const userInputData = {
+            'achievement-level': 'ACHIEVED',
+            'progression-comments': 'Some other progression comments',
+            'additional-task-comments': 'Some other task comments',
+          }
+
+          const presenter = new EndOfServiceReportOutcomePresenter(
+            referral,
+            endOfServiceReport,
+            serviceCategory,
+            desiredOutcome,
+            desiredOutcomeNumber,
+            outcome,
+            userInputData
+          )
+
+          expect(presenter.fields).toEqual({
+            achievementLevel: {
+              errorMessage: null,
+              values: [
+                {
+                  selected: true,
+                  text: 'Achieved',
+                  value: 'ACHIEVED',
+                },
+                {
+                  selected: false,
+                  text: 'Partially achieved',
+                  value: 'PARTIALLY_ACHIEVED',
+                },
+                {
+                  selected: false,
+                  text: 'Not achieved',
+                  value: 'NOT_ACHIEVED',
+                },
+              ],
+            },
+            additionalTaskComments: { value: 'Some other task comments' },
+            progressionComments: { value: 'Some other progression comments' },
+          })
+        })
+      })
+    })
+
+    describe('when there is user input data', () => {
+      it('returns the values from the user input data', () => {
+        const userInputData = {
+          'achievement-level': 'ACHIEVED',
+          'progression-comments': 'Some other progression comments',
+          'additional-task-comments': 'Some other task comments',
+        }
+
+        const presenter = new EndOfServiceReportOutcomePresenter(
+          referral,
+          endOfServiceReport,
+          serviceCategory,
+          desiredOutcome,
+          desiredOutcomeNumber,
+          null,
+          userInputData
+        )
+
+        expect(presenter.fields).toEqual({
+          achievementLevel: {
+            errorMessage: null,
+            values: [
+              {
+                selected: true,
+                text: 'Achieved',
+                value: 'ACHIEVED',
+              },
+              {
+                selected: false,
+                text: 'Partially achieved',
+                value: 'PARTIALLY_ACHIEVED',
+              },
+              {
+                selected: false,
+                text: 'Not achieved',
+                value: 'NOT_ACHIEVED',
+              },
+            ],
+          },
+          additionalTaskComments: { value: 'Some other task comments' },
+          progressionComments: { value: 'Some other progression comments' },
+        })
+      })
+    })
+
+    describe('when there is an error on achievement-level', () => {
+      it('includes an error message', () => {
+        const error = {
+          errors: [
+            {
+              formFields: ['achievement-level'],
+              errorSummaryLinkedField: 'achievement-level',
+              message: 'Enter an achievement level',
+            },
+          ],
+        }
+        const presenter = new EndOfServiceReportOutcomePresenter(
+          referral,
+          endOfServiceReport,
+          serviceCategory,
+          desiredOutcome,
+          desiredOutcomeNumber,
+          null,
+          null,
+          error
+        )
+
+        expect(presenter.fields).toMatchObject({
+          achievementLevel: {
+            errorMessage: 'Enter an achievement level',
+          },
+        })
+      })
+    })
+  })
+
+  describe('errorSummary', () => {
+    describe('when there is no error', () => {
+      it('returns error information', () => {
+        const error = {
+          errors: [
+            {
+              formFields: ['achievement-level'],
+              errorSummaryLinkedField: 'achievement-level',
+              message: 'Enter an achievement level',
+            },
+          ],
+        }
+        const presenter = new EndOfServiceReportOutcomePresenter(
+          referral,
+          endOfServiceReport,
+          serviceCategory,
+          desiredOutcome,
+          desiredOutcomeNumber,
+          null,
+          null,
+          error
+        )
+
+        expect(presenter.errorSummary).toEqual([{ field: 'achievement-level', message: 'Enter an achievement level' }])
+      })
+    })
+
+    describe('when there is an error', () => {
+      it('returns null', () => {
+        const presenter = new EndOfServiceReportOutcomePresenter(
+          referral,
+          endOfServiceReport,
+          serviceCategory,
+          desiredOutcome,
+          desiredOutcomeNumber,
+          null
+        )
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/endOfServiceReportOutcomePresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportOutcomePresenter.ts
@@ -1,0 +1,61 @@
+import {
+  DesiredOutcome,
+  EndOfServiceReport,
+  EndOfServiceReportOutcome,
+  SentReferral,
+  ServiceCategory,
+} from '../../services/interventionsService'
+import { FormValidationError } from '../../utils/formValidationError'
+import PresenterUtils from '../../utils/presenterUtils'
+import EndOfServiceReportFormPresenter from './endOfServiceReportFormPresenter'
+
+export default class EndOfServiceReportOutcomePresenter {
+  constructor(
+    private readonly referral: SentReferral,
+    private readonly endOfServiceReport: EndOfServiceReport,
+    private readonly serviceCategory: ServiceCategory,
+    private readonly desiredOutcome: DesiredOutcome,
+    private readonly desiredOutcomeNumber: number,
+    private readonly outcome: EndOfServiceReportOutcome | null,
+    private readonly userInputData: Record<string, unknown> | null = null,
+    private readonly error: FormValidationError | null = null
+  ) {}
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error)
+
+  readonly text = {
+    subTitle: `About desired outcome ${this.desiredOutcomeNumber}`,
+    desiredOutcomeNumberDescription: `Desired outcome ${this.desiredOutcomeNumber}`,
+    desiredOutcomeDescription: this.desiredOutcome.description,
+    achievementLevel: {
+      label: `Overall, did ${this.referral.referral.serviceUser.firstName} achieve desired outcome ${this.desiredOutcomeNumber}?`,
+    },
+  }
+
+  readonly formPagePresenter = new EndOfServiceReportFormPresenter(
+    this.serviceCategory,
+    this.referral
+  ).desiredOutcomePage(this.desiredOutcomeNumber)
+
+  private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly fields = {
+    achievementLevel: {
+      errorMessage: PresenterUtils.errorMessage(this.error, 'achievement-level'),
+      values: [
+        { text: 'Achieved', value: 'ACHIEVED' },
+        { text: 'Partially achieved', value: 'PARTIALLY_ACHIEVED' },
+        { text: 'Not achieved', value: 'NOT_ACHIEVED' },
+      ].map(option => ({
+        ...option,
+        selected: this.utils.stringValue(this.outcome?.achievementLevel ?? null, 'achievement-level') === option.value,
+      })),
+    },
+    progressionComments: {
+      value: this.utils.stringValue(this.outcome?.progressionComments ?? null, 'progression-comments'),
+    },
+    additionalTaskComments: {
+      value: this.utils.stringValue(this.outcome?.additionalTaskComments ?? null, 'additional-task-comments'),
+    },
+  }
+}

--- a/server/routes/serviceProviderReferrals/endOfServiceReportOutcomeView.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportOutcomeView.ts
@@ -1,0 +1,57 @@
+import { RadiosArgs, TextareaArgs } from '../../utils/govukFrontendTypes'
+import ViewUtils from '../../utils/viewUtils'
+import EndOfServiceReportOutcomePresenter from './endOfServiceReportOutcomePresenter'
+
+export default class EndOfServiceReportOutcomeView {
+  constructor(private readonly presenter: EndOfServiceReportOutcomePresenter) {}
+
+  private readonly achievementLevelRadiosArgs: RadiosArgs = {
+    idPrefix: 'achievement-level',
+    name: 'achievement-level',
+    fieldset: {
+      legend: {
+        text: this.presenter.text.achievementLevel.label,
+      },
+      classes: 'govuk-!-margin-top-3',
+    },
+    items: this.presenter.fields.achievementLevel.values.map(val => ({
+      value: val.value,
+      text: val.text,
+      checked: val.selected,
+    })),
+    errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.achievementLevel.errorMessage),
+  }
+
+  private readonly progressionCommentsTextareaArgs: TextareaArgs = {
+    id: 'progression-comments',
+    name: 'progression-comments',
+    value: this.presenter.fields.progressionComments.value,
+    label: {
+      text: 'Do you have any further comments about their progression on this outcome?',
+    },
+  }
+
+  private readonly additionalTaskCommentsTextareaArgs: TextareaArgs = {
+    id: 'additional-task-comments',
+    name: 'additional-task-comments',
+    value: this.presenter.fields.additionalTaskComments.value,
+    label: {
+      text: 'Is there anything else that needs doing to achieve this outcome?',
+    },
+  }
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/endOfServiceReport/outcome',
+      {
+        presenter: this.presenter,
+        errorSummaryArgs: this.errorSummaryArgs,
+        achievementLevelRadiosArgs: this.achievementLevelRadiosArgs,
+        progressionCommentsTextareaArgs: this.progressionCommentsTextareaArgs,
+        additionalTaskCommentsTextareaArgs: this.additionalTaskCommentsTextareaArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -4,6 +4,7 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import serviceUserFactory from '../../../testutils/factories/deliusServiceUser'
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
+import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
 
 describe(InterventionProgressPresenter, () => {
   describe('createActionPlanFormAction', () => {
@@ -192,6 +193,43 @@ describe(InterventionProgressPresenter, () => {
         })
       })
     })
+
+    describe('endOfServiceReportStatus', () => {
+      describe('when there is no end of service report', () => {
+        it('returns “Not submitted”', () => {
+          const referral = sentReferralFactory.build({ endOfServiceReport: null })
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+          expect(presenter.text).toMatchObject({ endOfServiceReportStatus: 'Not submitted' })
+        })
+      })
+
+      describe('when the end of service report has not been submitted', () => {
+        it('returns “Not submitted”', () => {
+          const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
+          const referral = sentReferralFactory.build({ endOfServiceReport })
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+          expect(presenter.text).toMatchObject({ endOfServiceReportStatus: 'Not submitted' })
+        })
+      })
+
+      describe('when the end of service report has been submitted', () => {
+        it('returns “Submitted”', () => {
+          const endOfServiceReport = endOfServiceReportFactory.submitted().build()
+          const referral = sentReferralFactory.build({ endOfServiceReport })
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+          expect(presenter.text).toMatchObject({ endOfServiceReportStatus: 'Submitted' })
+        })
+      })
+    })
   })
 
   describe('actionPlanStatusStyle', () => {
@@ -274,6 +312,68 @@ describe(InterventionProgressPresenter, () => {
       const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
 
       expect(presenter.referralAssigned).toEqual(true)
+    })
+  })
+
+  describe('endOfServiceReportStatusStyle', () => {
+    describe('when there is no end of service report', () => {
+      it('returns the inactive style', () => {
+        const referral = sentReferralFactory.build({ endOfServiceReport: null })
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+        expect(presenter.endOfServiceReportStatusStyle).toEqual('inactive')
+      })
+    })
+
+    describe('when the end of service report has not been submitted', () => {
+      it('returns the active style', () => {
+        const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
+        const referral = sentReferralFactory.build({ endOfServiceReport })
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+        expect(presenter.endOfServiceReportStatusStyle).toEqual('inactive')
+      })
+    })
+
+    describe('when the end of service report has been submitted', () => {
+      it('returns the active style', () => {
+        const endOfServiceReport = endOfServiceReportFactory.submitted().build()
+        const referral = sentReferralFactory.build({ endOfServiceReport })
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+        expect(presenter.endOfServiceReportStatusStyle).toEqual('active')
+      })
+    })
+  })
+
+  describe('allowEndOfServiceReportCreation', () => {
+    describe('when there is no end of service report', () => {
+      it('returns true', () => {
+        const referral = sentReferralFactory.build({ endOfServiceReport: null })
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+        expect(presenter.allowEndOfServiceReportCreation).toEqual(true)
+      })
+    })
+
+    describe('when there is an end of service report', () => {
+      it('returns false', () => {
+        const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
+        const referral = sentReferralFactory.build({ endOfServiceReport })
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+        expect(presenter.allowEndOfServiceReportCreation).toEqual(false)
+      })
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -33,6 +33,7 @@ export default class InterventionProgressPresenter {
   readonly text = {
     title: utils.convertToTitleCase(this.serviceCategory.name),
     actionPlanStatus: this.actionPlanSubmitted ? 'Submitted' : 'Not submitted',
+    endOfServiceReportStatus: this.endOfServiceReportSubmitted ? 'Submitted' : 'Not submitted',
   }
 
   readonly actionPlanStatusStyle: 'active' | 'inactive' = this.actionPlanSubmitted ? 'active' : 'inactive'
@@ -102,5 +103,19 @@ export default class InterventionProgressPresenter {
           linkHTML: `<a class="govuk-link" href="${editUrl}">Edit session details</a>`,
         }
     }
+  }
+
+  readonly createEndOfServiceReportFormAction = `/service-provider/referrals/${this.referral.id}/end-of-service-report`
+
+  readonly endOfServiceReportStatusStyle: 'active' | 'inactive' = this.endOfServiceReportSubmitted
+    ? 'active'
+    : 'inactive'
+
+  private get endOfServiceReportSubmitted() {
+    return this.referral.endOfServiceReport !== null && this.referral.endOfServiceReport.submittedAt !== null
+  }
+
+  get allowEndOfServiceReportCreation(): boolean {
+    return this.referral.endOfServiceReport === null
   }
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -87,6 +87,40 @@ export default class InterventionProgressView {
     href: '/service-provider/dashboard',
   }
 
+  private endOfServiceReportSummaryListArgs(tagMacro: (args: TagArgs) => string, csrfToken: string): SummaryListArgs {
+    const rows: SummaryListArgsRow[] = [
+      {
+        key: { text: 'End of service report status' },
+        value: {
+          text: tagMacro({
+            text: this.presenter.text.endOfServiceReportStatus,
+            classes: this.endOfServiceReportTagClass,
+            attributes: { id: 'end-of-service-report-status' },
+          }),
+        },
+      },
+    ]
+
+    if (this.presenter.allowEndOfServiceReportCreation) {
+      rows.push({
+        key: { text: 'Action' },
+        value: {
+          html: `<form method="post" action="${ViewUtils.escape(this.presenter.createEndOfServiceReportFormAction)}">
+                   <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken)}">
+                   <button class="govuk-button govuk-button--secondary">
+                     Create end of service report
+                   </button>
+                 </form>`,
+        },
+      })
+    }
+
+    return { rows }
+  }
+
+  private readonly endOfServiceReportTagClass =
+    this.presenter.endOfServiceReportStatusStyle === 'active' ? '' : 'govuk-tag--grey'
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/interventionProgress',
@@ -98,6 +132,7 @@ export default class InterventionProgressView {
         actionPlanSummaryListArgs: this.actionPlanSummaryListArgs.bind(this),
         sessionTableArgs: this.sessionTableArgs.bind(this),
         backLinkArgs: this.backLinkArgs,
+        endOfServiceReportSummaryListArgs: this.endOfServiceReportSummaryListArgs.bind(this),
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1221,3 +1221,17 @@ describe('GET /service-provider/end-of-service-report/:id/check-answers', () => 
       })
   })
 })
+
+describe('POST /service-provider/end-of-service-report/:id/submit', () => {
+  it('submits the end of service report on the interventions service, and redirects to the confirmation page', async () => {
+    const endOfServiceReport = endOfServiceReportFactory.build()
+    interventionsService.submitEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+
+    await request(app)
+      .post(`/service-provider/end-of-service-report/${endOfServiceReport.id}/submit`)
+      .expect(302)
+      .expect('Location', `/service-provider/end-of-service-report/${endOfServiceReport.id}/confirmation`)
+
+    expect(interventionsService.submitEndOfServiceReport).toHaveBeenCalledWith('token', endOfServiceReport.id)
+  })
+})

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1186,3 +1186,38 @@ describe('POST /service-provider/end-of-service-report/:id/further-information',
     })
   })
 })
+
+describe('GET /service-provider/end-of-service-report/:id/check-answers', () => {
+  it('renders a page with the contents of the end of service report', async () => {
+    const serviceCategory = serviceCategoryFactory.build()
+    const referral = sentReferralFactory.build({
+      referral: { desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id] },
+    })
+    const endOfServiceReport = endOfServiceReportFactory.build({
+      outcomes: [
+        {
+          desiredOutcome: serviceCategory.desiredOutcomes[0],
+          achievementLevel: 'ACHIEVED',
+          progressionComments: 'Some progression comments',
+          additionalTaskComments: 'Some task comments',
+        },
+      ],
+      furtherInformation: 'Some further information',
+    })
+
+    interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+
+    await request(app)
+      .get(`/service-provider/end-of-service-report/${endOfServiceReport.id}/check-answers`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Achieved')
+        expect(res.text).toContain(serviceCategory.desiredOutcomes[0].description)
+        expect(res.text).toContain('Some progression comments')
+        expect(res.text).toContain('Some task comments')
+        expect(res.text).toContain('Some further information')
+      })
+  })
+})

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1235,3 +1235,22 @@ describe('POST /service-provider/end-of-service-report/:id/submit', () => {
     expect(interventionsService.submitEndOfServiceReport).toHaveBeenCalledWith('token', endOfServiceReport.id)
   })
 })
+
+describe('GET /service-provider/end-of-service-report/:id/confirmation', () => {
+  it('displays a confirmation page for that end of service report', async () => {
+    const endOfServiceReport = endOfServiceReportFactory.build()
+    const referral = sentReferralFactory.build()
+    const serviceCategory = serviceCategoryFactory.build()
+
+    interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+
+    await request(app)
+      .get(`/service-provider/end-of-service-report/${endOfServiceReport.id}/confirmation`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('End of service report submitted')
+      })
+  })
+})

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1146,3 +1146,43 @@ describe('POST /service-provider/end-of-service-report/:id/outcomes/:number', ()
     })
   })
 })
+
+describe('GET /service-provider/end-of-service-report/:id/further-information', () => {
+  it('renders a form page', async () => {
+    const endOfServiceReport = endOfServiceReportFactory.build()
+    const referral = sentReferralFactory.build()
+    const serviceCategory = serviceCategoryFactory.build()
+
+    interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+
+    await request(app)
+      .get(`/service-provider/end-of-service-report/${endOfServiceReport.id}/further-information`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain(
+          'Would you like to give any additional information about this intervention (optional)?'
+        )
+      })
+  })
+})
+
+describe('POST /service-provider/end-of-service-report/:id/further-information', () => {
+  it('updates the appointment on the interventions service and redirects to the check your answers page', async () => {
+    const endOfServiceReport = endOfServiceReportFactory.build()
+
+    interventionsService.updateDraftEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+
+    await request(app)
+      .post(`/service-provider/end-of-service-report/${endOfServiceReport.id}/further-information`)
+      .type('form')
+      .send({ 'further-information': 'Some further information' })
+      .expect(302)
+      .expect('Location', `/service-provider/end-of-service-report/${endOfServiceReport.id}/check-answers`)
+
+    expect(interventionsService.updateDraftEndOfServiceReport).toHaveBeenCalledWith('token', endOfServiceReport.id, {
+      furtherInformation: 'Some further information',
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -51,6 +51,8 @@ import EndOfServiceReportFurtherInformationPresenter from './endOfServiceReportF
 import EndOfServiceReportFurtherInformationView from './endOfServiceReportFurtherInformationView'
 import EndOfServiceReportCheckAnswersPresenter from './endOfServiceReportCheckAnswersPresenter'
 import EndOfServiceReportCheckAnswersView from './endOfServiceReportCheckAnswersView'
+import EndOfServiceReportConfirmationPresenter from './endOfServiceReportConfirmationPresenter'
+import EndOfServiceReportConfirmationView from './endOfServiceReportConfirmationView'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -758,5 +760,21 @@ export default class ServiceProviderReferralsController {
   async submitEndOfServiceReport(req: Request, res: Response): Promise<void> {
     await this.interventionsService.submitEndOfServiceReport(res.locals.user.token.accessToken, req.params.id)
     res.redirect(`/service-provider/end-of-service-report/${req.params.id}/confirmation`)
+  }
+
+  async showEndOfServiceReportConfirmation(req: Request, res: Response): Promise<void> {
+    const { accessToken } = res.locals.user.token
+
+    const endOfServiceReport = await this.interventionsService.getEndOfServiceReport(accessToken, req.params.id)
+    const referral = await this.interventionsService.getSentReferral(accessToken, endOfServiceReport.referralId)
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      accessToken,
+      referral.referral.serviceCategoryId
+    )
+
+    const presenter = new EndOfServiceReportConfirmationPresenter(referral, serviceCategory)
+    const view = new EndOfServiceReportConfirmationView(presenter)
+
+    res.render(...view.renderArgs)
   }
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -46,6 +46,9 @@ import SubmittedPostSessionFeedbackPresenter from '../shared/submittedPostSessio
 import EndOfServiceReportOutcomeForm from './endOfServiceReportOutcomeForm'
 import EndOfServiceReportOutcomePresenter from './endOfServiceReportOutcomePresenter'
 import EndOfServiceReportOutcomeView from './endOfServiceReportOutcomeView'
+import EndOfServiceReportFurtherInformationForm from './endOfServiceReportFurtherInformationForm'
+import EndOfServiceReportFurtherInformationPresenter from './endOfServiceReportFurtherInformationPresenter'
+import EndOfServiceReportFurtherInformationView from './endOfServiceReportFurtherInformationView'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -702,6 +705,34 @@ export default class ServiceProviderReferralsController {
       formValidationError
     )
     const view = new EndOfServiceReportOutcomeView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async editEndOfServiceReportFurtherInformation(req: Request, res: Response): Promise<void> {
+    const { accessToken } = res.locals.user.token
+    const { id } = req.params
+
+    if (req.method === 'POST') {
+      const form = new EndOfServiceReportFurtherInformationForm(req)
+      await this.interventionsService.updateDraftEndOfServiceReport(accessToken, id, form.paramsForUpdate)
+      res.redirect(`/service-provider/end-of-service-report/${id}/check-answers`)
+      return
+    }
+
+    const endOfServiceReport = await this.interventionsService.getEndOfServiceReport(accessToken, req.params.id)
+    const referral = await this.interventionsService.getSentReferral(accessToken, endOfServiceReport.referralId)
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      accessToken,
+      referral.referral.serviceCategoryId
+    )
+    const presenter = new EndOfServiceReportFurtherInformationPresenter(
+      endOfServiceReport,
+      serviceCategory,
+      referral,
+      null
+    )
+    const view = new EndOfServiceReportFurtherInformationView(presenter)
 
     res.render(...view.renderArgs)
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -49,6 +49,8 @@ import EndOfServiceReportOutcomeView from './endOfServiceReportOutcomeView'
 import EndOfServiceReportFurtherInformationForm from './endOfServiceReportFurtherInformationForm'
 import EndOfServiceReportFurtherInformationPresenter from './endOfServiceReportFurtherInformationPresenter'
 import EndOfServiceReportFurtherInformationView from './endOfServiceReportFurtherInformationView'
+import EndOfServiceReportCheckAnswersPresenter from './endOfServiceReportCheckAnswersPresenter'
+import EndOfServiceReportCheckAnswersView from './endOfServiceReportCheckAnswersView'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -733,6 +735,22 @@ export default class ServiceProviderReferralsController {
       null
     )
     const view = new EndOfServiceReportFurtherInformationView(presenter)
+
+    res.render(...view.renderArgs)
+  }
+
+  async endOfServiceReportCheckAnswers(req: Request, res: Response): Promise<void> {
+    const { accessToken } = res.locals.user.token
+
+    const endOfServiceReport = await this.interventionsService.getEndOfServiceReport(accessToken, req.params.id)
+    const referral = await this.interventionsService.getSentReferral(accessToken, endOfServiceReport.referralId)
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      accessToken,
+      referral.referral.serviceCategoryId
+    )
+
+    const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+    const view = new EndOfServiceReportCheckAnswersView(presenter)
 
     res.render(...view.renderArgs)
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -754,4 +754,9 @@ export default class ServiceProviderReferralsController {
 
     res.render(...view.renderArgs)
   }
+
+  async submitEndOfServiceReport(req: Request, res: Response): Promise<void> {
+    await this.interventionsService.submitEndOfServiceReport(res.locals.user.token.accessToken, req.params.id)
+    res.redirect(`/service-provider/end-of-service-report/${req.params.id}/confirmation`)
+  }
 }

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -89,4 +89,9 @@ export default {
       invalidDuration: 'The session duration must be a real duration',
     },
   },
+  endOfServiceReportOutcome: {
+    achievementLevel: {
+      empty: (name: string) => `Select whether ${name} achieved the desired outcome`,
+    },
+  },
 }

--- a/server/views/serviceProviderReferrals/endOfServiceReport/checkAnswers.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/checkAnswers.njk
@@ -1,0 +1,40 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "./formTemplate.njk" %}
+
+{% block formSection %}
+  {{ govukSummaryList(interventionSummarySummaryListArgs) }}
+
+  {% for outcome in presenter.outcomes %}
+    <h3 class="govuk-heading-m">{{ outcome.title }}</h3>
+
+    {{ govukTag({ text: outcome.achievementLevelText, classes: achievementLevelTagClass(outcome.achievementLevelStyle) }) }}
+
+    <br>
+
+    <div class="govuk-inset-text">{{ outcome.subtitle }}</div>
+
+    <p class="govuk-body"><strong>Do you have any further comments about their progression on this outcome?</strong></p>
+    <p class="govuk-body">{{ outcome.progressionComments }}</p>
+
+    <p class="govuk-body"><strong>Is there anything else that needs doing to achieve this outcome?</strong></p>
+    <p class="govuk-body">{{ outcome.additionalTaskComments }}</p>
+
+    <p>
+    <a class="govuk-link" id="change-outcome-{{loop.index}}" href="{{ outcome.changeHref }}">Change</a>
+    </p>
+  {% endfor %}
+
+  <h3 class="govuk-heading-m">Additional information</h3>
+
+  <p class="govuk-body">{{ presenter.furtherInformation.text }}</p>
+  <p>
+  <a class="govuk-link" id="change-further-information" href="{{ presenter.furtherInformation.changeHref }}">Change</a>
+  </p>
+
+  <form method="post" action="{{ presenter.formAction }}">
+    {{ govukButton({ text: "Submit the report" }) }}
+  </form>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/endOfServiceReport/confirmation.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/confirmation.njk
@@ -1,0 +1,32 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% block pageTitle %}
+  HMPPS Interventions - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({titleText: "End of service report submitted"}) }}
+
+      <h2 class="govuk-heading-m">Service user details</h2>
+
+      {{ govukSummaryList(summaryListArgs) }}
+
+      <h2 class="govuk-heading-m">What happens next?</h2>
+
+      <p class="govuk-body">
+      The end of service report has been saved and submitted.
+      </p>
+
+      <p class="govuk-body">
+      This case will appear in your dashboard.
+      </p>
+
+      <a href="{{ presenter.progressHref }}" class="govuk-button">Return to service progress</a>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/endOfServiceReport/furtherInformation.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/furtherInformation.njk
@@ -1,0 +1,14 @@
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "./formTemplate.njk" %}
+
+{% block formSection %}
+  <form method="post">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+    {{ govukTextarea(furtherInformationTextareaArgs) }}
+
+    {{ govukButton({ text: "Save and continue" }) }}
+  </form>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/endOfServiceReport/outcome.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/outcome.njk
@@ -1,0 +1,31 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "./formTemplate.njk" %}
+
+{% block pageTitle %}
+  HMPPS Interventions - GOV.UK
+{% endblock %}
+
+{% block formSection %}
+  <p class="govuk-body">
+  <strong>{{ presenter.text.desiredOutcomeNumberDescription }}</strong>
+  </p>
+
+  <div class="govuk-inset-text">
+    {{ presenter.text.desiredOutcomeDescription }}
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--visible">
+
+  <form method="post">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+    {{ govukRadios(achievementLevelRadiosArgs) }}
+    {{ govukTextarea(progressionCommentsTextareaArgs) }}
+    {{ govukTextarea(additionalTaskCommentsTextareaArgs) }}
+
+    {{ govukButton({ text: "Save and continue" }) }}
+  </form>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -56,9 +56,9 @@
   <h2 class="govuk-heading-m">End of service report</h2>
 
   <p class="govuk-body">
-    You can start the end of service report when all sessions are delivered.
+  You can start the end of service report when all sessions are delivered.
   </p>
-</div>
-</div>
+
+  {{ govukSummaryList(endOfServiceReportSummaryListArgs(govukTag, csrfToken)) }}
 
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

This builds the journey that allows a service provider caseworker to:

- click on a "Create end of service report" button on the intervention progress page
- fill in the end of service report's outcomes and further information
- check their answers
- submit the end of service report

## Notes

- We can't test this locally at the moment since we're waiting for the backend to add `referralId` to the end of service report.
- This is a large PR but the structure is pretty simple:
  - updating the intervention progress page to add the button that starts the journey and show the end of service report status
  - a bunch of new pages (with no new concepts)
  - an integration test
- The only thing that's a little bit new, I suppose, is determining which page to redirect to when the user fills submits one of the outcome pages - either the next outcome or the further information page, depending on whether it was the final outcome. This is in the commit "SP user can enter outcomes in end of service report".

## What is the intent behind these changes?

To allow a service provider user to write an end of service report and hence finish the intervention.

## Screenshots

![image](https://user-images.githubusercontent.com/53756884/115682653-94d92480-a34d-11eb-9cff-925b57f3aac2.png)
![localhost_3007_service-provider_end-of-service-report_1_outcomes_1](https://user-images.githubusercontent.com/53756884/115682895-ceaa2b00-a34d-11eb-9bff-297c3a5c8a77.png)
![localhost_3007_service-provider_end-of-service-report_1_outcomes_1 (1)](https://user-images.githubusercontent.com/53756884/115682994-e5e91880-a34d-11eb-8fd3-9742936d57af.png)
![localhost_3007_service-provider_end-of-service-report_1_check-answers](https://user-images.githubusercontent.com/53756884/115683094-031de700-a34e-11eb-9406-d983285738d5.png)
![localhost_3007_service-provider_end-of-service-report_1_confirmation](https://user-images.githubusercontent.com/53756884/115683174-1761e400-a34e-11eb-9f81-77825fad1976.png)

