### PR TITLE
Refactor logged-in user header to use presenter

### DIFF
--- a/server/routes/shared/headerPresenter.test.ts
+++ b/server/routes/shared/headerPresenter.test.ts
@@ -1,5 +1,4 @@
 import HeaderPresenter from './headerPresenter'
-import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 import { User } from '../../authentication/passport'
 import { ServiceProviderOrg } from '../../services/userService'
 

--- a/server/routes/shared/headerPresenter.test.ts
+++ b/server/routes/shared/headerPresenter.test.ts
@@ -1,0 +1,37 @@
+import HeaderPresenter from './headerPresenter'
+import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
+import { User } from '../../authentication/passport'
+import { ServiceProviderOrg } from '../../services/userService'
+
+describe(HeaderPresenter, () => {
+  const createUser = (organizations: ServiceProviderOrg[]): User => {
+    return { name: 'john percy smith', organizations } as User
+  }
+
+  describe('userDescription', () => {
+    describe('when there is no logged-in user', () => {
+      it('returns an empty string', () => {
+        const presenter = new HeaderPresenter(null)
+        expect(presenter.userDescription).toEqual('')
+      })
+    })
+
+    describe('when there is a logged-in user', () => {
+      describe('and they have no organizations', () => {
+        it('returns their abbreviated name', () => {
+          const user = createUser([])
+          const presenter = new HeaderPresenter(user)
+          expect(presenter.userDescription).toEqual('J. Smith')
+        })
+      })
+
+      describe('and they have organizations', () => {
+        it('returns their abbreviated name and the name of their first organization', () => {
+          const user = createUser([{ id: '', name: 'Harmony Living' }])
+          const presenter = new HeaderPresenter(user)
+          expect(presenter.userDescription).toEqual('J. Smith (Harmony Living)')
+        })
+      })
+    })
+  })
+})

--- a/server/routes/shared/headerPresenter.ts
+++ b/server/routes/shared/headerPresenter.ts
@@ -1,0 +1,26 @@
+import { User } from '../../authentication/passport'
+import utils from '../../utils/utils'
+
+export default class HeaderPresenter {
+  constructor(private readonly loggedInUser: User | null) {}
+
+  get userDescription(): string {
+    if (!this.loggedInUser) {
+      return ''
+    }
+
+    let result = this.displayName
+
+    if (this.loggedInUser.organizations?.length ?? 0 > 0) {
+      // fixme: it's possible that a user belongs to multiple organizations
+      result += ` (${this.loggedInUser.organizations![0].name})`
+    }
+
+    return result
+  }
+
+  private get displayName(): string {
+    const nameParts = utils.convertToTitleCase(this.loggedInUser!.name).split(' ')
+    return `${nameParts[0][0]}. ${nameParts.reverse()[0]}`
+  }
+}

--- a/server/routes/shared/headerPresenter.ts
+++ b/server/routes/shared/headerPresenter.ts
@@ -11,7 +11,7 @@ export default class HeaderPresenter {
 
     let result = this.displayName
 
-    if (this.loggedInUser.organizations?.length ?? 0 > 0) {
+    if (this.loggedInUser.organizations?.length) {
       // fixme: it's possible that a user belongs to multiple organizations
       result += ` (${this.loggedInUser.organizations![0].name})`
     }

--- a/server/routes/shared/layoutPresenter.ts
+++ b/server/routes/shared/layoutPresenter.ts
@@ -1,8 +1,12 @@
 import DeliusServiceUser from '../../models/delius/deliusServiceUser'
+import HeaderPresenter from './headerPresenter'
 import ServiceUserBannerPresenter from './serviceUserBannerPresenter'
+import { User } from '../../authentication/passport'
 
 export default class LayoutPresenter {
-  constructor(private readonly serviceUser: DeliusServiceUser | null) {}
+  constructor(private readonly loggedInUser: User | null, readonly serviceUser: DeliusServiceUser | null) {}
 
   readonly serviceUserBannerPresenter = this.serviceUser ? new ServiceUserBannerPresenter(this.serviceUser) : null
+
+  readonly headerPresenter = new HeaderPresenter(this.loggedInUser)
 }

--- a/server/routes/shared/layoutView.ts
+++ b/server/routes/shared/layoutView.ts
@@ -17,6 +17,7 @@ export default class LayoutView {
       this.content.renderArgs[0],
       {
         ...(this.serviceUserBannerView?.locals ?? {}),
+        headerPresenter: this.presenter.headerPresenter,
         ...this.content.renderArgs[1],
       },
     ]

--- a/server/routes/testutils/mocks/mockUserService.ts
+++ b/server/routes/testutils/mocks/mockUserService.ts
@@ -5,7 +5,6 @@ import { User } from '../../../authentication/passport'
 export const user: User = {
   name: 'john smith',
   username: 'user1',
-  displayName: 'J. Smith',
   token: {
     accessToken: 'token',
     expiry: 7265674811, // tests will fail in ~180 years
@@ -23,7 +22,6 @@ export class MockUserService extends UserService {
   async getUserDetails(_token: string): Promise<UserDetails> {
     return {
       name: user.name,
-      displayName: user.displayName,
     }
   }
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -41,12 +41,6 @@ describe('User service', () => {
       ])
       userService = new UserService(hmppsAuthClient)
     })
-    it('Retrieves and formats user name', async () => {
-      hmppsAuthClient.getCurrentUser.mockResolvedValue(deliusUser)
-      const result = await userService.getUserDetails(token)
-      expect(result.name).toEqual('john percy smith')
-      expect(result.displayName).toEqual('J. Smith')
-    })
     it('filters auth user groups', async () => {
       hmppsAuthClient.getCurrentUser.mockResolvedValue(authUser)
       const result = await userService.getUserDetails(token)

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,9 +1,7 @@
-import utils from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
 
 export interface UserDetails {
   name: string
-  displayName: string
   organizations?: ServiceProviderOrg[]
 }
 
@@ -17,8 +15,6 @@ export default class UserService {
 
   async getUserDetails(token: string): Promise<UserDetails> {
     const user = await this.hmppsAuthClient.getCurrentUser(token)
-    const nameParts = utils.convertToTitleCase(user.name).split(' ')
-    const displayName = `${nameParts[0][0]}. ${nameParts.reverse()[0]}`
 
     const organizations =
       user.authSource === 'auth'
@@ -30,6 +26,6 @@ export default class UserService {
             }))
         : undefined
 
-    return { name: user.name, displayName, organizations }
+    return { name: user.name, organizations }
   }
 }

--- a/server/utils/controllerUtils.test.ts
+++ b/server/utils/controllerUtils.test.ts
@@ -5,20 +5,24 @@ import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUse
 describe(ControllerUtils, () => {
   describe('.renderWithLayout', () => {
     describe('with null serviceUser', () => {
-      it('calls render on the response, passing the content view’s renderArgs', () => {
-        const res = ({ render: jest.fn() } as unknown) as Response
+      it('calls render on the response, passing the content view’s renderArgs augmented with a headerPresenter object in the locals', () => {
+        const res = ({ render: jest.fn(), locals: { user: null } } as unknown) as Response
         const renderArgs: [string, Record<string, unknown>] = ['myTemplate', { foo: '1', bar: '2' }]
         const contentView = { renderArgs }
 
         ControllerUtils.renderWithLayout(res, contentView, null)
 
-        expect(res.render).toHaveBeenCalledWith('myTemplate', { foo: '1', bar: '2' })
+        expect(res.render).toHaveBeenCalledWith('myTemplate', {
+          foo: '1',
+          bar: '2',
+          headerPresenter: expect.anything(),
+        })
       })
     })
 
     describe('with non-null serviceUser', () => {
-      it('calls render on the response, passing the content view’s renderArgs, augmented with a serviceUserNotificationBannerArgs object in the locals', () => {
-        const res = ({ render: jest.fn() } as unknown) as Response
+      it('calls render on the response, passing the content view’s renderArgs, augmented with headerPresenter and serviceUserNotificationBannerArgs objects in the locals', () => {
+        const res = ({ render: jest.fn(), locals: { user: null } } as unknown) as Response
         const renderArgs: [string, Record<string, unknown>] = ['myTemplate', { foo: '1', bar: '2' }]
         const contentView = { renderArgs }
         const serviceUser = deliusServiceUserFactory.build()
@@ -28,6 +32,7 @@ describe(ControllerUtils, () => {
         expect(res.render).toHaveBeenCalledWith('myTemplate', {
           foo: '1',
           bar: '2',
+          headerPresenter: expect.anything(),
           serviceUserNotificationBannerArgs: expect.anything(),
         })
       })

--- a/server/utils/controllerUtils.ts
+++ b/server/utils/controllerUtils.ts
@@ -5,7 +5,7 @@ import DeliusServiceUser from '../models/delius/deliusServiceUser'
 
 export default class ControllerUtils {
   static renderWithLayout(res: Response, contentView: PageContentView, serviceUser: DeliusServiceUser | null): void {
-    const presenter = new LayoutPresenter(serviceUser)
+    const presenter = new LayoutPresenter(res.locals.user, serviceUser)
     const view = new LayoutView(presenter, contentView)
 
     res.render(...view.renderArgs)

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -15,11 +15,7 @@
     {% if user %}
       <div id="user-block" class="govuk-!-padding-top-1 govuk-!-padding-bottom-1">
         <div id="header-user-name" data-qa="header-user-name">
-          {{ user.displayName }}
-          {% if user.organizations.length %}
-            {# fixme: it's possible that a user belongs to multiple organizations #}
-            ({{ user.organizations[0].name }})
-          {% endif %}
+          {{ headerPresenter.userDescription }}
         </div>
         <div class="govuk-!-padding-right-0">
           <a data-qa="logout" href="/logout">Sign out</a>


### PR DESCRIPTION
## What does this pull request do?

Removes presentation logic from the view and service classes, and moves it to a presenter.

## What is the intent behind these changes?

Architectural consistency.