### PR TITLE
IC-1321: Add Referral cancellation check answers page

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -249,6 +249,8 @@ describe('Probation Practitioner monitor journey', () => {
       cy.contains('Service user has moved out of delivery area').click()
       cy.contains('Additional comments (optional)').type('Some additional comments')
       cy.contains('Continue').click()
+
+      cy.contains('Are you sure you want to cancel this referral?')
     })
   })
 })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -189,6 +189,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/probation-practitioner/referrals/:id/cancellation/reason', (req, res) =>
     probationPractitionerReferralsController.showReferralCancellationReasonPage(req, res)
   )
+  get('/probation-practitioner/referrals/:id/cancellation/check-your-answers', (req, res) =>
+    probationPractitionerReferralsController.showReferralCancellationCheckAnswersPage(req, res)
+  )
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
   get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -189,8 +189,8 @@ export default function routes(router: Router, services: Services): Router {
   get('/probation-practitioner/referrals/:id/cancellation/reason', (req, res) =>
     probationPractitionerReferralsController.showReferralCancellationReasonPage(req, res)
   )
-  get('/probation-practitioner/referrals/:id/cancellation/check-your-answers', (req, res) =>
-    probationPractitionerReferralsController.showReferralCancellationCheckAnswersPage(req, res)
+  post('/probation-practitioner/referrals/:id/cancellation/check-your-answers', (req, res) =>
+    probationPractitionerReferralsController.submitFormAndShowCancellationCheckAnswersPage(req, res)
   )
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -190,3 +190,21 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/reason', () => 
       })
   })
 })
+
+describe('GET /probation-practitioner/referrals/:id/cancellation/check-your-answers', () => {
+  it('renders a page where the PP can confirm whether or not to cancel a referral', async () => {
+    const referral = sentReferralFactory.assigned().build()
+    const serviceUser = deliusServiceUserFactory.build()
+
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+
+    await request(app)
+      .get(`/probation-practitioner/referrals/${referral.id}/cancellation/check-your-answers`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Referral Cancellation')
+        expect(res.text).toContain('Are you sure you want to cancel this referral?')
+      })
+  })
+})

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -191,20 +191,26 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/reason', () => 
   })
 })
 
-describe('GET /probation-practitioner/referrals/:id/cancellation/check-your-answers', () => {
-  it('renders a page where the PP can confirm whether or not to cancel a referral', async () => {
+describe('POST /probation-practitioner/referrals/:id/cancellation/check-your-answers', () => {
+  it('passes through params to a page where the PP can confirm whether or not to cancel a referral', async () => {
     const referral = sentReferralFactory.assigned().build()
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const serviceUser = deliusServiceUserFactory.build()
 
     interventionsService.getSentReferral.mockResolvedValue(referral)
     communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
 
     await request(app)
-      .get(`/probation-practitioner/referrals/${referral.id}/cancellation/check-your-answers`)
+      .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/check-your-answers`)
+      .type('form')
+      .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Referral Cancellation')
         expect(res.text).toContain('Are you sure you want to cancel this referral?')
+        expect(res.text).toContain('MOV')
+        expect(res.text).toContain('Alex has moved out of the area')
       })
   })
 })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -14,6 +14,8 @@ import ReferralCancellationReasonPresenter from './referralCancellationReasonPre
 import ReferralCancellationReasonView from './referralCancellationReasonView'
 import EndOfServiceReportPresenter from './endOfServiceReportPresenter'
 import EndOfServiceReportView from './endOfServiceReportView'
+import ReferralCancellationCheckAnswersPresenter from './referralCancellationCheckAnswersPresenter'
+import ReferralCancellationCheckAnswersView from './referralCancellationCheckAnswersView'
 
 export default class ProbationPractitionerReferralsController {
   constructor(
@@ -135,6 +137,20 @@ export default class ProbationPractitionerReferralsController {
       cancellationReasons
     )
     const view = new ReferralCancellationReasonView(presenter)
+
+    return res.render(...view.renderArgs)
+  }
+
+  async showReferralCancellationCheckAnswersPage(req: Request, res: Response): Promise<void> {
+    const { user } = res.locals
+    const { accessToken } = user.token
+
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
+
+    const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
+
+    const presenter = new ReferralCancellationCheckAnswersPresenter(req.params.id, serviceUser)
+    const view = new ReferralCancellationCheckAnswersView(presenter)
 
     return res.render(...view.renderArgs)
   }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -16,6 +16,8 @@ import EndOfServiceReportPresenter from './endOfServiceReportPresenter'
 import EndOfServiceReportView from './endOfServiceReportView'
 import ReferralCancellationCheckAnswersPresenter from './referralCancellationCheckAnswersPresenter'
 import ReferralCancellationCheckAnswersView from './referralCancellationCheckAnswersView'
+import { FormValidationError } from '../../utils/formValidationError'
+import ReferralCancellationReasonForm from './referralCancellationReasonForm'
 
 export default class ProbationPractitionerReferralsController {
   constructor(
@@ -141,15 +143,47 @@ export default class ProbationPractitionerReferralsController {
     return res.render(...view.renderArgs)
   }
 
-  async showReferralCancellationCheckAnswersPage(req: Request, res: Response): Promise<void> {
+  async submitFormAndShowCancellationCheckAnswersPage(req: Request, res: Response): Promise<void> {
     const { user } = res.locals
     const { accessToken } = user.token
+    let formError: FormValidationError | null = null
 
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
-
     const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
 
-    const presenter = new ReferralCancellationCheckAnswersPresenter(req.params.id, serviceUser)
+    const data = await new ReferralCancellationReasonForm(req).data()
+
+    if (data.error) {
+      res.status(400)
+      formError = data.error
+
+      const serviceCategory = await this.interventionsService.getServiceCategory(
+        accessToken,
+        sentReferral.referral.serviceCategoryId
+      )
+      const cancellationReasons = await this.interventionsService.getReferralCancellationReasons(accessToken)
+
+      const presenter = new ReferralCancellationReasonPresenter(
+        sentReferral,
+        serviceCategory,
+        serviceUser,
+        cancellationReasons,
+        formError
+      )
+      const view = new ReferralCancellationReasonView(presenter)
+
+      return res.render(...view.renderArgs)
+    }
+
+    const { cancellationReason, cancellationComments } = data.paramsForUpdate
+
+    const presenter = new ReferralCancellationCheckAnswersPresenter(
+      req.params.id,
+      serviceUser,
+      cancellationReason,
+      cancellationComments
+    )
+
     const view = new ReferralCancellationCheckAnswersView(presenter)
 
     return res.render(...view.renderArgs)

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.test.ts
@@ -41,4 +41,21 @@ describe(ReferralCancellationCheckAnswersPresenter, () => {
       expect(presenter.serviceUserBannerPresenter).toBeDefined()
     })
   })
+
+  describe('hiddenFields', () => {
+    it('contains the cancellation code and comments', () => {
+      const serviceUser = deliusServiceUser.build()
+      const presenter = new ReferralCancellationCheckAnswersPresenter(
+        '89047822-1014-4f8f-a52c-c348137c89a5',
+        serviceUser,
+        'MOV',
+        'Alex moved out of the area'
+      )
+
+      expect(presenter.hiddenFields).toMatchObject({
+        cancellationReason: 'MOV',
+        cancellationComments: 'Alex moved out of the area',
+      })
+    })
+  })
 })

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.test.ts
@@ -1,0 +1,44 @@
+import deliusServiceUser from '../../../testutils/factories/deliusServiceUser'
+import ReferralCancellationCheckAnswersPresenter from './referralCancellationCheckAnswersPresenter'
+
+describe(ReferralCancellationCheckAnswersPresenter, () => {
+  describe('text', () => {
+    it('contains a title and confirmation question', () => {
+      const serviceUser = deliusServiceUser.build()
+      const presenter = new ReferralCancellationCheckAnswersPresenter(
+        '89047822-1014-4f8f-a52c-c348137c89a5',
+        serviceUser
+      )
+
+      expect(presenter.text).toMatchObject({
+        title: 'Referral Cancellation',
+        confirmationQuestion: 'Are you sure you want to cancel this referral?',
+      })
+    })
+  })
+
+  describe('confirmCancellationHref', () => {
+    it('contains a reference to the referral cancellation endpoint', () => {
+      const serviceUser = deliusServiceUser.build()
+      const presenter = new ReferralCancellationCheckAnswersPresenter(
+        '89047822-1014-4f8f-a52c-c348137c89a5',
+        serviceUser
+      )
+      expect(presenter.confirmCancellationHref).toEqual(
+        '/probation-practitioner/referrals/89047822-1014-4f8f-a52c-c348137c89a5/cancellation/submit'
+      )
+    })
+  })
+
+  describe('serviceUserBanner', () => {
+    it('is defined', () => {
+      const serviceUser = deliusServiceUser.build()
+      const presenter = new ReferralCancellationCheckAnswersPresenter(
+        '89047822-1014-4f8f-a52c-c348137c89a5',
+        serviceUser
+      )
+
+      expect(presenter.serviceUserBannerPresenter).toBeDefined()
+    })
+  })
+})

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.ts
@@ -2,7 +2,12 @@ import { DeliusServiceUser } from '../../services/communityApiService'
 import ServiceUserBannerPresenter from '../shared/serviceUserBannerPresenter'
 
 export default class ReferralCancellationCheckAnswersPresenter {
-  constructor(private readonly referralId: string, private readonly serviceUser: DeliusServiceUser) {}
+  constructor(
+    private readonly referralId: string,
+    private readonly serviceUser: DeliusServiceUser,
+    private readonly cancellationReason?: string,
+    private readonly cancellationComments?: string
+  ) {}
 
   readonly text = {
     title: 'Referral Cancellation',
@@ -12,4 +17,9 @@ export default class ReferralCancellationCheckAnswersPresenter {
   readonly confirmCancellationHref = `/probation-practitioner/referrals/${this.referralId}/cancellation/submit`
 
   readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
+
+  readonly hiddenFields = {
+    cancellationReason: this.cancellationReason,
+    cancellationComments: this.cancellationComments,
+  }
 }

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.ts
@@ -1,0 +1,15 @@
+import { DeliusServiceUser } from '../../services/communityApiService'
+import ServiceUserBannerPresenter from '../shared/serviceUserBannerPresenter'
+
+export default class ReferralCancellationCheckAnswersPresenter {
+  constructor(private readonly referralId: string, private readonly serviceUser: DeliusServiceUser) {}
+
+  readonly text = {
+    title: 'Referral Cancellation',
+    confirmationQuestion: 'Are you sure you want to cancel this referral?',
+  }
+
+  readonly confirmCancellationHref = `/probation-practitioner/referrals/${this.referralId}/cancellation/submit`
+
+  readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
+}

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersView.ts
@@ -9,6 +9,7 @@ export default class ReferralCancellationCheckAnswersView {
       {
         presenter: this.presenter,
         serviceUserNotificationBannerArgs: this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs,
+        hiddenFields: this.presenter.hiddenFields,
       },
     ]
   }

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersView.ts
@@ -1,0 +1,15 @@
+import ReferralCancellationCheckAnswersPresenter from './referralCancellationCheckAnswersPresenter'
+
+export default class ReferralCancellationCheckAnswersView {
+  constructor(private readonly presenter: ReferralCancellationCheckAnswersPresenter) {}
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'probationPractitionerReferrals/referralCancellationCheckAnswers',
+      {
+        presenter: this.presenter,
+        serviceUserNotificationBannerArgs: this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonForm.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonForm.test.ts
@@ -1,0 +1,44 @@
+import TestUtils from '../../../testutils/testUtils'
+import ReferralCancellationReasonForm from './referralCancellationReasonForm'
+
+describe(ReferralCancellationReasonForm, () => {
+  describe('data', () => {
+    describe('when both cancellation reason and comments are passed', () => {
+      it('returns a paramsForUpdate with the cancellationReason and cancellationComments properties', async () => {
+        const request = TestUtils.createRequest({
+          'cancellation-reason': 'MOV',
+          'cancellation-comments': 'Alex has moved to a new area',
+        })
+        const data = await new ReferralCancellationReasonForm(request).data()
+
+        expect(data.paramsForUpdate?.cancellationReason).toEqual('MOV')
+        expect(data.paramsForUpdate?.cancellationComments).toEqual('Alex has moved to a new area')
+      })
+    })
+
+    describe('when only cancellation reason is passed', () => {
+      it('returns a paramsForUpdate with the cancellationReason property', async () => {
+        const request = TestUtils.createRequest({
+          'cancellation-reason': 'MOV',
+        })
+        const data = await new ReferralCancellationReasonForm(request).data()
+
+        expect(data.paramsForUpdate?.cancellationReason).toEqual('MOV')
+      })
+    })
+  })
+
+  describe('invalid fields', () => {
+    it('returns an error when the cancellationReason property is not present', async () => {
+      const request = TestUtils.createRequest({})
+
+      const data = await new ReferralCancellationReasonForm(request).data()
+
+      expect(data.error?.errors).toContainEqual({
+        errorSummaryLinkedField: 'cancellation-reason',
+        formFields: ['cancellation-reason'],
+        message: 'Select a reason for cancelling the referral',
+      })
+    })
+  })
+})

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonForm.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonForm.ts
@@ -1,0 +1,52 @@
+import { Request } from 'express'
+import { body, Result, ValidationChain, ValidationError } from 'express-validator'
+import errorMessages from '../../utils/errorMessages'
+import { FormData } from '../../utils/forms/formData'
+import FormUtils from '../../utils/formUtils'
+import { FormValidationError } from '../../utils/formValidationError'
+
+export default class ReferralCancellationReasonForm {
+  constructor(private readonly request: Request) {}
+
+  async data(): Promise<FormData<Partial<{ cancellationReason: string; cancellationComments: string }>>> {
+    const validationResult = await FormUtils.runValidations({
+      request: this.request,
+      validations: ReferralCancellationReasonForm.validations,
+    })
+
+    const error = this.error(validationResult)
+
+    if (error) {
+      return {
+        paramsForUpdate: null,
+        error,
+      }
+    }
+
+    return {
+      paramsForUpdate: {
+        cancellationReason: this.request.body['cancellation-reason'],
+        cancellationComments: this.request.body['cancellation-comments'],
+      },
+      error: null,
+    }
+  }
+
+  static get validations(): ValidationChain[] {
+    return [body('cancellation-reason').notEmpty().withMessage(errorMessages.cancelReferral.cancellationReason.empty)]
+  }
+
+  private error(validationResult: Result<ValidationError>): FormValidationError | null {
+    if (validationResult.isEmpty()) {
+      return null
+    }
+
+    return {
+      errors: validationResult.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
+  }
+}

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
@@ -51,4 +51,90 @@ describe(ReferralCancellationReasonPresenter, () => {
       ])
     })
   })
+
+  describe('errorSummary', () => {
+    const sentReferral = sentReferralFactory.build()
+    const serviceUser = deliusServiceUserFactory.build()
+    const serviceCategory = serviceCategoryFactory.build()
+    const cancellationReasons: CancellationReason[] = []
+
+    describe('when there is an error', () => {
+      it('returns a summary of the error', () => {
+        const presenter = new ReferralCancellationReasonPresenter(
+          sentReferral,
+          serviceCategory,
+          serviceUser,
+          cancellationReasons,
+          {
+            errors: [
+              {
+                errorSummaryLinkedField: 'cancellation-reason',
+                formFields: ['cancellation-reason'],
+                message: 'Select a reason for cancelling the referral',
+              },
+            ],
+          }
+        )
+
+        expect(presenter.errorSummary).toEqual([
+          { field: 'cancellation-reason', message: 'Select a reason for cancelling the referral' },
+        ])
+      })
+    })
+
+    describe('when there is no error', () => {
+      it('returns null', () => {
+        const presenter = new ReferralCancellationReasonPresenter(
+          sentReferral,
+          serviceCategory,
+          serviceUser,
+          cancellationReasons
+        )
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+  })
+
+  describe('errorMessage', () => {
+    const sentReferral = sentReferralFactory.build()
+    const serviceUser = deliusServiceUserFactory.build()
+    const serviceCategory = serviceCategoryFactory.build()
+    const cancellationReasons: CancellationReason[] = []
+
+    describe('when there is an error', () => {
+      it('returns the error message', () => {
+        const presenter = new ReferralCancellationReasonPresenter(
+          sentReferral,
+          serviceCategory,
+          serviceUser,
+          cancellationReasons,
+          {
+            errors: [
+              {
+                errorSummaryLinkedField: 'cancellation-reason',
+                formFields: ['cancellation-reason'],
+                message: 'Select a reason for cancelling the referral',
+              },
+            ],
+          }
+        )
+
+        expect(presenter.errorMessage).toEqual('Select a reason for cancelling the referral')
+      })
+    })
+
+    describe('when there is no error', () => {
+      it('returns null', () => {
+        const presenter = new ReferralCancellationReasonPresenter(
+          sentReferral,
+          serviceCategory,
+          serviceUser,
+          cancellationReasons
+        )
+
+        expect(presenter.errorMessage).toBeNull()
+      })
+    })
+  })
 })

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
@@ -1,13 +1,16 @@
 import a from 'indefinite'
 import { DeliusServiceUser } from '../../services/communityApiService'
 import { CancellationReason, SentReferral, ServiceCategory } from '../../services/interventionsService'
+import { FormValidationError } from '../../utils/formValidationError'
+import PresenterUtils from '../../utils/presenterUtils'
 
 export default class ReferralCancellationReasonPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly serviceCategory: ServiceCategory,
     private readonly serviceUser: DeliusServiceUser,
-    private readonly cancellationReasons: CancellationReason[]
+    private readonly cancellationReasons: CancellationReason[],
+    private readonly error: FormValidationError | null = null
   ) {}
 
   readonly text = {
@@ -25,4 +28,10 @@ export default class ReferralCancellationReasonPresenter {
       checked: false,
     }))
   }
+
+  readonly errorMessage = PresenterUtils.errorMessage(this.error, 'cancellation-reason')
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error)
+
+  readonly checkAnswersHref = `/probation-practitioner/referrals/${this.sentReferral.id}/cancellation/check-your-answers`
 }

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonView.ts
@@ -1,8 +1,11 @@
 import { RadiosArgs, TextareaArgs } from '../../utils/govukFrontendTypes'
+import ViewUtils from '../../utils/viewUtils'
 import ReferralCancellationReasonPresenter from './referralCancellationReasonPresenter'
 
 export default class ReferralCancellationReasonView {
   constructor(private readonly presenter: ReferralCancellationReasonPresenter) {}
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   private get referralCancellationRadiosArgs(): RadiosArgs {
     return {
@@ -13,6 +16,7 @@ export default class ReferralCancellationReasonView {
           classes: 'govuk-fieldset__legend--m govuk-!-margin-bottom-6',
         },
       },
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
       name: 'cancellation-reason',
       items: this.presenter.cancellationReasonsFields,
     }
@@ -33,6 +37,7 @@ export default class ReferralCancellationReasonView {
       'probationPractitionerReferrals/referralCancellationReason',
       {
         presenter: this.presenter,
+        errorSummaryArgs: this.errorSummaryArgs,
         referralCancellationRadiosArgs: this.referralCancellationRadiosArgs,
         additionalCommentsTextareaArgs: this.additionalCommentsTextareaArgs,
       },

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -94,4 +94,9 @@ export default {
       empty: (name: string) => `Select whether ${name} achieved the desired outcome`,
     },
   },
+  cancelReferral: {
+    cancellationReason: {
+      empty: 'Select a reason for cancelling the referral',
+    },
+  },
 }

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -19,6 +19,8 @@
     </div>
     <form method="post" action="#">
       <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      <input type="hidden" name="cancellation-reason" value="{{ hiddenFields.cancellationReason }}">
+      <input type="hidden" name="cancellation-comments" value="{{ hiddenFields.cancellationComments }}">
 
       {{ govukButton({ text: "Cancel referral" }) }}
     </form>

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -1,0 +1,26 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "HMPPS Interventions" %}
+{% block pageTitle %}{{ pageTitle }}
+  - GOV.UK{% endblock %}
+
+{% block content %}
+ {% if serviceUserNotificationBannerArgs !== undefined and serviceUserNotificationBannerArgs !== null %}
+    {{ govukNotificationBanner(serviceUserNotificationBannerArgs) }}
+  {% endif %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+      <p class="govuk-body-m govuk-!-margin-bottom-8">{{ presenter.text.confirmationQuestion }}</p>
+    </div>
+    <form method="post" action="#">
+      <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+      {{ govukButton({ text: "Cancel referral" }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/server/views/probationPractitionerReferrals/referralCancellationReason.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationReason.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -11,10 +12,14 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <p class="govuk-body-m govuk-!-margin-bottom-8">{{ presenter.text.information }}</p>
     </div>
-    <form method="post">
+    <form method="post" action="{{ presenter.checkAnswersHref }}">
       <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
       {{ govukRadios(referralCancellationRadiosArgs) }}


### PR DESCRIPTION
## What does this pull request do?

- Adds check your answers page to the referral cancellation journey, via a redirect when POSTing from the "select reason for cancellation" page.
- Adds form for validating that user has selected a cancellation radio button on the previous page, and displays errors if not.

Passing objects through multiple screens is something we haven't really done yet - we've tended to update an object on the backend in between each screen. As such, this may require a bit of re-working to submit the reason to the backend and cancel the referral, but this will come in a subsequent PR.

## Screenshot

<img width="997" alt="image" src="https://user-images.githubusercontent.com/19826940/116228624-6db79400-a74d-11eb-9bc7-165702d39622.png">
