### PR TITLE
IC-1646: Pact tests for accessing forbidden referral

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -15,6 +15,31 @@ describe('Service provider referrals dashboard', () => {
     cy.task('stubServiceProviderAuthUser')
   })
 
+  describe('User access referral restrictions', () => {
+    it('user should be restricted access to referral if they referral is a different service provider from their organization', () => {
+      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const referralParams = { referral: { serviceCategoryId: serviceCategory.id } }
+      const referral = sentReferralFactory.build(referralParams)
+      const deliusUser = deliusUserFactory.build()
+      const deliusServiceUser = deliusServiceUserFactory.build()
+      const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
+
+      cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+      cy.stubGetSentReferralUnauthorized(referral.id)
+      cy.stubGetSentReferrals([referral])
+      cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+      cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
+      cy.stubGetAuthUserByEmailAddress([hmppsAuthUser])
+      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubAssignSentReferral(referral.id, referral)
+
+      cy.login()
+
+      cy.visit({ url: `/service-provider/referrals/${referral.id}/details`, failOnStatusCode: false })
+      cy.contains('Forbidden')
+    })
+  })
+
   it('User views a list of sent referrals and the referral details page', () => {
     const accommodationServiceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -73,6 +73,10 @@ module.exports = on => {
       return interventionsService.stubGetSentReferral(arg.id, arg.responseJson)
     },
 
+    stubGetSentReferralUnauthorized: arg => {
+      return interventionsService.stubGetSentReferralUnauthorized(arg.id)
+    },
+
     stubGetSentReferrals: arg => {
       return interventionsService.stubGetSentReferrals(arg.responseJson)
     },

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -26,6 +26,10 @@ Cypress.Commands.add('stubGetSentReferral', (id, responseJson) => {
   cy.task('stubGetSentReferral', { id, responseJson })
 })
 
+Cypress.Commands.add('stubGetSentReferralUnauthorized', id => {
+  cy.task('stubGetSentReferralUnauthorized', { id })
+})
+
 Cypress.Commands.add('stubGetSentReferrals', responseJson => {
   cy.task('stubGetSentReferrals', { responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -116,6 +116,21 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubGetSentReferralUnauthorized = async (id: string): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/sent-referral/${id}`,
+      },
+      response: {
+        status: 403,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    })
+  }
+
   stubGetSentReferrals = async (responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {


### PR DESCRIPTION
## What does this pull request do?

Adds an additional test to assert that user is presented with forbidden when accessing restricted referral.

## What is the intent behind these changes?

To ensure that user knows that they have attempted to access a restricted referral
