### PR TITLE
IC-1321: Add SU banner to referral cancellation reasons

### DIFF
--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
@@ -137,4 +137,22 @@ describe(ReferralCancellationReasonPresenter, () => {
       })
     })
   })
+
+  describe('serviceUserBanner', () => {
+    it('is defined', () => {
+      const sentReferral = sentReferralFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const cancellationReasons: CancellationReason[] = []
+
+      const presenter = new ReferralCancellationReasonPresenter(
+        sentReferral,
+        serviceCategory,
+        serviceUser,
+        cancellationReasons
+      )
+
+      expect(presenter.serviceUserBannerPresenter).toBeDefined()
+    })
+  })
 })

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
@@ -3,6 +3,7 @@ import { DeliusServiceUser } from '../../services/communityApiService'
 import { CancellationReason, SentReferral, ServiceCategory } from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import ServiceUserBannerPresenter from '../shared/serviceUserBannerPresenter'
 
 export default class ReferralCancellationReasonPresenter {
   constructor(
@@ -28,6 +29,8 @@ export default class ReferralCancellationReasonPresenter {
       checked: false,
     }))
   }
+
+  readonly serviceUserBannerPresenter = new ServiceUserBannerPresenter(this.serviceUser)
 
   readonly errorMessage = PresenterUtils.errorMessage(this.error, 'cancellation-reason')
 

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonView.ts
@@ -7,6 +7,8 @@ export default class ReferralCancellationReasonView {
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
+  private readonly serviceUserBannerArgs = this.presenter.serviceUserBannerPresenter.serviceUserBannerArgs
+
   private get referralCancellationRadiosArgs(): RadiosArgs {
     return {
       fieldset: {
@@ -38,6 +40,7 @@ export default class ReferralCancellationReasonView {
       {
         presenter: this.presenter,
         errorSummaryArgs: this.errorSummaryArgs,
+        serviceUserNotificationBannerArgs: this.serviceUserBannerArgs,
         referralCancellationRadiosArgs: this.referralCancellationRadiosArgs,
         additionalCommentsTextareaArgs: this.additionalCommentsTextareaArgs,
       },

--- a/server/views/probationPractitionerReferrals/referralCancellationReason.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationReason.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -10,6 +11,10 @@
   - GOV.UK{% endblock %}
 
 {% block content %}
+   {% if serviceUserNotificationBannerArgs !== undefined and serviceUserNotificationBannerArgs !== null %}
+    {{ govukNotificationBanner(serviceUserNotificationBannerArgs) }}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
       {% if errorSummaryArgs !== null %}


### PR DESCRIPTION
## What does this pull request do?

Adds missing SU banner to referral cancellation page. We'll probably want to do this in a more consistent way to stop us having to do it everywhere, but this can come as a later refactor.

## Screenshot

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/19826940/116374690-6d2f0400-a806-11eb-8444-890cf8830c68.png">

