### PR TITLE
IC 1345: Add screen where the SP can see that the intervention has been ended

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -5,5 +5,6 @@ $path: "/assets/images/"
 @import 'moj/all'
 
 @import './components/header-bar'
+@import './components/notification-banner'
 
 @import './local'

--- a/assets/sass/components/_notification-banner.scss
+++ b/assets/sass/components/_notification-banner.scss
@@ -1,0 +1,4 @@
+.govuk-notification-banner--warning {
+  background-color: govuk-colour('orange');
+  border-color: govuk-colour('orange');
+}

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -7,6 +7,47 @@ import actionPlanAppointmentFactory from '../../../testutils/factories/actionPla
 import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
 
 describe(InterventionProgressPresenter, () => {
+  describe('referralEnded', () => {
+    it('returns true when the referral has ended', () => {
+      const referral = sentReferralFactory.endRequested().build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+      expect(presenter.referralEnded).toEqual(true)
+    })
+    it('returns false when the referral has not ended', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+      expect(presenter.referralEnded).toEqual(false)
+    })
+  })
+  describe('referralEndedFields', () => {
+    it('returns ended fields when the referral has ended', () => {
+      const referral = sentReferralFactory.endRequested().build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+      expect(presenter.referralEndedFields.endRequestedComments).toEqual(referral.endRequestedComments)
+      expect(presenter.referralEndedFields.endRequestedReason).toEqual(referral.endRequestedReason)
+      expect(presenter.referralEndedFields.endRequestedAt).toEqual(referral.endRequestedAt)
+    })
+    it('returns null values when the referral has not ended', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const serviceUser = serviceUserFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, serviceUser, [])
+
+      expect(presenter.referralEndedFields.endRequestedComments).toBeNull()
+      expect(presenter.referralEndedFields.endRequestedReason).toBeNull()
+      expect(presenter.referralEndedFields.endRequestedAt).toBeNull()
+    })
+  })
+
   describe('createActionPlanFormAction', () => {
     it('returns the relative URL for creating a draft action plan', () => {
       const referral = sentReferralFactory.build()

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -6,6 +6,11 @@ import DateUtils from '../../utils/dateUtils'
 import sessionStatus, { SessionStatus } from '../../utils/sessionStatus'
 import SessionStatusPresenter from '../shared/sessionStatusPresenter'
 
+interface EndedFields {
+  endRequestedAt: string | null
+  endRequestedComments: string | null
+  endRequestedReason: string | null
+}
 export default class InterventionProgressPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
 
@@ -44,6 +49,18 @@ export default class InterventionProgressPresenter {
 
   get allowActionPlanCreation(): boolean {
     return this.actionPlan === null
+  }
+
+  get referralEnded(): boolean {
+    return this.referral.endRequestedAt !== null
+  }
+
+  get referralEndedFields(): EndedFields {
+    return {
+      endRequestedAt: this.referral.endRequestedAt,
+      endRequestedComments: this.referral.endRequestedComments,
+      endRequestedReason: this.referral.endRequestedReason,
+    }
   }
 
   readonly hasSessions = this.actionPlanAppointments.length !== 0

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -1,10 +1,44 @@
-import { TagArgs, SummaryListArgs, SummaryListArgsRow, TableArgs } from '../../utils/govukFrontendTypes'
+import {
+  NotificationBannerArgs,
+  SummaryListArgs,
+  SummaryListArgsRow,
+  TableArgs,
+  TagArgs,
+} from '../../utils/govukFrontendTypes'
 
 import ViewUtils from '../../utils/viewUtils'
 import InterventionProgressPresenter from './interventionProgressPresenter'
+import DateUtils from '../../utils/dateUtils'
 
 export default class InterventionProgressView {
   constructor(private readonly presenter: InterventionProgressPresenter) {}
+
+  get cancelledReferralNotificationBannerArgs(): NotificationBannerArgs {
+    let cancellationReasonHTML = ''
+    let cancellationCommentsHTML = ''
+    if (this.presenter.referralEndedFields.endRequestedAt && this.presenter.referralEndedFields.endRequestedReason) {
+      const formattedEndDate = DateUtils.getDateStringFromDateTimeString(
+        this.presenter.referralEndedFields.endRequestedAt
+      )
+      cancellationReasonHTML = `
+        <p>
+            The probation practitioner cancelled this intervention on ${formattedEndDate} 
+            with reason: ${ViewUtils.escape(this.presenter.referralEndedFields.endRequestedReason)}.
+        </p>`
+    }
+    if (this.presenter.referralEndedFields.endRequestedComments) {
+      cancellationCommentsHTML = `
+        <p>
+            Additional information: ${ViewUtils.escape(this.presenter.referralEndedFields.endRequestedComments)}
+        </p>`
+    }
+    const html = `<div>${cancellationReasonHTML}${cancellationCommentsHTML}</div>`
+    return {
+      titleText: 'Intervention cancelled',
+      html,
+      classes: 'govuk-notification-banner--warning',
+    }
+  }
 
   private initialAssessmentSummaryListArgs(tagMacro: (args: TagArgs) => string): SummaryListArgs {
     return {
@@ -133,6 +167,7 @@ export default class InterventionProgressView {
         sessionTableArgs: this.sessionTableArgs.bind(this),
         backLinkArgs: this.backLinkArgs,
         endOfServiceReportSummaryListArgs: this.endOfServiceReportSummaryListArgs.bind(this),
+        cancelledReferralNotificationBannerArgs: this.cancelledReferralNotificationBannerArgs,
       },
     ]
   }

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -1,10 +1,15 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../partials/referralNavigationTemplate.njk" %}
 
 {% block referralPageSection %}
+
+  {% if presenter.referralEnded %}
+     {{ govukNotificationBanner(cancelledReferralNotificationBannerArgs) }}
+  {% endif %}
 
   <h2 class="govuk-heading-m">Initial assessment appointment</h2>
 

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -67,7 +67,7 @@ class SentReferralFactory extends Factory<SentReferral> {
 
   endRequested() {
     return this.assigned().params({
-      endRequestedAt: '2021-4-28T20:45:21.986389Z',
+      endRequestedAt: '2021-04-28T20:45:21.986389Z',
       endRequestedReason: 'Service user was recalled',
       endRequestedComments: "you'll be seeing alex again soon i'm sure!",
     })


### PR DESCRIPTION
## What does this pull request do?

Adds an intervention notification banner onto the service user progress page when the referral has been ended by the PP user.
Attached is the screenshot for how it looks: ![image](https://user-images.githubusercontent.com/83066216/116426729-4808b880-a83b-11eb-82c6-58f6a1a6d58e.png)

The text was derived from the comment left on ticket https://dsdmoj.atlassian.net/browse/IC-1543

## What is the intent behind these changes?

Enabled visibility of intervention status to the SP user.
