### PR TITLE
IC-1321: Allow cancellation comments to be null

### DIFF
--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -624,7 +624,7 @@ export default class InterventionsService {
     token: string,
     referralId: string,
     reasonCode: string,
-    cancellationComments: string
+    cancellationComments: string | null
   ): Promise<EndedReferral> {
     const restClient = this.createRestClient(token)
     return (await restClient.post({


### PR DESCRIPTION
## What does this pull request do?

Allows cancellation comments to be `null` when cancelling a referral.

## What is the intent behind these changes?

Cancellation comments is an optional field in the UI journey.
