### PR TITLE
IC-1603: Add the contracts needed to build the "select service category" page for cohort interventions

### DIFF
--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -8,6 +8,7 @@ export interface ReferralFields {
   completionDeadline: string
   serviceProvider: ServiceProvider
   serviceCategoryId: string
+  serviceCategoryIds: string[]
   complexityLevelId: string
   furtherInformation: string
   relevantSentenceId: number

--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -7,6 +7,7 @@ export interface ReferralFields {
   createdAt: string
   completionDeadline: string
   serviceProvider: ServiceProvider
+  interventionId: string
   serviceCategoryId: string
   serviceCategoryIds: string[]
   complexityLevelId: string
@@ -29,4 +30,5 @@ export default interface DraftReferral extends WithNullableValues<ReferralFields
   id: string
   createdAt: string
   serviceUser: ServiceUser
+  interventionId: string
 }

--- a/server/models/intervention.ts
+++ b/server/models/intervention.ts
@@ -17,6 +17,7 @@ export default interface Intervention {
   npsRegion: NPSRegion | null
   pccRegions: PCCRegion[]
   serviceCategory: ServiceCategory
+  serviceCategories: ServiceCategory[]
   serviceProvider: ServiceProvider
   eligibility: Eligibility
 }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -995,6 +995,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         name: 'Harmony Living',
       },
       serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+      serviceCategoryIds: ['428ee70f-3001-4399-95a6-ad25eaaede16'],
       complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
       furtherInformation: 'Some information about the service user',
       relevantSentenceId: 2600295124,

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -223,6 +223,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             id: 'dfb64747-f658-40e0-a827-87b4b0bdcfed',
             createdAt: '2020-12-07T20:45:21.986389Z',
             serviceUser: { crn: serviceUserCrn },
+            interventionId,
           }),
           headers: {
             'Content-Type': 'application/json',
@@ -236,6 +237,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       const referral = await interventionsService.createDraftReferral(token, serviceUserCrn, interventionId)
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.serviceUser.crn).toBe(serviceUserCrn)
+      expect(referral.interventionId).toBe(interventionId)
     })
   })
 
@@ -1032,6 +1034,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       serviceProvider: {
         name: 'Harmony Living',
       },
+      interventionId: '000b2538-914b-4641-a1cc-a293409536bf',
       serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
       serviceCategoryIds: ['428ee70f-3001-4399-95a6-ad25eaaede16'],
       complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -799,6 +799,44 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(referral.usingRarDays).toBe(false)
       expect(referral.maximumRarDays).toBeNull()
     })
+
+    it('returns the updated referral when setting serviceCategoryIds', async () => {
+      await provider.addInteraction({
+        state: 'There is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962',
+        uponReceiving: 'a PATCH request to update serviceCategoryIds',
+        withRequest: {
+          method: 'PATCH',
+          path: '/draft-referral/d496e4a7-7cc1-44ea-ba67-c295084f1962',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: {
+            serviceCategoryIds: ['c81b6da3-77ef-4e9d-b8c7-c703b2cc7e8f', 'eaed6f70-f8cb-40dd-a0ca-8d91c5906d12'],
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
+            serviceCategoryIds: ['c81b6da3-77ef-4e9d-b8c7-c703b2cc7e8f', 'eaed6f70-f8cb-40dd-a0ca-8d91c5906d12'],
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.patchDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962', {
+        serviceCategoryIds: ['c81b6da3-77ef-4e9d-b8c7-c703b2cc7e8f', 'eaed6f70-f8cb-40dd-a0ca-8d91c5906d12'],
+      })
+      expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
+      expect(referral.serviceCategoryIds).toEqual([
+        'c81b6da3-77ef-4e9d-b8c7-c703b2cc7e8f',
+        'eaed6f70-f8cb-40dd-a0ca-8d91c5906d12',
+      ])
+    })
   })
 
   describe('getServiceCategory', () => {

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -111,6 +111,7 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   completionDeadline: null,
   serviceProvider: null,
   serviceCategoryId: null,
+  serviceCategoryIds: [],
   complexityLevelId: null,
   furtherInformation: null,
   relevantSentenceId: null,

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -1,6 +1,7 @@
 import { Factory } from 'fishery'
 import DraftReferral from '../../server/models/draftReferral'
 import serviceCategoryFactory from './serviceCategory'
+import interventionFactory from './intervention'
 
 class DraftReferralFactory extends Factory<DraftReferral> {
   justCreated() {
@@ -110,6 +111,7 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   },
   completionDeadline: null,
   serviceProvider: null,
+  interventionId: interventionFactory.build().id,
   serviceCategoryId: null,
   serviceCategoryIds: [],
   complexityLevelId: null,

--- a/testutils/factories/intervention.ts
+++ b/testutils/factories/intervention.ts
@@ -4,10 +4,13 @@ import serviceCategoryFactory from './serviceCategory'
 import serviceProviderFactory from './serviceProvider'
 import eligibilityFactory from './eligibility'
 
-export default Factory.define<Intervention>(sequence => ({
-  id: sequence.toString(),
-  title: 'Better solutions (anger management)',
-  description: `To provide service users with key tools and strategies to address issues of anger management and temper control and
+export default Factory.define<Intervention>(({ sequence }) => {
+  const serviceCategory = serviceCategoryFactory.build()
+
+  return {
+    id: sequence.toString(),
+    title: 'Better solutions (anger management)',
+    description: `To provide service users with key tools and strategies to address issues of anger management and temper control and
 explore the link between thoughts, emotions and behaviour. It provides the opportunity for service users to practice
 these strategies in a safe and closed environment.
 
@@ -16,14 +19,16 @@ The service will use the following methods:
 • Group therapy sessions
 • One-to-one coaching
 • Hypnotherapy`,
-  npsRegion: { id: 'B', name: 'North West' },
-  pccRegions: [
-    { id: 'cheshire', name: 'Cheshire' },
-    { id: 'cumbria', name: 'Cumbria' },
-    { id: 'lancashire', name: 'Lancashire' },
-    { id: 'merseyside', name: 'Merseyside' },
-  ],
-  serviceCategory: serviceCategoryFactory.build(),
-  serviceProvider: serviceProviderFactory.build(),
-  eligibility: eligibilityFactory.allAdults().build(),
-}))
+    npsRegion: { id: 'B', name: 'North West' },
+    pccRegions: [
+      { id: 'cheshire', name: 'Cheshire' },
+      { id: 'cumbria', name: 'Cumbria' },
+      { id: 'lancashire', name: 'Lancashire' },
+      { id: 'merseyside', name: 'Merseyside' },
+    ],
+    serviceCategory,
+    serviceCategories: [serviceCategory],
+    serviceProvider: serviceProviderFactory.build(),
+    eligibility: eligibilityFactory.allAdults().build(),
+  }
+})

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -2,6 +2,7 @@ import { Factory } from 'fishery'
 import SentReferral from '../../server/models/sentReferral'
 import { ReferralFields } from '../../server/models/draftReferral'
 import serviceCategoryFactory from './serviceCategory'
+import interventionFactory from './intervention'
 
 const exampleReferralFields = () => {
   const serviceCategoryId = serviceCategoryFactory.build().id
@@ -12,6 +13,7 @@ const exampleReferralFields = () => {
     serviceProvider: {
       name: 'Harmony Living',
     },
+    interventionId: interventionFactory.build().id,
     serviceCategoryId,
     serviceCategoryIds: [serviceCategoryId],
     complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -4,13 +4,16 @@ import { ReferralFields } from '../../server/models/draftReferral'
 import serviceCategoryFactory from './serviceCategory'
 
 const exampleReferralFields = () => {
+  const serviceCategoryId = serviceCategoryFactory.build().id
+
   return {
     createdAt: '2020-12-07T20:45:21.986389Z',
     completionDeadline: '2021-04-01',
     serviceProvider: {
       name: 'Harmony Living',
     },
-    serviceCategoryId: serviceCategoryFactory.build().id,
+    serviceCategoryId,
+    serviceCategoryIds: [serviceCategoryId],
     complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
     furtherInformation: 'Some information about the service user',
     relevantSentenceId: 2600295124,


### PR DESCRIPTION
## What does this pull request do?

Adds the API contracts needed to build the "select service category" page for cohort interventions. Specifically, it:

- allows an intervention to present a list of service categories, which the probation practitioner will pick from as part of the referral to a cohort intervention
- provides the information needed to be able to fetch an intervention given a referral
- allows a referral to have a list of service categories

## What is the intent behind these changes?

To allow us to start building the referral journey for cohort interventions.
