### PR TITLE
IC-1305: Probation practitioner user can view a submitted end of service report

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -1,5 +1,6 @@
 import sentReferralFactory from '../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
+import endOfServiceReportFactory from '../../testutils/factories/endOfServiceReport'
 
 describe('Probation practitioner referrals dashboard', () => {
   beforeEach(() => {
@@ -69,5 +70,41 @@ describe('Probation practitioner referrals dashboard', () => {
           Action: 'View',
         },
       ])
+  })
+
+  it('user views an end of service report', () => {
+    cy.stubGetSentReferrals([])
+    cy.login()
+
+    const serviceCategory = serviceCategoryFactory.build()
+    const referral = sentReferralFactory.build({
+      referral: { serviceCategoryId: serviceCategory.id, desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id] },
+    })
+    const endOfServiceReport = endOfServiceReportFactory.build({
+      referralId: referral.id,
+      outcomes: [
+        {
+          desiredOutcome: serviceCategory.desiredOutcomes[0],
+          achievementLevel: 'ACHIEVED',
+          progressionComments: 'Some progression comments',
+          additionalTaskComments: 'Some task comments',
+        },
+      ],
+      furtherInformation: 'Some further information',
+    })
+
+    cy.stubGetEndOfServiceReport(endOfServiceReport.id, endOfServiceReport)
+    cy.stubGetSentReferral(referral.id, referral)
+    cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+
+    cy.visit(`/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`)
+
+    cy.contains('End of service report')
+    cy.contains('The service provider has created an end of service report')
+    cy.contains('Achieved')
+    cy.contains(serviceCategory.desiredOutcomes[0].description)
+    cy.contains('Some progression comments')
+    cy.contains('Some task comments')
+    cy.contains('Some further information')
   })
 })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -182,6 +182,9 @@ export default function routes(router: Router, services: Services): Router {
     '/probation-practitioner/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback',
     (req, res) => probationPractitionerReferralsController.viewSubmittedPostSessionFeedback(req, res)
   )
+  get('/probation-practitioner/end-of-service-report/:id', (req, res) =>
+    probationPractitionerReferralsController.viewEndOfServiceReport(req, res)
+  )
 
   get('/probation-practitioner/referrals/:id/cancellation/reason', (req, res) =>
     probationPractitionerReferralsController.showReferralCancellationPage(req, res)

--- a/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.test.ts
@@ -1,0 +1,54 @@
+import EndOfServiceReportPresenter from './endOfServiceReportPresenter'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
+
+describe(EndOfServiceReportPresenter, () => {
+  const referral = sentReferralFactory.build({
+    referral: { desiredOutcomesIds: ['1', '3'], serviceUser: { firstName: 'Alex', lastName: 'River' } },
+  })
+  const serviceCategory = serviceCategoryFactory.build({
+    name: 'social inclusion',
+    desiredOutcomes: [
+      { id: '1', description: 'Description of desired outcome 1' },
+      { id: '2', description: 'Description of desired outcome 2' },
+      { id: '3', description: 'Description of desired outcome 3' },
+    ],
+  })
+  const buildEndOfServiceReport = () =>
+    endOfServiceReportFactory.build({
+      outcomes: [
+        {
+          desiredOutcome: serviceCategory.desiredOutcomes[0],
+          achievementLevel: 'ACHIEVED',
+          progressionComments: 'Example progression comments 1',
+          additionalTaskComments: 'Example task comments 1',
+        },
+        {
+          desiredOutcome: serviceCategory.desiredOutcomes[2],
+          achievementLevel: 'PARTIALLY_ACHIEVED',
+          progressionComments: 'Example progression comments 2',
+          additionalTaskComments: 'Example task comments 2',
+        },
+      ],
+    })
+
+  describe('text', () => {
+    it('returns text to be displayed', () => {
+      const presenter = new EndOfServiceReportPresenter(referral, buildEndOfServiceReport(), serviceCategory)
+
+      expect(presenter.text).toEqual({
+        introduction:
+          'The service provider has created an end of service report for Alex River’s intervention. Please view the following end of service report.',
+      })
+    })
+  })
+
+  describe('answersPresenter', () => {
+    it('returns a presenter', () => {
+      const presenter = new EndOfServiceReportPresenter(referral, buildEndOfServiceReport(), serviceCategory)
+
+      expect(presenter.answersPresenter).toBeDefined()
+    })
+  })
+})

--- a/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.ts
@@ -1,0 +1,24 @@
+import { EndOfServiceReport, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import EndOfServiceReportAnswersPresenter from '../shared/endOfServiceReportAnswersPresenter'
+import PresenterUtils from '../../utils/presenterUtils'
+
+export default class EndOfServiceReportPresenter {
+  constructor(
+    private readonly referral: SentReferral,
+    private readonly endOfServiceReport: EndOfServiceReport,
+    private readonly serviceCategory: ServiceCategory
+  ) {}
+
+  readonly text = {
+    introduction: `The service provider has created an end of service report for ${PresenterUtils.fullName(
+      this.referral.referral.serviceUser
+    )}’s intervention. Please view the following end of service report.`,
+  }
+
+  readonly answersPresenter = new EndOfServiceReportAnswersPresenter(
+    this.referral,
+    this.endOfServiceReport,
+    this.serviceCategory,
+    false
+  )
+}

--- a/server/routes/probationPractitionerReferrals/endOfServiceReportView.ts
+++ b/server/routes/probationPractitionerReferrals/endOfServiceReportView.ts
@@ -1,0 +1,16 @@
+import EndOfServiceReportAnswersView from '../shared/endOfServiceReportAnswersView'
+import EndOfServiceReportPresenter from './endOfServiceReportPresenter'
+
+export default class EndOfServiceReportView {
+  constructor(private readonly presenter: EndOfServiceReportPresenter) {}
+
+  private readonly answersView = new EndOfServiceReportAnswersView(this.presenter.answersPresenter)
+
+  readonly renderArgs: [string, Record<string, unknown>] = [
+    'probationPractitionerReferrals/endOfServiceReport',
+    {
+      presenter: this.presenter,
+      ...this.answersView.locals,
+    },
+  ]
+}

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -9,6 +9,7 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
+import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
 
 import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
 import CommunityApiService from '../../services/communityApiService'
@@ -125,6 +126,41 @@ describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:ses
         expect(res.text).toContain('Alex was well-behaved')
         expect(res.text).toContain('No')
       })
+  })
+
+  describe('GET /probation-practitioner/end-of-service-report/:id', () => {
+    it('renders a page with the contents of the end of service report', async () => {
+      const serviceCategory = serviceCategoryFactory.build()
+      const referral = sentReferralFactory.build({
+        referral: { desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id] },
+      })
+      const endOfServiceReport = endOfServiceReportFactory.build({
+        outcomes: [
+          {
+            desiredOutcome: serviceCategory.desiredOutcomes[0],
+            achievementLevel: 'ACHIEVED',
+            progressionComments: 'Some progression comments',
+            additionalTaskComments: 'Some task comments',
+          },
+        ],
+        furtherInformation: 'Some further information',
+      })
+
+      interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+      interventionsService.getSentReferral.mockResolvedValue(referral)
+      interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+
+      await request(app)
+        .get(`/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('Achieved')
+          expect(res.text).toContain(serviceCategory.desiredOutcomes[0].description)
+          expect(res.text).toContain('Some progression comments')
+          expect(res.text).toContain('Some task comments')
+          expect(res.text).toContain('Some further information')
+        })
+    })
   })
 })
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -12,6 +12,8 @@ import SubmittedPostSessionFeedbackPresenter from '../shared/submittedPostSessio
 import SubmittedPostSessionFeedbackView from '../shared/submittedPostSessionFeedbackView'
 import ReferralCancellationPresenter from './referralCancellationPresenter'
 import ReferralCancellationView from './referralCancellationView'
+import EndOfServiceReportPresenter from './endOfServiceReportPresenter'
+import EndOfServiceReportView from './endOfServiceReportView'
 
 export default class ProbationPractitionerReferralsController {
   constructor(
@@ -130,5 +132,21 @@ export default class ProbationPractitionerReferralsController {
     const view = new ReferralCancellationView(presenter)
 
     return res.render(...view.renderArgs)
+  }
+
+  async viewEndOfServiceReport(req: Request, res: Response): Promise<void> {
+    const { accessToken } = res.locals.user.token
+
+    const endOfServiceReport = await this.interventionsService.getEndOfServiceReport(accessToken, req.params.id)
+    const referral = await this.interventionsService.getSentReferral(accessToken, endOfServiceReport.referralId)
+    const serviceCategory = await this.interventionsService.getServiceCategory(
+      accessToken,
+      referral.referral.serviceCategoryId
+    )
+
+    const presenter = new EndOfServiceReportPresenter(referral, endOfServiceReport, serviceCategory)
+    const view = new EndOfServiceReportView(presenter)
+
+    res.render(...view.renderArgs)
   }
 }

--- a/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.test.ts
@@ -47,98 +47,15 @@ describe(EndOfServiceReportCheckAnswersPresenter, () => {
     })
   })
 
-  describe('interventionSummary', () => {
-    it('returns a summary of the intervention', () => {
+  describe('answersPresenter', () => {
+    it('returns a presenter', () => {
       const presenter = new EndOfServiceReportCheckAnswersPresenter(
         referral,
         buildEndOfServiceReport(),
         serviceCategory
       )
 
-      expect(presenter.interventionSummary).toEqual([
-        {
-          isList: false,
-          key: 'Service user’s name',
-          lines: ['Alex River'],
-        },
-      ])
-    })
-  })
-
-  describe('outcomes', () => {
-    it('replays the user’s outcome answers from the draft end of service report, with a link for changing the answer', () => {
-      const presenter = new EndOfServiceReportCheckAnswersPresenter(
-        referral,
-        buildEndOfServiceReport(),
-        serviceCategory
-      )
-
-      expect(presenter.outcomes).toEqual([
-        {
-          achievementLevelStyle: 'ACHIEVED',
-          achievementLevelText: 'Achieved',
-          additionalTaskComments: 'Example task comments 1',
-          changeHref: '/service-provider/end-of-service-report/3/outcomes/1',
-          progressionComments: 'Example progression comments 1',
-          subtitle: 'Description of desired outcome 1',
-          title: 'Outcome 1',
-        },
-        {
-          achievementLevelStyle: 'PARTIALLY_ACHIEVED',
-          achievementLevelText: 'Partially achieved',
-          additionalTaskComments: 'Example task comments 2',
-          changeHref: '/service-provider/end-of-service-report/3/outcomes/2',
-          progressionComments: 'Example progression comments 2',
-          subtitle: 'Description of desired outcome 3',
-          title: 'Outcome 2',
-        },
-      ])
-    })
-
-    describe('progressionComments', () => {
-      it('returns “None” when there are no comments', () => {
-        const endOfServiceReport = buildEndOfServiceReport()
-        endOfServiceReport.outcomes[0].progressionComments = ''
-
-        const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, endOfServiceReport, serviceCategory)
-
-        expect(presenter.outcomes[0].progressionComments).toEqual('None')
-      })
-    })
-
-    describe('additionalTaskComments', () => {
-      it('returns “None” when there are no comments', () => {
-        const endOfServiceReport = buildEndOfServiceReport()
-        endOfServiceReport.outcomes[0].additionalTaskComments = ''
-
-        const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, endOfServiceReport, serviceCategory)
-
-        expect(presenter.outcomes[0].additionalTaskComments).toEqual('None')
-      })
-    })
-  })
-
-  describe('furtherInformation', () => {
-    it('replays the user’s further information answer from the draft end of service report, with a link for changing the answer', () => {
-      const presenter = new EndOfServiceReportCheckAnswersPresenter(
-        referral,
-        buildEndOfServiceReport(),
-        serviceCategory
-      )
-
-      expect(presenter.furtherInformation).toEqual({
-        changeHref: '/service-provider/end-of-service-report/6/further-information',
-        text: 'None',
-      })
-    })
-
-    it('returns “None” for the text when there are no comments', () => {
-      const endOfServiceReport = buildEndOfServiceReport()
-      endOfServiceReport.furtherInformation = ''
-
-      const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, endOfServiceReport, serviceCategory)
-
-      expect(presenter.furtherInformation.text).toEqual('None')
+      expect(presenter.answersPresenter).toBeDefined()
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.ts
@@ -1,11 +1,5 @@
-import {
-  EndOfServiceReport,
-  EndOfServiceReportOutcome,
-  SentReferral,
-  ServiceCategory,
-} from '../../services/interventionsService'
-import PresenterUtils from '../../utils/presenterUtils'
-import { SummaryListItem } from '../../utils/summaryList'
+import { EndOfServiceReport, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import EndOfServiceReportAnswersPresenter from '../shared/endOfServiceReportAnswersPresenter'
 import EndOfServiceReportFormPresenter from './endOfServiceReportFormPresenter'
 
 export type EndOfServiceReportAchievementLevelStyle = 'ACHIEVED' | 'PARTIALLY_ACHIEVED' | 'NOT_ACHIEVED'
@@ -35,53 +29,9 @@ export default class EndOfServiceReportCheckAnswersPresenter {
 
   readonly formPagePresenter = new EndOfServiceReportFormPresenter(this.serviceCategory, this.referral).checkAnswersPage
 
-  readonly interventionSummary: SummaryListItem[] = [
-    // TODO IC-1322 Populate this fully
-    { key: 'Service user’s name', lines: [PresenterUtils.fullName(this.referral.referral.serviceUser)], isList: false },
-  ]
-
-  readonly outcomes: OutcomePresenter[] = this.referral.referral.desiredOutcomesIds.map((desiredOutcomeId, index) => {
-    const number = index + 1
-    const outcome = this.endOfServiceReport.outcomes.find(anOutcome => anOutcome.desiredOutcome.id === desiredOutcomeId)
-
-    if (!outcome) {
-      throw new Error(`Outcome not found for desired outcome ${desiredOutcomeId}`)
-    }
-
-    const desiredOutcome = this.serviceCategory.desiredOutcomes.find(
-      aDesiredOutcome => aDesiredOutcome.id === desiredOutcomeId
-    )
-
-    if (!desiredOutcome) {
-      throw new Error(`Desired outcome ${desiredOutcomeId} not found`)
-    }
-
-    return {
-      title: `Outcome ${number}`,
-      subtitle: desiredOutcome.description,
-      progressionComments: outcome.progressionComments?.length ? outcome.progressionComments : 'None',
-      additionalTaskComments: outcome.additionalTaskComments?.length ? outcome.additionalTaskComments : 'None',
-      changeHref: `/service-provider/end-of-service-report/${this.endOfServiceReport.id}/outcomes/${number}`,
-      achievementLevelText: this.achievementLevelText(outcome),
-      achievementLevelStyle: outcome.achievementLevel,
-    }
-  })
-
-  private achievementLevelText(outcome: EndOfServiceReportOutcome): string {
-    switch (outcome.achievementLevel) {
-      case 'ACHIEVED':
-        return 'Achieved'
-      case 'NOT_ACHIEVED':
-        return 'Not achieved'
-      case 'PARTIALLY_ACHIEVED':
-        return 'Partially achieved'
-      default:
-        return ''
-    }
-  }
-
-  readonly furtherInformation = {
-    text: this.endOfServiceReport.furtherInformation?.length ? this.endOfServiceReport.furtherInformation : 'None',
-    changeHref: `/service-provider/end-of-service-report/${this.endOfServiceReport.id}/further-information`,
-  }
+  readonly answersPresenter = new EndOfServiceReportAnswersPresenter(
+    this.referral,
+    this.endOfServiceReport,
+    this.serviceCategory
+  )
 }

--- a/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.ts
@@ -2,18 +2,6 @@ import { EndOfServiceReport, SentReferral, ServiceCategory } from '../../service
 import EndOfServiceReportAnswersPresenter from '../shared/endOfServiceReportAnswersPresenter'
 import EndOfServiceReportFormPresenter from './endOfServiceReportFormPresenter'
 
-export type EndOfServiceReportAchievementLevelStyle = 'ACHIEVED' | 'PARTIALLY_ACHIEVED' | 'NOT_ACHIEVED'
-
-interface OutcomePresenter {
-  title: string
-  subtitle: string
-  progressionComments: string
-  additionalTaskComments: string
-  changeHref: string
-  achievementLevelText: string
-  achievementLevelStyle: EndOfServiceReportAchievementLevelStyle
-}
-
 export default class EndOfServiceReportCheckAnswersPresenter {
   constructor(
     private readonly referral: SentReferral,
@@ -32,6 +20,7 @@ export default class EndOfServiceReportCheckAnswersPresenter {
   readonly answersPresenter = new EndOfServiceReportAnswersPresenter(
     this.referral,
     this.endOfServiceReport,
-    this.serviceCategory
+    this.serviceCategory,
+    true
   )
 }

--- a/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersView.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersView.ts
@@ -1,32 +1,16 @@
-import ViewUtils from '../../utils/viewUtils'
-import EndOfServiceReportCheckAnswersPresenter, {
-  EndOfServiceReportAchievementLevelStyle,
-} from './endOfServiceReportCheckAnswersPresenter'
+import EndOfServiceReportAnswersView from '../shared/endOfServiceReportAnswersView'
+import EndOfServiceReportCheckAnswersPresenter from './endOfServiceReportCheckAnswersPresenter'
 
 export default class EndOfServiceReportCheckAnswersView {
   constructor(private readonly presenter: EndOfServiceReportCheckAnswersPresenter) {}
 
-  private readonly interventionSummarySummaryListArgs = ViewUtils.summaryListArgs(this.presenter.interventionSummary)
-
-  private readonly achievementLevelTagClass = (style: EndOfServiceReportAchievementLevelStyle) => {
-    switch (style) {
-      case 'ACHIEVED':
-        return 'govuk-tag--green'
-      case 'PARTIALLY_ACHIEVED':
-        return 'govuk-tag--blue'
-      case 'NOT_ACHIEVED':
-        return 'govuk-tag--red'
-      default:
-        return ''
-    }
-  }
+  private readonly answersView = new EndOfServiceReportAnswersView(this.presenter.answersPresenter)
 
   readonly renderArgs: [string, Record<string, unknown>] = [
     'serviceProviderReferrals/endOfServiceReport/checkAnswers',
     {
       presenter: this.presenter,
-      interventionSummarySummaryListArgs: this.interventionSummarySummaryListArgs,
-      achievementLevelTagClass: this.achievementLevelTagClass,
+      ...this.answersView.locals,
     },
   ]
 }

--- a/server/routes/shared/endOfServiceReportAnswersPresenter.test.ts
+++ b/server/routes/shared/endOfServiceReportAnswersPresenter.test.ts
@@ -1,0 +1,120 @@
+import EndOfServiceReportAnswersPresenter from './endOfServiceReportAnswersPresenter'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
+
+describe(EndOfServiceReportAnswersPresenter, () => {
+  const referral = sentReferralFactory.build({
+    referral: { desiredOutcomesIds: ['1', '3'], serviceUser: { firstName: 'Alex', lastName: 'River' } },
+  })
+  const serviceCategory = serviceCategoryFactory.build({
+    name: 'social inclusion',
+    desiredOutcomes: [
+      { id: '1', description: 'Description of desired outcome 1' },
+      { id: '2', description: 'Description of desired outcome 2' },
+      { id: '3', description: 'Description of desired outcome 3' },
+    ],
+  })
+  const buildEndOfServiceReport = () =>
+    endOfServiceReportFactory.build({
+      outcomes: [
+        {
+          desiredOutcome: serviceCategory.desiredOutcomes[0],
+          achievementLevel: 'ACHIEVED',
+          progressionComments: 'Example progression comments 1',
+          additionalTaskComments: 'Example task comments 1',
+        },
+        {
+          desiredOutcome: serviceCategory.desiredOutcomes[2],
+          achievementLevel: 'PARTIALLY_ACHIEVED',
+          progressionComments: 'Example progression comments 2',
+          additionalTaskComments: 'Example task comments 2',
+        },
+      ],
+    })
+
+  describe('interventionSummary', () => {
+    it('returns a summary of the intervention', () => {
+      const presenter = new EndOfServiceReportAnswersPresenter(referral, buildEndOfServiceReport(), serviceCategory)
+
+      expect(presenter.interventionSummary).toEqual([
+        {
+          isList: false,
+          key: 'Service user’s name',
+          lines: ['Alex River'],
+        },
+      ])
+    })
+  })
+
+  describe('outcomes', () => {
+    it('replays the user’s outcome answers from the draft end of service report, with a link for changing the answer', () => {
+      const endOfServiceReport = buildEndOfServiceReport()
+      const presenter = new EndOfServiceReportAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+
+      expect(presenter.outcomes).toEqual([
+        {
+          achievementLevelStyle: 'ACHIEVED',
+          achievementLevelText: 'Achieved',
+          additionalTaskComments: 'Example task comments 1',
+          changeHref: `/service-provider/end-of-service-report/${endOfServiceReport.id}/outcomes/1`,
+          progressionComments: 'Example progression comments 1',
+          subtitle: 'Description of desired outcome 1',
+          title: 'Outcome 1',
+        },
+        {
+          achievementLevelStyle: 'PARTIALLY_ACHIEVED',
+          achievementLevelText: 'Partially achieved',
+          additionalTaskComments: 'Example task comments 2',
+          changeHref: `/service-provider/end-of-service-report/${endOfServiceReport.id}/outcomes/2`,
+          progressionComments: 'Example progression comments 2',
+          subtitle: 'Description of desired outcome 3',
+          title: 'Outcome 2',
+        },
+      ])
+    })
+
+    describe('progressionComments', () => {
+      it('returns “None” when there are no comments', () => {
+        const endOfServiceReport = buildEndOfServiceReport()
+        endOfServiceReport.outcomes[0].progressionComments = ''
+
+        const presenter = new EndOfServiceReportAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+
+        expect(presenter.outcomes[0].progressionComments).toEqual('None')
+      })
+    })
+
+    describe('additionalTaskComments', () => {
+      it('returns “None” when there are no comments', () => {
+        const endOfServiceReport = buildEndOfServiceReport()
+        endOfServiceReport.outcomes[0].additionalTaskComments = ''
+
+        const presenter = new EndOfServiceReportAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+
+        expect(presenter.outcomes[0].additionalTaskComments).toEqual('None')
+      })
+    })
+  })
+
+  describe('furtherInformation', () => {
+    it('replays the user’s further information answer from the draft end of service report, with a link for changing the answer', () => {
+      const endOfServiceReport = buildEndOfServiceReport()
+      const presenter = new EndOfServiceReportAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+
+      expect(presenter.furtherInformation).toEqual({
+        changeHref: `/service-provider/end-of-service-report/${endOfServiceReport.id}/further-information`,
+        text: 'None',
+      })
+    })
+
+    it('returns “None” for the text when there are no comments', () => {
+      const endOfServiceReport = buildEndOfServiceReport()
+      endOfServiceReport.furtherInformation = ''
+
+      const presenter = new EndOfServiceReportAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+
+      expect(presenter.furtherInformation.text).toEqual('None')
+    })
+  })
+})

--- a/server/routes/shared/endOfServiceReportAnswersPresenter.ts
+++ b/server/routes/shared/endOfServiceReportAnswersPresenter.ts
@@ -23,7 +23,8 @@ export default class EndOfServiceReportAnswersPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategory: ServiceCategory
+    private readonly serviceCategory: ServiceCategory,
+    private readonly allowChange: boolean = true
   ) {}
 
   readonly interventionSummary: SummaryListItem[] = [

--- a/server/routes/shared/endOfServiceReportAnswersPresenter.ts
+++ b/server/routes/shared/endOfServiceReportAnswersPresenter.ts
@@ -1,0 +1,78 @@
+import {
+  EndOfServiceReport,
+  EndOfServiceReportOutcome,
+  SentReferral,
+  ServiceCategory,
+} from '../../services/interventionsService'
+import PresenterUtils from '../../utils/presenterUtils'
+import { SummaryListItem } from '../../utils/summaryList'
+
+export type EndOfServiceReportAchievementLevelStyle = 'ACHIEVED' | 'PARTIALLY_ACHIEVED' | 'NOT_ACHIEVED'
+
+interface OutcomePresenter {
+  title: string
+  subtitle: string
+  progressionComments: string
+  additionalTaskComments: string
+  changeHref: string
+  achievementLevelText: string
+  achievementLevelStyle: EndOfServiceReportAchievementLevelStyle
+}
+
+export default class EndOfServiceReportAnswersPresenter {
+  constructor(
+    private readonly referral: SentReferral,
+    private readonly endOfServiceReport: EndOfServiceReport,
+    private readonly serviceCategory: ServiceCategory
+  ) {}
+
+  readonly interventionSummary: SummaryListItem[] = [
+    // TODO IC-1322 Populate this fully
+    { key: 'Service user’s name', lines: [PresenterUtils.fullName(this.referral.referral.serviceUser)], isList: false },
+  ]
+
+  readonly outcomes: OutcomePresenter[] = this.referral.referral.desiredOutcomesIds.map((desiredOutcomeId, index) => {
+    const number = index + 1
+    const outcome = this.endOfServiceReport.outcomes.find(anOutcome => anOutcome.desiredOutcome.id === desiredOutcomeId)
+
+    if (!outcome) {
+      throw new Error(`Outcome not found for desired outcome ${desiredOutcomeId}`)
+    }
+
+    const desiredOutcome = this.serviceCategory.desiredOutcomes.find(
+      aDesiredOutcome => aDesiredOutcome.id === desiredOutcomeId
+    )
+
+    if (!desiredOutcome) {
+      throw new Error(`Desired outcome ${desiredOutcomeId} not found`)
+    }
+
+    return {
+      title: `Outcome ${number}`,
+      subtitle: desiredOutcome.description,
+      progressionComments: outcome.progressionComments?.length ? outcome.progressionComments : 'None',
+      additionalTaskComments: outcome.additionalTaskComments?.length ? outcome.additionalTaskComments : 'None',
+      changeHref: `/service-provider/end-of-service-report/${this.endOfServiceReport.id}/outcomes/${number}`,
+      achievementLevelText: this.achievementLevelText(outcome),
+      achievementLevelStyle: outcome.achievementLevel,
+    }
+  })
+
+  private achievementLevelText(outcome: EndOfServiceReportOutcome): string {
+    switch (outcome.achievementLevel) {
+      case 'ACHIEVED':
+        return 'Achieved'
+      case 'NOT_ACHIEVED':
+        return 'Not achieved'
+      case 'PARTIALLY_ACHIEVED':
+        return 'Partially achieved'
+      default:
+        return ''
+    }
+  }
+
+  readonly furtherInformation = {
+    text: this.endOfServiceReport.furtherInformation?.length ? this.endOfServiceReport.furtherInformation : 'None',
+    changeHref: `/service-provider/end-of-service-report/${this.endOfServiceReport.id}/further-information`,
+  }
+}

--- a/server/routes/shared/endOfServiceReportAnswersView.ts
+++ b/server/routes/shared/endOfServiceReportAnswersView.ts
@@ -1,0 +1,29 @@
+import ViewUtils from '../../utils/viewUtils'
+import EndOfServiceReportAnswersPresenter, {
+  EndOfServiceReportAchievementLevelStyle,
+} from './endOfServiceReportAnswersPresenter'
+
+export default class EndOfServiceReportAnswersView {
+  constructor(private readonly presenter: EndOfServiceReportAnswersPresenter) {}
+
+  private readonly interventionSummarySummaryListArgs = ViewUtils.summaryListArgs(this.presenter.interventionSummary)
+
+  private readonly achievementLevelTagClass = (style: EndOfServiceReportAchievementLevelStyle) => {
+    switch (style) {
+      case 'ACHIEVED':
+        return 'govuk-tag--green'
+      case 'PARTIALLY_ACHIEVED':
+        return 'govuk-tag--blue'
+      case 'NOT_ACHIEVED':
+        return 'govuk-tag--red'
+      default:
+        return ''
+    }
+  }
+
+  readonly locals = {
+    endOfServiceReportAnswersPresenter: this.presenter,
+    interventionSummarySummaryListArgs: this.interventionSummarySummaryListArgs,
+    achievementLevelTagClass: this.achievementLevelTagClass,
+  }
+}

--- a/server/views/partials/endOfServiceReportAnswers.njk
+++ b/server/views/partials/endOfServiceReportAnswers.njk
@@ -15,14 +15,18 @@
   <p class="govuk-body"><strong>Is there anything else that needs doing to achieve this outcome?</strong></p>
   <p class="govuk-body">{{ outcome.additionalTaskComments }}</p>
 
-  <p>
-  <a class="govuk-link" id="change-outcome-{{loop.index}}" href="{{ outcome.changeHref }}">Change</a>
-  </p>
+  {% if endOfServiceReportAnswersPresenter.allowChange %}
+    <p>
+    <a class="govuk-link" id="change-outcome-{{loop.index}}" href="{{ outcome.changeHref }}">Change</a>
+    </p>
+  {% endif %}
 {% endfor %}
 
 <h3 class="govuk-heading-m">Additional information</h3>
 
 <p class="govuk-body">{{ endOfServiceReportAnswersPresenter.furtherInformation.text }}</p>
-<p>
-<a class="govuk-link" id="change-further-information" href="{{ endOfServiceReportAnswersPresenter.furtherInformation.changeHref }}">Change</a>
-</p>
+{% if endOfServiceReportAnswersPresenter.allowChange %}
+  <p>
+  <a class="govuk-link" id="change-further-information" href="{{ endOfServiceReportAnswersPresenter.furtherInformation.changeHref }}">Change</a>
+  </p>
+{% endif %}

--- a/server/views/partials/endOfServiceReportAnswers.njk
+++ b/server/views/partials/endOfServiceReportAnswers.njk
@@ -1,0 +1,28 @@
+{{ govukSummaryList(interventionSummarySummaryListArgs) }}
+
+{% for outcome in endOfServiceReportAnswersPresenter.outcomes %}
+  <h3 class="govuk-heading-m">{{ outcome.title }}</h3>
+
+  {{ govukTag({ text: outcome.achievementLevelText, classes: achievementLevelTagClass(outcome.achievementLevelStyle) }) }}
+
+  <br>
+
+  <div class="govuk-inset-text">{{ outcome.subtitle }}</div>
+
+  <p class="govuk-body"><strong>Do you have any further comments about their progression on this outcome?</strong></p>
+  <p class="govuk-body">{{ outcome.progressionComments }}</p>
+
+  <p class="govuk-body"><strong>Is there anything else that needs doing to achieve this outcome?</strong></p>
+  <p class="govuk-body">{{ outcome.additionalTaskComments }}</p>
+
+  <p>
+  <a class="govuk-link" id="change-outcome-{{loop.index}}" href="{{ outcome.changeHref }}">Change</a>
+  </p>
+{% endfor %}
+
+<h3 class="govuk-heading-m">Additional information</h3>
+
+<p class="govuk-body">{{ endOfServiceReportAnswersPresenter.furtherInformation.text }}</p>
+<p>
+<a class="govuk-link" id="change-further-information" href="{{ endOfServiceReportAnswersPresenter.furtherInformation.changeHref }}">Change</a>
+</p>

--- a/server/views/probationPractitionerReferrals/endOfServiceReport.njk
+++ b/server/views/probationPractitionerReferrals/endOfServiceReport.njk
@@ -1,0 +1,17 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">End of service report</h1>
+
+      <p class="govuk-body">{{ presenter.text.introduction }}</p>
+
+      {% include "../partials/endOfServiceReportAnswers.njk" %}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/serviceProviderReferrals/endOfServiceReport/checkAnswers.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/checkAnswers.njk
@@ -5,34 +5,7 @@
 {% extends "./formTemplate.njk" %}
 
 {% block formSection %}
-  {{ govukSummaryList(interventionSummarySummaryListArgs) }}
-
-  {% for outcome in presenter.outcomes %}
-    <h3 class="govuk-heading-m">{{ outcome.title }}</h3>
-
-    {{ govukTag({ text: outcome.achievementLevelText, classes: achievementLevelTagClass(outcome.achievementLevelStyle) }) }}
-
-    <br>
-
-    <div class="govuk-inset-text">{{ outcome.subtitle }}</div>
-
-    <p class="govuk-body"><strong>Do you have any further comments about their progression on this outcome?</strong></p>
-    <p class="govuk-body">{{ outcome.progressionComments }}</p>
-
-    <p class="govuk-body"><strong>Is there anything else that needs doing to achieve this outcome?</strong></p>
-    <p class="govuk-body">{{ outcome.additionalTaskComments }}</p>
-
-    <p>
-    <a class="govuk-link" id="change-outcome-{{loop.index}}" href="{{ outcome.changeHref }}">Change</a>
-    </p>
-  {% endfor %}
-
-  <h3 class="govuk-heading-m">Additional information</h3>
-
-  <p class="govuk-body">{{ presenter.furtherInformation.text }}</p>
-  <p>
-  <a class="govuk-link" id="change-further-information" href="{{ presenter.furtherInformation.changeHref }}">Change</a>
-  </p>
+  {% include "../../partials/endOfServiceReportAnswers.njk" %}
 
   <form method="post" action="{{ presenter.formAction }}">
     {{ govukButton({ text: "Submit the report" }) }}


### PR DESCRIPTION
## What does this pull request do?

Adds a page for the probation practitioner to view a submitted end of service report.

## What is the intent behind these changes?

To allow the probation practitioner to find out how a finished intervention went.

## Screenshot

![Screenshot 2021-04-26 at 09 38 27](https://user-images.githubusercontent.com/53756884/116054949-23aeaf80-a674-11eb-95b9-d2b3257bddf2.png)
