### PR TITLE
Refactor: Stop passing HTML strings from Intervention Progress Presenter to View

### DIFF
--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -249,8 +249,11 @@ describe(InterventionProgressPresenter, () => {
       expect(presenter.endOfServiceReportTableRows).toEqual([
         {
           caseworker: 'john.bloggs',
-          linkHtml: `<a class="govuk-link" href="/probation-practitioner/end-of-service-report/${endOfServiceReport.id}">View</a>`,
           tagArgs: { classes: 'govuk-tag--green', text: 'Completed' },
+          link: {
+            href: `/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`,
+            text: 'View',
+          },
         },
       ])
     })

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -13,6 +13,11 @@ interface ProgressSessionTableRow {
   link: { text: string; href: string }
 }
 
+interface EndOfServiceTableRow {
+  caseworker: string
+  tagArgs: { text: string; classes: string }
+  link: { text: string; href: string }
+}
 export default class InterventionProgressPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
 
@@ -103,7 +108,7 @@ export default class InterventionProgressPresenter {
 
   readonly endOfServiceReportTableHeaders = ['Caseworker', 'Status', 'Action']
 
-  get endOfServiceReportTableRows(): Record<string, unknown>[] {
+  get endOfServiceReportTableRows(): EndOfServiceTableRow[] {
     return [
       {
         caseworker: this.referral.assignedTo?.username ?? '',
@@ -111,7 +116,10 @@ export default class InterventionProgressPresenter {
           text: this.endOfServiceReportTableParams.text,
           classes: this.endOfServiceReportTableParams.tagClass,
         },
-        linkHtml: this.endOfServiceReportTableParams.linkHTML,
+        link: {
+          href: this.endOfServiceReportTableParams.linkHref,
+          text: this.endOfServiceReportTableParams.linkText,
+        },
       },
     ]
   }
@@ -120,6 +128,7 @@ export default class InterventionProgressPresenter {
     // At the moment this method is only used by the template when the end of service report is submitted, hence the hardcoded "Completed"
     text: 'Completed',
     tagClass: 'govuk-tag--green',
-    linkHTML: `<a class="govuk-link" href="/probation-practitioner/end-of-service-report/${this.referral.endOfServiceReport?.id}">View</a>`,
+    linkHref: `/probation-practitioner/end-of-service-report/${this.referral.endOfServiceReport?.id}`,
+    linkText: 'View',
   }
 }

--- a/server/routes/probationPractitionerReferrals/interventionProgressView.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressView.ts
@@ -35,7 +35,11 @@ export default class InterventionProgressView {
         return { text: header }
       }),
       rows: this.presenter.endOfServiceReportTableRows.map(row => {
-        return [{ text: `${row.caseworker}` }, { text: tagMacro(row.tagArgs as TagArgs) }, { html: `${row.linkHtml}` }]
+        return [
+          { text: `${row.caseworker}` },
+          { text: tagMacro(row.tagArgs as TagArgs) },
+          { html: `${this.linkHtml(row.link)}` },
+        ]
       }),
     }
   }


### PR DESCRIPTION
## What does this pull request do?

Refactors Intervention Progress page tables to pass more structured data from Presenters to then construct into an HTML string in the View layer.

## What is the intent behind these changes?

Passing long HTML strings around the application is more brittle, particularly in testing, where we're relying on all attributes on an HTML string to be in the specified order, when that shouldn't matter to us.

I'd like to do this in the SP Intervention Progress page in the near-future, if this change is accepted, but that will be a bit more complicated as there are multiple links displayed in the table, so we won't be able to use exactly the same structure.
