### PR TITLE
IC-1535: Fix links on 'Make a referral' screen

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -133,7 +133,6 @@ describe('Referral form', () => {
     cy.get('[data-cy=status]').eq(0).contains('NOT STARTED', { matchCase: false })
     cy.get('[data-cy=status]').eq(1).contains('CANNOT START YET', { matchCase: false })
     cy.get('[data-cy=status]').eq(2).contains('CANNOT START YET', { matchCase: false })
-    cy.get('[data-cy=status]').eq(3).contains('CANNOT START YET', { matchCase: false })
 
     cy.contains('Confirm service user’s personal details').click()
 
@@ -177,7 +176,6 @@ describe('Referral form', () => {
     cy.get('[data-cy=status]').eq(0).contains('COMPLETED', { matchCase: false })
     cy.get('[data-cy=status]').eq(1).contains('NOT STARTED', { matchCase: false })
     cy.get('[data-cy=status]').eq(2).contains('CANNOT START YET', { matchCase: false })
-    cy.get('[data-cy=status]').eq(3).contains('CANNOT START YET', { matchCase: false })
 
     cy.contains('Select the relevant sentence for the accommodation referral').click()
 
@@ -230,8 +228,7 @@ describe('Referral form', () => {
 
     cy.get('[data-cy=status]').eq(0).contains('COMPLETED', { matchCase: false })
     cy.get('[data-cy=status]').eq(1).contains('COMPLETED', { matchCase: false })
-    cy.get('[data-cy=status]').eq(2).contains('COMPLETED', { matchCase: false })
-    cy.get('[data-cy=status]').eq(3).contains('COMPLETED', { matchCase: false })
+    cy.get('[data-cy=status]').eq(2).contains('NOT STARTED', { matchCase: false })
 
     cy.get('a').contains('Check your answers').click()
     cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/check-answers`)

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -6,72 +6,249 @@ describe('ReferralFormPresenter', () => {
   describe('sections', () => {
     describe('review service user information section', () => {
       describe('when no required values have been set', () => {
-        it('should contain a "Not started" label', () => {
+        it('should contain a "Not started" label and "server-user-details" url visible', () => {
           const referral = draftReferralFactory.build()
           const presenter = new ReferralFormPresenter(referral, 'social inclusion')
           const expected = [
-            referralFormSectionFactory.reviewServiceUser().status(ReferralFormStatus.NotStarted).build(),
+            referralFormSectionFactory.reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information').build(),
             referralFormSectionFactory
-              .interventionDetails('social inclusion')
-              .status(ReferralFormStatus.CannotStartYet)
+              .interventionDetails('social inclusion', ReferralFormStatus.CannotStartYet)
               .build(),
-            referralFormSectionFactory.responsibleOfficerDetails().status(ReferralFormStatus.CannotStartYet).build(),
-            referralFormSectionFactory.checkAnswers().status(ReferralFormStatus.CannotStartYet).build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
+      describe('when "Service user details" has been set', () => {
+        it('should contain a "Not started" label and "risk-information" url visible', () => {
+          const referral = draftReferralFactory.serviceUserSelected().build()
+          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const expected = [
+            referralFormSectionFactory.reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information').build(),
+            referralFormSectionFactory
+              .interventionDetails('social inclusion', ReferralFormStatus.CannotStartYet)
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
+      describe('when "risk information" has been set', () => {
+        it('should contain a "Not started" label and "needs-and-requirements" url visible', () => {
+          const referral = draftReferralFactory.serviceUserSelected().riskInformation().build()
+          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information', 'needs-and-requirements')
+              .build(),
+            referralFormSectionFactory
+              .interventionDetails('social inclusion', ReferralFormStatus.CannotStartYet)
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
       })
       describe('when all required values have been set', () => {
-        it('should contain a "Completed" label and interventions details section can be started', () => {
-          const referral = draftReferralFactory.serviceUserDetailsSet().build()
+        it('should contain a "Completed" label and service category details section can be started', () => {
+          const referral = draftReferralFactory.serviceUserSelected().riskInformation().needsAndRequirements().build()
           const presenter = new ReferralFormPresenter(referral, 'social inclusion')
           const expected = [
-            referralFormSectionFactory.reviewServiceUser().status(ReferralFormStatus.Completed).build(),
             referralFormSectionFactory
-              .interventionDetails('social inclusion')
-              .status(ReferralFormStatus.NotStarted)
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
-            referralFormSectionFactory.responsibleOfficerDetails().status(ReferralFormStatus.CannotStartYet).build(),
-            referralFormSectionFactory.checkAnswers().status(ReferralFormStatus.CannotStartYet).build(),
+            referralFormSectionFactory
+              .interventionDetails('social inclusion', ReferralFormStatus.NotStarted, 'relevant-sentence')
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
       })
     })
-    describe('intervention details section', () => {
-      describe('when no desired Outcomes have been set', () => {
-        it('should contain a "Not Started" label', () => {
+    describe('service category referral details section', () => {
+      describe('when "relevant sentence" has been set', () => {
+        it('should contain a "Not Started" label and "relevant-sentence" url visible', () => {
           const referral = draftReferralFactory
-            .serviceUserDetailsSet()
-            .interventionDetailsSet()
-            .build({ desiredOutcomesIds: [] })
+            .serviceUserSelected()
+            .riskInformation()
+            .needsAndRequirements()
+            .relevantSentence()
+            .build()
           const presenter = new ReferralFormPresenter(referral, 'social inclusion')
           const expected = [
-            referralFormSectionFactory.reviewServiceUser().status(ReferralFormStatus.Completed).build(),
             referralFormSectionFactory
-              .interventionDetails('social inclusion')
-              .status(ReferralFormStatus.NotStarted)
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
-            referralFormSectionFactory.responsibleOfficerDetails().status(ReferralFormStatus.CannotStartYet).build(),
-            referralFormSectionFactory.checkAnswers().status(ReferralFormStatus.CannotStartYet).build(),
+            referralFormSectionFactory
+              .interventionDetails(
+                'social inclusion',
+                ReferralFormStatus.NotStarted,
+                'relevant-sentence',
+                'desired-outcomes'
+              )
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
+      describe('when "desired outcomes" has been set', () => {
+        it('should contain a "Not Started" label and "complexity-level" url visible', () => {
+          const referral = draftReferralFactory
+            .serviceUserSelected()
+            .riskInformation()
+            .needsAndRequirements()
+            .relevantSentence()
+            .desiredOutcomes()
+            .build()
+          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+              .build(),
+            referralFormSectionFactory
+              .interventionDetails(
+                'social inclusion',
+                ReferralFormStatus.NotStarted,
+                'relevant-sentence',
+                'desired-outcomes',
+                'complexity-level'
+              )
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
+      describe('when "complexity level" has been set', () => {
+        it('should contain a "Not Started" label and "completion-deadline" url visible', () => {
+          const referral = draftReferralFactory
+            .serviceUserSelected()
+            .riskInformation()
+            .needsAndRequirements()
+            .relevantSentence()
+            .desiredOutcomes()
+            .complexityLevel()
+            .build()
+          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+              .build(),
+            referralFormSectionFactory
+              .interventionDetails(
+                'social inclusion',
+                ReferralFormStatus.NotStarted,
+                'relevant-sentence',
+                'desired-outcomes',
+                'complexity-level',
+                'completion-deadline'
+              )
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
+      describe('when "date completed by" has been set', () => {
+        it('should contain a "Not Started" label and "rar-days" url visible', () => {
+          const referral = draftReferralFactory
+            .serviceUserSelected()
+            .riskInformation()
+            .needsAndRequirements()
+            .relevantSentence()
+            .desiredOutcomes()
+            .complexityLevel()
+            .completionDate()
+            .build()
+          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+              .build(),
+            referralFormSectionFactory
+              .interventionDetails(
+                'social inclusion',
+                ReferralFormStatus.NotStarted,
+                'relevant-sentence',
+                'desired-outcomes',
+                'complexity-level',
+                'completion-deadline',
+                'rar-days'
+              )
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
+      describe('when "rar days" has been set', () => {
+        it('should contain a "Not Started" label and "further-information" url visible', () => {
+          const referral = draftReferralFactory
+            .serviceUserSelected()
+            .riskInformation()
+            .needsAndRequirements()
+            .relevantSentence()
+            .desiredOutcomes()
+            .complexityLevel()
+            .completionDate()
+            .rarDays()
+            .build()
+          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+              .build(),
+            referralFormSectionFactory
+              .interventionDetails(
+                'social inclusion',
+                ReferralFormStatus.NotStarted,
+                'relevant-sentence',
+                'desired-outcomes',
+                'complexity-level',
+                'completion-deadline',
+                'rar-days',
+                'further-information'
+              )
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
       })
       describe('when all required values have been set', () => {
         it('should contain a "Completed" label and allow user to submit answers', () => {
-          const referral = draftReferralFactory.serviceUserDetailsSet().interventionDetailsSet().build()
+          const referral = draftReferralFactory
+            .serviceUserSelected()
+            .riskInformation()
+            .needsAndRequirements()
+            .relevantSentence()
+            .desiredOutcomes()
+            .complexityLevel()
+            .completionDate()
+            .rarDays()
+            .furtherInformation()
+            .build()
           const presenter = new ReferralFormPresenter(referral, 'social inclusion')
           const expected = [
-            referralFormSectionFactory.reviewServiceUser().status(ReferralFormStatus.Completed).build(),
             referralFormSectionFactory
-              .interventionDetails('social inclusion')
-              .status(ReferralFormStatus.Completed)
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
-            referralFormSectionFactory.responsibleOfficerDetails().status(ReferralFormStatus.Completed).build(),
             referralFormSectionFactory
-              .checkAnswers()
-              .status(ReferralFormStatus.Completed)
+              .interventionDetails(
+                'social inclusion',
+                ReferralFormStatus.Completed,
+                'relevant-sentence',
+                'desired-outcomes',
+                'complexity-level',
+                'completion-deadline',
+                'rar-days',
+                'further-information'
+              )
+              .build(),
+            referralFormSectionFactory
+              .checkAnswers(ReferralFormStatus.NotStarted)
               .build({ tasks: [{ title: 'Check your answers', url: 'check-answers' }] }),
           ]
           expect(presenter.sections).toEqual(expected)

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -1,159 +1,192 @@
+/* eslint max-classes-per-file: 0 */
 import DraftReferral from '../../models/draftReferral'
 
 export default class ReferralFormPresenter {
-  constructor(private readonly referral: DraftReferral, private readonly serviceCategoryName: string) {}
+  private readonly taskValues: typeof ReferralFormPresenter.TaskValues.prototype
 
-  get sections(): ReferralFormSectionPresenter[] {
-    const serviceUserSectionFormStatus = this.referralFormStatus(this.requiredServiceUserFormValues)
-    const interventionDetailsSectionFormStatus = this.referralFormStatus(
-      this.requiredInterventionFormValues,
-      serviceUserSectionFormStatus
-    )
-    const responsibleOfficerDetailsSectionFormStatus = this.referralFormStatus(
-      this.requiredResponsibleOfficerFormValues,
-      interventionDetailsSectionFormStatus
-    )
-    const checkAnswersSectionFormStatus = this.referralFormStatus(
-      this.requiredCheckAnswersFormValues,
-      responsibleOfficerDetailsSectionFormStatus
-    )
+  private readonly sectionValues: typeof ReferralFormPresenter.SectionValues.prototype
 
-    return [
-      {
-        type: 'single',
-        title: 'Review service user’s information',
-        number: '1',
-        status: serviceUserSectionFormStatus,
-        tasks: [
-          {
-            title: 'Confirm service user’s personal details',
-            url: 'service-user-details',
-          },
-          {
-            title: 'Service user’s risk information',
-            url: 'risk-information',
-          },
-          {
-            title: 'Service user’s needs and requirements',
-            url: 'needs-and-requirements',
-          },
-        ],
-      },
-      {
-        type: 'single',
-        title: `Add ${this.serviceCategoryName} referral details`,
-        number: '2',
-        status: interventionDetailsSectionFormStatus,
-        tasks: [
-          {
-            title: `Select the relevant sentence for the ${this.serviceCategoryName} referral`,
-            url: 'relevant-sentence',
-          },
-          {
-            title: 'Select desired outcomes',
-            url: 'desired-outcomes',
-          },
-          {
-            title: 'Select required complexity level',
-            url: 'complexity-level',
-          },
-          {
-            title: `What date does the ${this.serviceCategoryName} service need to be completed by?`,
-            url: 'completion-deadline',
-          },
-          {
-            title: 'Enter RAR days used',
-            url: 'rar-days',
-          },
-          {
-            title: 'Further information for service provider',
-            url: 'further-information',
-          },
-        ],
-      },
-      {
-        type: 'single',
-        title: 'Review responsible officer’s information',
-        number: '3',
-        status: responsibleOfficerDetailsSectionFormStatus,
-        tasks: [
-          {
-            title: 'Responsible officer information',
-            url: null,
-          },
-        ],
-      },
-      {
-        type: 'single',
-        title: 'Check your answers',
-        number: '4',
-        status: checkAnswersSectionFormStatus,
-        tasks: [
-          {
-            title: 'Check your answers',
-            url: checkAnswersSectionFormStatus !== ReferralFormStatus.CannotStartYet ? 'check-answers' : null,
-          },
-        ],
-      },
-    ]
+  constructor(private readonly referral: DraftReferral, private readonly serviceCategoryName: string) {
+    this.taskValues = new ReferralFormPresenter.TaskValues(referral)
+    this.sectionValues = new ReferralFormPresenter.SectionValues(this.taskValues)
   }
 
-  private referralFormStatus(
-    draftReferralValues: DraftReferralValues,
-    previousFormStatus: ReferralFormStatus = ReferralFormStatus.Completed
-  ): ReferralFormStatus {
-    if (previousFormStatus !== ReferralFormStatus.Completed) {
-      return ReferralFormStatus.CannotStartYet
+  get sections(): ReferralFormSectionPresenter[] {
+    const reviewServiceUserInformation: ReferralFormSingleListSectionPresenter = {
+      type: 'single',
+      title: 'Review service user’s information',
+      number: '1',
+      status: this.calculateStatus(this.sectionValues.reviewServiceUserInformation),
+      tasks: [
+        {
+          title: 'Confirm service user’s personal details',
+          url: 'service-user-details',
+        },
+        {
+          title: 'Service user’s risk information',
+          url: this.calculateTaskUrl('risk-information', this.taskValues.serviceUserDetails),
+        },
+        {
+          title: 'Service user’s needs and requirements',
+          url: this.calculateTaskUrl('needs-and-requirements', this.taskValues.riskInformation),
+        },
+      ],
     }
-    const hasCompleted = draftReferralValues.every(field => {
+    const serviceCategoryReferralDetails: ReferralFormSingleListSectionPresenter = {
+      type: 'single',
+      title: `Add ${this.serviceCategoryName} referral details`,
+      number: '2',
+      status: this.calculateStatus(
+        this.sectionValues.serviceCategoryReferralDetails,
+        reviewServiceUserInformation.status
+      ),
+      tasks: [
+        {
+          title: `Select the relevant sentence for the ${this.serviceCategoryName} referral`,
+          url: this.calculateTaskUrl('relevant-sentence', this.taskValues.needsAndRequirements),
+        },
+        {
+          title: 'Select desired outcomes',
+          url: this.calculateTaskUrl('desired-outcomes', this.taskValues.relevantSentence),
+        },
+        {
+          title: 'Select required complexity level',
+          url: this.calculateTaskUrl('complexity-level', this.taskValues.desiredOutcomes),
+        },
+        {
+          title: `What date does the ${this.serviceCategoryName} service need to be completed by?`,
+          url: this.calculateTaskUrl('completion-deadline', this.taskValues.complexityLevel),
+        },
+        {
+          title: 'Enter RAR days used',
+          url: this.calculateTaskUrl('rar-days', this.taskValues.completionDeadline),
+        },
+        {
+          title: 'Further information for service provider',
+          url: this.calculateTaskUrl('further-information', this.taskValues.rarDays),
+        },
+      ],
+    }
+    const checkYourAnswers: ReferralFormSingleListSectionPresenter = {
+      type: 'single',
+      title: 'Check your answers',
+      number: '3',
+      status: this.calculateStatus(this.sectionValues.checkYourAnswers, serviceCategoryReferralDetails.status),
+      tasks: [
+        {
+          title: 'Check your answers',
+          url: this.calculateTaskUrl('check-answers', this.taskValues.furtherInformation),
+        },
+      ],
+    }
+    return [reviewServiceUserInformation, serviceCategoryReferralDetails, checkYourAnswers]
+  }
+
+  private calculateTaskUrl(url: string | null, displayCriteria: DraftReferralValues): string | null {
+    const everyFieldHasValues = displayCriteria.every(field => {
       if (field === null) {
         return false
       }
       return Array.isArray(field) ? field.length !== 0 : true
     })
-    if (hasCompleted) {
+    return everyFieldHasValues ? url : null
+  }
+
+  private calculateStatus(
+    draftReferralValues: DraftReferralValues,
+    previousSectionStatus: ReferralFormStatus = ReferralFormStatus.Completed
+  ): ReferralFormStatus {
+    if (previousSectionStatus !== ReferralFormStatus.Completed) {
+      return ReferralFormStatus.CannotStartYet
+    }
+    const allFieldsHaveValues = draftReferralValues.every(field => {
+      if (field === null) {
+        return false
+      }
+      return Array.isArray(field) ? field.length !== 0 : true
+    })
+    if (allFieldsHaveValues) {
       return ReferralFormStatus.Completed
     }
     return ReferralFormStatus.NotStarted
   }
 
-  private get requiredServiceUserFormValues(): DraftReferralValues {
-    return [
-      this.referral.serviceUser.crn,
-      this.referral.serviceUser.title,
-      this.referral.serviceUser.firstName,
-      this.referral.serviceUser.lastName,
-      this.referral.serviceUser.dateOfBirth,
-      this.referral.serviceUser.gender,
-      this.referral.serviceUser.ethnicity,
-      this.referral.serviceUser.preferredLanguage,
-      this.referral.serviceUser.religionOrBelief,
-      this.referral.needsInterpreter,
-      this.referral.hasAdditionalResponsibilities,
-    ]
+  private static SectionValues = class {
+    constructor(private taskValues: typeof ReferralFormPresenter.TaskValues.prototype) {}
+
+    get reviewServiceUserInformation(): DraftReferralValues {
+      return (
+        this.taskValues.serviceUserDetails && this.taskValues.riskInformation && this.taskValues.needsAndRequirements
+      )
+    }
+
+    get serviceCategoryReferralDetails(): DraftReferralValues {
+      return (
+        this.taskValues.relevantSentence &&
+        this.taskValues.desiredOutcomes &&
+        this.taskValues.complexityLevel &&
+        this.taskValues.completionDeadline &&
+        this.taskValues.rarDays &&
+        this.taskValues.furtherInformation
+      )
+    }
+
+    get checkYourAnswers(): DraftReferralValues {
+      return this.taskValues.checkAnswers
+    }
   }
 
-  private get requiredInterventionFormValues(): DraftReferralValues {
-    return [
-      this.referral.relevantSentenceId,
-      this.referral.desiredOutcomesIds,
-      this.referral.complexityLevelId,
-      this.referral.completionDeadline,
-      this.referral.usingRarDays,
-    ]
-  }
+  private static TaskValues = class {
+    constructor(private referral: DraftReferral) {}
 
-  /* TODO: Page form values need to be defined */
-  private get requiredResponsibleOfficerFormValues(): DraftReferralValues {
-    return []
-  }
+    // TODO: IC-1676. We need a field to confirm that the user has "checked" service user details.
+    get serviceUserDetails(): DraftReferralValues {
+      return []
+    }
 
-  /* TODO: Page form values need to be defined */
-  private get requiredCheckAnswersFormValues(): DraftReferralValues {
-    return []
+    get riskInformation(): DraftReferralValues {
+      return [this.referral.additionalRiskInformation]
+    }
+
+    get needsAndRequirements(): DraftReferralValues {
+      return [
+        this.referral.additionalNeedsInformation,
+        this.referral.accessibilityNeeds,
+        this.referral.needsInterpreter,
+        this.referral.hasAdditionalResponsibilities,
+      ]
+    }
+
+    get relevantSentence(): DraftReferralValues {
+      return [this.referral.relevantSentenceId]
+    }
+
+    get desiredOutcomes(): DraftReferralValues {
+      return [this.referral.desiredOutcomesIds]
+    }
+
+    get complexityLevel(): DraftReferralValues {
+      return [this.referral.complexityLevelId]
+    }
+
+    get completionDeadline(): DraftReferralValues {
+      return [this.referral.completionDeadline]
+    }
+
+    get rarDays(): DraftReferralValues {
+      return [this.referral.usingRarDays]
+    }
+
+    get furtherInformation(): DraftReferralValues {
+      return [this.referral.furtherInformation]
+    }
+
+    // null is used to ensure that section is never in a `completed` status. This is because there are no fields to confirm a user has checked the answers.
+    get checkAnswers(): DraftReferralValues {
+      return [null]
+    }
   }
 }
-
 export type ReferralFormSectionPresenter =
   | ReferralFormSingleListSectionPresenter
   | ReferralFormMultiListSectionPresenter

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -20,21 +20,8 @@ class DraftReferralFactory extends Factory<DraftReferral> {
     return this.params({ completionDeadline: '2021-08-24' })
   }
 
-  interventionDetailsSet() {
-    return this.params({
-      relevantSentenceId: 123456789,
-      desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
-      complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
-      completionDeadline: '2021-08-24',
-      usingRarDays: false,
-    })
-  }
-
   serviceUserDetailsSet() {
-    return this.serviceUserSelected().params({
-      needsInterpreter: false,
-      hasAdditionalResponsibilities: false,
-    })
+    return this.serviceUserSelected().riskInformation().needsAndRequirements()
   }
 
   serviceUserSelected() {
@@ -51,6 +38,57 @@ class DraftReferralFactory extends Factory<DraftReferral> {
         religionOrBelief: 'Agnostic',
         disabilities: ['Autism spectrum condition', 'sciatica'],
       },
+    })
+  }
+
+  riskInformation() {
+    return this.params({
+      additionalRiskInformation: '',
+    })
+  }
+
+  needsAndRequirements() {
+    return this.params({
+      additionalNeedsInformation: '',
+      accessibilityNeeds: '',
+      needsInterpreter: false,
+      hasAdditionalResponsibilities: false,
+    })
+  }
+
+  relevantSentence() {
+    return this.params({
+      relevantSentenceId: 123456789,
+    })
+  }
+
+  desiredOutcomes() {
+    return this.params({
+      desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+    })
+  }
+
+  complexityLevel() {
+    return this.params({
+      complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+    })
+  }
+
+  completionDate() {
+    return this.params({
+      completionDeadline: '2021-08-24',
+    })
+  }
+
+  rarDays() {
+    return this.params({
+      usingRarDays: false,
+    })
+  }
+
+  furtherInformation() {
+    return this.params({
+      furtherInformation: '',
     })
   }
 }

--- a/testutils/factories/referralFormSection.ts
+++ b/testutils/factories/referralFormSection.ts
@@ -1,62 +1,64 @@
 import { Factory } from 'fishery'
-import { ReferralFormStatus, ReferralFormSectionPresenter } from '../../server/routes/referrals/referralFormPresenter'
+import { ReferralFormSectionPresenter, ReferralFormStatus } from '../../server/routes/referrals/referralFormPresenter'
 
 class ReferralFormSectionFactory extends Factory<ReferralFormSectionPresenter> {
-  status(referralFormStatus: ReferralFormStatus) {
-    return this.params({ status: referralFormStatus })
-  }
-
-  reviewServiceUser() {
+  reviewServiceUser(
+    referralFormStatus: ReferralFormStatus = ReferralFormStatus.NotStarted,
+    riskInformationUrl: string | null = null,
+    needsAndRequirementsUrl: string | null = null
+  ) {
     return this.params({
       type: 'single',
       title: 'Review service user’s information',
       number: '1',
-      status: ReferralFormStatus.NotStarted,
+      status: referralFormStatus,
       tasks: [
         { title: 'Confirm service user’s personal details', url: 'service-user-details' },
-        { title: 'Service user’s risk information', url: 'risk-information' },
-        { title: 'Service user’s needs and requirements', url: 'needs-and-requirements' },
+        { title: 'Service user’s risk information', url: riskInformationUrl },
+        { title: 'Service user’s needs and requirements', url: needsAndRequirementsUrl },
       ],
     })
   }
 
-  interventionDetails(serviceCategoryName: string) {
+  interventionDetails(
+    serviceCategoryName: string,
+    referralFormStatus: ReferralFormStatus = ReferralFormStatus.CannotStartYet,
+    relevantSentenceUrl: string | null = null,
+    desiredOutcomesUrl: string | null = null,
+    complexityLevelUrl: string | null = null,
+    completionDateUrl: string | null = null,
+    rarDaysUrl: string | null = null,
+    furtherInformationUrl: string | null = null
+  ) {
     return this.params({
       type: 'single',
       title: `Add ${serviceCategoryName} referral details`,
       number: '2',
-      status: ReferralFormStatus.CannotStartYet,
+      status: referralFormStatus,
       tasks: [
-        { title: 'Select the relevant sentence for the social inclusion referral', url: 'relevant-sentence' },
-        { title: 'Select desired outcomes', url: 'desired-outcomes' },
-        { title: 'Select required complexity level', url: 'complexity-level' },
+        { title: 'Select the relevant sentence for the social inclusion referral', url: relevantSentenceUrl },
+        { title: 'Select desired outcomes', url: desiredOutcomesUrl },
+        { title: 'Select required complexity level', url: complexityLevelUrl },
         {
           title: 'What date does the social inclusion service need to be completed by?',
-          url: 'completion-deadline',
+          url: completionDateUrl,
         },
-        { title: 'Enter RAR days used', url: 'rar-days' },
-        { title: 'Further information for service provider', url: 'further-information' },
+        { title: 'Enter RAR days used', url: rarDaysUrl },
+        { title: 'Further information for service provider', url: furtherInformationUrl },
       ],
     })
   }
 
-  responsibleOfficerDetails() {
-    return this.params({
-      type: 'single',
-      title: 'Review responsible officer’s information',
-      number: '3',
-      status: ReferralFormStatus.CannotStartYet,
-      tasks: [{ title: 'Responsible officer information', url: null }],
-    })
-  }
-
-  checkAnswers() {
+  checkAnswers(
+    referralFormStatus: ReferralFormStatus = ReferralFormStatus.CannotStartYet,
+    checkAnswersUrl: string | null = null
+  ) {
     return this.params({
       type: 'single',
       title: 'Check your answers',
-      number: '4',
-      status: ReferralFormStatus.CannotStartYet,
-      tasks: [{ title: 'Check your answers', url: null }],
+      number: '3',
+      status: referralFormStatus,
+      tasks: [{ title: 'Check your answers', url: checkAnswersUrl }],
     })
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Only makes links active on the "Make a referral" form page based on current progress of form completion.
Links are disabled until the user has completed all the details from the previous page.
Optional string values are considered incomplete when they are null, if the user does not enter a value then they are passed an empty string. There are no other optional types.

![image](https://user-images.githubusercontent.com/83066216/117123256-b5ae6a80-ad8e-11eb-9774-0de82d66ad2b.png)

## What is the intent behind these changes?

To force users to complete the form in sequence
