### PR TITLE
Adds veracode appsec scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - node/install-npm:
           version: 7.5.4
       - node/install-packages
-      - run: npm run build
+      - run: npm run build:prod
       - run: npm prune --production --no-audit
       - run:
           # copies what the Dockerfile does, without build-info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   hmpps: ministryofjustice/hmpps@2.3.2
   snyk: snyk/snyk@0.0.12
   node: circleci/node@4.1.0
+  veracode: orb-01scan/sast-orb@0.0.9
 
 executors:
   integration:
@@ -27,7 +28,7 @@ jobs:
     steps:
       - checkout
       - node/install-npm:
-        version: 7.5.4
+          version: 7.5.4
       - node/install-packages
       - run: npm run test
       - store_artifacts:
@@ -43,12 +44,41 @@ jobs:
       - run: npm run scripts:typecheck
       - run: npm run lint
 
+  assemble:
+    executor:
+      name: hmpps/node
+      tag: 14.16.0-browsers
+    steps:
+      - checkout
+      - node/install-npm:
+          version: 7.5.4
+      - node/install-packages
+      - run: npm run build
+      - run: npm prune --production --no-audit
+      - run:
+          # copies what the Dockerfile does, without build-info
+          name: Package production code for scanning
+          command: tar czf hmpps-interventions-ui.tar.gz package*.json assets/ dist/ node_modules/
+      - persist_to_workspace:
+          root: .
+          paths:
+            - hmpps-interventions-ui.tar.gz
+
+  appsec_scan:
+    executor: veracode/default
+    steps:
+      - attach_workspace:
+          at: ./build
+      - veracode/policy-scan:
+          filepath: ./build/hmpps-interventions-ui.tar.gz
+          teams: hmpps-interventions
+
   integration_test:
     executor: integration
     steps:
       - checkout
       - node/install-npm:
-        version: 7.5.4
+          version: 7.5.4
       - node/install-packages
       - run: npm run build
       - run: # Run linter after build because the integration test code depends on compiled typescript...
@@ -87,6 +117,10 @@ workflows:
       - build
       - integration_test
       - hmpps/helm_lint
+      - assemble
+      - appsec_scan:
+          requires: [assemble]
+          context: [veracode-credentials]
       - vulnerability_scan:
           name: vulnerability_scan_and_monitor
           monitor: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY package*.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit
 
 COPY . .
-RUN npm run build
+RUN npm run build:prod
 
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 ENV GIT_REF ${GIT_REF:-dummy}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build:views": "cp -R server/views dist/server/",
     "build:sass": "sass --no-source-map --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend ./assets/sass/application.sass:./assets/stylesheets/application.css ./assets/sass/application-ie8.sass:./assets/stylesheets/application-ie8.css --style compressed",
     "build:typecheck": "tsc",
+    "build:typecheck:prod": "tsc --build tsconfig.prod.json",
+    "build:prod": "npm run build:sass && npm run build:typecheck:prod && npm run build:views",
     "build": "npm run build:sass && npm run build:typecheck && npm run build:views",
     "watch:ts": "tsc -w",
     "watch:views": "nodemon --watch server/views -e html,njk -x npm run build:views",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,22 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "sourceMap": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "skipLibCheck": true,
+    "noEmit": false,
+    "allowJs": true,
+    "checkJs": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "strict": true
+  },
+  "exclude": ["node_modules", "**/*.test.*", "**/testutils", "**/*mock*"],
+  "include": ["server/**/*.js", "server/**/*.ts"]
+}


### PR DESCRIPTION
## What does this pull request do?

Adds veracode appsec scanning, for continuous security.

📝 This is a never-blocking CI job. To see raised issues, visit [the app's latest report on veracode](https://analysiscenter.veracode.com/auth/index.jsp#ViewReportsResultSummary:77328:1141100:12074944:12049330:12064993:3228117)

It looks like test and mock files are currently included in the `dist/` folder, so this PR also includes a `build:prod` command.

## What is the intent behind these changes?

To align on direction in continuous security in the Ministry of Justice.