### PR TITLE
IC-1321: Add referral cancellation confirmation page

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -248,9 +248,15 @@ describe('Probation Practitioner monitor journey', () => {
       cy.contains('Cancel this referral').click()
       cy.contains('Service user has moved out of delivery area').click()
       cy.contains('Additional comments (optional)').type('Some additional comments')
+
+      cy.stubCancelReferral(assignedReferral.id, assignedReferral)
+
       cy.contains('Continue').click()
 
       cy.contains('Are you sure you want to cancel this referral?')
+
+      cy.contains('Cancel referral').click()
+      cy.contains('This referral has been cancelled')
     })
   })
 })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -192,6 +192,12 @@ export default function routes(router: Router, services: Services): Router {
   post('/probation-practitioner/referrals/:id/cancellation/check-your-answers', (req, res) =>
     probationPractitionerReferralsController.submitFormAndShowCancellationCheckAnswersPage(req, res)
   )
+  post('/probation-practitioner/referrals/:id/cancellation/submit', (req, res) =>
+    probationPractitionerReferralsController.cancelReferral(req, res)
+  )
+  get('/probation-practitioner/referrals/:id/cancellation/confirmation', (req, res) =>
+    probationPractitionerReferralsController.showCancellationConfirmationPage(req, res)
+  )
 
   get('/integrations/delius/user', integrationSamples.viewDeliusUserSample)
   get('/integrations/oasys/assessment', integrationSamples.viewOasysAssessmentSample)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -214,3 +214,24 @@ describe('POST /probation-practitioner/referrals/:id/cancellation/check-your-ans
       })
   })
 })
+
+describe('POST /probation-practitioner/referrals/:id/cancellation/submit', () => {
+  it('submits a request to cancel the referral on the backend and redirects to the confirmation screen', async () => {
+    await request(app)
+      .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/submit`)
+      .type('form')
+      .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
+      .expect(302)
+      .expect(
+        'Location',
+        `/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/confirmation`
+      )
+
+    expect(interventionsService.cancelReferral).toHaveBeenCalledWith(
+      'token',
+      '9747b7fb-51bc-40e2-bbbd-791a9be9284b',
+      'MOV',
+      'Alex has moved out of the area'
+    )
+  })
+})

--- a/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.test.ts
@@ -1,0 +1,59 @@
+import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import ReferralCancellationConfirmationPresenter from './referralCancellationConfirmationPresenter'
+
+describe(ReferralCancellationConfirmationPresenter, () => {
+  describe('text', () => {
+    it('contains a panel title and what happens next text', () => {
+      const serviceUser = deliusServiceUserFactory.build()
+      const sentReferral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, serviceCategory, serviceUser)
+
+      expect(presenter.text).toMatchObject({
+        confirmationText: 'This referral has been cancelled',
+        whatHappensNextText:
+          "Service provider will be notified about the cancellation. You don't have to do anything else.",
+      })
+    })
+  })
+
+  describe('serviceUserBannerPresenter', () => {
+    it('is defined', () => {
+      const serviceUser = deliusServiceUserFactory.build()
+      const sentReferral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, serviceCategory, serviceUser)
+
+      expect(presenter.serviceUserBannerPresenter).toBeDefined()
+    })
+  })
+
+  describe('serviceUserSummary', () => {
+    it('displays information about the referral and service user', () => {
+      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex', surname: 'River' })
+      const sentReferral = sentReferralFactory.build({ referenceNumber: 'AB1234' })
+      const serviceCategory = serviceCategoryFactory.build({ name: 'Accommodation' })
+      const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, serviceCategory, serviceUser)
+
+      expect(presenter.serviceUserSummary).toEqual([
+        {
+          key: 'Name',
+          lines: ['Alex River'],
+          isList: false,
+        },
+        {
+          key: 'Referral number',
+          lines: ['AB1234'],
+          isList: false,
+        },
+        {
+          key: 'Type of referral',
+          lines: ['Accommodation'],
+          isList: false,
+        },
+      ])
+    })
+  })
+})

--- a/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.ts
@@ -1,0 +1,42 @@
+import { DeliusServiceUser } from '../../services/communityApiService'
+import { SentReferral, ServiceCategory } from '../../services/interventionsService'
+import PresenterUtils from '../../utils/presenterUtils'
+import { SummaryListItem } from '../../utils/summaryList'
+import utils from '../../utils/utils'
+import ServiceUserBannerPresenter from '../shared/serviceUserBannerPresenter'
+
+export default class ReferralCancellationConfirmationPresenter {
+  constructor(
+    private readonly referral: SentReferral,
+    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceUser: DeliusServiceUser
+  ) {}
+
+  readonly text = {
+    confirmationText: 'This referral has been cancelled',
+    whatHappensNextText:
+      "Service provider will be notified about the cancellation. You don't have to do anything else.",
+  }
+
+  readonly myCasesHref = '/probation-practitioner/dashboard'
+
+  readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
+
+  readonly serviceUserSummary: SummaryListItem[] = [
+    {
+      key: 'Name',
+      lines: [PresenterUtils.fullName(this.referral.referral.serviceUser)],
+      isList: false,
+    },
+    {
+      key: 'Referral number',
+      lines: [this.referral.referenceNumber],
+      isList: false,
+    },
+    {
+      key: 'Type of referral',
+      lines: [utils.convertToProperCase(this.serviceCategory.name)],
+      isList: false,
+    },
+  ]
+}

--- a/server/routes/probationPractitionerReferrals/referralCancellationConfirmationView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationConfirmationView.ts
@@ -1,0 +1,25 @@
+import ViewUtils from '../../utils/viewUtils'
+import ReferralCancellationConfirmationPresenter from './referralCancellationConfirmationPresenter'
+
+export default class ReferralCancellationConfirmationView {
+  constructor(private readonly presenter: ReferralCancellationConfirmationPresenter) {}
+
+  private get summaryListArgs() {
+    return ViewUtils.summaryListArgs(this.presenter.serviceUserSummary)
+  }
+
+  private get serviceUserBannerArgs() {
+    return this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'probationPractitionerReferrals/referralCancellationConfirmation',
+      {
+        presenter: this.presenter,
+        serviceUserNotificationBannerArgs: this.serviceUserBannerArgs,
+        summaryListArgs: this.summaryListArgs,
+      },
+    ]
+  }
+}

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -17,7 +17,7 @@
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <p class="govuk-body-m govuk-!-margin-bottom-8">{{ presenter.text.confirmationQuestion }}</p>
     </div>
-    <form method="post" action="#">
+    <form method="post" action="{{ presenter.confirmCancellationHref }}">
       <input type="hidden" name="_csrf" value="{{csrfToken}}">
       <input type="hidden" name="cancellation-reason" value="{{ hiddenFields.cancellationReason }}">
       <input type="hidden" name="cancellation-comments" value="{{ hiddenFields.cancellationComments }}">

--- a/server/views/probationPractitionerReferrals/referralCancellationConfirmation.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationConfirmation.njk
@@ -1,0 +1,29 @@
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}
+  HMPPS Inteventions - GOV.UK
+{% endblock %}
+
+{% block content %}
+ {% if serviceUserNotificationBannerArgs !== undefined and serviceUserNotificationBannerArgs !== null %}
+    {{ govukNotificationBanner(serviceUserNotificationBannerArgs) }}
+  {% endif %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({titleText: presenter.text.confirmationText }) }}
+
+      <h2 class="govuk-heading-m">Service user details</h2>
+      {{ govukSummaryList(summaryListArgs) }}
+
+      <h2 class="govuk-heading-m">What happens next?</h2>
+      <p class="govuk-body">{{presenter.text.whatHappensNextText}}</p>
+
+      <a href="{{ presenter.myCasesHref }}" class="govuk-button">Go back to My Cases</a>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds confirmation page for referral cancellation journey. This calls the `sent-referral/:id/end` endpoint to mark the referral as ended on the backend.

## What is the intent behind these changes?

To allow the PP to request an end to the service.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/116371030-e75d8980-a802-11eb-9fa3-9ef344100ba1.png)

