### PR TITLE
Fix: Unfocus referrals controller test

### DIFF
--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -814,7 +814,7 @@ describe('GET /referrals/:id/service-categories', () => {
 })
 
 describe('POST /referrals/:id/service-categories', () => {
-  fit('updates the referral on the backend and redirects to the next question', async () => {
+  it('updates the referral on the backend and redirects to the next question', async () => {
     const serviceCategory = serviceCategoryFactory.build({
       id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
       name: 'social inclusion',


### PR DESCRIPTION
## What does this pull request do?

Removes the `f` from a focused test to ensure all tests are running.

It looks like this was added in error in ba42422 and although since
then I've seen 'x skipped tests' in the output, I seem to not have put 2
and 2 together.
