### PR TITLE
Update SP call to action for end of service report

### DIFF
--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -56,7 +56,7 @@
   <h2 class="govuk-heading-m">End of service report</h2>
 
   <p class="govuk-body">
-  You can start the end of service report when all sessions are delivered.
+  Please complete the end of service report once the intervention has ended.
   </p>
 
   {{ govukSummaryList(endOfServiceReportSummaryListArgs(govukTag, csrfToken)) }}


### PR DESCRIPTION
## What does this pull request do?

Changes the text displayed on the service provider intervention progress page for starting an end of service report.

Currently, the SP end of service report journey isn’t gated behind any
pre-conditions, so we want to keep this text generic.

## What is the intent behind these changes?

To make the page more comprehensible.