### PR TITLE
Add missing CSRF token

### DIFF
--- a/server/views/serviceProviderReferrals/endOfServiceReport/checkAnswers.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/checkAnswers.njk
@@ -8,6 +8,7 @@
   {% include "../../partials/endOfServiceReportAnswers.njk" %}
 
   <form method="post" action="{{ presenter.formAction }}">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
     {{ govukButton({ text: "Submit the report" }) }}
   </form>
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a missing CSRF token for submitting the end of service report.

This has caught me out a couple of times, when the backend hasn't yet
been ready so I've been relying on the integration tests to test a
feature. The CSRF checks are disabled for the tests, which makes sense
maybe for the unit tests, but I think not for integration. We should
consider enabling them for the integration tests, but here I’m just
fixing the immediate issue.

## What is the intent behind these changes?

To make the SP end of service report journey work.