### PR TITLE
Probation practitioner can navigate to end of service report

### DIFF
--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -3,6 +3,8 @@ import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import serviceUserFactory from '../../../testutils/factories/deliusServiceUser'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
+import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
+import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 
 describe(InterventionProgressPresenter, () => {
   describe('sessionTableRows', () => {
@@ -164,6 +166,78 @@ describe(InterventionProgressPresenter, () => {
       const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [])
 
       expect(presenter.referralAssigned).toEqual(true)
+    })
+  })
+
+  describe('hasEndOfServiceReport', () => {
+    describe('when the referral has no end of service report', () => {
+      it('returns false', () => {
+        const referral = sentReferralFactory.build({ endOfServiceReport: null })
+        const serviceCategory = serviceCategoryFactory.build()
+        const serviceUser = serviceUserFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [])
+
+        expect(presenter.hasEndOfServiceReport).toEqual(false)
+      })
+    })
+    describe('when the referral has an end of service report', () => {
+      describe('and it is not submitted', () => {
+        it('returns false', () => {
+          const referral = sentReferralFactory.build({
+            endOfServiceReport: endOfServiceReportFactory.justCreated().build(),
+          })
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [])
+
+          expect(presenter.hasEndOfServiceReport).toEqual(false)
+        })
+      })
+
+      describe('and it is submitted', () => {
+        it('returns true', () => {
+          const referral = sentReferralFactory.build({
+            endOfServiceReport: endOfServiceReportFactory.submitted().build(),
+          })
+          const serviceCategory = serviceCategoryFactory.build()
+          const serviceUser = serviceUserFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [])
+
+          expect(presenter.hasEndOfServiceReport).toEqual(true)
+        })
+      })
+    })
+  })
+
+  describe('endOfServiceReportTableHeaders', () => {
+    it('returns the headers for the end of service report table', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [])
+
+      expect(presenter.endOfServiceReportTableHeaders).toEqual(['Caseworker', 'Status', 'Action'])
+    })
+  })
+
+  describe('endOfServiceReportTableRows', () => {
+    it('returns the contents of a table detailing the end of service report', () => {
+      const endOfServiceReport = endOfServiceReportFactory.submitted().build()
+      const referral = sentReferralFactory.build({
+        assignedTo: hmppsAuthUserFactory.build({ username: 'john.bloggs' }),
+        endOfServiceReport,
+      })
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, serviceUser, [])
+
+      expect(presenter.endOfServiceReportTableRows).toEqual([
+        {
+          caseworker: 'john.bloggs',
+          linkHtml: `<a class="govuk-link" href="/probation-practitioner/end-of-service-report/${endOfServiceReport.id}">View</a>`,
+          tagArgs: { classes: 'govuk-tag--green', text: 'Completed' },
+        },
+      ])
     })
   })
 })

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -85,4 +85,28 @@ export default class InterventionProgressPresenter {
         }
     }
   }
+
+  readonly hasEndOfServiceReport = (this.referral.endOfServiceReport?.submittedAt ?? null) !== null
+
+  readonly endOfServiceReportTableHeaders = ['Caseworker', 'Status', 'Action']
+
+  get endOfServiceReportTableRows(): Record<string, unknown>[] {
+    return [
+      {
+        caseworker: this.referral.assignedTo?.username ?? '',
+        tagArgs: {
+          text: this.endOfServiceReportTableParams.text,
+          classes: this.endOfServiceReportTableParams.tagClass,
+        },
+        linkHtml: this.endOfServiceReportTableParams.linkHTML,
+      },
+    ]
+  }
+
+  private endOfServiceReportTableParams = {
+    // At the moment this method is only used by the template when the end of service report is submitted, hence the hardcoded "Completed"
+    text: 'Completed',
+    tagClass: 'govuk-tag--green',
+    linkHTML: `<a class="govuk-link" href="/probation-practitioner/end-of-service-report/${this.referral.endOfServiceReport?.id}">View</a>`,
+  }
 }

--- a/server/routes/probationPractitionerReferrals/interventionProgressView.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressView.ts
@@ -21,6 +21,17 @@ export default class InterventionProgressView {
     }
   }
 
+  private endOfServiceReportTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
+    return {
+      head: this.presenter.endOfServiceReportTableHeaders.map((header: string) => {
+        return { text: header }
+      }),
+      rows: this.presenter.endOfServiceReportTableRows.map(row => {
+        return [{ text: `${row.caseworker}` }, { text: tagMacro(row.tagArgs as TagArgs) }, { html: `${row.linkHtml}` }]
+      }),
+    }
+  }
+
   private readonly backLinkArgs = {
     text: 'Back',
     href: '/probation-practitioner/dashboard',
@@ -35,6 +46,7 @@ export default class InterventionProgressView {
         subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         serviceUserBannerArgs: this.presenter.referralOverviewPagePresenter.serviceUserBannerArgs,
         sessionTableArgs: this.sessionTableArgs.bind(this),
+        endOfServiceReportTableArgs: this.endOfServiceReportTableArgs.bind(this),
       },
     ]
   }

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -22,7 +22,13 @@
   {% endif %}
 
   <h2 class="govuk-heading-m">End of service report</h2>
-  <p>Below you will be able to find the end of service report created by the service provider. Once submitted, you will be able to read and download it.</p>
+  {% if presenter.hasEndOfServiceReport %}
+    <p>This is the end of service report created by the service provider.</p>
+
+    {{ govukTable(endOfServiceReportTableArgs(govukTag)) }}
+  {% else %}
+    <p>Below you will be able to find the end of service report created by the service provider. Once submitted, you will be able to read and download it.</p>
+  {% endif %}
 
   <a href='{{ presenter.referralCancellationHref }}'>Cancel this referral</a>
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

This adds a link to the probation practitioner intervention progress
page, so that they can see a submitted end of service report. Until now,
they’ve only been able to view the end of service report by following a
link in a notification email.

The implementation is copied from that of the session progress table in
the same file. I think there are some improvements we could make here
(presenters shouldn’t be emitting HTML) but I want to get this done in
time for show and tell, and I’ll stick with consistency and what works.

## What is the intent behind these changes?

To allow a probation practitioner to view an end of service report at any time.

## Screenshots

### No end of service report submitted

![image](https://user-images.githubusercontent.com/53756884/116235674-0eaa4d00-a756-11eb-982a-85c46c522e51.png)

### End of service report submitted

![image](https://user-images.githubusercontent.com/53756884/116235731-208bf000-a756-11eb-9c91-55f95cf1d63d.png)
