### PR TITLE
IC-1321 & IC-1330: Check answers and submit referral cancellation journey 

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -248,7 +248,12 @@ describe('Probation Practitioner monitor journey', () => {
       cy.contains('Cancel this referral').click()
       cy.contains('Service user has moved out of delivery area').click()
       cy.contains('Additional comments (optional)').type('Some additional comments')
+      cy.stubCancelReferral(assignedReferral.id, sentReferralFactory.build())
       cy.contains('Continue').click()
+      cy.contains('Are you sure you want to cancel this referral?')
+
+      cy.contains('Cancel this referral').click()
+      cy.contains('This referral has been cancelled')
     })
   })
 })

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -149,8 +149,8 @@ module.exports = on => {
       return interventionsService.stubSubmitEndOfServiceReport(arg.id, arg.responseJson)
     },
 
-    stubEndReferral: arg => {
-      return interventionsService.stubEndReferral(arg.referralId, arg.responseJson)
+    stubCancelReferral: arg => {
+      return interventionsService.stubCancelReferral(arg.referralId, arg.responseJson)
     },
 
     stubGetReferralCancellationReasons: arg => {

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -106,8 +106,8 @@ Cypress.Commands.add('stubSubmitEndOfServiceReport', (id, responseJson) => {
   cy.task('stubSubmitEndOfServiceReport', { id, responseJson })
 })
 
-Cypress.Commands.add('stubEndReferral', (referralId, responseJson) => {
-  cy.task('stubEndReferral', { referralId, responseJson })
+Cypress.Commands.add('stubCancelReferral', (referralId, responseJson) => {
+  cy.task('stubCancelReferral', { referralId, responseJson })
 })
 
 Cypress.Commands.add('stubGetReferralCancellationReasons', responseJson => {

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -433,7 +433,7 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubEndReferral = async (referralId: string, responseJson: unknown): Promise<unknown> => {
+  stubCancelReferral = async (referralId: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'POST',

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -192,6 +192,12 @@ export default function routes(router: Router, services: Services): Router {
   post('/probation-practitioner/referrals/:id/cancellation/check-your-answers', (req, res) =>
     probationPractitionerReferralsController.redirectToCancellationCheckAnswersPage(req, res)
   )
+  post('/probation-practitioner/referrals/:id/cancellation/submit', (req, res) =>
+    probationPractitionerReferralsController.cancelReferral(req, res)
+  )
+  get('/probation-practitioner/referrals/:id/cancellation/confirmation', (req, res) =>
+    probationPractitionerReferralsController.showCancellationConfirmationPage(req, res)
+  )
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
   get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -189,6 +189,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/probation-practitioner/referrals/:id/cancellation/reason', (req, res) =>
     probationPractitionerReferralsController.showReferralCancellationPage(req, res)
   )
+  post('/probation-practitioner/referrals/:id/cancellation/check-your-answers', (req, res) =>
+    probationPractitionerReferralsController.redirectToCancellationCheckAnswersPage(req, res)
+  )
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
   get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -190,3 +190,13 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/reason', () => 
       })
   })
 })
+
+describe('POST /probation-practitioner/referrals/:id/cancellation/check-your-answers', () => {
+  it('passes through params to a page where the PP can confirm whether or not to cancel a referral', async () => {
+    await request(app)
+      .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/check-your-answers`)
+      .type('form')
+      .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
+      .expect(200)
+  })
+})

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -200,3 +200,24 @@ describe('POST /probation-practitioner/referrals/:id/cancellation/check-your-ans
       .expect(200)
   })
 })
+
+describe('POST /probation-practitioner/referrals/:id/cancellation/submit', () => {
+  it('submits a request to cancel the referral on the backend and redirects to the confirmation screen', async () => {
+    await request(app)
+      .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/submit`)
+      .type('form')
+      .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
+      .expect(302)
+      .expect(
+        'Location',
+        `/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/confirmation`
+      )
+
+    expect(interventionsService.cancelReferral).toHaveBeenCalledWith(
+      'token',
+      '9747b7fb-51bc-40e2-bbbd-791a9be9284b',
+      'MOV',
+      'Alex has moved out of the area'
+    )
+  })
+})

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -190,4 +190,21 @@ export default class ProbationPractitionerReferralsController {
 
     return res.render(...view.renderArgs)
   }
+
+  async cancelReferral(req: Request, res: Response): Promise<void> {
+    const { user } = res.locals
+    const { accessToken } = user.token
+    const referralId = req.params.id
+
+    const cancellationReason = req.body['cancellation-reason']
+    const cancellationComments = req.body['cancellation-comments']
+
+    await this.interventionsService.cancelReferral(accessToken, referralId, cancellationReason, cancellationComments)
+
+    return res.redirect(`/probation-practitioner/referrals/${referralId}/cancellation/confirmation`)
+  }
+
+  async showCancellationConfirmationPage(req: Request, res: Response): Promise<void> {
+    res.render('probationPractitionerReferrals/referralCancellationConfirmation')
+  }
 }

--- a/server/routes/probationPractitionerReferrals/referralCancellationForm.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationForm.test.ts
@@ -1,0 +1,44 @@
+import TestUtils from '../../../testutils/testUtils'
+import ReferralCancellationForm from './referralCancellationForm'
+
+describe(ReferralCancellationForm, () => {
+  describe('data', () => {
+    describe('when both cancellation reason and comments are passed', () => {
+      it('returns a paramsForUpdate with the cancellationReason and cancellationComments properties', async () => {
+        const request = TestUtils.createRequest({
+          'cancellation-reason': 'MOV',
+          'cancellation-comments': 'Alex has moved to a new area',
+        })
+        const data = await new ReferralCancellationForm(request).data()
+
+        expect(data.paramsForUpdate?.cancellationReason).toEqual('MOV')
+        expect(data.paramsForUpdate?.cancellationComments).toEqual('Alex has moved to a new area')
+      })
+    })
+
+    describe('when only cancellation reason is passed', () => {
+      it('returns a paramsForUpdate with the cancellationReason property', async () => {
+        const request = TestUtils.createRequest({
+          'cancellation-reason': 'MOV',
+        })
+        const data = await new ReferralCancellationForm(request).data()
+
+        expect(data.paramsForUpdate?.cancellationReason).toEqual('MOV')
+      })
+    })
+  })
+
+  describe('invalid fields', () => {
+    it('returns an error when the cancellationReason property is not present', async () => {
+      const request = TestUtils.createRequest({})
+
+      const data = await new ReferralCancellationForm(request).data()
+
+      expect(data.error?.errors).toContainEqual({
+        errorSummaryLinkedField: 'cancellation-reason',
+        formFields: ['cancellation-reason'],
+        message: 'Select a reason for cancelling the referral',
+      })
+    })
+  })
+})

--- a/server/routes/probationPractitionerReferrals/referralCancellationForm.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationForm.ts
@@ -1,0 +1,52 @@
+import { Request } from 'express'
+import { body, Result, ValidationChain, ValidationError } from 'express-validator'
+import errorMessages from '../../utils/errorMessages'
+import { FormData } from '../../utils/forms/formData'
+import FormUtils from '../../utils/formUtils'
+import { FormValidationError } from '../../utils/formValidationError'
+
+export default class ReferralCancellationForm {
+  constructor(private readonly request: Request) {}
+
+  async data(): Promise<FormData<Partial<{ cancellationReason: string; cancellationComments: string }>>> {
+    const validationResult = await FormUtils.runValidations({
+      request: this.request,
+      validations: ReferralCancellationForm.validations,
+    })
+
+    const error = this.error(validationResult)
+
+    if (error) {
+      return {
+        paramsForUpdate: null,
+        error,
+      }
+    }
+
+    return {
+      paramsForUpdate: {
+        cancellationReason: this.request.body['cancellation-reason'],
+        cancellationComments: this.request.body['cancellation-comments'],
+      },
+      error: null,
+    }
+  }
+
+  static get validations(): ValidationChain[] {
+    return [body('cancellation-reason').notEmpty().withMessage(errorMessages.cancelReferral.cancellationReason.empty)]
+  }
+
+  private error(validationResult: Result<ValidationError>): FormValidationError | null {
+    if (validationResult.isEmpty()) {
+      return null
+    }
+
+    return {
+      errors: validationResult.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
+  }
+}

--- a/server/routes/probationPractitionerReferrals/referralCancellationPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationPresenter.test.ts
@@ -51,4 +51,90 @@ describe(ReferralCancellationPresenter, () => {
       ])
     })
   })
+
+  describe('errorSummary', () => {
+    const sentReferral = sentReferralFactory.build()
+    const serviceUser = deliusServiceUserFactory.build()
+    const serviceCategory = serviceCategoryFactory.build()
+    const cancellationReasons: CancellationReason[] = []
+
+    describe('when there is an error', () => {
+      it('returns a summary of the error', () => {
+        const presenter = new ReferralCancellationPresenter(
+          sentReferral,
+          serviceCategory,
+          serviceUser,
+          cancellationReasons,
+          {
+            errors: [
+              {
+                errorSummaryLinkedField: 'cancellation-reason',
+                formFields: ['cancellation-reason'],
+                message: 'Select a reason for cancelling the referral',
+              },
+            ],
+          }
+        )
+
+        expect(presenter.errorSummary).toEqual([
+          { field: 'cancellation-reason', message: 'Select a reason for cancelling the referral' },
+        ])
+      })
+    })
+
+    describe('when there is no error', () => {
+      it('returns null', () => {
+        const presenter = new ReferralCancellationPresenter(
+          sentReferral,
+          serviceCategory,
+          serviceUser,
+          cancellationReasons
+        )
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+  })
+
+  describe('errorMessage', () => {
+    const sentReferral = sentReferralFactory.build()
+    const serviceUser = deliusServiceUserFactory.build()
+    const serviceCategory = serviceCategoryFactory.build()
+    const cancellationReasons: CancellationReason[] = []
+
+    describe('when there is an error', () => {
+      it('returns the error message', () => {
+        const presenter = new ReferralCancellationPresenter(
+          sentReferral,
+          serviceCategory,
+          serviceUser,
+          cancellationReasons,
+          {
+            errors: [
+              {
+                errorSummaryLinkedField: 'cancellation-reason',
+                formFields: ['cancellation-reason'],
+                message: 'Select a reason for cancelling the referral',
+              },
+            ],
+          }
+        )
+
+        expect(presenter.errorMessage).toEqual('Select a reason for cancelling the referral')
+      })
+    })
+
+    describe('when there is no error', () => {
+      it('returns null', () => {
+        const presenter = new ReferralCancellationPresenter(
+          sentReferral,
+          serviceCategory,
+          serviceUser,
+          cancellationReasons
+        )
+
+        expect(presenter.errorMessage).toBeNull()
+      })
+    })
+  })
 })

--- a/server/routes/probationPractitionerReferrals/referralCancellationPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationPresenter.ts
@@ -1,13 +1,16 @@
 import a from 'indefinite'
 import { DeliusServiceUser } from '../../services/communityApiService'
 import { CancellationReason, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { FormValidationError } from '../../utils/formValidationError'
+import PresenterUtils from '../../utils/presenterUtils'
 
 export default class ReferralCancellationPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly serviceCategory: ServiceCategory,
     private readonly serviceUser: DeliusServiceUser,
-    private readonly cancellationReasons: CancellationReason[]
+    private readonly cancellationReasons: CancellationReason[],
+    private readonly error: FormValidationError | null = null
   ) {}
 
   readonly text = {
@@ -17,6 +20,12 @@ export default class ReferralCancellationPresenter {
     )} intervention with ${this.sentReferral.referral.serviceProvider.name}.`,
     additionalCommentsLabel: 'Additional comments (optional):',
   }
+
+  readonly errorMessage = PresenterUtils.errorMessage(this.error, 'cancellation-reason')
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error)
+
+  readonly checkAnswersHref = `/probation-practitioner/referrals/${this.sentReferral.id}/cancellation/check-your-answers`
 
   get cancellationReasonsFields(): { value: string; text: string; checked: boolean }[] {
     return this.cancellationReasons.map(cancellationReason => ({

--- a/server/routes/probationPractitionerReferrals/referralCancellationView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationView.ts
@@ -20,8 +20,8 @@ export default class ReferralCancellationView {
 
   private get additionalCommentsTextareaArgs(): TextareaArgs {
     return {
-      id: 'progression-comments',
-      name: 'progression-comments',
+      id: 'cancellation-comments',
+      name: 'cancellation-comments',
       label: {
         text: this.presenter.text.additionalCommentsLabel,
       },

--- a/server/routes/probationPractitionerReferrals/referralCancellationView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationView.ts
@@ -1,8 +1,11 @@
 import { RadiosArgs, TextareaArgs } from '../../utils/govukFrontendTypes'
+import ViewUtils from '../../utils/viewUtils'
 import ReferralCancellationPresenter from './referralCancellationPresenter'
 
 export default class ReferralCancellationView {
   constructor(private readonly presenter: ReferralCancellationPresenter) {}
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   private get referralCancellationRadiosArgs(): RadiosArgs {
     return {
@@ -13,6 +16,7 @@ export default class ReferralCancellationView {
           classes: 'govuk-fieldset__legend--m govuk-!-margin-bottom-6',
         },
       },
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
       name: 'cancellation-reason',
       items: this.presenter.cancellationReasonsFields,
     }
@@ -33,6 +37,7 @@ export default class ReferralCancellationView {
       'probationPractitionerReferrals/referralCancellation',
       {
         presenter: this.presenter,
+        errorSummaryArgs: this.errorSummaryArgs,
         referralCancellationRadiosArgs: this.referralCancellationRadiosArgs,
         additionalCommentsTextareaArgs: this.additionalCommentsTextareaArgs,
       },

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2184,8 +2184,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('endReferral', () => {
-    const endedReferral = {
+  describe('cancelReferral', () => {
+    const cancelledReferral = {
       id: '400be4c6-1aa4-4f52-ae86-cbd5d23309bf',
       referenceNumber: 'SJ12345AC',
       endedAt: '2021-05-13T12:30:00Z',
@@ -2214,7 +2214,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
         willRespondWith: {
           status: 200,
-          body: Matchers.like(endedReferral),
+          body: Matchers.like(cancelledReferral),
           headers: { 'Content-Type': 'application/json' },
         },
       })
@@ -2228,7 +2228,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           'REC',
           'Alex was arrested for driving without insurance and immediately recalled.'
         )
-      ).toMatchObject(endedReferral)
+      ).toMatchObject(cancelledReferral)
     })
   })
 

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -94,4 +94,9 @@ export default {
       empty: (name: string) => `Select whether ${name} achieved the desired outcome`,
     },
   },
+  cancelReferral: {
+    cancellationReason: {
+      empty: 'Select a reason for cancelling the referral',
+    },
+  },
 }

--- a/server/views/probationPractitionerReferrals/referralCancellation.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellation.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -11,10 +12,15 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <p class="govuk-body-m govuk-!-margin-bottom-8">{{ presenter.text.information }}</p>
     </div>
-    <form method="post">
+
+    <form method="post" action="{{ presenter.checkAnswersHref }}">
       <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
       {{ govukRadios(referralCancellationRadiosArgs) }}

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -16,6 +16,8 @@
     </div>
     <form method="post" action='{{ href }}'>
       <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      <input type="hidden" name="cancellation-reason" value="{{ cancellationReason }}">
+      <input type="hidden" name="cancellation-comments" value="{{ cancellationComments }}">
 
       {{ govukButton({ text: "Cancel this referral" }) }}
     </form>

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -1,0 +1,23 @@
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }}
+  - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      <h1 class="govuk-heading-xl">Referral Cancellation</h1>
+      <p class="govuk-body-m govuk-!-margin-bottom-8">Are you sure you want to cancel this referral?</p>
+    </div>
+    <form method="post" action='{{ href }}'>
+      <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+      {{ govukButton({ text: "Cancel this referral" }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/server/views/probationPractitionerReferrals/referralCancellationConfirmation.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationConfirmation.njk
@@ -1,0 +1,15 @@
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}
+  HMPPS Inteventions - GOV.UK
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({titleText: "This referral has been cancelled" }) }}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds form methods, check your answers and rough confirmation screen for cancelling a referral.

I'm opening this as a draft, as I'm a bit unsure of the best way for doing this, as this is the first example of us not updating a draft object on the backend (as we do with `DraftReferrals`), and trying to do everything in-session. Something doesn't feel quite right, particularly the repeated redirects, and doing a lot of functionality in the Controller, rather than in view/presenter methods, but I'd like to get a second pair of eyes on this.

## What is the intent behind these changes?

To allow PPs to cancel a referral for reasons specified by the Interventions Service.
