### PR TITLE
IC-1534: Added status information for form section on referral form page

### DIFF
--- a/server/views/referrals/partials/taskListSection.njk
+++ b/server/views/referrals/partials/taskListSection.njk
@@ -4,7 +4,7 @@ it to get a right-floated tag. There’s a broader question of whether
 we’ve mis-implemented the MoJ task list pattern, in which tags are
 only used on individual completed tasks. Needs some design review.
 #}
-<strong class="{{ classForStatus(taskListSection.status) }} moj-task-list__task-completed">
+<strong data-cy="status" class="{{ classForStatus(taskListSection.status) }} moj-task-list__task-completed">
   {{ taskListSection.status }}
 </strong>
 

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -20,6 +20,23 @@ class DraftReferralFactory extends Factory<DraftReferral> {
     return this.params({ completionDeadline: '2021-08-24' })
   }
 
+  interventionDetailsSet() {
+    return this.params({
+      relevantSentenceId: 123456789,
+      desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+      complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+      completionDeadline: '2021-08-24',
+      usingRarDays: false,
+    })
+  }
+
+  serviceUserDetailsSet() {
+    return this.serviceUserSelected().params({
+      needsInterpreter: false,
+      hasAdditionalResponsibilities: false,
+    })
+  }
+
   serviceUserSelected() {
     return this.params({
       serviceUser: {

--- a/testutils/factories/referralFormSection.ts
+++ b/testutils/factories/referralFormSection.ts
@@ -1,0 +1,71 @@
+import { Factory } from 'fishery'
+import { ReferralFormStatus, ReferralFormSectionPresenter } from '../../server/routes/referrals/referralFormPresenter'
+
+class ReferralFormSectionFactory extends Factory<ReferralFormSectionPresenter> {
+  status(referralFormStatus: ReferralFormStatus) {
+    return this.params({ status: referralFormStatus })
+  }
+
+  reviewServiceUser() {
+    return this.params({
+      type: 'single',
+      title: 'Review service user’s information',
+      number: '1',
+      status: ReferralFormStatus.NotStarted,
+      tasks: [
+        { title: 'Confirm service user’s personal details', url: 'service-user-details' },
+        { title: 'Service user’s risk information', url: 'risk-information' },
+        { title: 'Service user’s needs and requirements', url: 'needs-and-requirements' },
+      ],
+    })
+  }
+
+  interventionDetails(serviceCategoryName: string) {
+    return this.params({
+      type: 'single',
+      title: `Add ${serviceCategoryName} referral details`,
+      number: '2',
+      status: ReferralFormStatus.CannotStartYet,
+      tasks: [
+        { title: 'Select the relevant sentence for the social inclusion referral', url: 'relevant-sentence' },
+        { title: 'Select desired outcomes', url: 'desired-outcomes' },
+        { title: 'Select required complexity level', url: 'complexity-level' },
+        {
+          title: 'What date does the social inclusion service need to be completed by?',
+          url: 'completion-deadline',
+        },
+        { title: 'Enter RAR days used', url: 'rar-days' },
+        { title: 'Further information for service provider', url: 'further-information' },
+      ],
+    })
+  }
+
+  responsibleOfficerDetails() {
+    return this.params({
+      type: 'single',
+      title: 'Review responsible officer’s information',
+      number: '3',
+      status: ReferralFormStatus.CannotStartYet,
+      tasks: [{ title: 'Responsible officer information', url: null }],
+    })
+  }
+
+  checkAnswers() {
+    return this.params({
+      type: 'single',
+      title: 'Check your answers',
+      number: '4',
+      status: ReferralFormStatus.CannotStartYet,
+      tasks: [{ title: 'Check your answers', url: null }],
+    })
+  }
+}
+type SectionFormType = 'single' | 'multi'
+const singleSectionForm: SectionFormType = 'single'
+export default ReferralFormSectionFactory.define(() => ({
+  type: singleSectionForm,
+  title: '',
+  number: '1',
+  tasks: [],
+  status: ReferralFormStatus.CannotStartYet,
+}))


### PR DESCRIPTION
## What does this pull request do?

Adds status changes to the referral form for each relevant section of the form.
![image](https://user-images.githubusercontent.com/83066216/116712265-951b9480-a9cb-11eb-9654-393341ee2f65.png)

## What is the intent behind these changes?

To provide PP users ability to see their progress of completing the referral form.

## Notes

The '**Check your answers**' and '**Review responsible officer's information**' sections are still to be completed and outside the scope of this ticket. It is assumed that these details have been completed when the PP user completes the '**Review service user's information**' and '**referral details**' sections.

It is also assumed that `In progress` status should not be implemented as that is not defined on the ticket; however if you feel that I should include it then I could add some logic for when at least one but not all fields are not null then the section is `In progress`

Using the following best practices for cypress tests: https://docs.cypress.io/guides/references/best-practices#Selecting-Elements

