### PR TITLE
IC-1639: Display message to PP on intervention progress page when they have requested to end a referral

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -257,6 +257,19 @@ describe('Probation Practitioner monitor journey', () => {
 
       cy.contains('Cancel referral').click()
       cy.contains('This referral has been cancelled')
+
+      const referralWithEndRequested = sentReferralFactory.endRequested().build({
+        ...referralParams,
+        assignedTo: { username: probationPractitioner.username },
+        actionPlanId: actionPlan.id,
+        endRequestedAt: '2021-04-04T20:45:21.986389Z',
+      })
+
+      cy.stubGetSentReferral(referralWithEndRequested.id, referralWithEndRequested)
+
+      cy.visit(`/probation-practitioner/referrals/${referralWithEndRequested.id}/progress`)
+
+      cy.contains('You requested to end this service on 04 Apr 2021')
     })
   })
 })

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -174,6 +174,44 @@ describe(InterventionProgressPresenter, () => {
     })
   })
 
+  describe('referralEndRequested', () => {
+    it('returns true when the referral has ended', () => {
+      const referral = sentReferralFactory.endRequested().build()
+      const serviceCategory = serviceCategoryFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+
+      expect(presenter.referralEndRequested).toEqual(true)
+    })
+
+    it('returns false when the referral has not ended', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+
+      expect(presenter.referralEndRequested).toEqual(false)
+    })
+  })
+
+  describe('referralEndRequestedText', () => {
+    it('returns the requested end date when an end has been requested', () => {
+      const referral = sentReferralFactory.endRequested().build({ endRequestedAt: '2021-04-28T20:45:21.986389Z' })
+      const serviceCategory = serviceCategoryFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+
+      expect(presenter.referralEndRequestedText).toEqual('You requested to end this service on 28 Apr 2021.')
+    })
+
+    it('returns an empty string when an end has not been requested', () => {
+      const referral = sentReferralFactory.build()
+      const serviceCategory = serviceCategoryFactory.build()
+
+      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+
+      expect(presenter.referralEndRequestedText).toEqual('')
+    })
+  })
+
   describe('hasEndOfServiceReport', () => {
     describe('when the referral has no end of service report', () => {
       it('returns false', () => {

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -38,6 +38,20 @@ export default class InterventionProgressPresenter {
     return this.referral.assignedTo !== null
   }
 
+  get referralEndRequested(): boolean {
+    return this.referral.endRequestedAt !== null
+  }
+
+  get referralEndRequestedText(): string {
+    const shortenedDateString = DateUtils.getDateStringFromDateTimeString(this.referral.endRequestedAt)
+
+    if (!shortenedDateString) {
+      return ''
+    }
+
+    return `You requested to end this service on ${shortenedDateString}.`
+  }
+
   readonly text = {
     title: `${utils.convertToTitleCase(this.serviceCategory.name)} progress`,
   }

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -30,5 +30,9 @@
     <p>Below you will be able to find the end of service report created by the service provider. Once submitted, you will be able to read and download it.</p>
   {% endif %}
 
-  <a href='{{ presenter.referralCancellationHref }}'>Cancel this referral</a>
+  {% if presenter.referralEndRequested %}
+    <p class="govuk-body">{{ presenter.referralEndRequestedText }}</p>
+  {% else %}
+    <a href='{{ presenter.referralCancellationHref }}'>Cancel this referral</a>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Displays a message to PP on intervention progress page when they have requested to end a referral to show requested end date, rather than a link to cancel the referral again.

## What is the intent behind these changes?

To prevent them from being able to cancel a referral, and know that they have requested an end to the service.

## Screenshot

<img width="764" alt="image" src="https://user-images.githubusercontent.com/19826940/116540453-126ada80-a8e2-11eb-8ca3-f872ea76e7d5.png">

