### PR TITLE
Refactor: Break Session Table HTML down into structured data

### DIFF
--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -34,8 +34,8 @@ describe(InterventionProgressPresenter, () => {
               classes: 'govuk-tag--grey',
             },
             link: {
-              text: '',
-              href: '',
+              text: null,
+              href: null,
             },
           },
         ])
@@ -63,8 +63,8 @@ describe(InterventionProgressPresenter, () => {
               classes: 'govuk-tag--blue',
             },
             link: {
-              text: '',
-              href: '',
+              text: null,
+              href: null,
             },
           },
         ])

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -10,7 +10,7 @@ interface ProgressSessionTableRow {
   sessionNumber: number
   appointmentTime: string
   tagArgs: { text: string; classes: string }
-  link: { text: string; href: string }
+  link: { text: string | null; href: string | null }
 }
 
 interface EndOfServiceTableRow {
@@ -68,7 +68,7 @@ export default class InterventionProgressPresenter {
 
   private sessionTableParams(
     appointment: ActionPlanAppointment
-  ): { text: string; tagClass: string; linkText: string; linkHref: string } {
+  ): { text: string; tagClass: string; linkText: string | null; linkHref: string | null } {
     const status = sessionStatus.forAppointment(appointment)
     const presenter = new SessionStatusPresenter(status)
 
@@ -91,15 +91,15 @@ export default class InterventionProgressPresenter {
         return {
           text: presenter.text,
           tagClass: presenter.tagClass,
-          linkText: '',
-          linkHref: '',
+          linkText: null,
+          linkHref: null,
         }
       default:
         return {
           text: presenter.text,
           tagClass: presenter.tagClass,
-          linkText: '',
-          linkHref: '',
+          linkText: null,
+          linkHref: null,
         }
     }
   }

--- a/server/routes/probationPractitionerReferrals/interventionProgressView.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressView.ts
@@ -21,7 +21,7 @@ export default class InterventionProgressView {
     }
   }
 
-  private linkHtml(link: { text: string; href: string }): string {
+  private linkHtml(link: { text: string | null; href: string | null }): string {
     if (link.text && link.href) {
       return `<a class="govuk-link" href="${link.href}">${link.text}</a>`
     }

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -86,8 +86,12 @@ describe(InterventionProgressPresenter, () => {
               text: 'not scheduled',
               classes: 'govuk-tag--grey',
             },
-            linkHtml:
-              '<a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/sessions/1/edit">Edit session details</a>',
+            links: [
+              {
+                href: '/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/sessions/1/edit',
+                text: 'Edit session details',
+              },
+            ],
           },
         ])
       })
@@ -114,7 +118,17 @@ describe(InterventionProgressPresenter, () => {
               text: 'scheduled',
               classes: 'govuk-tag--blue',
             },
-            linkHtml: `<a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/sessions/1/edit">Reschedule session</a><br><a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/1/post-session-feedback/attendance">Give feedback</a>`,
+            links: [
+              {
+                href: '/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/sessions/1/edit',
+                text: 'Reschedule session',
+              },
+              {
+                href:
+                  '/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/1/post-session-feedback/attendance',
+                text: 'Give feedback',
+              },
+            ],
           },
         ])
       })
@@ -140,8 +154,13 @@ describe(InterventionProgressPresenter, () => {
                 text: 'completed',
                 classes: 'govuk-tag--green',
               },
-              linkHtml:
-                '<a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/1/post-session-feedback">View feedback form</a>',
+              links: [
+                {
+                  href:
+                    '/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/1/post-session-feedback',
+                  text: 'View feedback form',
+                },
+              ],
             },
             {
               sessionNumber: 2,
@@ -150,8 +169,13 @@ describe(InterventionProgressPresenter, () => {
                 text: 'completed',
                 classes: 'govuk-tag--green',
               },
-              linkHtml:
-                '<a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/2/post-session-feedback">View feedback form</a>',
+              links: [
+                {
+                  href:
+                    '/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/2/post-session-feedback',
+                  text: 'View feedback form',
+                },
+              ],
             },
           ])
         })
@@ -175,8 +199,13 @@ describe(InterventionProgressPresenter, () => {
                 text: 'did not attend',
                 classes: 'govuk-tag--purple',
               },
-              linkHtml:
-                '<a class="govuk-link" href="/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/1/post-session-feedback">View feedback form</a>',
+              links: [
+                {
+                  href:
+                    '/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/appointment/1/post-session-feedback',
+                  text: 'View feedback form',
+                },
+              ],
             },
           ])
         })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -11,6 +11,14 @@ interface EndedFields {
   endRequestedComments: string | null
   endRequestedReason: string | null
 }
+
+interface ProgressSessionTableRow {
+  sessionNumber: number
+  appointmentTime: string
+  tagArgs: { text: string; classes: string }
+  links: { text: string; href: string }[]
+}
+
 export default class InterventionProgressPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
 
@@ -67,7 +75,7 @@ export default class InterventionProgressPresenter {
 
   readonly sessionTableHeaders = ['Session details', 'Date and time', 'Status', 'Action']
 
-  get sessionTableRows(): Record<string, unknown>[] {
+  get sessionTableRows(): ProgressSessionTableRow[] {
     if (!this.hasSessions) {
       return []
     }
@@ -79,45 +87,75 @@ export default class InterventionProgressPresenter {
         sessionNumber: appointment.sessionNumber,
         appointmentTime: DateUtils.formatDateTimeOrEmptyString(appointment.appointmentTime),
         tagArgs: { text: sessionTableParams.text, classes: sessionTableParams.tagClass },
-        linkHtml: sessionTableParams.linkHTML,
+        links: sessionTableParams.links.map(link => ({ text: link.text, href: link.href })),
       }
     })
   }
 
-  private sessionTableParams(appointment: ActionPlanAppointment): { text: string; tagClass: string; linkHTML: string } {
+  private sessionTableParams(
+    appointment: ActionPlanAppointment
+  ): {
+    text: string
+    tagClass: string
+    links: { text: string; href: string }[]
+  } {
     const status = sessionStatus.forAppointment(appointment)
     const presenter = new SessionStatusPresenter(status)
 
-    const editUrl = `/service-provider/action-plan/${this.actionPlan!.id}/sessions/${appointment.sessionNumber}/edit`
+    const viewHref = `/service-provider/action-plan/${this.actionPlan!.id}/appointment/${
+      appointment.sessionNumber
+    }/post-session-feedback`
+    const editHref = `/service-provider/action-plan/${this.actionPlan!.id}/sessions/${appointment.sessionNumber}/edit`
+    const giveFeedbackHref = `/service-provider/action-plan/${this.actionPlan?.id}/appointment/${appointment.sessionNumber}/post-session-feedback/attendance`
 
     switch (status) {
       case SessionStatus.didNotAttend:
         return {
           text: presenter.text,
           tagClass: presenter.tagClass,
-          linkHTML: `<a class="govuk-link" href="/service-provider/action-plan/${this.actionPlan!.id}/appointment/${
-            appointment.sessionNumber
-          }/post-session-feedback">View feedback form</a>`,
+          links: [
+            {
+              text: 'View feedback form',
+              href: viewHref,
+            },
+          ],
         }
       case SessionStatus.completed:
         return {
           text: presenter.text,
           tagClass: presenter.tagClass,
-          linkHTML: `<a class="govuk-link" href="/service-provider/action-plan/${this.actionPlan!.id}/appointment/${
-            appointment.sessionNumber
-          }/post-session-feedback">View feedback form</a>`,
+          links: [
+            {
+              text: 'View feedback form',
+              href: viewHref,
+            },
+          ],
         }
       case SessionStatus.scheduled:
         return {
           text: presenter.text,
           tagClass: presenter.tagClass,
-          linkHTML: `<a class="govuk-link" href="${editUrl}">Reschedule session</a><br><a class="govuk-link" href="/service-provider/action-plan/${this.actionPlan?.id}/appointment/${appointment.sessionNumber}/post-session-feedback/attendance">Give feedback</a>`,
+          links: [
+            {
+              text: 'Reschedule session',
+              href: editHref,
+            },
+            {
+              text: 'Give feedback',
+              href: giveFeedbackHref,
+            },
+          ],
         }
       default:
         return {
           text: presenter.text,
           tagClass: presenter.tagClass,
-          linkHTML: `<a class="govuk-link" href="${editUrl}">Edit session details</a>`,
+          links: [
+            {
+              text: 'Edit session details',
+              href: editHref,
+            },
+          ],
         }
     }
   }

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -110,10 +110,16 @@ export default class InterventionProgressView {
           { text: `Session ${row.sessionNumber}` },
           { text: `${row.appointmentTime}` },
           { text: tagMacro(row.tagArgs as TagArgs) },
-          { html: `${row.linkHtml}` },
+          { html: this.linkHtml(row.links) },
         ]
       }),
     }
+  }
+
+  private linkHtml(links: { text: string; href: string }[]): string {
+    return links
+      .map(link => `<a class="govuk-link" href="${ViewUtils.escape(link.href)}">${ViewUtils.escape(link.text)}</a>`)
+      .join('<br>')
   }
 
   private readonly backLinkArgs = {


### PR DESCRIPTION
## What does this pull request do?

Refactors SP intervention progress presenter to no longer pass HTML to the View layer, instead constructing the HTML inside the view layer from structured data passed by the presenter.

## What is the intent behind these changes?

Passing structured data around the application rather than long HTML strings feels safer and less brittle to test, as we're not testing whole strings and asserting that the HTML attributes are in a specific order. It should be the View's responsibility to add HTML to the data passed to it.
