### PR TITLE
IC-1349 use new 'getReferral' method for populating referral in SP progress page.

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -218,9 +218,9 @@ describe('Service provider referrals dashboard', () => {
     const assignedReferral = referralFactory.assigned().build({
       id: oldStyleAssignedReferral.id,
       serviceUser: { crn: referralParams.referral.serviceUser.crn },
-      draftReferralFields: { desiredOutcomesIds: selectedDesiredOutcomesIds },
+      formFields: { desiredOutcomesIds: selectedDesiredOutcomesIds },
     })
-    assignedReferral.sentReferralFields.assignedTo = { username: hmppsAuthUser.username }
+    assignedReferral.sentFields.assignedTo = { username: hmppsAuthUser.username }
     const draftActionPlan = actionPlanFactory.justCreated(assignedReferral.id).build()
     const actionPlanAppointments = [
       actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 1 }),
@@ -315,7 +315,7 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('Save and continue').click()
 
     const referralWithActionPlanId = referralFactory.build({ ...assignedReferral })
-    referralWithActionPlanId.sentReferralFields.actionPlanId = draftActionPlan.id
+    referralWithActionPlanId.sentFields.actionPlanId = draftActionPlan.id
     const submittedActionPlan = { ...draftActionPlanWithNumberOfSessions, submittedAt: new Date().toISOString() }
 
     cy.stubGetReferral(assignedReferral.id, referralWithActionPlanId)
@@ -422,7 +422,7 @@ describe('Service provider referrals dashboard', () => {
       const assignedReferral = referralFactory
         .assigned()
         .build({ id: referralParams.id, serviceUser: { crn: referralParams.referral.serviceUser.crn } })
-      assignedReferral.sentReferralFields.actionPlanId = actionPlan.id
+      assignedReferral.sentFields.actionPlanId = actionPlan.id
 
       cy.stubGetSentReferrals([oldStyleAssignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
@@ -566,7 +566,7 @@ describe('Service provider referrals dashboard', () => {
       const assignedReferral = referralFactory
         .assigned()
         .build({ id: referralParams.id, serviceUser: { crn: referralParams.referral.serviceUser.crn } })
-      assignedReferral.sentReferralFields.actionPlanId = actionPlan.id
+      assignedReferral.sentFields.actionPlanId = actionPlan.id
 
       cy.stubGetSentReferrals([oldStyleAssignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
@@ -676,7 +676,7 @@ describe('Service provider referrals dashboard', () => {
         id: referralParams.id,
         serviceUser: { crn: referralParams.referral.serviceUser.crn },
       })
-      assignedReferral.sentReferralFields.actionPlanId = actionPlan.id
+      assignedReferral.sentFields.actionPlanId = actionPlan.id
 
       cy.stubGetSentReferrals([oldStyleAssignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
@@ -761,7 +761,7 @@ describe('Service provider referrals dashboard', () => {
     const referral = referralFactory.assigned().build({
       id: oldStyleReferral.id,
       serviceUser: referralParams.serviceUser,
-      draftReferralFields: { desiredOutcomesIds: selectedDesiredOutcomesIds },
+      formFields: { desiredOutcomesIds: selectedDesiredOutcomesIds },
     })
 
     const actionPlan = actionPlanFactory.submitted(referral.id).build()
@@ -891,7 +891,7 @@ describe('Service provider referrals dashboard', () => {
     }
 
     const referralWithEosr = referralFactory.build({ ...referral })
-    referralWithEosr.sentReferralFields.endOfServiceReport = submittedEndOfServiceReport
+    referralWithEosr.sentFields.endOfServiceReport = submittedEndOfServiceReport
     cy.stubGetReferral(referralWithEosr.id, referralWithEosr)
     cy.stubSubmitEndOfServiceReport(submittedEndOfServiceReport.id, submittedEndOfServiceReport)
 

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1,4 +1,5 @@
 import sentReferralFactory from '../../testutils/factories/sentReferral'
+import referralFactory from '../../testutils/factories/referral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
 import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
@@ -201,15 +202,25 @@ describe('Service provider referrals dashboard', () => {
     ]
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })
     const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
-    const referralParams = {
-      referral: { serviceCategoryId: serviceCategory.id, desiredOutcomesIds: selectedDesiredOutcomesIds },
-    }
     const deliusServiceUser = deliusServiceUserFactory.build()
-    const deliusUser = deliusUserFactory.build()
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
-    const assignedReferral = sentReferralFactory
-      .assigned()
-      .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username } })
+
+    const referralParams = {
+      referral: {
+        serviceCategoryId: serviceCategory.id,
+        desiredOutcomesIds: selectedDesiredOutcomesIds,
+        serviceUser: { crn: deliusServiceUser.otherIds.crn },
+      },
+      assignedTo: { username: hmppsAuthUser.username },
+    }
+    const deliusUser = deliusUserFactory.build()
+    const oldStyleAssignedReferral = sentReferralFactory.assigned().build({ ...referralParams })
+    const assignedReferral = referralFactory.assigned().build({
+      id: oldStyleAssignedReferral.id,
+      serviceUser: { crn: referralParams.referral.serviceUser.crn },
+      draftReferralFields: { desiredOutcomesIds: selectedDesiredOutcomesIds },
+    })
+    assignedReferral.sentReferralFields.assignedTo = { username: hmppsAuthUser.username }
     const draftActionPlan = actionPlanFactory.justCreated(assignedReferral.id).build()
     const actionPlanAppointments = [
       actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 1 }),
@@ -218,13 +229,14 @@ describe('Service provider referrals dashboard', () => {
       actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 4 }),
     ]
 
-    cy.stubGetSentReferrals([assignedReferral])
+    cy.stubGetSentReferrals([oldStyleAssignedReferral])
 
     cy.stubGetActionPlan(draftActionPlan.id, draftActionPlan)
     cy.stubCreateDraftActionPlan(draftActionPlan)
     cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
-    cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
-    cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetSentReferral(oldStyleAssignedReferral.id, oldStyleAssignedReferral)
+    cy.stubGetReferral(assignedReferral.id, assignedReferral)
+    cy.stubGetServiceUserByCRN(assignedReferral.serviceUser.crn, deliusServiceUser)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
     cy.stubGetActionPlanAppointments(draftActionPlan.id, actionPlanAppointments)
@@ -302,10 +314,11 @@ describe('Service provider referrals dashboard', () => {
 
     cy.contains('Save and continue').click()
 
-    const referralWithActionPlanId = { ...assignedReferral, actionPlanId: draftActionPlan.id }
+    const referralWithActionPlanId = referralFactory.build({ ...assignedReferral })
+    referralWithActionPlanId.sentReferralFields.actionPlanId = draftActionPlan.id
     const submittedActionPlan = { ...draftActionPlanWithNumberOfSessions, submittedAt: new Date().toISOString() }
 
-    cy.stubGetSentReferral(assignedReferral.id, referralWithActionPlanId)
+    cy.stubGetReferral(assignedReferral.id, referralWithActionPlanId)
     cy.stubSubmitActionPlan(draftActionPlan.id, submittedActionPlan)
     cy.stubGetActionPlan(draftActionPlan.id, submittedActionPlan)
 
@@ -378,16 +391,12 @@ describe('Service provider referrals dashboard', () => {
   describe('Recording post session feedback', () => {
     it('user records the Service User as having attended, and fills out behaviour screen', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const deliusServiceUser = deliusServiceUserFactory.build()
       const referralParams = {
         id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
-        referral: { serviceCategoryId: serviceCategory.id },
+        referral: { serviceCategoryId: serviceCategory.id, serviceUser: { crn: deliusServiceUser.otherIds.crn } },
       }
-      const deliusServiceUser = deliusServiceUserFactory.build()
-      const probationPractitioner = deliusUserFactory.build({
-        firstName: 'John',
-        surname: 'Smith',
-        username: 'john.smith',
-      })
+
       const actionPlan = actionPlanFactory.submitted().build({
         referralId: referralParams.id,
         numberOfSessions: 4,
@@ -406,18 +415,21 @@ describe('Service provider referrals dashboard', () => {
         }),
       ]
 
-      const assignedReferral = sentReferralFactory.assigned().build({
+      const oldStyleAssignedReferral = sentReferralFactory.assigned().build({
         ...referralParams,
-        assignedTo: { username: probationPractitioner.username },
         actionPlanId: actionPlan.id,
       })
+      const assignedReferral = referralFactory
+        .assigned()
+        .build({ id: referralParams.id, serviceUser: { crn: referralParams.referral.serviceUser.crn } })
+      assignedReferral.sentReferralFields.actionPlanId = actionPlan.id
 
-      cy.stubGetSentReferrals([assignedReferral])
+      cy.stubGetSentReferrals([oldStyleAssignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
       cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
-      cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
-      cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
-      cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
+      cy.stubGetSentReferral(oldStyleAssignedReferral.id, oldStyleAssignedReferral)
+      cy.stubGetReferral(assignedReferral.id, assignedReferral)
+      cy.stubGetServiceUserByCRN(assignedReferral.serviceUser.crn, deliusServiceUser)
 
       cy.stubGetActionPlanAppointments(actionPlan.id, appointments)
       cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointments[0])
@@ -523,16 +535,11 @@ describe('Service provider referrals dashboard', () => {
 
     it('user records the Service User as having not attended, and skips behaviour screen', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const deliusServiceUser = deliusServiceUserFactory.build()
       const referralParams = {
         id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
-        referral: { serviceCategoryId: serviceCategory.id },
+        referral: { serviceCategoryId: serviceCategory.id, serviceUser: { crn: deliusServiceUser.otherIds.crn } },
       }
-      const deliusServiceUser = deliusServiceUserFactory.build()
-      const probationPractitioner = deliusUserFactory.build({
-        firstName: 'John',
-        surname: 'Smith',
-        username: 'john.smith',
-      })
       const actionPlan = actionPlanFactory.submitted().build({
         referralId: referralParams.id,
         numberOfSessions: 4,
@@ -551,18 +558,22 @@ describe('Service provider referrals dashboard', () => {
         }),
       ]
 
-      const assignedReferral = sentReferralFactory.assigned().build({
+      const oldStyleAssignedReferral = sentReferralFactory.assigned().build({
         ...referralParams,
-        assignedTo: { username: probationPractitioner.username },
         actionPlanId: actionPlan.id,
       })
 
-      cy.stubGetSentReferrals([assignedReferral])
+      const assignedReferral = referralFactory
+        .assigned()
+        .build({ id: referralParams.id, serviceUser: { crn: referralParams.referral.serviceUser.crn } })
+      assignedReferral.sentReferralFields.actionPlanId = actionPlan.id
+
+      cy.stubGetSentReferrals([oldStyleAssignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
       cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
-      cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
-      cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
-      cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
+      cy.stubGetSentReferral(oldStyleAssignedReferral.id, oldStyleAssignedReferral)
+      cy.stubGetReferral(assignedReferral.id, assignedReferral)
+      cy.stubGetServiceUserByCRN(assignedReferral.serviceUser.crn, deliusServiceUser)
 
       cy.stubGetActionPlanAppointments(actionPlan.id, appointments)
       cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointments[0])
@@ -650,33 +661,29 @@ describe('Service provider referrals dashboard', () => {
   describe('Viewing session feedback', () => {
     it('allows users to click through to a page to view session feedback', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const deliusServiceUser = deliusServiceUserFactory.build()
       const referralParams = {
         id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
-        referral: { serviceCategoryId: serviceCategory.id },
+        referral: { serviceCategoryId: serviceCategory.id, serviceUser: { crn: deliusServiceUser.otherIds.crn } },
       }
-      const deliusServiceUser = deliusServiceUserFactory.build()
-      const probationPractitioner = deliusUserFactory.build({
-        firstName: 'John',
-        surname: 'Smith',
-        username: 'john.smith',
-      })
       const actionPlan = actionPlanFactory.submitted().build({
         referralId: referralParams.id,
         numberOfSessions: 4,
       })
 
-      const assignedReferral = sentReferralFactory.assigned().build({
-        ...referralParams,
-        assignedTo: { username: probationPractitioner.username },
-        actionPlanId: actionPlan.id,
+      const oldStyleAssignedReferral = sentReferralFactory.assigned().build(referralParams)
+      const assignedReferral = referralFactory.assigned().build({
+        id: referralParams.id,
+        serviceUser: { crn: referralParams.referral.serviceUser.crn },
       })
+      assignedReferral.sentReferralFields.actionPlanId = actionPlan.id
 
-      cy.stubGetSentReferrals([assignedReferral])
+      cy.stubGetSentReferrals([oldStyleAssignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
       cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
-      cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
-      cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
-      cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
+      cy.stubGetReferral(assignedReferral.id, assignedReferral)
+      cy.stubGetSentReferral(oldStyleAssignedReferral.id, oldStyleAssignedReferral)
+      cy.stubGetServiceUserByCRN(assignedReferral.serviceUser.crn, deliusServiceUser)
 
       const appointmentsWithSubmittedFeedback = [
         actionPlanAppointmentFactory.scheduled().build({
@@ -734,29 +741,39 @@ describe('Service provider referrals dashboard', () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })
     const selectedDesiredOutcomes = [desiredOutcomes[0], desiredOutcomes[1]]
     const selectedDesiredOutcomesIds = selectedDesiredOutcomes.map(outcome => outcome.id)
+    const deliusServiceUser = deliusServiceUserFactory.build()
+    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
+
     const referralParams = {
       referral: {
         serviceCategoryId: serviceCategory.id,
         desiredOutcomesIds: selectedDesiredOutcomesIds,
-        serviceUser: { firstName: 'Alex', lastName: 'River' },
+        serviceUser: {
+          crn: deliusServiceUser.otherIds.crn,
+          firstName: deliusServiceUser.firstName,
+          lastName: deliusServiceUser.surname,
+        },
       },
+      assignedTo: { username: hmppsAuthUser.username },
     }
-    const deliusServiceUser = deliusServiceUserFactory.build()
     const deliusUser = deliusUserFactory.build()
-    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
-    const referral = sentReferralFactory
-      .assigned()
-      .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username } })
+    const oldStyleReferral = sentReferralFactory.assigned().build({ ...referralParams })
+    const referral = referralFactory.assigned().build({
+      id: oldStyleReferral.id,
+      serviceUser: referralParams.serviceUser,
+      draftReferralFields: { desiredOutcomesIds: selectedDesiredOutcomesIds },
+    })
+
     const actionPlan = actionPlanFactory.submitted(referral.id).build()
     referral.actionPlanId = actionPlan.id
     const draftEndOfServiceReport = endOfServiceReportFactory.justCreated().build({ referralId: referral.id })
 
-    cy.stubGetSentReferrals([referral])
-
+    cy.stubGetSentReferrals([oldStyleReferral])
     cy.stubGetActionPlan(actionPlan.id, actionPlan)
     cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
-    cy.stubGetSentReferral(referral.id, referral)
-    cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetSentReferral(oldStyleReferral.id, oldStyleReferral)
+    cy.stubGetReferral(referral.id, referral)
+    cy.stubGetServiceUserByCRN(referral.serviceUser.crn, deliusServiceUser)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
     cy.stubCreateDraftEndOfServiceReport(draftEndOfServiceReport)
@@ -873,7 +890,9 @@ describe('Service provider referrals dashboard', () => {
       submittedAt: new Date().toISOString(),
     }
 
-    cy.stubGetSentReferral(referral.id, { ...referral, endOfServiceReport: submittedEndOfServiceReport })
+    const referralWithEosr = referralFactory.build({ ...referral })
+    referralWithEosr.sentReferralFields.endOfServiceReport = submittedEndOfServiceReport
+    cy.stubGetReferral(referralWithEosr.id, referralWithEosr)
     cy.stubSubmitEndOfServiceReport(submittedEndOfServiceReport.id, submittedEndOfServiceReport)
 
     cy.contains('Submit the report').click()

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -156,5 +156,9 @@ module.exports = on => {
     stubGetReferralCancellationReasons: arg => {
       return interventionsService.stubGetReferralCancellationReasons(arg.responseJson)
     },
+
+    stubGetReferral: arg => {
+      return interventionsService.stubGetReferral(arg.id, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -113,3 +113,7 @@ Cypress.Commands.add('stubCancelReferral', (referralId, responseJson) => {
 Cypress.Commands.add('stubGetReferralCancellationReasons', responseJson => {
   cy.task('stubGetReferralCancellationReasons', { responseJson })
 })
+
+Cypress.Commands.add('stubGetReferral', (id, responseJson) => {
+  cy.task('stubGetReferral', { id, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -464,4 +464,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubGetReferral = async (id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/referral/${id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@types/redis": "^2.8.28",
         "@types/superagent": "^4.1.10",
         "@types/supertest": "^2.0.10",
+        "@types/uuid": "^8.3.0",
         "@typescript-eslint/eslint-plugin": "^4.4.1",
         "@typescript-eslint/parser": "^4.4.1",
         "concurrently": "^5.3.0",
@@ -94,7 +95,8 @@
         "supertest": "^4.0.2",
         "ts-jest": "^26.4.1",
         "ts-node": "^9.1.1",
-        "typescript": "^4.0.3"
+        "typescript": "^4.0.3",
+        "uuid": "^3.4.0"
       },
       "engines": {
         "node": ">=14",
@@ -2930,6 +2932,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -20386,6 +20394,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@types/redis": "^2.8.28",
     "@types/superagent": "^4.1.10",
     "@types/supertest": "^2.0.10",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
     "concurrently": "^5.3.0",
@@ -178,6 +179,7 @@
     "supertest": "^4.0.2",
     "ts-jest": "^26.4.1",
     "ts-node": "^9.1.1",
-    "typescript": "^4.0.3"
+    "typescript": "^4.0.3",
+    "uuid": "^3.4.0"
   }
 }

--- a/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.ts
@@ -1,4 +1,4 @@
-import { EndOfServiceReport, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { EndOfServiceReport, SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import EndOfServiceReportAnswersPresenter from '../shared/endOfServiceReportAnswersPresenter'
 import PresenterUtils from '../../utils/presenterUtils'
 
@@ -6,7 +6,7 @@ export default class EndOfServiceReportPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategory: ServiceCategory
+    private readonly serviceCategory: ServiceCategoryFull
   ) {}
 
   readonly text = {

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -1,4 +1,4 @@
-import { ActionPlanAppointment, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { ActionPlanAppointment, SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import utils from '../../utils/utils'
 import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from '../shared/referralOverviewPagePresenter'
 import { DeliusServiceUser } from '../../services/communityApiService'
@@ -11,7 +11,7 @@ export default class InterventionProgressPresenter {
 
   constructor(
     private readonly referral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     serviceUser: DeliusServiceUser,
     private readonly actionPlanAppointments: ActionPlanAppointment[]
   ) {

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -17,7 +17,7 @@ export default class InterventionProgressPresenter {
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Progress,
-      referral,
+      referral.id,
       serviceUser,
       'probation-practitioner'
     )

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
@@ -1,10 +1,13 @@
-import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import PresenterUtils from '../../utils/presenterUtils'
 import { SortableTableHeaders, SortableTableRow } from '../../utils/viewUtils'
 import DashboardNavPresenter from './dashboardNavPresenter'
 
 export default class MyCasesPresenter {
-  constructor(private readonly sentReferrals: SentReferral[], private readonly serviceCategories: ServiceCategory[]) {}
+  constructor(
+    private readonly sentReferrals: SentReferral[],
+    private readonly serviceCategories: ServiceCategoryFull[]
+  ) {}
 
   readonly navItemsPresenter = new DashboardNavPresenter('My cases')
 

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
@@ -1,13 +1,13 @@
 import a from 'indefinite'
 import { DeliusServiceUser } from '../../services/communityApiService'
-import { CancellationReason, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { CancellationReason, SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class ReferralCancellationReasonPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly serviceUser: DeliusServiceUser,
     private readonly cancellationReasons: CancellationReason[],
     private readonly error: FormValidationError | null = null

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -1,7 +1,7 @@
-import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategoryFull } from '../../services/interventionsService'
 
 export default class CheckAnswersPresenter {
-  constructor(private readonly referral: DraftReferral, private readonly serviceCategory: ServiceCategory) {}
+  constructor(private readonly referral: DraftReferral, private readonly serviceCategory: ServiceCategoryFull) {}
 
   // TODO IC-679 build this page properly - this
   // is just a placeholder to show the data’s coming in

--- a/server/routes/referrals/completionDeadlinePresenter.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.ts
@@ -1,4 +1,4 @@
-import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import CalendarDay from '../../utils/calendarDay'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
@@ -12,7 +12,7 @@ export default class CompletionDeadlinePresenter {
 
   constructor(
     private readonly referral: DraftReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}

--- a/server/routes/referrals/complexityLevelPresenter.ts
+++ b/server/routes/referrals/complexityLevelPresenter.ts
@@ -1,11 +1,11 @@
-import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class ComplexityLevelPresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}

--- a/server/routes/referrals/desiredOutcomesPresenter.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.ts
@@ -1,11 +1,11 @@
-import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class DesiredOutcomesPresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, string[]> | null = null
   ) {}

--- a/server/routes/referrals/furtherInformationPresenter.ts
+++ b/server/routes/referrals/furtherInformationPresenter.ts
@@ -1,11 +1,11 @@
-import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class FurtherInformationPresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, string> | null = null
   ) {}

--- a/server/routes/referrals/rarDaysForm.ts
+++ b/server/routes/referrals/rarDaysForm.ts
@@ -1,6 +1,6 @@
 import { Request } from 'express'
 import { Result, ValidationChain, ValidationError } from 'express-validator'
-import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import errorMessages from '../../utils/errorMessages'
 import FormUtils from '../../utils/formUtils'
 import { FormValidationError } from '../../utils/formValidationError'
@@ -8,14 +8,14 @@ import { FormValidationError } from '../../utils/formValidationError'
 export default class RarDaysForm {
   private constructor(private readonly request: Request, private readonly result: Result<ValidationError>) {}
 
-  static async createForm(request: Request, serviceCategory: ServiceCategory): Promise<RarDaysForm> {
+  static async createForm(request: Request, serviceCategory: ServiceCategoryFull): Promise<RarDaysForm> {
     return new RarDaysForm(
       request,
       await FormUtils.runValidations({ request, validations: this.validations(serviceCategory) })
     )
   }
 
-  static validations(serviceCategory: ServiceCategory): ValidationChain[] {
+  static validations(serviceCategory: ServiceCategoryFull): ValidationChain[] {
     const firstName = serviceCategory.name
 
     return FormUtils.yesNoRadioWithConditionalInputValidationChain({

--- a/server/routes/referrals/rarDaysPresenter.ts
+++ b/server/routes/referrals/rarDaysPresenter.ts
@@ -1,11 +1,11 @@
-import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class RarDaysPresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}

--- a/server/routes/referrals/relevantSentencePresenter.ts
+++ b/server/routes/referrals/relevantSentencePresenter.ts
@@ -1,12 +1,12 @@
 import { DeliusConviction } from '../../services/communityApiService'
-import { DraftReferral, ServiceCategory } from '../../services/interventionsService'
+import { DraftReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class RelevantSentencePresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly convictions: DeliusConviction[],
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null

--- a/server/routes/serviceProviderReferrals/actionPlanConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/actionPlanConfirmationPresenter.ts
@@ -1,10 +1,10 @@
-import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import { SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class ActionPlanConfirmationPresenter {
-  constructor(private readonly sentReferral: SentReferral, private readonly serviceCategory: ServiceCategory) {}
+  constructor(private readonly sentReferral: SentReferral, private readonly serviceCategory: ServiceCategoryFull) {}
 
   progressHref = `/service-provider/referrals/${this.sentReferral.id}/progress`
 

--- a/server/routes/serviceProviderReferrals/actionPlanNumberOfSessionsPresenter.ts
+++ b/server/routes/serviceProviderReferrals/actionPlanNumberOfSessionsPresenter.ts
@@ -1,4 +1,4 @@
-import { ActionPlan, ServiceCategory } from '../../services/interventionsService'
+import { ActionPlan, ServiceCategoryFull } from '../../services/interventionsService'
 import utils from '../../utils/utils'
 import { DeliusServiceUser } from '../../services/communityApiService'
 import { FormValidationError } from '../../utils/formValidationError'
@@ -9,7 +9,7 @@ export default class ActionPlanNumberOfSessionsPresenter {
   constructor(
     private readonly actionPlan: ActionPlan,
     private readonly serviceUser: DeliusServiceUser,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -3,7 +3,7 @@ import {
   Activity,
   DesiredOutcome,
   SentReferral,
-  ServiceCategory,
+  ServiceCategoryFull,
 } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import utils from '../../utils/utils'
@@ -12,7 +12,7 @@ import PresenterUtils from '../../utils/presenterUtils'
 export default class AddActionPlanActivitiesPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly actionPlan: ActionPlan,
     private readonly errors: { desiredOutcomeId: string; error: FormValidationError }[] = []
   ) {}

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
@@ -1,5 +1,5 @@
 import { AuthUser } from '../../data/hmppsAuthClient'
-import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import { SummaryListItem } from '../../utils/summaryList'
 import PresenterUtils from '../../utils/presenterUtils'
 import utils from '../../utils/utils'
@@ -7,7 +7,7 @@ import utils from '../../utils/utils'
 export default class AssignmentConfirmationPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly assignee: AuthUser
   ) {}
 

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
@@ -1,5 +1,5 @@
 import { AuthUser } from '../../data/hmppsAuthClient'
-import { ServiceCategory } from '../../services/interventionsService'
+import { ServiceCategoryFull } from '../../services/interventionsService'
 import { SummaryListItem } from '../../utils/summaryList'
 import PresenterUtils from '../../utils/presenterUtils'
 
@@ -8,7 +8,7 @@ export default class CheckAssignmentPresenter {
     private readonly referralId: string,
     private readonly assignee: AuthUser,
     private readonly email: string,
-    private readonly serviceCategory: ServiceCategory
+    private readonly serviceCategory: ServiceCategoryFull
   ) {}
 
   readonly text = {

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -1,11 +1,11 @@
-import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import CalendarDay from '../../utils/calendarDay'
 import PresenterUtils from '../../utils/presenterUtils'
 import utils from '../../utils/utils'
 import { SortableTableHeaders, SortableTableRow } from '../../utils/viewUtils'
 
 export default class DashboardPresenter {
-  constructor(private readonly referrals: SentReferral[], private readonly serviceCategories: ServiceCategory[]) {}
+  constructor(private readonly referrals: SentReferral[], private readonly serviceCategories: ServiceCategoryFull[]) {}
 
   readonly tableHeadings: SortableTableHeaders = [
     { text: 'Date received', sort: 'none' },

--- a/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.ts
@@ -1,4 +1,4 @@
-import { EndOfServiceReport, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { EndOfServiceReport, SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import EndOfServiceReportAnswersPresenter from '../shared/endOfServiceReportAnswersPresenter'
 import EndOfServiceReportFormPresenter from './endOfServiceReportFormPresenter'
 
@@ -6,7 +6,7 @@ export default class EndOfServiceReportCheckAnswersPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategory: ServiceCategory
+    private readonly serviceCategory: ServiceCategoryFull
   ) {}
 
   readonly formAction = `/service-provider/end-of-service-report/${this.endOfServiceReport.id}/submit`

--- a/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.ts
@@ -1,10 +1,10 @@
-import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import PresenterUtils from '../../utils/presenterUtils'
 import { SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
 
 export default class EndOfServiceReportConfirmationPresenter {
-  constructor(private readonly referral: SentReferral, private readonly serviceCategory: ServiceCategory) {}
+  constructor(private readonly referral: SentReferral, private readonly serviceCategory: ServiceCategoryFull) {}
 
   progressHref = `/service-provider/referrals/${this.referral.id}/progress`
 

--- a/server/routes/serviceProviderReferrals/endOfServiceReportFormPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFormPresenter.ts
@@ -1,4 +1,4 @@
-import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import utils from '../../utils/utils'
 
 interface EndOfServiceReportFormPagePresenter {
@@ -10,7 +10,7 @@ interface EndOfServiceReportFormPagePresenter {
 }
 
 export default class EndOfServiceReportFormPresenter {
-  constructor(private readonly serviceCategory: ServiceCategory, private readonly referral: SentReferral) {}
+  constructor(private readonly serviceCategory: ServiceCategoryFull, private readonly referral: SentReferral) {}
 
   private get numberOfDesiredOutcomes(): number {
     return this.referral.referral.desiredOutcomesIds.length

--- a/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFurtherInformationPresenter.ts
@@ -1,11 +1,11 @@
-import { EndOfServiceReport, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { EndOfServiceReport, SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import PresenterUtils from '../../utils/presenterUtils'
 import EndOfServiceReportFormPresenter from './endOfServiceReportFormPresenter'
 
 export default class EndOfServiceReportFurtherInformationPresenter {
   constructor(
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly referral: SentReferral,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}

--- a/server/routes/serviceProviderReferrals/endOfServiceReportOutcomePresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportOutcomePresenter.ts
@@ -3,7 +3,7 @@ import {
   EndOfServiceReport,
   EndOfServiceReportOutcome,
   SentReferral,
-  ServiceCategory,
+  ServiceCategoryFull,
 } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
@@ -13,7 +13,7 @@ export default class EndOfServiceReportOutcomePresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly desiredOutcome: DesiredOutcome,
     private readonly desiredOutcomeNumber: number,
     private readonly outcome: EndOfServiceReportOutcome | null,

--- a/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.ts
+++ b/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.ts
@@ -1,4 +1,4 @@
-import { ActionPlan, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { ActionPlan, SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import errorMessages from '../../utils/errorMessages'
 
@@ -6,7 +6,7 @@ export default class FinaliseActionPlanActivitiesForm {
   constructor(
     private readonly referral: SentReferral,
     private readonly actionPlan: ActionPlan,
-    private readonly serviceCategory: ServiceCategory
+    private readonly serviceCategory: ServiceCategoryFull
   ) {}
 
   get isValid(): boolean {

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -1,6 +1,5 @@
 import InterventionProgressPresenter from './interventionProgressPresenter'
-import sentReferralFactory from '../../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import ReferralFactory from '../../../testutils/factories/referral'
 import serviceUserFactory from '../../../testutils/factories/deliusServiceUser'
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
@@ -9,10 +8,9 @@ import endOfServiceReportFactory from '../../../testutils/factories/endOfService
 describe(InterventionProgressPresenter, () => {
   describe('createActionPlanFormAction', () => {
     it('returns the relative URL for creating a draft action plan', () => {
-      const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
+      const referral = ReferralFactory.sent().build()
       const serviceUser = serviceUserFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+      const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
       expect(presenter.createActionPlanFormAction).toEqual(`/service-provider/referrals/${referral.id}/action-plan`)
     })
@@ -20,21 +18,19 @@ describe(InterventionProgressPresenter, () => {
 
   describe('sessionTableRows', () => {
     it('returns an empty list if there are no appointments', () => {
-      const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
+      const referral = ReferralFactory.sent().build()
       const serviceUser = serviceUserFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+      const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
       expect(presenter.sessionTableRows).toEqual([])
     })
 
     describe('when a session exists but an appointment has not yet been scheduled', () => {
       it('populates the table with formatted session information, with the "Edit session details" link displayed', () => {
-        const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build()
         const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [
+        const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [
           actionPlanAppointmentFactory.newlyCreated().build(),
         ])
         expect(presenter.sessionTableRows).toEqual([
@@ -54,11 +50,10 @@ describe(InterventionProgressPresenter, () => {
 
     describe('when an appointment has been scheduled', () => {
       it('populates the table with formatted session information, with the "Reschedule session" and "Give feedback" links displayed', () => {
-        const referral = sentReferralFactory.build()
+        const referral = ReferralFactory.sent().build()
         const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
-        const serviceCategory = serviceCategoryFactory.build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [
+        const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [
           actionPlanAppointmentFactory.build({
             sessionNumber: 1,
             appointmentTime: '2020-12-07T13:00:00.000000Z',
@@ -82,11 +77,10 @@ describe(InterventionProgressPresenter, () => {
     describe('when the session feedback has been recorded', () => {
       describe('when the service user attended the session or was late', () => {
         it('populates the table with the "completed" status against that session and a link to view it', () => {
-          const referral = sentReferralFactory.build()
+          const referral = ReferralFactory.sent().build()
           const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
-          const serviceCategory = serviceCategoryFactory.build()
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [
+          const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [
             actionPlanAppointmentFactory.attended('yes').build({ sessionNumber: 1 }),
             actionPlanAppointmentFactory.attended('late').build({ sessionNumber: 2 }),
           ])
@@ -118,11 +112,10 @@ describe(InterventionProgressPresenter, () => {
 
       describe('when the service did not attend the session', () => {
         it('populates the table with the "failure to attend" status against that session and a link to view it', () => {
-          const referral = sentReferralFactory.build()
+          const referral = ReferralFactory.sent().build()
           const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
-          const serviceCategory = serviceCategoryFactory.build()
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [
+          const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [
             actionPlanAppointmentFactory.attended('no').build(),
           ])
 
@@ -146,10 +139,13 @@ describe(InterventionProgressPresenter, () => {
   describe('text', () => {
     describe('title', () => {
       it('returns a title to be displayed', () => {
-        const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+        const referral = ReferralFactory.sent().build({
+          serviceCategory: {
+            name: 'accommodation',
+          },
+        })
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
         expect(presenter.text).toMatchObject({
           title: 'Accommodation',
@@ -160,10 +156,9 @@ describe(InterventionProgressPresenter, () => {
     describe('actionPlanStatus', () => {
       describe('when there is no action plan', () => {
         it('returns “Not submitted”', () => {
-          const referral = sentReferralFactory.build()
-          const serviceCategory = serviceCategoryFactory.build()
+          const referral = ReferralFactory.sent().build()
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+          const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Not submitted' })
         })
@@ -171,11 +166,10 @@ describe(InterventionProgressPresenter, () => {
 
       describe('when the action plan has not been submitted', () => {
         it('returns “Not submitted”', () => {
-          const referral = sentReferralFactory.build()
-          const serviceCategory = serviceCategoryFactory.build()
+          const referral = ReferralFactory.sent().build()
           const actionPlan = actionPlanFactory.notSubmitted().build()
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
+          const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [])
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Not submitted' })
         })
@@ -183,11 +177,10 @@ describe(InterventionProgressPresenter, () => {
 
       describe('when the action plan has been submitted', () => {
         it('returns “Submitted”', () => {
-          const referral = sentReferralFactory.build()
-          const serviceCategory = serviceCategoryFactory.build()
+          const referral = ReferralFactory.sent().build()
           const actionPlan = actionPlanFactory.submitted().build()
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
+          const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [])
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Submitted' })
         })
@@ -197,10 +190,9 @@ describe(InterventionProgressPresenter, () => {
     describe('endOfServiceReportStatus', () => {
       describe('when there is no end of service report', () => {
         it('returns “Not submitted”', () => {
-          const referral = sentReferralFactory.build({ endOfServiceReport: null })
-          const serviceCategory = serviceCategoryFactory.build()
+          const referral = ReferralFactory.sent().build()
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+          const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
           expect(presenter.text).toMatchObject({ endOfServiceReportStatus: 'Not submitted' })
         })
@@ -209,10 +201,13 @@ describe(InterventionProgressPresenter, () => {
       describe('when the end of service report has not been submitted', () => {
         it('returns “Not submitted”', () => {
           const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
-          const referral = sentReferralFactory.build({ endOfServiceReport })
-          const serviceCategory = serviceCategoryFactory.build()
+          const referral = ReferralFactory.sent().build({
+            sentReferralFields: {
+              endOfServiceReport,
+            },
+          })
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+          const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
           expect(presenter.text).toMatchObject({ endOfServiceReportStatus: 'Not submitted' })
         })
@@ -221,10 +216,13 @@ describe(InterventionProgressPresenter, () => {
       describe('when the end of service report has been submitted', () => {
         it('returns “Submitted”', () => {
           const endOfServiceReport = endOfServiceReportFactory.submitted().build()
-          const referral = sentReferralFactory.build({ endOfServiceReport })
-          const serviceCategory = serviceCategoryFactory.build()
+          const referral = ReferralFactory.sent().build({
+            sentReferralFields: {
+              endOfServiceReport,
+            },
+          })
           const serviceUser = serviceUserFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+          const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
           expect(presenter.text).toMatchObject({ endOfServiceReportStatus: 'Submitted' })
         })
@@ -235,10 +233,9 @@ describe(InterventionProgressPresenter, () => {
   describe('actionPlanStatusStyle', () => {
     describe('when there is no action plan', () => {
       it('returns the inactive style', () => {
-        const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
         expect(presenter.actionPlanStatusStyle).toEqual('inactive')
       })
@@ -246,11 +243,10 @@ describe(InterventionProgressPresenter, () => {
 
     describe('when the action plan has not been submitted', () => {
       it('returns the active style', () => {
-        const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build()
         const actionPlan = actionPlanFactory.notSubmitted().build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [])
 
         expect(presenter.actionPlanStatusStyle).toEqual('inactive')
       })
@@ -258,11 +254,10 @@ describe(InterventionProgressPresenter, () => {
 
     describe('when the action plan has been submitted', () => {
       it('returns the active style', () => {
-        const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build()
         const actionPlan = actionPlanFactory.submitted().build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [])
 
         expect(presenter.actionPlanStatusStyle).toEqual('active')
       })
@@ -272,10 +267,9 @@ describe(InterventionProgressPresenter, () => {
   describe('allowActionPlanCreation', () => {
     describe('when there is no action plan', () => {
       it('returns true', () => {
-        const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
         expect(presenter.allowActionPlanCreation).toEqual(true)
       })
@@ -283,11 +277,10 @@ describe(InterventionProgressPresenter, () => {
 
     describe('when there is an action plan', () => {
       it('returns false', () => {
-        const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build()
         const actionPlan = actionPlanFactory.notSubmitted().build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [])
 
         expect(presenter.allowActionPlanCreation).toEqual(false)
       })
@@ -296,20 +289,18 @@ describe(InterventionProgressPresenter, () => {
 
   describe('referralAssigned', () => {
     it('returns false when the referral has no assignee', () => {
-      const referral = sentReferralFactory.unassigned().build()
-      const serviceCategory = serviceCategoryFactory.build()
+      const referral = ReferralFactory.sent().build()
       const actionPlan = actionPlanFactory.submitted().build()
       const serviceUser = serviceUserFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
+      const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [])
 
       expect(presenter.referralAssigned).toEqual(false)
     })
     it('returns true when the referral has an assignee', () => {
-      const referral = sentReferralFactory.assigned().build()
-      const serviceCategory = serviceCategoryFactory.build()
+      const referral = ReferralFactory.assigned().build()
       const actionPlan = actionPlanFactory.submitted().build()
       const serviceUser = serviceUserFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, serviceUser, [])
+      const presenter = new InterventionProgressPresenter(referral, actionPlan, serviceUser, [])
 
       expect(presenter.referralAssigned).toEqual(true)
     })
@@ -318,10 +309,9 @@ describe(InterventionProgressPresenter, () => {
   describe('endOfServiceReportStatusStyle', () => {
     describe('when there is no end of service report', () => {
       it('returns the inactive style', () => {
-        const referral = sentReferralFactory.build({ endOfServiceReport: null })
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
         expect(presenter.endOfServiceReportStatusStyle).toEqual('inactive')
       })
@@ -330,10 +320,13 @@ describe(InterventionProgressPresenter, () => {
     describe('when the end of service report has not been submitted', () => {
       it('returns the active style', () => {
         const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
-        const referral = sentReferralFactory.build({ endOfServiceReport })
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build({
+          sentReferralFields: {
+            endOfServiceReport,
+          },
+        })
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
         expect(presenter.endOfServiceReportStatusStyle).toEqual('inactive')
       })
@@ -342,10 +335,13 @@ describe(InterventionProgressPresenter, () => {
     describe('when the end of service report has been submitted', () => {
       it('returns the active style', () => {
         const endOfServiceReport = endOfServiceReportFactory.submitted().build()
-        const referral = sentReferralFactory.build({ endOfServiceReport })
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build({
+          sentReferralFields: {
+            endOfServiceReport,
+          },
+        })
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
         expect(presenter.endOfServiceReportStatusStyle).toEqual('active')
       })
@@ -355,10 +351,9 @@ describe(InterventionProgressPresenter, () => {
   describe('allowEndOfServiceReportCreation', () => {
     describe('when there is no end of service report', () => {
       it('returns true', () => {
-        const referral = sentReferralFactory.build({ endOfServiceReport: null })
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build()
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
         expect(presenter.allowEndOfServiceReportCreation).toEqual(true)
       })
@@ -367,10 +362,13 @@ describe(InterventionProgressPresenter, () => {
     describe('when there is an end of service report', () => {
       it('returns false', () => {
         const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
-        const referral = sentReferralFactory.build({ endOfServiceReport })
-        const serviceCategory = serviceCategoryFactory.build()
+        const referral = ReferralFactory.sent().build({
+          sentReferralFields: {
+            endOfServiceReport,
+          },
+        })
         const serviceUser = serviceUserFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+        const presenter = new InterventionProgressPresenter(referral, null, serviceUser, [])
 
         expect(presenter.allowEndOfServiceReportCreation).toEqual(false)
       })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -202,7 +202,7 @@ describe(InterventionProgressPresenter, () => {
         it('returns “Not submitted”', () => {
           const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
           const referral = ReferralFactory.sent().build({
-            sentReferralFields: {
+            sentFields: {
               endOfServiceReport,
             },
           })
@@ -217,7 +217,7 @@ describe(InterventionProgressPresenter, () => {
         it('returns “Submitted”', () => {
           const endOfServiceReport = endOfServiceReportFactory.submitted().build()
           const referral = ReferralFactory.sent().build({
-            sentReferralFields: {
+            sentFields: {
               endOfServiceReport,
             },
           })
@@ -321,7 +321,7 @@ describe(InterventionProgressPresenter, () => {
       it('returns the active style', () => {
         const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
         const referral = ReferralFactory.sent().build({
-          sentReferralFields: {
+          sentFields: {
             endOfServiceReport,
           },
         })
@@ -336,7 +336,7 @@ describe(InterventionProgressPresenter, () => {
       it('returns the active style', () => {
         const endOfServiceReport = endOfServiceReportFactory.submitted().build()
         const referral = ReferralFactory.sent().build({
-          sentReferralFields: {
+          sentFields: {
             endOfServiceReport,
           },
         })
@@ -363,7 +363,7 @@ describe(InterventionProgressPresenter, () => {
       it('returns false', () => {
         const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
         const referral = ReferralFactory.sent().build({
-          sentReferralFields: {
+          sentFields: {
             endOfServiceReport,
           },
         })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -1,4 +1,9 @@
-import { ActionPlan, ActionPlanAppointment, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import {
+  ActionPlan,
+  ActionPlanAppointment,
+  SentReferral,
+  ServiceCategoryFull,
+} from '../../services/interventionsService'
 import utils from '../../utils/utils'
 import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from '../shared/referralOverviewPagePresenter'
 import { DeliusServiceUser } from '../../services/communityApiService'
@@ -11,7 +16,7 @@ export default class InterventionProgressPresenter {
 
   constructor(
     private readonly referral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly actionPlan: ActionPlan | null,
     serviceUser: DeliusServiceUser,
     private readonly actionPlanAppointments: ActionPlanAppointment[]

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -23,7 +23,7 @@ export default class InterventionProgressPresenter {
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Progress,
-      referral,
+      referral.id,
       serviceUser,
       'service-provider'
     )

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -1,9 +1,4 @@
-import {
-  ActionPlan,
-  ActionPlanAppointment,
-  SentReferral,
-  ServiceCategoryFull,
-} from '../../services/interventionsService'
+import { ActionPlan, ActionPlanAppointment, Referral } from '../../services/interventionsService'
 import utils from '../../utils/utils'
 import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from '../shared/referralOverviewPagePresenter'
 import { DeliusServiceUser } from '../../services/communityApiService'
@@ -15,8 +10,7 @@ export default class InterventionProgressPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
 
   constructor(
-    private readonly referral: SentReferral,
-    private readonly serviceCategory: ServiceCategoryFull,
+    private readonly referral: Referral,
     private readonly actionPlan: ActionPlan | null,
     serviceUser: DeliusServiceUser,
     private readonly actionPlanAppointments: ActionPlanAppointment[]
@@ -30,13 +24,13 @@ export default class InterventionProgressPresenter {
   }
 
   get referralAssigned(): boolean {
-    return this.referral.assignedTo !== null
+    return this.referral.sentReferralFields?.assignedTo != null
   }
 
   readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
 
   readonly text = {
-    title: utils.convertToTitleCase(this.serviceCategory.name),
+    title: utils.convertToTitleCase(this.referral.serviceCategory.name),
     actionPlanStatus: this.actionPlanSubmitted ? 'Submitted' : 'Not submitted',
     endOfServiceReportStatus: this.endOfServiceReportSubmitted ? 'Submitted' : 'Not submitted',
   }
@@ -117,10 +111,10 @@ export default class InterventionProgressPresenter {
     : 'inactive'
 
   private get endOfServiceReportSubmitted() {
-    return this.referral.endOfServiceReport !== null && this.referral.endOfServiceReport.submittedAt !== null
+    return this.referral.sentReferralFields?.endOfServiceReport?.submittedAt != null
   }
 
   get allowEndOfServiceReportCreation(): boolean {
-    return this.referral.endOfServiceReport === null
+    return this.referral.sentReferralFields?.endOfServiceReport == null
   }
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -24,7 +24,7 @@ export default class InterventionProgressPresenter {
   }
 
   get referralAssigned(): boolean {
-    return this.referral.sentReferralFields?.assignedTo != null
+    return this.referral.sentFields?.assignedTo != null
   }
 
   readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
@@ -111,10 +111,10 @@ export default class InterventionProgressPresenter {
     : 'inactive'
 
   private get endOfServiceReportSubmitted() {
-    return this.referral.sentReferralFields?.endOfServiceReport?.submittedAt != null
+    return this.referral.sentFields?.endOfServiceReport?.submittedAt != null
   }
 
   get allowEndOfServiceReportCreation(): boolean {
-    return this.referral.sentReferralFields?.endOfServiceReport == null
+    return this.referral.sentFields?.endOfServiceReport == null
   }
 }

--- a/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.ts
+++ b/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.ts
@@ -3,14 +3,14 @@ import {
   Activity,
   DesiredOutcome,
   SentReferral,
-  ServiceCategory,
+  ServiceCategoryFull,
 } from '../../services/interventionsService'
 import utils from '../../utils/utils'
 
 export default class ReviewActionPlanPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly actionPlan: ActionPlan
   ) {}
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -4,6 +4,7 @@ import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
 import InterventionsService from '../../services/interventionsService'
 import apiConfig from '../../config'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import referralFactory from '../../../testutils/factories/referral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import deliusUserFactory from '../../../testutils/factories/deliusUser'
 import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
@@ -148,14 +149,10 @@ describe('GET /service-provider/referrals/:id/details', () => {
 
 describe('GET /service-provider/referrals/:id/progress', () => {
   it('displays information about the intervention progress', async () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const serviceUser = deliusServiceUser.build()
-    const sentReferral = sentReferralFactory.assigned().build({
-      referral: { serviceCategoryId: serviceCategory.id },
-    })
+    const sentReferral = referralFactory.assigned().build()
 
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
-    interventionsService.getSentReferral.mockResolvedValue(sentReferral)
+    interventionsService.getReferral.mockResolvedValue(sentReferral)
     communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
 
     await request(app)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -129,18 +129,15 @@ export default class ServiceProviderReferralsController {
 
   async showInterventionProgress(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getReferral(res.locals.user.token.accessToken, req.params.id)
-    if (referral.sentReferralFields === null) {
+    if (referral.sentFields === null) {
       throw Error("referral hasn't been sent yet")
     }
 
     const serviceUserPromise = this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn)
     const actionPlanPromise =
-      referral.sentReferralFields.actionPlanId === null
+      referral.sentFields.actionPlanId === null
         ? Promise.resolve(null)
-        : this.interventionsService.getActionPlan(
-            res.locals.user.token.accessToken,
-            referral.sentReferralFields.actionPlanId
-          )
+        : this.interventionsService.getActionPlan(res.locals.user.token.accessToken, referral.sentFields.actionPlanId)
 
     const [actionPlan, serviceUser] = await Promise.all([actionPlanPromise, serviceUserPromise])
 

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -1,6 +1,6 @@
 import { AuthUser } from '../../data/hmppsAuthClient'
 import { DeliusServiceUser, DeliusUser } from '../../services/communityApiService'
-import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { SentReferral, ServiceCategoryFull } from '../../services/interventionsService'
 import { SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
 import PresenterUtils from '../../utils/presenterUtils'
@@ -13,7 +13,7 @@ export default class ShowReferralPresenter {
 
   constructor(
     private readonly sentReferral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly sentBy: DeliusUser,
     serviceUser: DeliusServiceUser,
     private readonly assignee: AuthUser | null,

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -21,7 +21,7 @@ export default class ShowReferralPresenter {
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,
-      sentReferral,
+      sentReferral.id,
       serviceUser,
       'service-provider'
     )

--- a/server/routes/shared/endOfServiceReportAnswersPresenter.ts
+++ b/server/routes/shared/endOfServiceReportAnswersPresenter.ts
@@ -2,7 +2,7 @@ import {
   EndOfServiceReport,
   EndOfServiceReportOutcome,
   SentReferral,
-  ServiceCategory,
+  ServiceCategoryFull,
 } from '../../services/interventionsService'
 import PresenterUtils from '../../utils/presenterUtils'
 import { SummaryListItem } from '../../utils/summaryList'
@@ -23,7 +23,7 @@ export default class EndOfServiceReportAnswersPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategory: ServiceCategoryFull,
     private readonly allowChange: boolean = true
   ) {}
 

--- a/server/routes/shared/referralOverviewPagePresenter.test.ts
+++ b/server/routes/shared/referralOverviewPagePresenter.test.ts
@@ -10,7 +10,7 @@ describe(ReferralOverviewPagePresenter, () => {
       const sentReferral = sentReferralFactory.build()
       const presenter = new ReferralOverviewPagePresenter(
         ReferralOverviewPageSection.Details,
-        sentReferral,
+        sentReferral.id,
         serviceUser,
         'service-provider'
       )
@@ -25,7 +25,7 @@ describe(ReferralOverviewPagePresenter, () => {
 
       const detailsPresenter = new ReferralOverviewPagePresenter(
         ReferralOverviewPageSection.Details,
-        sentReferral,
+        sentReferral.id,
         serviceUser,
         'service-provider'
       )
@@ -35,7 +35,7 @@ describe(ReferralOverviewPagePresenter, () => {
 
       const progressPresenter = new ReferralOverviewPagePresenter(
         ReferralOverviewPageSection.Progress,
-        sentReferral,
+        sentReferral.id,
         serviceUser,
         'service-provider'
       )
@@ -51,7 +51,7 @@ describe(ReferralOverviewPagePresenter, () => {
 
     const presenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,
-      sentReferral,
+      sentReferral.id,
       serviceUser,
       'service-provider'
     )

--- a/server/routes/shared/referralOverviewPagePresenter.ts
+++ b/server/routes/shared/referralOverviewPagePresenter.ts
@@ -1,6 +1,5 @@
 import { DeliusServiceUser } from '../../services/communityApiService'
 import ServiceUserBannerPresenter from './serviceUserBannerPresenter'
-import { SentReferral } from '../../services/interventionsService'
 
 export enum ReferralOverviewPageSection {
   Progress = 1,
@@ -13,7 +12,7 @@ export default class ReferralOverviewPagePresenter {
 
   constructor(
     private readonly section: ReferralOverviewPageSection,
-    private readonly referral: SentReferral,
+    private readonly referralId: string,
     serviceUser: DeliusServiceUser,
     private readonly subNavUrlPrefix: 'service-provider' | 'probation-practitioner'
   ) {
@@ -28,17 +27,17 @@ export default class ReferralOverviewPagePresenter {
     items: [
       {
         text: 'Progress',
-        href: `/${this.subNavUrlPrefix}/referrals/${this.referral.id}/progress`,
+        href: `/${this.subNavUrlPrefix}/referrals/${this.referralId}/progress`,
         active: this.section === ReferralOverviewPageSection.Progress,
       },
       {
         text: 'Case notes',
-        href: `/${this.subNavUrlPrefix}/referrals/${this.referral.id}/case-notes`,
+        href: `/${this.subNavUrlPrefix}/referrals/${this.referralId}/case-notes`,
         active: this.section === ReferralOverviewPageSection.CaseNotes,
       },
       {
         text: 'Referral details',
-        href: `/${this.subNavUrlPrefix}/referrals/${this.referral.id}/details`,
+        href: `/${this.subNavUrlPrefix}/referrals/${this.referralId}/details`,
         active: this.section === ReferralOverviewPageSection.Details,
       },
     ],

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -14,7 +14,7 @@ export interface InterventionsServiceValidationError {
 
 type WithNullableValues<T> = { [K in keyof T]: T[K] | null }
 
-export interface DraftReferralFields {
+export interface FormFields {
   completionDeadline: string | null
   complexityLevelId: string | null
   furtherInformation: string | null
@@ -31,7 +31,7 @@ export interface DraftReferralFields {
   maximumRarDays: number | null
 }
 
-export interface SentReferralFields {
+export interface SentFields {
   sentAt: string
   sentBy: AuthUser
   referenceNumber: string
@@ -40,7 +40,7 @@ export interface SentReferralFields {
   endOfServiceReport: EndOfServiceReport | null
 }
 
-export interface EndedReferralFields {
+export interface EndedFields {
   endedAt: string
   endedBy: AuthUser
   cancellationReason: string
@@ -54,9 +54,9 @@ export interface Referral {
   serviceCategory: ServiceCategory
   serviceProvider: ServiceProvider
 
-  draftReferralFields: DraftReferralFields
-  sentReferralFields: SentReferralFields | null
-  endedReferralField: EndedReferralFields | null
+  formFields: FormFields
+  sentFields: SentFields | null
+  endedFields: EndedFields | null
 }
 
 export interface ReferralFields {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -14,6 +14,51 @@ export interface InterventionsServiceValidationError {
 
 type WithNullableValues<T> = { [K in keyof T]: T[K] | null }
 
+export interface DraftReferralFields {
+  completionDeadline: string | null
+  complexityLevelId: string | null
+  furtherInformation: string | null
+  relevantSentenceId: number | null
+  desiredOutcomesIds: string[] | null
+  additionalNeedsInformation: string | null
+  accessibilityNeeds: string | null
+  needsInterpreter: boolean | null
+  interpreterLanguage: string | null
+  hasAdditionalResponsibilities: boolean | null
+  whenUnavailable: string | null
+  additionalRiskInformation: string | null
+  usingRarDays: boolean | null
+  maximumRarDays: number | null
+}
+
+export interface SentReferralFields {
+  sentAt: string
+  sentBy: AuthUser
+  referenceNumber: string
+  assignedTo: AuthUser | null
+  actionPlanId: string | null
+  endOfServiceReport: EndOfServiceReport | null
+}
+
+export interface EndedReferralFields {
+  endedAt: string
+  endedBy: AuthUser
+  cancellationReason: string
+  cancellationComments: string | null
+}
+
+export interface Referral {
+  id: string
+  createdAt: string
+  serviceUser: ServiceUser
+  serviceCategory: ServiceCategory
+  serviceProvider: ServiceProvider
+
+  draftReferralFields: DraftReferralFields
+  sentReferralFields: SentReferralFields | null
+  endedReferralField: EndedReferralFields | null
+}
+
 export interface ReferralFields {
   createdAt: string
   completionDeadline: string
@@ -60,6 +105,11 @@ export interface EndedReferral {
   endedBy: AuthUser
   cancellationReason: string
   cancellationComments: string | null
+}
+
+export interface ServiceCategory {
+  id: string
+  name: string
 }
 
 export interface ServiceCategoryFull {
@@ -362,6 +412,15 @@ export default class InterventionsService {
       path: `/sent-referral/${id}`,
       headers: { Accept: 'application/json' },
     })) as SentReferral
+  }
+
+  async getReferral(token: string, id: string): Promise<Referral> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/referral/${id}`,
+      headers: { Accept: 'application/json' },
+    })) as Referral
   }
 
   async getReferralsSentByProbationPractitioner(token: string, userId: string): Promise<SentReferral[]> {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -62,7 +62,7 @@ export interface EndedReferral {
   cancellationComments: string | null
 }
 
-export interface ServiceCategory {
+export interface ServiceCategoryFull {
   id: string
   name: string
   complexityLevels: ComplexityLevel[]
@@ -109,7 +109,7 @@ export interface Intervention {
   description: string
   npsRegion: NPSRegion | null
   pccRegions: PCCRegion[]
-  serviceCategory: ServiceCategory
+  serviceCategory: ServiceCategoryFull
   serviceProvider: ServiceProvider
   eligibility: Eligibility
 }
@@ -323,14 +323,14 @@ export default class InterventionsService {
     }
   }
 
-  async getServiceCategory(token: string, id: string): Promise<ServiceCategory> {
+  async getServiceCategory(token: string, id: string): Promise<ServiceCategoryFull> {
     const restClient = this.createRestClient(token)
 
     try {
       return (await restClient.get({
         path: `/service-category/${id}`,
         headers: { Accept: 'application/json' },
-      })) as ServiceCategory
+      })) as ServiceCategoryFull
     } catch (e) {
       throw this.createServiceError(e)
     }

--- a/testutils/factories/referral.ts
+++ b/testutils/factories/referral.ts
@@ -10,7 +10,7 @@ class ReferralFactory extends Factory<Referral> {
 
   sent() {
     return this.params({
-      sentReferralFields: {
+      sentFields: {
         sentAt: new Date().toISOString(),
         sentBy: {
           username: 'bernard.beaks',
@@ -27,7 +27,7 @@ class ReferralFactory extends Factory<Referral> {
 
   assigned() {
     return this.params({
-      sentReferralFields: {
+      sentFields: {
         sentAt: new Date().toISOString(),
         sentBy: {
           username: 'bernard.beaks',
@@ -73,7 +73,7 @@ export default ReferralFactory.define(({ sequence }) => ({
   },
   serviceProvider: ServiceProviderFactory.build(),
 
-  draftReferralFields: {
+  formFields: {
     completionDeadline: null,
     complexityLevelId: null,
     furtherInformation: null,
@@ -89,6 +89,6 @@ export default ReferralFactory.define(({ sequence }) => ({
     usingRarDays: null,
     maximumRarDays: null,
   },
-  sentReferralFields: null,
-  endedReferralField: null,
+  sentFields: null,
+  endedFields: null,
 }))

--- a/testutils/factories/referral.ts
+++ b/testutils/factories/referral.ts
@@ -1,0 +1,94 @@
+import { Factory } from 'fishery'
+import ServiceProviderFactory from './serviceProvider'
+import { Referral } from '../../server/services/interventionsService'
+
+class ReferralFactory extends Factory<Referral> {
+  draft() {
+    // todo
+    return this.params({})
+  }
+
+  sent() {
+    return this.params({
+      sentReferralFields: {
+        sentAt: new Date().toISOString(),
+        sentBy: {
+          username: 'bernard.beaks',
+          userId: '123456',
+          authSource: 'delius',
+        },
+        referenceNumber: 'KA3825AC',
+        assignedTo: null,
+        actionPlanId: null,
+        endOfServiceReport: null,
+      },
+    })
+  }
+
+  assigned() {
+    return this.params({
+      sentReferralFields: {
+        sentAt: new Date().toISOString(),
+        sentBy: {
+          username: 'bernard.beaks',
+          userId: '123456',
+          authSource: 'delius',
+        },
+        referenceNumber: 'KA3825AC',
+        assignedTo: {
+          username: 'UserABC',
+          userId: '555224b3-865c-4b56-97dd-c3e817592ba3',
+          authSource: 'auth',
+        },
+        actionPlanId: null,
+        endOfServiceReport: null,
+      },
+    })
+  }
+
+  ended() {
+    // todo
+    return this.params({})
+  }
+}
+
+export default ReferralFactory.define(({ sequence }) => ({
+  id: sequence.toString(),
+  createdAt: new Date().toISOString(),
+  serviceUser: {
+    crn: sequence.toString(),
+    title: 'Mr',
+    firstName: 'Alex',
+    lastName: 'River',
+    dateOfBirth: '1980-01-01',
+    gender: 'Male',
+    ethnicity: 'British',
+    preferredLanguage: 'English',
+    religionOrBelief: 'Agnostic',
+    disabilities: ['Autism spectrum condition', 'Sciatica'],
+  },
+  serviceCategory: {
+    id: sequence.toString(),
+    name: 'accommodation',
+  },
+  serviceProvider: ServiceProviderFactory.build(),
+
+  draftReferralFields: {
+    completionDeadline: null,
+    complexityLevelId: null,
+    furtherInformation: null,
+    relevantSentenceId: null,
+    desiredOutcomesIds: null,
+    additionalNeedsInformation: null,
+    accessibilityNeeds: null,
+    needsInterpreter: null,
+    interpreterLanguage: null,
+    hasAdditionalResponsibilities: null,
+    whenUnavailable: null,
+    additionalRiskInformation: null,
+    usingRarDays: null,
+    maximumRarDays: null,
+  },
+  sentReferralFields: null,
+  endedReferralField: null,
+}))

--- a/testutils/factories/referral.ts
+++ b/testutils/factories/referral.ts
@@ -1,15 +1,37 @@
 import { Factory } from 'fishery'
+import { v4 as uuidv4 } from 'uuid'
 import ServiceProviderFactory from './serviceProvider'
 import { Referral } from '../../server/services/interventionsService'
 
 class ReferralFactory extends Factory<Referral> {
-  draft() {
-    // todo
+  justCreated() {
     return this.params({})
   }
 
+  draft() {
+    const today = new Date()
+    return this.justCreated().params({
+      formFields: {
+        completionDeadline: new Date(today.setMonth(today.getMonth() + 6)).toISOString(),
+        complexityLevelId: uuidv4(),
+        furtherInformation: '',
+        relevantSentenceId: 8976125623,
+        desiredOutcomesIds: [uuidv4(), uuidv4()],
+        additionalNeedsInformation: '',
+        accessibilityNeeds: 'alex requires wheelchair access',
+        needsInterpreter: true,
+        interpreterLanguage: 'urdu',
+        hasAdditionalResponsibilities: true,
+        whenUnavailable: 'wednesdays',
+        additionalRiskInformation: '',
+        usingRarDays: true,
+        maximumRarDays: 5,
+      },
+    })
+  }
+
   sent() {
-    return this.params({
+    return this.draft().params({
       sentFields: {
         sentAt: new Date().toISOString(),
         sentBy: {
@@ -26,7 +48,7 @@ class ReferralFactory extends Factory<Referral> {
   }
 
   assigned() {
-    return this.params({
+    return this.draft().params({
       sentFields: {
         sentAt: new Date().toISOString(),
         sentBy: {
@@ -37,7 +59,7 @@ class ReferralFactory extends Factory<Referral> {
         referenceNumber: 'KA3825AC',
         assignedTo: {
           username: 'UserABC',
-          userId: '555224b3-865c-4b56-97dd-c3e817592ba3',
+          userId: uuidv4(),
           authSource: 'auth',
         },
         actionPlanId: null,
@@ -47,13 +69,23 @@ class ReferralFactory extends Factory<Referral> {
   }
 
   ended() {
-    // todo
-    return this.params({})
+    return this.assigned().params({
+      endedFields: {
+        endedAt: '2021-05-13T12:30:00Z',
+        endedBy: {
+          username: 'BERNARD.BEAKS',
+          userId: '555224b3-865c-4b56-97dd-c3e817592ba3',
+          authSource: 'delius',
+        },
+        cancellationReason: 'Service user has been recalled',
+        cancellationComments: 'Alex was arrested for driving without insurance and immediately recalled',
+      },
+    })
   }
 }
 
 export default ReferralFactory.define(({ sequence }) => ({
-  id: sequence.toString(),
+  id: uuidv4(),
   createdAt: new Date().toISOString(),
   serviceUser: {
     crn: sequence.toString(),
@@ -68,7 +100,7 @@ export default ReferralFactory.define(({ sequence }) => ({
     disabilities: ['Autism spectrum condition', 'Sciatica'],
   },
   serviceCategory: {
-    id: sequence.toString(),
+    id: uuidv4(),
     name: 'accommodation',
   },
   serviceProvider: ServiceProviderFactory.build(),

--- a/testutils/factories/serviceCategory.ts
+++ b/testutils/factories/serviceCategory.ts
@@ -1,7 +1,7 @@
 import { Factory } from 'fishery'
-import { ServiceCategory } from '../../server/services/interventionsService'
+import { ServiceCategoryFull } from '../../server/services/interventionsService'
 
-export default Factory.define<ServiceCategory>(({ sequence }) => ({
+export default Factory.define<ServiceCategoryFull>(({ sequence }) => ({
   id: sequence.toString(),
   name: 'accommodation',
   complexityLevels: [


### PR DESCRIPTION
## What does this pull request do?

- the first commit is large, but a really simple refactor of 'ServiceCategory' to 'ServiceCategoryFull'. This is the DTO with all the outcomes and complexity levels in. The reason for this is that the new endpoint returns a 'ServiceCategory' which contains just the name and id.
- the next commit changes a simple shared presenter class to take a referral id instead of a 'SentReferral'. This allows us to use this class with any type of referral object, including the new 'generic' one.
- finally the new service layer method is implemented. There are some simple test changes required, and a new factory class. But most of the changes are removing the need to pass 'service category' to the presenter, and removing the need to create service categories and mock them in the tests. It's neater that way IMO. 

## What is the intent behind these changes?

two-fold, firstly general improvements in the API layer, but primarily this will unblock work on determining if a referral has beebn cancelled in the SP progress page. 
