### PR TITLE
IC-1321: Add Referral cancellation reason radio buttons

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -232,6 +232,10 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
+      cy.stubGetReferralCancellationReasons([
+        { code: 'MIS', description: 'Referral was made by mistake' },
+        { code: 'MOV', description: 'Service user has moved out of delivery area' },
+      ])
 
       cy.stubGetActionPlanAppointments(actionPlan.id, appointments)
       cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointments[0])
@@ -242,6 +246,7 @@ describe('Probation Practitioner monitor journey', () => {
       cy.visit(`/probation-practitioner/referrals/${assignedReferral.id}/progress`)
 
       cy.contains('Cancel this referral').click()
+      cy.contains('Service user has moved out of delivery area').click()
       cy.contains('Additional comments (optional)').type('Some additional comments')
       cy.contains('Continue').click()
     })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -137,12 +137,19 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/reason', () => 
     interventionsService.getSentReferral.mockResolvedValue(referral)
     communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getReferralCancellationReasons.mockResolvedValue([
+      { code: 'MIS', description: 'Referral was made by mistake' },
+      { code: 'MOV', description: 'Service user has moved out of delivery area' },
+    ])
 
     await request(app)
       .get(`/probation-practitioner/referrals/${referral.id}/cancellation/reason`)
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Referral cancellation')
+        expect(res.text).toContain('What is the reason for the cancellation of this referral?')
+        expect(res.text).toContain('Referral was made by mistake')
+        expect(res.text).toContain('Service user has moved out of delivery area')
         expect(res.text).toContain('Additional comments (optional)')
       })
   })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -120,12 +120,13 @@ export default class ProbationPractitionerReferralsController {
 
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
     const serviceCategory = await this.interventionsService.getServiceCategory(
-      res.locals.user.token.accessToken,
+      accessToken,
       sentReferral.referral.serviceCategoryId
     )
     const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
+    const cancellationReasons = await this.interventionsService.getReferralCancellationReasons(accessToken)
 
-    const presenter = new ReferralCancellationPresenter(sentReferral, serviceCategory, serviceUser)
+    const presenter = new ReferralCancellationPresenter(sentReferral, serviceCategory, serviceUser, cancellationReasons)
     const view = new ReferralCancellationView(presenter)
 
     return res.render(...view.renderArgs)

--- a/server/routes/probationPractitionerReferrals/referralCancellationPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationPresenter.test.ts
@@ -2,6 +2,7 @@ import deliusServiceUserFactory from '../../../testutils/factories/deliusService
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import serviceProviderFactory from '../../../testutils/factories/serviceProvider'
+import { CancellationReason } from '../../services/interventionsService'
 import ReferralCancellationPresenter from './referralCancellationPresenter'
 
 describe(ReferralCancellationPresenter, () => {
@@ -11,13 +12,43 @@ describe(ReferralCancellationPresenter, () => {
       const sentReferral = sentReferralFactory.build({ referral: { serviceProvider } })
       const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex', surname: 'River' })
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const cancellationReasons: CancellationReason[] = []
 
-      const presenter = new ReferralCancellationPresenter(sentReferral, serviceCategory, serviceUser)
+      const presenter = new ReferralCancellationPresenter(
+        sentReferral,
+        serviceCategory,
+        serviceUser,
+        cancellationReasons
+      )
       expect(presenter.text.title).toEqual('Referral cancellation')
       expect(presenter.text.information).toEqual(
         "You are about to cancel Alex River's referral for an accommodation intervention with Harmony Living."
       )
       expect(presenter.text.additionalCommentsLabel).toEqual('Additional comments (optional):')
+    })
+  })
+
+  describe('referralCancellationFields', () => {
+    it('returns an array of fields to be passed as radio button args', () => {
+      const sentReferral = sentReferralFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const cancellationReasons: CancellationReason[] = [
+        { code: 'MIS', description: 'Referral was made by mistake' },
+        { code: 'MOV', description: 'Service user has moved out of delivery area' },
+      ]
+
+      const presenter = new ReferralCancellationPresenter(
+        sentReferral,
+        serviceCategory,
+        serviceUser,
+        cancellationReasons
+      )
+
+      expect(presenter.cancellationReasonsFields).toEqual([
+        { value: 'MIS', text: 'Referral was made by mistake', checked: false },
+        { value: 'MOV', text: 'Service user has moved out of delivery area', checked: false },
+      ])
     })
   })
 })

--- a/server/routes/probationPractitionerReferrals/referralCancellationPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationPresenter.ts
@@ -1,12 +1,13 @@
 import a from 'indefinite'
 import { DeliusServiceUser } from '../../services/communityApiService'
-import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { CancellationReason, SentReferral, ServiceCategory } from '../../services/interventionsService'
 
 export default class ReferralCancellationPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly serviceCategory: ServiceCategory,
-    private readonly serviceUser: DeliusServiceUser
+    private readonly serviceUser: DeliusServiceUser,
+    private readonly cancellationReasons: CancellationReason[]
   ) {}
 
   readonly text = {
@@ -15,5 +16,13 @@ export default class ReferralCancellationPresenter {
       this.serviceCategory.name
     )} intervention with ${this.sentReferral.referral.serviceProvider.name}.`,
     additionalCommentsLabel: 'Additional comments (optional):',
+  }
+
+  get cancellationReasonsFields(): { value: string; text: string; checked: boolean }[] {
+    return this.cancellationReasons.map(cancellationReason => ({
+      value: cancellationReason.code,
+      text: cancellationReason.description,
+      checked: false,
+    }))
   }
 }

--- a/server/routes/probationPractitionerReferrals/referralCancellationView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationView.ts
@@ -1,8 +1,22 @@
-import { TextareaArgs } from '../../utils/govukFrontendTypes'
+import { RadiosArgs, TextareaArgs } from '../../utils/govukFrontendTypes'
 import ReferralCancellationPresenter from './referralCancellationPresenter'
 
 export default class ReferralCancellationView {
   constructor(private readonly presenter: ReferralCancellationPresenter) {}
+
+  private get referralCancellationRadiosArgs(): RadiosArgs {
+    return {
+      fieldset: {
+        legend: {
+          text: 'What is the reason for the cancellation of this referral?',
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--m govuk-!-margin-bottom-6',
+        },
+      },
+      name: 'cancellation-reason',
+      items: this.presenter.cancellationReasonsFields,
+    }
+  }
 
   private get additionalCommentsTextareaArgs(): TextareaArgs {
     return {
@@ -19,6 +33,7 @@ export default class ReferralCancellationView {
       'probationPractitionerReferrals/referralCancellation',
       {
         presenter: this.presenter,
+        referralCancellationRadiosArgs: this.referralCancellationRadiosArgs,
         additionalCommentsTextareaArgs: this.additionalCommentsTextareaArgs,
       },
     ]

--- a/server/views/probationPractitionerReferrals/referralCancellation.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellation.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% extends "../partials/layout.njk" %}
@@ -11,11 +12,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
-      <p class="govuk-body-m">{{ presenter.text.information }}</p>
+      <p class="govuk-body-m govuk-!-margin-bottom-8">{{ presenter.text.information }}</p>
     </div>
     <form method="post">
       <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
+      {{ govukRadios(referralCancellationRadiosArgs) }}
       {{ govukTextarea(additionalCommentsTextareaArgs) }}
 
       {{ govukButton({ text: "Continue" }) }}


### PR DESCRIPTION
## What does this pull request do?

Adds referral cancellation reason radio buttons to cancellation page.

These come from the interventions service, and their "code" vales will
be stored on the ended referral.

They're not currently submitted yet.

## What is the intent behind these changes?

To allow PPs to select a reason for cancelling a referral.

## Screenshot

<img width="924" alt="image" src="https://user-images.githubusercontent.com/19826940/115866422-8bc18380-a431-11eb-98e0-37ae79fadd68.png">
