### PR TITLE
IC-1603 Add page for selecting service categories for a Cohort Referral

### DIFF
--- a/mocks.ts
+++ b/mocks.ts
@@ -2,12 +2,13 @@ import Wiremock from './mockApis/wiremock'
 import InterventionsServiceMocks from './mockApis/interventionsService'
 /*
 import sentReferralFactory from './testutils/factories/sentReferral'
-import serviceCategoryFactory from './testutils/factories/serviceCategory'
-import interventionFactory from './testutils/factories/intervention'
 import deliusUserFactory from './testutils/factories/deliusUser'
 import actionPlanFactory from './testutils/factories/actionPlan'
 */
+import interventionFactory from './testutils/factories/intervention'
 import actionPlanAppointmentFactory from './testutils/factories/actionPlanAppointment'
+import draftReferralFactory from './testutils/factories/draftReferral'
+import serviceCategoryFactory from './testutils/factories/serviceCategory'
 
 const wiremock = new Wiremock('http://localhost:9092/__admin')
 const interventionsMocks = new InterventionsServiceMocks(wiremock, '')
@@ -111,6 +112,32 @@ export default async function setUpMocks(): Promise<void> {
     interventionsMocks.stubGetActionPlan(actionPlan.id, actionPlan),
   ])
   */
+
+  const accommodationServiceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+  const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+  const intervention = interventionFactory.build({
+    serviceCategories: [accommodationServiceCategory, socialInclusionServiceCategory],
+  })
+
+  const draftReferral = draftReferralFactory
+    .serviceCategorySelected()
+    .serviceUserDetailsSet()
+    .build({
+      id: '98a42c61-c30f-4beb-8062-04033c376e2d',
+      serviceUser: {
+        crn: 'CRN11',
+        title: 'Mr',
+        firstName: 'Ken',
+        lastName: 'River',
+        dateOfBirth: '1980-01-01',
+        gender: 'Male',
+        ethnicity: 'British',
+        preferredLanguage: 'English',
+        religionOrBelief: 'Agnostic',
+        disabilities: ['Autism spectrum condition', 'sciatica'],
+      },
+    })
+
   await Promise.all([
     interventionsMocks.stubGetActionPlanAppointment(
       '1',
@@ -121,5 +148,8 @@ export default async function setUpMocks(): Promise<void> {
         durationInMinutes: 75,
       })
     ),
+
+    interventionsMocks.stubGetIntervention(draftReferral.interventionId, intervention),
+    interventionsMocks.stubGetDraftReferral(draftReferral.id, draftReferral),
   ])
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -207,6 +207,8 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/:id/form', (req, res) => referralsController.viewReferralForm(req, res))
   get('/referrals/:id/service-user-details', (req, res) => referralsController.viewServiceUserDetails(req, res))
   post('/referrals/:id/service-user-details', (req, res) => referralsController.confirmServiceUserDetails(req, res))
+  get('/referrals/:id/service-categories', (req, res) => referralsController.updateServiceCategories(req, res))
+  post('/referrals/:id/service-categories', (req, res) => referralsController.updateServiceCategories(req, res))
   get('/referrals/:id/complexity-level', (req, res) => referralsController.viewComplexityLevel(req, res))
   post('/referrals/:id/complexity-level', (req, res) => referralsController.updateComplexityLevel(req, res))
   get('/referrals/:id/completion-deadline', (req, res) => referralsController.viewCompletionDeadline(req, res))

--- a/server/routes/referrals/updateServiceCategoriesForm.test.ts
+++ b/server/routes/referrals/updateServiceCategoriesForm.test.ts
@@ -1,0 +1,37 @@
+import TestUtils from '../../../testutils/testUtils'
+import UpdateServiceCategoriesForm from './updateServiceCategoriesForm'
+
+describe(UpdateServiceCategoriesForm, () => {
+  describe('data', () => {
+    describe('when service category ids are passed', () => {
+      it('returns params for update when the service-category-ids property is present and not empty in the body', async () => {
+        const request = TestUtils.createRequest({
+          'service-category-ids': ['29843fdf-8b88-4b08-a0f9-dfbd3208fd2e', '43557c7a-c286-49c2-a994-d0a821295c7a'],
+        })
+        const data = await new UpdateServiceCategoriesForm(request).data()
+
+        expect(data.paramsForUpdate?.serviceCategoryIds).toEqual([
+          '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
+          '43557c7a-c286-49c2-a994-d0a821295c7a',
+        ])
+      })
+    })
+
+    describe('when service category ids are empty', () => {
+      it('returns an error when the service-category-ids property is empty in the body', async () => {
+        const request = TestUtils.createRequest({
+          body: {
+            'service-category-ids': [],
+          },
+        })
+        const data = await new UpdateServiceCategoriesForm(request).data()
+
+        expect(data.error?.errors).toContainEqual({
+          errorSummaryLinkedField: 'service-category-ids',
+          formFields: ['service-category-ids'],
+          message: 'At least one service type must be selected',
+        })
+      })
+    })
+  })
+})

--- a/server/routes/referrals/updateServiceCategoriesForm.ts
+++ b/server/routes/referrals/updateServiceCategoriesForm.ts
@@ -1,0 +1,52 @@
+import { Request } from 'express'
+import { ValidationChain, body, Result, ValidationError } from 'express-validator'
+import DraftReferral from '../../models/draftReferral'
+import errorMessages from '../../utils/errorMessages'
+import { FormValidationError } from '../../utils/formValidationError'
+import { FormData } from '../../utils/forms/formData'
+import FormUtils from '../../utils/formUtils'
+
+export default class UpdateServiceCategoriesForm {
+  constructor(private readonly request: Request) {}
+
+  async data(): Promise<FormData<Partial<DraftReferral>>> {
+    const validationResult = await FormUtils.runValidations({
+      request: this.request,
+      validations: UpdateServiceCategoriesForm.validations,
+    })
+
+    const error = this.error(validationResult)
+
+    if (error) {
+      return {
+        paramsForUpdate: null,
+        error,
+      }
+    }
+
+    return {
+      paramsForUpdate: {
+        serviceCategoryIds: this.request.body['service-category-ids'],
+      },
+      error: null,
+    }
+  }
+
+  static get validations(): ValidationChain[] {
+    return [body('service-category-ids').notEmpty().withMessage(errorMessages.serviceCategories.empty)]
+  }
+
+  private error(validationResult: Result<ValidationError>): FormValidationError | null {
+    if (validationResult.isEmpty()) {
+      return null
+    }
+
+    return {
+      errors: validationResult.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
+  }
+}

--- a/server/routes/referrals/updateServiceCategoriesPresenter.test.ts
+++ b/server/routes/referrals/updateServiceCategoriesPresenter.test.ts
@@ -1,0 +1,118 @@
+import draftReferral from '../../../testutils/factories/draftReferral'
+import serviceCategory from '../../../testutils/factories/serviceCategory'
+import UpdateServiceCategoriesPresenter from './updateServiceCategoriesPresenter'
+
+describe(UpdateServiceCategoriesPresenter, () => {
+  describe('text', () => {
+    it("contains a title including the Service User's name", () => {
+      const referral = draftReferral.serviceUserSelected().build()
+      const serviceCategoriesFromIntervention = serviceCategory.buildList(2)
+
+      const presenter = new UpdateServiceCategoriesPresenter(referral, serviceCategoriesFromIntervention)
+
+      expect(presenter.text.title).toEqual('What service types are you referring Alex to?')
+    })
+  })
+
+  describe('hasSelectedServiceCategory', () => {
+    describe('when the referral has not had any service categories selected', () => {
+      it('returns false for the specified service categories', () => {
+        const referral = draftReferral.build()
+        const serviceCategoriesFromIntervention = serviceCategory.buildList(2)
+
+        const presenter = new UpdateServiceCategoriesPresenter(referral, serviceCategoriesFromIntervention)
+
+        expect(presenter.hasSelectedServiceCategory(serviceCategoriesFromIntervention[0].id)).toEqual(false)
+        expect(presenter.hasSelectedServiceCategory(serviceCategoriesFromIntervention[1].id)).toEqual(false)
+      })
+    })
+
+    describe('when the referral has already had service categories selected', () => {
+      it('returns true for the specified service categories', () => {
+        const firstSelectedServiceCategory = serviceCategory.build()
+        const secondSelectedServiceCategory = serviceCategory.build()
+        const unselectedServiceCategory = serviceCategory.build()
+
+        const serviceCategoriesFromIntervention = [
+          firstSelectedServiceCategory,
+          secondSelectedServiceCategory,
+          unselectedServiceCategory,
+        ]
+
+        const referral = draftReferral.build({
+          serviceCategoryIds: [firstSelectedServiceCategory.id, secondSelectedServiceCategory.id],
+        })
+
+        const presenter = new UpdateServiceCategoriesPresenter(referral, serviceCategoriesFromIntervention)
+
+        expect(presenter.hasSelectedServiceCategory(firstSelectedServiceCategory.id)).toEqual(true)
+        expect(presenter.hasSelectedServiceCategory(secondSelectedServiceCategory.id)).toEqual(true)
+        expect(presenter.hasSelectedServiceCategory(unselectedServiceCategory.id)).toEqual(false)
+      })
+    })
+  })
+
+  describe('errorMessage', () => {
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
+        const referral = draftReferral.serviceUserSelected().build()
+        const serviceCategoriesFromIntervention = serviceCategory.buildList(2)
+
+        const presenter = new UpdateServiceCategoriesPresenter(referral, serviceCategoriesFromIntervention)
+        expect(presenter.errorMessage).toBeNull()
+      })
+    })
+
+    describe('when an error is passed in', () => {
+      it('returns error information', () => {
+        const referral = draftReferral.serviceUserSelected().build()
+        const serviceCategoriesFromIntervention = serviceCategory.buildList(2)
+
+        const presenter = new UpdateServiceCategoriesPresenter(referral, serviceCategoriesFromIntervention, {
+          errors: [
+            {
+              formFields: ['service-category-ids'],
+              errorSummaryLinkedField: 'service-category-ids',
+              message: 'At least one service type must be selected',
+            },
+          ],
+        })
+
+        expect(presenter.errorMessage).toEqual('At least one service type must be selected')
+      })
+    })
+  })
+
+  describe('errorSummary', () => {
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
+        const referral = draftReferral.serviceUserSelected().build()
+        const serviceCategoriesFromIntervention = serviceCategory.buildList(2)
+
+        const presenter = new UpdateServiceCategoriesPresenter(referral, serviceCategoriesFromIntervention)
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when an error is passed in', () => {
+      it('returns error information', () => {
+        const referral = draftReferral.serviceUserSelected().build()
+        const serviceCategoriesFromIntervention = serviceCategory.buildList(2)
+
+        const presenter = new UpdateServiceCategoriesPresenter(referral, serviceCategoriesFromIntervention, {
+          errors: [
+            {
+              formFields: ['service-category-ids'],
+              errorSummaryLinkedField: 'service-category-ids',
+              message: 'At least one service type must be selected',
+            },
+          ],
+        })
+
+        expect(presenter.errorSummary).toEqual([
+          { field: 'service-category-ids', message: 'At least one service type must be selected' },
+        ])
+      })
+    })
+  })
+})

--- a/server/routes/referrals/updateServiceCategoriesPresenter.ts
+++ b/server/routes/referrals/updateServiceCategoriesPresenter.ts
@@ -1,0 +1,24 @@
+import DraftReferral from '../../models/draftReferral'
+import ServiceCategory from '../../models/serviceCategory'
+import { FormValidationError } from '../../utils/formValidationError'
+import PresenterUtils from '../../utils/presenterUtils'
+
+export default class UpdateServiceCategoriesPresenter {
+  constructor(
+    private readonly referral: DraftReferral,
+    readonly serviceCategories: ServiceCategory[],
+    private readonly error: FormValidationError | null = null
+  ) {}
+
+  readonly text = {
+    title: `What service types are you referring ${this.referral.serviceUser.firstName} to?`,
+  }
+
+  readonly errorMessage = PresenterUtils.errorMessage(this.error, 'service-category-ids')
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error)
+
+  hasSelectedServiceCategory(serviceCategoryId: string): boolean {
+    return (this.referral.serviceCategoryIds || []).includes(serviceCategoryId)
+  }
+}

--- a/server/routes/referrals/updateServiceCategoriesView.ts
+++ b/server/routes/referrals/updateServiceCategoriesView.ts
@@ -1,0 +1,42 @@
+import { CheckboxesArgs } from '../../utils/govukFrontendTypes'
+import utils from '../../utils/utils'
+import ViewUtils from '../../utils/viewUtils'
+import UpdateServiceCategoriesPresenter from './updateServiceCategoriesPresenter'
+
+export default class UpdateServiceCategoriesView {
+  constructor(private readonly presenter: UpdateServiceCategoriesPresenter) {}
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+
+  private get checkboxArgs(): CheckboxesArgs {
+    return {
+      classes: 'govuk-checkboxes',
+      idPrefix: 'service-category-ids',
+      name: 'service-category-ids[]',
+      fieldset: {
+        legend: {
+          text: this.presenter.text.title,
+          classes: 'govuk-fieldset__legend--xl',
+          isPageHeading: true,
+        },
+      },
+      items: this.presenter.serviceCategories.map(serviceCategory => ({
+        value: serviceCategory.id,
+        text: utils.convertToProperCase(serviceCategory.name),
+        checked: this.presenter.hasSelectedServiceCategory(serviceCategory.id),
+      })),
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referrals/updateServiceCategories',
+      {
+        presenter: this.presenter,
+        checkboxArgs: this.checkboxArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
+      },
+    ]
+  }
+}

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -15,6 +15,9 @@ export default {
     invalidDate: 'The date by which the service needs to be completed must be a real date',
     mustBeInFuture: 'The date by which the service needs to be completed must be in the future',
   },
+  serviceCategories: {
+    empty: 'At least one service type must be selected',
+  },
   complexityLevel: {
     empty: 'Select a complexity level',
   },

--- a/server/views/referrals/updateServiceCategories.njk
+++ b/server/views/referrals/updateServiceCategories.njk
@@ -1,0 +1,27 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}
+  HMPPS Interventions - GOV.UK
+{% endblock %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {% if errorSummaryArgs !== null %}
+          {{ govukErrorSummary(errorSummaryArgs) }}
+        {% endif %}
+
+        {{ govukCheckboxes(checkboxArgs) }}
+
+        {{ govukButton({ text: "Save and continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -17,6 +17,13 @@ class DraftReferralFactory extends Factory<DraftReferral> {
     return this.params({ serviceCategoryId: resolvedServiceCategoryId })
   }
 
+  serviceCategoriesSelected(serviceCategoryIds?: string[]) {
+    const resolvedServiceCategoryIds =
+      serviceCategoryIds ?? serviceCategoryFactory.buildList(3).map(category => category.id)
+
+    return this.params({ serviceCategoryIds: resolvedServiceCategoryIds })
+  }
+
   completionDeadlineSet() {
     return this.params({ completionDeadline: '2021-08-24' })
   }


### PR DESCRIPTION
## What does this pull request do?

Adds screen for selecting service types on a Cohort referral. This curently isn't linked to by the referral form (that's coming in IC-1686) and isn't linked up to any other parts of the journey. I've added mocks to get this to work locally, as the backend hasn't been built for this feature.

## What is the intent behind these changes?

Cohort referrals encompass multiple service categories, so the PP needs to select the relevant ones for the service user, after which they'll select desired outcomes and complexity level for these.

## Screenshots

![image](https://user-images.githubusercontent.com/19826940/117676809-ca7f6980-b1a5-11eb-9c83-82f7a9a8c07e.png)

