### PR TITLE
IC-1604: Add contracts for new desired outcomes structure to support cohort referrals

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -57,6 +57,10 @@ module.exports = on => {
       return interventionsService.stubPatchDraftReferral(arg.id, arg.responseJson)
     },
 
+    stubSetDesiredOutcomesForServiceCategory: arg => {
+      return interventionsService.stubPatchDraftReferral(arg.referralId, arg.serviceCategoryId, arg.responseJson)
+    },
+
     stubGetServiceCategory: arg => {
       return interventionsService.stubGetServiceCategory(arg.id, arg.responseJson)
     },

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -10,6 +10,10 @@ Cypress.Commands.add('stubPatchDraftReferral', (id, responseJson) => {
   cy.task('stubPatchDraftReferral', { id, responseJson })
 })
 
+Cypress.Commands.add('setDesiredOutcomesForServiceCategory', (referralId, serviceCategoryId, responseJson) => {
+  cy.task('stubPatchDraftReferral', { referralId, serviceCategoryId, responseJson })
+})
+
 Cypress.Commands.add('stubGetServiceCategory', (id, responseJson) => {
   cy.task('stubGetServiceCategory', { id, responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -52,6 +52,26 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubSetDesiredOutcomesForServiceCategory = async (
+    referralId: string,
+    serviceCategoryId: string,
+    responseJson: Record<string, unknown>
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/draft-referral/${referralId}/desired-outcomes`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
   stubGetServiceCategory = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -1,3 +1,4 @@
+import ReferralDesiredOutcomes from './referralDesiredOutcomes'
 import ServiceProvider from './serviceProvider'
 import ServiceUser from './serviceUser'
 
@@ -13,7 +14,8 @@ export interface ReferralFields {
   complexityLevelId: string
   furtherInformation: string
   relevantSentenceId: number
-  desiredOutcomesIds: string[]
+  desiredOutcomesIds: string[] // deprecated in favour of desiredOutcomes
+  desiredOutcomes: ReferralDesiredOutcomes[]
   additionalNeedsInformation: string
   accessibilityNeeds: string
   needsInterpreter: boolean

--- a/server/models/referralDesiredOutcomes.ts
+++ b/server/models/referralDesiredOutcomes.ts
@@ -1,0 +1,4 @@
+export default interface ReferralDesiredOutcomes {
+  serviceCategoryId: string
+  desiredOutcomesIds: string[]
+}

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -520,7 +520,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(referral.relevantSentenceId).toEqual(2600295124)
     })
 
-    it('returns the updated referral when selecting desired outcomes', async () => {
+    it('returns the updated referral when selecting desired outcomes on a single-service referral', async () => {
       await provider.addInteraction({
         state:
           'There is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962, and it has had a service category selected',
@@ -882,6 +882,59 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(referral.serviceCategoryIds).toEqual([
         'c81b6da3-77ef-4e9d-b8c7-c703b2cc7e8f',
         'eaed6f70-f8cb-40dd-a0ca-8d91c5906d12',
+      ])
+    })
+  })
+
+  describe('setDesiredOutcomesForServiceCategory', () => {
+    it('returns the updated referral when selecting desired outcomes on a cohort referral', async () => {
+      await provider.addInteraction({
+        state: `There is an existing draft cohort referral with ID of 06716f8e-f507-42d4-bdcc-44c90e18dbd7, and it has had multiple service categories selected`,
+        uponReceiving: 'a PATCH request to set the desired outcomes for a service category on a referral',
+        withRequest: {
+          method: 'PATCH',
+          path: `/draft-referral/06716f8e-f507-42d4-bdcc-44c90e18dbd7/desired-outcomes`,
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: {
+            serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+            desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: '06716f8e-f507-42d4-bdcc-44c90e18dbd7',
+            desiredOutcomes: Matchers.like([
+              {
+                serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+                desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+              },
+            ]),
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.setDesiredOutcomesForServiceCategory(
+        token,
+        '06716f8e-f507-42d4-bdcc-44c90e18dbd7',
+        {
+          serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+          desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+        }
+      )
+
+      expect(referral.id).toBe('06716f8e-f507-42d4-bdcc-44c90e18dbd7')
+      expect(referral.desiredOutcomes![0].serviceCategoryId).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
+      expect(referral.desiredOutcomes![0].desiredOutcomesIds).toEqual([
+        '301ead30-30a4-4c7c-8296-2768abfb59b5',
+        '65924ac6-9724-455b-ad30-906936291421',
       ])
     })
   })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -115,7 +115,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
     })
 
-    describe('for a referral that has had desired outcomes selected', () => {
+    describe('for a single-service referral that has had desired outcomes selected', () => {
       beforeEach(async () => {
         await provider.addInteraction({
           state:
@@ -145,6 +145,51 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         expect(referral.desiredOutcomesIds).toEqual([
           '301ead30-30a4-4c7c-8296-2768abfb59b5',
           '65924ac6-9724-455b-ad30-906936291421',
+        ])
+      })
+    })
+
+    describe('for a cohort referral that has had desired outcomes selected', () => {
+      it('returns a referral for the given ID, with the desired outcomes selected', async () => {
+        await provider.addInteraction({
+          state: `There is an existing draft cohort referral with ID of 06716f8e-f507-42d4-bdcc-44c90e18dbd7, and it has had desired outcomes selected for multiple service categories`,
+          uponReceiving: 'a request for that referral',
+          withRequest: {
+            method: 'GET',
+            path: '/draft-referral/06716f8e-f507-42d4-bdcc-44c90e18dbd7',
+            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like({
+              id: '06716f8e-f507-42d4-bdcc-44c90e18dbd7',
+              desiredOutcomes: [
+                {
+                  serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+                  desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+                },
+                {
+                  serviceCategoryId: '3c7d6bc9-540a-4aef-a3fe-dfdff7a3c124',
+                  desiredOutcomesIds: ['263821e1-3ad1-44ee-8ec5-c1a925f7a828', '0694fcc9-833f-4756-8d93-28199c0ec58a'],
+                },
+              ],
+            }),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        const referral = await interventionsService.getDraftReferral(token, '06716f8e-f507-42d4-bdcc-44c90e18dbd7')
+
+        expect(referral.id).toBe('06716f8e-f507-42d4-bdcc-44c90e18dbd7')
+        expect(referral.desiredOutcomes![0].serviceCategoryId).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
+        expect(referral.desiredOutcomes![0].desiredOutcomesIds).toEqual([
+          '301ead30-30a4-4c7c-8296-2768abfb59b5',
+          '65924ac6-9724-455b-ad30-906936291421',
+        ])
+        expect(referral.desiredOutcomes![1].serviceCategoryId).toEqual('3c7d6bc9-540a-4aef-a3fe-dfdff7a3c124')
+        expect(referral.desiredOutcomes![1].desiredOutcomesIds).toEqual([
+          '263821e1-3ad1-44ee-8ec5-c1a925f7a828',
+          '0694fcc9-833f-4756-8d93-28199c0ec58a',
         ])
       })
     })
@@ -1041,6 +1086,16 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       furtherInformation: 'Some information about the service user',
       relevantSentenceId: 2600295124,
       desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+      desiredOutcomes: [
+        {
+          serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+          desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+        },
+        {
+          serviceCategoryId: '3c7d6bc9-540a-4aef-a3fe-dfdff7a3c124',
+          desiredOutcomesIds: ['263821e1-3ad1-44ee-8ec5-c1a925f7a828', '0694fcc9-833f-4756-8d93-28199c0ec58a'],
+        },
+      ],
       additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
       accessibilityNeeds: 'She uses a wheelchair',
       needsInterpreter: true,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -14,6 +14,7 @@ import ServiceCategory from '../models/serviceCategory'
 import ActionPlan, { ActionPlanAppointment, AppointmentAttendance, AppointmentBehaviour } from '../models/actionPlan'
 import DraftReferral from '../models/draftReferral'
 import SentReferral from '../models/sentReferral'
+import ReferralDesiredOutcomes from '../models/referralDesiredOutcomes'
 
 export type InterventionsServiceError = SanitisedError & { validationErrors?: InterventionsServiceValidationError[] }
 
@@ -147,6 +148,24 @@ export default class InterventionsService {
         path: `/draft-referral/${id}`,
         headers: { Accept: 'application/json' },
         data: patch,
+      })) as DraftReferral
+    } catch (e) {
+      throw this.createServiceError(e)
+    }
+  }
+
+  async setDesiredOutcomesForServiceCategory(
+    token: string,
+    referralId: string,
+    desiredOutcomes: Partial<ReferralDesiredOutcomes>
+  ): Promise<DraftReferral> {
+    const restClient = this.createRestClient(token)
+
+    try {
+      return (await restClient.patch({
+        path: `/draft-referral/${referralId}/desired-outcomes`,
+        headers: { Accept: 'application/json' },
+        data: desiredOutcomes,
       })) as DraftReferral
     } catch (e) {
       throw this.createServiceError(e)

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -125,6 +125,7 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   furtherInformation: null,
   relevantSentenceId: null,
   desiredOutcomesIds: null,
+  desiredOutcomes: null,
   additionalNeedsInformation: null,
   accessibilityNeeds: null,
   needsInterpreter: null,

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -20,6 +20,12 @@ const exampleReferralFields = () => {
     furtherInformation: 'Some information about the service user',
     relevantSentenceId: 2600295124,
     desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+    desiredOutcomes: [
+      {
+        serviceCategoryId,
+        desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
+      },
+    ],
     additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
     accessibilityNeeds: 'She uses a wheelchair',
     needsInterpreter: true,


### PR DESCRIPTION
## What does this pull request do?

Adds support for selecting multiple desired outcomes on cohort referrals.

This adds a contract that assuming we have the following endpoint on the backend that accepts a PATCH request: 
`/draft-referral/${referralId}/desired-outcomes`.

I've opted for a PATCH, rather than a PUT here, as PATCH should be used for a partial update to a resource, while PUT should be used when replacing that resource. Although we are effectively replacing the `desiredOutcomes` resource, that resource is actually on the `Referral`, which is the entity we're updating.

This PR doesn't use the new method yet.

## What is the intent behind these changes?

To allow PPs to select desired outcomes for a specific Service Category.

We initially thought we would be able to avoid adding a new endpoint and data structure, as we could identify which service category a desired outcome belongs to by fetching the Service Category and looking through its Desired Outcomes Ids. This has become a lot more complicated when trying to set the desired outcomes across multiple pages, as we don't want to overwrite desired outcomes that have been set in a previous page/step. If a user comes back to the previous page and unselects a desired outcome, we need to make sure we update that object on the backend as well.
