### PR TITLE
IC-1601: Make Region Find filters scrollable

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -6,5 +6,6 @@ $path: "/assets/images/"
 
 @import './components/header-bar'
 @import './components/notification-banner'
+@import './components/find-filters'
 
 @import './local'

--- a/assets/sass/components/_find-filters.scss
+++ b/assets/sass/components/_find-filters.scss
@@ -1,0 +1,8 @@
+.find-filters--scrollable {
+  max-height: 450px;
+  overflow-x: scroll;
+
+  input {
+    height: 100%;
+  }
+}

--- a/server/routes/findInterventions/searchResultsView.ts
+++ b/server/routes/findInterventions/searchResultsView.ts
@@ -27,6 +27,7 @@ export default class SearchResultsView {
           text: legend,
           classes: 'govuk-fieldset__legend--s',
         },
+        classes: 'find-filters--scrollable',
       },
       items: checkboxes.map(checkbox => ({
         value: checkbox.value,


### PR DESCRIPTION
## What does this pull request do?

Makes Region filters scrollable in Find journey.

## What is the intent behind these changes?

To stop users having to scroll to bottom of page to select a region.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/117024848-47b46580-acf2-11eb-87fa-c7def3b18185.png)
