### PR TITLE
IC-1594: Probation practitioner can find a cohort service

### DIFF
--- a/integration_tests/integration/findInterventions.spec.js
+++ b/integration_tests/integration/findInterventions.spec.js
@@ -1,5 +1,6 @@
 import interventionFactory from '../../testutils/factories/intervention'
 import pccRegionFactory from '../../testutils/factories/pccRegion'
+import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
 
 context('Find an intervention', () => {
   beforeEach(() => {
@@ -19,18 +20,18 @@ context('Find an intervention', () => {
     const interventions = [
       {
         title: 'Better solutions (anger management)',
-        categoryName: 'thinking and behaviour',
+        categoryNames: ['thinking and behaviour'],
         id: thinkingAndBehaviourInterventionId,
       },
       {
         title: 'HELP (domestic violence for males)',
-        categoryName: 'relationships',
+        categoryNames: ['relationships', 'emotional wellbeing'],
         id: 'bf3eb0df-2ef4-4aa9-9d98-bb0078be5042',
       },
     ].map(params => {
       return interventionFactory.build({
         title: params.title,
-        serviceCategory: { name: params.categoryName },
+        serviceCategories: params.categoryNames.map(name => serviceCategoryFactory.build({ name })),
         id: params.id,
         serviceProvider: { name: 'Harmony Living' },
       })

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -167,10 +167,10 @@ three lines.`,
       })
     })
 
-    describe('Criminogenic needs', () => {
+    describe('Service type', () => {
       it('is the service category name', () => {
         expect(
-          linesForKey('Criminogenic needs', {
+          linesForKey('Service type', {
             serviceCategory: { name: 'accommodation' },
           })
         ).toEqual(['Accommodation'])

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -6,7 +6,7 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import Intervention from '../../models/intervention'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
 import TestUtils from '../../../testutils/testUtils'
-import { SummaryListItem } from '../../utils/summaryList'
+import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 
 describe(InterventionDetailsPresenter, () => {
   describe('title', () => {
@@ -112,7 +112,6 @@ three lines.`,
             {
               key: 'Name',
               lines: ['Harmony Living'],
-              isList: false,
             },
           ],
         },
@@ -190,7 +189,7 @@ three lines.`,
             ],
           })
           const item = summary.find(anItem => anItem.key === 'Service types')
-          expect(item).toMatchObject({ lines: ['Accommodation', 'Emotional wellbeing'], isList: true })
+          expect(item).toMatchObject({ lines: ['Accommodation', 'Emotional wellbeing'], listStyle: ListStyle.bulleted })
         })
       })
     })

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -180,10 +180,10 @@ three lines.`,
     describe('Provider', () => {
       it('is the service provider’s name', () => {
         expect(
-          linesForKey('Criminogenic needs', {
-            serviceCategory: { name: 'accommodation' },
+          linesForKey('Provider', {
+            serviceProvider: { name: 'Harmony Living' },
           })
-        ).toEqual(['Accommodation'])
+        ).toEqual(['Harmony Living'])
       })
     })
 

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -1,5 +1,5 @@
 import Intervention, { Eligibility } from '../../models/intervention'
-import { SummaryListItem } from '../../utils/summaryList'
+import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
 
 export default class InterventionDetailsPresenter {
@@ -42,34 +42,29 @@ export default class InterventionDetailsPresenter {
       {
         key: 'Type',
         lines: ['Dynamic Framework'],
-        isList: false,
       },
       {
         key: 'Location',
         lines: [this.intervention.pccRegions.map(region => region.name).join(', ')],
-        isList: false,
       },
       {
         key: this.intervention.serviceCategories.length > 1 ? 'Service types' : 'Service type',
         lines: this.intervention.serviceCategories.map(serviceCategory =>
           utils.convertToProperCase(serviceCategory.name)
         ),
-        isList: this.intervention.serviceCategories.length > 1,
+        listStyle: this.intervention.serviceCategories.length > 1 ? ListStyle.bulleted : undefined,
       },
       {
         key: 'Provider',
         lines: [this.intervention.serviceProvider.name],
-        isList: false,
       },
       {
         key: 'Age group',
         lines: [InterventionDetailsPresenter.ageGroupDescription(this.intervention.eligibility)],
-        isList: false,
       },
       {
         key: 'Gender',
         lines: [InterventionDetailsPresenter.genderDescription(this.intervention.eligibility)],
-        isList: false,
       },
     ]
 
@@ -77,7 +72,6 @@ export default class InterventionDetailsPresenter {
       summary.splice(1, 0, {
         key: 'Region',
         lines: [utils.convertToTitleCase(this.intervention.npsRegion.name)],
-        isList: false,
       })
     }
 
@@ -110,7 +104,6 @@ export default class InterventionDetailsPresenter {
       {
         key: 'Name',
         lines: [this.intervention.serviceProvider.name],
-        isList: false,
       },
     ]
   }

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -50,7 +50,7 @@ export default class InterventionDetailsPresenter {
         isList: false,
       },
       {
-        key: 'Criminogenic needs',
+        key: 'Service type',
         lines: [utils.convertToProperCase(this.intervention.serviceCategory.name)],
         isList: false,
       },

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -50,9 +50,11 @@ export default class InterventionDetailsPresenter {
         isList: false,
       },
       {
-        key: 'Service type',
-        lines: [utils.convertToProperCase(this.intervention.serviceCategory.name)],
-        isList: false,
+        key: this.intervention.serviceCategories.length > 1 ? 'Service types' : 'Service type',
+        lines: this.intervention.serviceCategories.map(serviceCategory =>
+          utils.convertToProperCase(serviceCategory.name)
+        ),
+        isList: this.intervention.serviceCategories.length > 1,
       },
       {
         key: 'Provider',

--- a/server/routes/findInterventions/searchSummaryPresenter.ts
+++ b/server/routes/findInterventions/searchSummaryPresenter.ts
@@ -39,7 +39,7 @@ export default class SearchSummaryPresenter {
 
     names.sort()
 
-    return { key: 'In', lines: [names.join(', ')], isList: false }
+    return { key: 'In', lines: [names.join(', ')] }
   }
 
   private get genderItem(): SummaryListItem | null {
@@ -47,7 +47,7 @@ export default class SearchSummaryPresenter {
       return null
     }
 
-    return { key: 'For', lines: [this.filter.gender.map(utils.convertToProperCase).join(', ')], isList: false }
+    return { key: 'For', lines: [this.filter.gender.map(utils.convertToProperCase).join(', ')] }
   }
 
   private get ageItem(): SummaryListItem | null {
@@ -64,6 +64,6 @@ export default class SearchSummaryPresenter {
       }
     })
 
-    return { key: 'Aged', lines: [names.join(', ')], isList: false }
+    return { key: 'Aged', lines: [names.join(', ')] }
   }
 }

--- a/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.test.ts
@@ -27,17 +27,14 @@ describe(ReferralCancellationConfirmationPresenter, () => {
         {
           key: 'Name',
           lines: ['Alex River'],
-          isList: false,
         },
         {
           key: 'Referral number',
           lines: ['AB1234'],
-          isList: false,
         },
         {
           key: 'Type of referral',
           lines: ['Accommodation'],
-          isList: false,
         },
       ])
     })

--- a/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.ts
@@ -19,17 +19,14 @@ export default class ReferralCancellationConfirmationPresenter {
     {
       key: 'Name',
       lines: [PresenterUtils.fullName(this.referral.referral.serviceUser)],
-      isList: false,
     },
     {
       key: 'Referral number',
       lines: [this.referral.referenceNumber],
-      isList: false,
     },
     {
       key: 'Type of referral',
       lines: [utils.convertToProperCase(this.serviceCategory.name)],
-      isList: false,
     },
   ]
 }

--- a/server/routes/referrals/needsAndRequirementsPresenter.test.ts
+++ b/server/routes/referrals/needsAndRequirementsPresenter.test.ts
@@ -1,5 +1,6 @@
 import NeedsAndRequirementsPresenter from './needsAndRequirementsPresenter'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import { ListStyle } from '../../utils/summaryList'
 
 describe('NeedsAndRequirementsPresenter', () => {
   describe('summary', () => {
@@ -8,8 +9,8 @@ describe('NeedsAndRequirementsPresenter', () => {
       const presenter = new NeedsAndRequirementsPresenter(referral)
 
       expect(presenter.summary).toEqual([
-        { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], isList: true },
-        { key: 'Gender', lines: ['Male'], isList: false },
+        { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], listStyle: ListStyle.noMarkers },
+        { key: 'Gender', lines: ['Male'] },
       ])
     })
   })

--- a/server/routes/referrals/needsAndRequirementsPresenter.ts
+++ b/server/routes/referrals/needsAndRequirementsPresenter.ts
@@ -1,6 +1,6 @@
 import DraftReferral from '../../models/draftReferral'
 import { FormValidationError } from '../../utils/formValidationError'
-import { SummaryListItem } from '../../utils/summaryList'
+import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class NeedsAndRequirementsPresenter {
@@ -11,8 +11,8 @@ export default class NeedsAndRequirementsPresenter {
   ) {}
 
   readonly summary: SummaryListItem[] = [
-    { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], isList: true },
-    { key: 'Gender', lines: ['Male'], isList: false },
+    { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], listStyle: ListStyle.noMarkers },
+    { key: 'Gender', lines: ['Male'] },
     // TODO IC-746 populate with service user data once we have it
   ]
 

--- a/server/routes/referrals/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.test.ts
@@ -1,3 +1,4 @@
+import { ListStyle } from '../../utils/summaryList'
 import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
 
 describe(ServiceUserDetailsPresenter, () => {
@@ -46,16 +47,16 @@ describe(ServiceUserDetailsPresenter, () => {
       const presenter = new ServiceUserDetailsPresenter(serviceUser)
 
       expect(presenter.summary).toEqual([
-        { key: 'CRN', lines: [serviceUser.crn], isList: false },
-        { key: 'Title', lines: [serviceUser.title], isList: false },
-        { key: 'First name', lines: [serviceUser.firstName], isList: false },
-        { key: 'Last name', lines: [serviceUser.lastName], isList: false },
-        { key: 'Date of birth', lines: [serviceUser.dateOfBirth], isList: false },
-        { key: 'Gender', lines: [serviceUser.gender], isList: false },
-        { key: 'Ethnicity', lines: [serviceUser.ethnicity], isList: false },
-        { key: 'Preferred language', lines: [serviceUser.preferredLanguage], isList: false },
-        { key: 'Religion or belief', lines: [serviceUser.religionOrBelief], isList: false },
-        { key: 'Disabilities', lines: serviceUser.disabilities || [], isList: true },
+        { key: 'CRN', lines: [serviceUser.crn] },
+        { key: 'Title', lines: [serviceUser.title] },
+        { key: 'First name', lines: [serviceUser.firstName] },
+        { key: 'Last name', lines: [serviceUser.lastName] },
+        { key: 'Date of birth', lines: [serviceUser.dateOfBirth] },
+        { key: 'Gender', lines: [serviceUser.gender] },
+        { key: 'Ethnicity', lines: [serviceUser.ethnicity] },
+        { key: 'Preferred language', lines: [serviceUser.preferredLanguage] },
+        { key: 'Religion or belief', lines: [serviceUser.religionOrBelief] },
+        { key: 'Disabilities', lines: serviceUser.disabilities || [], listStyle: ListStyle.noMarkers },
       ])
     })
 
@@ -63,16 +64,16 @@ describe(ServiceUserDetailsPresenter, () => {
       const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser)
 
       expect(presenter.summary).toEqual([
-        { key: 'CRN', lines: ['X862134'], isList: false },
-        { key: 'Title', lines: [''], isList: false },
-        { key: 'First name', lines: [''], isList: false },
-        { key: 'Last name', lines: [''], isList: false },
-        { key: 'Date of birth', lines: [''], isList: false },
-        { key: 'Gender', lines: [''], isList: false },
-        { key: 'Ethnicity', lines: [''], isList: false },
-        { key: 'Preferred language', lines: [''], isList: false },
-        { key: 'Religion or belief', lines: [''], isList: false },
-        { key: 'Disabilities', lines: [], isList: true },
+        { key: 'CRN', lines: ['X862134'] },
+        { key: 'Title', lines: [''] },
+        { key: 'First name', lines: [''] },
+        { key: 'Last name', lines: [''] },
+        { key: 'Date of birth', lines: [''] },
+        { key: 'Gender', lines: [''] },
+        { key: 'Ethnicity', lines: [''] },
+        { key: 'Preferred language', lines: [''] },
+        { key: 'Religion or belief', lines: [''] },
+        { key: 'Disabilities', lines: [], listStyle: ListStyle.noMarkers },
       ])
     })
   })

--- a/server/routes/referrals/serviceUserDetailsPresenter.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.ts
@@ -1,5 +1,5 @@
 import ServiceUser from '../../models/serviceUser'
-import { SummaryListItem } from '../../utils/summaryList'
+import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 
 export default class ServiceUserDetailsPresenter {
   constructor(private readonly serviceUser: ServiceUser) {}
@@ -7,15 +7,15 @@ export default class ServiceUserDetailsPresenter {
   readonly title = `${this.serviceUser.firstName || 'Service user'}'s information`
 
   readonly summary: SummaryListItem[] = [
-    { key: 'CRN', lines: [this.serviceUser.crn], isList: false },
-    { key: 'Title', lines: [this.serviceUser.title ?? ''], isList: false },
-    { key: 'First name', lines: [this.serviceUser.firstName ?? ''], isList: false },
-    { key: 'Last name', lines: [this.serviceUser.lastName ?? ''], isList: false },
-    { key: 'Date of birth', lines: [this.serviceUser.dateOfBirth ?? ''], isList: false },
-    { key: 'Gender', lines: [this.serviceUser.gender ?? ''], isList: false },
-    { key: 'Ethnicity', lines: [this.serviceUser.ethnicity ?? ''], isList: false },
-    { key: 'Preferred language', lines: [this.serviceUser.preferredLanguage ?? ''], isList: false },
-    { key: 'Religion or belief', lines: [this.serviceUser.religionOrBelief ?? ''], isList: false },
-    { key: 'Disabilities', lines: this.serviceUser.disabilities ?? [], isList: true },
+    { key: 'CRN', lines: [this.serviceUser.crn] },
+    { key: 'Title', lines: [this.serviceUser.title ?? ''] },
+    { key: 'First name', lines: [this.serviceUser.firstName ?? ''] },
+    { key: 'Last name', lines: [this.serviceUser.lastName ?? ''] },
+    { key: 'Date of birth', lines: [this.serviceUser.dateOfBirth ?? ''] },
+    { key: 'Gender', lines: [this.serviceUser.gender ?? ''] },
+    { key: 'Ethnicity', lines: [this.serviceUser.ethnicity ?? ''] },
+    { key: 'Preferred language', lines: [this.serviceUser.preferredLanguage ?? ''] },
+    { key: 'Religion or belief', lines: [this.serviceUser.religionOrBelief ?? ''] },
+    { key: 'Disabilities', lines: this.serviceUser.disabilities ?? [], listStyle: ListStyle.noMarkers },
   ]
 }

--- a/server/routes/serviceProviderReferrals/actionPlanConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/actionPlanConfirmationPresenter.test.ts
@@ -23,16 +23,14 @@ describe(ActionPlanConfirmationPresenter, () => {
       const presenter = new ActionPlanConfirmationPresenter(sentReferral, serviceCategory)
 
       expect(presenter.summary).toEqual([
-        { key: 'Name', lines: ['Johnny Davis'], isList: false },
+        { key: 'Name', lines: ['Johnny Davis'] },
         {
           key: 'Referral number',
           lines: ['CEF345'],
-          isList: false,
         },
         {
           key: 'Service type',
           lines: ['Social inclusion'],
-          isList: false,
         },
       ])
     })

--- a/server/routes/serviceProviderReferrals/actionPlanConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/actionPlanConfirmationPresenter.ts
@@ -18,17 +18,14 @@ export default class ActionPlanConfirmationPresenter {
     {
       key: 'Name',
       lines: [PresenterUtils.fullName(this.sentReferral.referral.serviceUser)],
-      isList: false,
     },
     {
       key: 'Referral number',
       lines: [this.sentReferral.referenceNumber],
-      isList: false,
     },
     {
       key: 'Service type',
       lines: [utils.convertToProperCase(this.serviceCategory.name)],
-      isList: false,
     },
   ]
 }

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.test.ts
@@ -30,22 +30,18 @@ describe(AssignmentConfirmationPresenter, () => {
           {
             key: 'Name',
             lines: ['Johnny Davis'],
-            isList: false,
           },
           {
             key: 'Referral number',
             lines: ['CEF345'],
-            isList: false,
           },
           {
             key: 'Service type',
             lines: ['Social inclusion'],
-            isList: false,
           },
           {
             key: 'Assigned to',
             lines: ['Bernard Beaks'],
-            isList: false,
           },
         ])
       })
@@ -65,22 +61,18 @@ describe(AssignmentConfirmationPresenter, () => {
           {
             key: 'Name',
             lines: ['Johnny Davis'],
-            isList: false,
           },
           {
             key: 'Referral number',
             lines: ['CEF345'],
-            isList: false,
           },
           {
             key: 'Service type',
             lines: ['Social inclusion'],
-            isList: false,
           },
           {
             key: 'Assigned to',
             lines: ['Bernard '],
-            isList: false,
           },
         ])
       })
@@ -100,22 +92,18 @@ describe(AssignmentConfirmationPresenter, () => {
           {
             key: 'Name',
             lines: ['Johnny Davis'],
-            isList: false,
           },
           {
             key: 'Referral number',
             lines: ['CEF345'],
-            isList: false,
           },
           {
             key: 'Service type',
             lines: ['Social inclusion'],
-            isList: false,
           },
           {
             key: 'Assigned to',
             lines: [' Beaks'],
-            isList: false,
           },
         ])
       })
@@ -135,22 +123,18 @@ describe(AssignmentConfirmationPresenter, () => {
           {
             key: 'Name',
             lines: ['Johnny Davis'],
-            isList: false,
           },
           {
             key: 'Referral number',
             lines: ['CEF345'],
-            isList: false,
           },
           {
             key: 'Service type',
             lines: ['Social inclusion'],
-            isList: false,
           },
           {
             key: 'Assigned to',
             lines: [''],
-            isList: false,
           },
         ])
       })

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
@@ -18,22 +18,18 @@ export default class AssignmentConfirmationPresenter {
     {
       key: 'Name',
       lines: [PresenterUtils.fullName(this.sentReferral.referral.serviceUser)],
-      isList: false,
     },
     {
       key: 'Referral number',
       lines: [this.sentReferral.referenceNumber],
-      isList: false,
     },
     {
       key: 'Service type',
       lines: [utils.convertToProperCase(this.serviceCategory.name)],
-      isList: false,
     },
     {
       key: 'Assigned to',
       lines: [PresenterUtils.fullName(this.assignee)],
-      isList: false,
     },
   ]
 }

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
@@ -21,8 +21,8 @@ describe(CheckAssignmentPresenter, () => {
         const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', serviceCategory)
 
         expect(presenter.summary).toEqual([
-          { key: 'Name', lines: ['John Smith'], isList: false },
-          { key: 'Email address', lines: ['john@harmonyliving.org.uk'], isList: false },
+          { key: 'Name', lines: ['John Smith'] },
+          { key: 'Email address', lines: ['john@harmonyliving.org.uk'] },
         ])
       })
     })
@@ -34,8 +34,8 @@ describe(CheckAssignmentPresenter, () => {
         const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', serviceCategory)
 
         expect(presenter.summary).toEqual([
-          { key: 'Name', lines: ['John '], isList: false },
-          { key: 'Email address', lines: ['john@harmonyliving.org.uk'], isList: false },
+          { key: 'Name', lines: ['John '] },
+          { key: 'Email address', lines: ['john@harmonyliving.org.uk'] },
         ])
       })
     })
@@ -47,8 +47,8 @@ describe(CheckAssignmentPresenter, () => {
         const presenter = new CheckAssignmentPresenter('', user, 'smith@harmonyliving.org.uk', serviceCategory)
 
         expect(presenter.summary).toEqual([
-          { key: 'Name', lines: [' Smith'], isList: false },
-          { key: 'Email address', lines: ['smith@harmonyliving.org.uk'], isList: false },
+          { key: 'Name', lines: [' Smith'] },
+          { key: 'Email address', lines: ['smith@harmonyliving.org.uk'] },
         ])
       })
     })
@@ -60,8 +60,8 @@ describe(CheckAssignmentPresenter, () => {
         const presenter = new CheckAssignmentPresenter('', user, 'unknown@harmonyliving.org.uk', serviceCategory)
 
         expect(presenter.summary).toEqual([
-          { key: 'Name', lines: [''], isList: false },
-          { key: 'Email address', lines: ['unknown@harmonyliving.org.uk'], isList: false },
+          { key: 'Name', lines: [''] },
+          { key: 'Email address', lines: ['unknown@harmonyliving.org.uk'] },
         ])
       })
     })

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
@@ -16,8 +16,8 @@ export default class CheckAssignmentPresenter {
   }
 
   readonly summary: SummaryListItem[] = [
-    { key: 'Name', lines: [PresenterUtils.fullName(this.assignee)], isList: false },
-    { key: 'Email address', lines: [this.email], isList: false },
+    { key: 'Name', lines: [PresenterUtils.fullName(this.assignee)] },
+    { key: 'Email address', lines: [this.email] },
   ]
 
   readonly hiddenFields = {

--- a/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.test.ts
@@ -23,16 +23,14 @@ describe(EndOfServiceReportConfirmationPresenter, () => {
       const presenter = new EndOfServiceReportConfirmationPresenter(sentReferral, serviceCategory)
 
       expect(presenter.summary).toEqual([
-        { key: 'Name', lines: ['Johnny Davis'], isList: false },
+        { key: 'Name', lines: ['Johnny Davis'] },
         {
           key: 'Referral number',
           lines: ['CEF345'],
-          isList: false,
         },
         {
           key: 'Service type',
           lines: ['Social inclusion'],
-          isList: false,
         },
       ])
     })

--- a/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.ts
@@ -13,17 +13,14 @@ export default class EndOfServiceReportConfirmationPresenter {
     {
       key: 'Name',
       lines: [PresenterUtils.fullName(this.referral.referral.serviceUser)],
-      isList: false,
     },
     {
       key: 'Referral number',
       lines: [this.referral.referenceNumber],
-      isList: false,
     },
     {
       key: 'Service type',
       lines: [utils.convertToProperCase(this.serviceCategory.name)],
-      isList: false,
     },
   ]
 }

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.test.ts
@@ -31,12 +31,10 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
         {
           key: 'Date',
           lines: ['01 Feb 2021'],
-          isList: false,
         },
         {
           key: 'Time',
           lines: ['13:00'],
-          isList: false,
         },
       ])
     })

--- a/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionAttendanceFeedbackPresenter.ts
@@ -27,12 +27,10 @@ export default class PostSessionAttendanceFeedbackPresenter {
     {
       key: 'Date',
       lines: [DateUtils.getDateStringFromDateTimeString(this.appointment.appointmentTime)],
-      isList: false,
     },
     {
       key: 'Time',
       lines: [DateUtils.getTimeStringFromDateTimeString(this.appointment.appointmentTime)],
-      isList: false,
     },
   ]
 

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.test.ts
@@ -44,12 +44,10 @@ describe(PostSessionFeedbackCheckAnswersPresenter, () => {
         {
           key: 'Date',
           lines: ['01 Feb 2021'],
-          isList: false,
         },
         {
           key: 'Time',
           lines: ['13:00'],
-          isList: false,
         },
       ])
     })

--- a/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/serviceProviderReferrals/postSessionFeedbackCheckAnswersPresenter.ts
@@ -25,12 +25,10 @@ export default class PostSessionFeedbackCheckAnswersPresenter {
     {
       key: 'Date',
       lines: [DateUtils.getDateStringFromDateTimeString(this.appointment.appointmentTime)],
-      isList: false,
     },
     {
       key: 'Time',
       lines: [DateUtils.getTimeStringFromDateTimeString(this.appointment.appointmentTime)],
-      isList: false,
     },
   ]
 }

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -3,6 +3,7 @@ import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import deliusUserFactory from '../../../testutils/factories/deliusUser'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
+import { ListStyle } from '../../utils/summaryList'
 
 describe(ShowReferralPresenter, () => {
   const serviceCategory = serviceCategoryFactory.build({
@@ -104,8 +105,8 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, null, null)
 
       expect(presenter.probationPractitionerDetails).toEqual([
-        { isList: false, key: 'Name', lines: ['Bernard Beaks'] },
-        { isList: false, key: 'Email address', lines: ['bernard.beaks@justice.gov.uk'] },
+        { key: 'Name', lines: ['Bernard Beaks'] },
+        { key: 'Email address', lines: ['bernard.beaks@justice.gov.uk'] },
       ])
     })
   })
@@ -157,14 +158,14 @@ describe(ShowReferralPresenter, () => {
         )
 
         expect(presenter.interventionDetails).toEqual([
-          { key: 'Sentence information', lines: ['Not currently set'], isList: false },
+          { key: 'Sentence information', lines: ['Not currently set'] },
           {
             key: 'Desired outcomes',
             lines: [
               'Service User makes progress in obtaining accommodation',
               'Service User is helped to secure social or supported housing',
             ],
-            isList: true,
+            listStyle: ListStyle.noMarkers,
           },
           {
             key: 'Complexity level',
@@ -172,18 +173,15 @@ describe(ShowReferralPresenter, () => {
               'Low complexity',
               'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
             ],
-            isList: false,
           },
-          { key: 'Date to be completed by', lines: ['1 April 2021'], isList: false },
+          { key: 'Date to be completed by', lines: ['1 April 2021'] },
           {
             key: 'Maximum number of enforceable days',
             lines: ['10'],
-            isList: false,
           },
           {
             key: 'Further information for the provider',
             lines: ['Some information about the service user'],
-            isList: false,
           },
         ])
       })
@@ -235,14 +233,14 @@ describe(ShowReferralPresenter, () => {
         )
 
         expect(presenter.interventionDetails).toEqual([
-          { key: 'Sentence information', lines: ['Not currently set'], isList: false },
+          { key: 'Sentence information', lines: ['Not currently set'] },
           {
             key: 'Desired outcomes',
             lines: [
               'Service User makes progress in obtaining accommodation',
               'Service User is helped to secure social or supported housing',
             ],
-            isList: true,
+            listStyle: ListStyle.noMarkers,
           },
           {
             key: 'Complexity level',
@@ -250,18 +248,15 @@ describe(ShowReferralPresenter, () => {
               'Low complexity',
               'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
             ],
-            isList: false,
           },
-          { key: 'Date to be completed by', lines: ['1 April 2021'], isList: false },
+          { key: 'Date to be completed by', lines: ['1 April 2021'] },
           {
             key: 'Maximum number of enforceable days',
             lines: ['N/A'],
-            isList: false,
           },
           {
             key: 'Further information for the provider',
             lines: ['N/A'],
-            isList: false,
           },
         ])
       })
@@ -274,16 +269,20 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, null, null)
 
       expect(presenter.serviceUserDetails).toEqual([
-        { key: 'CRN', lines: [sentReferral.referral.serviceUser.crn], isList: false },
-        { key: 'Title', lines: [sentReferral.referral.serviceUser.title], isList: false },
-        { key: 'First name', lines: [sentReferral.referral.serviceUser.firstName], isList: false },
-        { key: 'Last name', lines: [sentReferral.referral.serviceUser.lastName], isList: false },
-        { key: 'Date of birth', lines: [sentReferral.referral.serviceUser.dateOfBirth], isList: false },
-        { key: 'Gender', lines: [sentReferral.referral.serviceUser.gender], isList: false },
-        { key: 'Ethnicity', lines: [sentReferral.referral.serviceUser.ethnicity], isList: false },
-        { key: 'Preferred language', lines: [sentReferral.referral.serviceUser.preferredLanguage], isList: false },
-        { key: 'Religion or belief', lines: [sentReferral.referral.serviceUser.religionOrBelief], isList: false },
-        { key: 'Disabilities', lines: sentReferral.referral.serviceUser.disabilities || [], isList: true },
+        { key: 'CRN', lines: [sentReferral.referral.serviceUser.crn] },
+        { key: 'Title', lines: [sentReferral.referral.serviceUser.title] },
+        { key: 'First name', lines: [sentReferral.referral.serviceUser.firstName] },
+        { key: 'Last name', lines: [sentReferral.referral.serviceUser.lastName] },
+        { key: 'Date of birth', lines: [sentReferral.referral.serviceUser.dateOfBirth] },
+        { key: 'Gender', lines: [sentReferral.referral.serviceUser.gender] },
+        { key: 'Ethnicity', lines: [sentReferral.referral.serviceUser.ethnicity] },
+        { key: 'Preferred language', lines: [sentReferral.referral.serviceUser.preferredLanguage] },
+        { key: 'Religion or belief', lines: [sentReferral.referral.serviceUser.religionOrBelief] },
+        {
+          key: 'Disabilities',
+          lines: sentReferral.referral.serviceUser.disabilities || [],
+          listStyle: ListStyle.noMarkers,
+        },
       ])
     })
   })
@@ -294,11 +293,11 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, null, null)
 
       expect(presenter.serviceUserRisks).toEqual([
-        { key: 'Risk to known adult', lines: ['Medium'], isList: false },
-        { key: 'Risk to public', lines: ['Low'], isList: false },
-        { key: 'Risk to children', lines: ['Low'], isList: false },
-        { key: 'Risk to staff', lines: ['Low'], isList: false },
-        { key: 'Additional risk information', lines: [sentReferral.referral.additionalRiskInformation], isList: false },
+        { key: 'Risk to known adult', lines: ['Medium'] },
+        { key: 'Risk to public', lines: ['Low'] },
+        { key: 'Risk to children', lines: ['Low'] },
+        { key: 'Risk to staff', lines: ['Low'] },
+        { key: 'Additional risk information', lines: [sentReferral.referral.additionalRiskInformation] },
       ])
     })
   })
@@ -350,33 +349,32 @@ describe(ShowReferralPresenter, () => {
         )
 
         expect(presenter.serviceUserNeeds).toEqual([
-          { key: 'Criminogenic needs', lines: ['Thinking and attitudes', 'Accommodation'], isList: true },
+          {
+            key: 'Criminogenic needs',
+            lines: ['Thinking and attitudes', 'Accommodation'],
+            listStyle: ListStyle.noMarkers,
+          },
           {
             key: 'Identify needs',
             lines: ["Alex is currently sleeping on her aunt's sofa"],
-            isList: false,
           },
           {
             key: 'Other mobility, disability or accessibility needs',
             lines: ['She uses a wheelchair'],
-            isList: false,
           },
-          { key: 'Interpreter required', lines: ['Yes'], isList: false },
-          { key: 'Interpreter language', lines: ['Spanish'], isList: false },
+          { key: 'Interpreter required', lines: ['Yes'] },
+          { key: 'Interpreter language', lines: ['Spanish'] },
           {
             key: 'Primary language',
             lines: ['Catalan'],
-            isList: false,
           },
           {
             key: 'Caring or employment responsibilities',
             lines: ['Yes'],
-            isList: false,
           },
           {
             key: `Provide details of when Alex will not be able to attend sessions`,
             lines: ['She works Mondays 9am - midday'],
-            isList: false,
           },
         ])
       })
@@ -428,33 +426,32 @@ describe(ShowReferralPresenter, () => {
         )
 
         expect(presenter.serviceUserNeeds).toEqual([
-          { key: 'Criminogenic needs', lines: ['Thinking and attitudes', 'Accommodation'], isList: true },
+          {
+            key: 'Criminogenic needs',
+            lines: ['Thinking and attitudes', 'Accommodation'],
+            listStyle: ListStyle.noMarkers,
+          },
           {
             key: 'Identify needs',
             lines: ['N/A'],
-            isList: false,
           },
           {
             key: 'Other mobility, disability or accessibility needs',
             lines: ['N/A'],
-            isList: false,
           },
-          { key: 'Interpreter required', lines: ['No'], isList: false },
-          { key: 'Interpreter language', lines: ['N/A'], isList: false },
+          { key: 'Interpreter required', lines: ['No'] },
+          { key: 'Interpreter language', lines: ['N/A'] },
           {
             key: 'Primary language',
             lines: ['English'],
-            isList: false,
           },
           {
             key: 'Caring or employment responsibilities',
             lines: ['No'],
-            isList: false,
           },
           {
             key: `Provide details of when Alex will not be able to attend sessions`,
             lines: ['N/A'],
-            isList: false,
           },
         ])
       })

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -1,7 +1,7 @@
 import SentReferral from '../../models/sentReferral'
 import ServiceCategory from '../../models/serviceCategory'
 import DeliusUser from '../../models/delius/deliusUser'
-import { SummaryListItem } from '../../utils/summaryList'
+import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
 import PresenterUtils from '../../utils/presenterUtils'
 import ServiceUserDetailsPresenter from '../referrals/serviceUserDetailsPresenter'
@@ -35,8 +35,8 @@ export default class ShowReferralPresenter {
   }
 
   readonly probationPractitionerDetails: SummaryListItem[] = [
-    { key: 'Name', lines: [`${this.sentBy.firstName} ${this.sentBy.surname}`], isList: false },
-    { key: 'Email address', lines: [this.sentBy.email ?? ''], isList: false },
+    { key: 'Name', lines: [`${this.sentBy.firstName} ${this.sentBy.surname}`] },
+    { key: 'Email address', lines: [this.sentBy.email ?? ''] },
   ]
 
   get interventionDetails(): SummaryListItem[] {
@@ -54,23 +54,20 @@ export default class ShowReferralPresenter {
     }
 
     return [
-      { key: 'Sentence information', lines: ['Not currently set'], isList: false },
-      { key: 'Desired outcomes', lines: selectedDesiredOutcomes, isList: true },
-      { key: 'Complexity level', lines: [complexityLevelText.level, complexityLevelText.text], isList: false },
+      { key: 'Sentence information', lines: ['Not currently set'] },
+      { key: 'Desired outcomes', lines: selectedDesiredOutcomes, listStyle: ListStyle.noMarkers },
+      { key: 'Complexity level', lines: [complexityLevelText.level, complexityLevelText.text] },
       {
         key: 'Date to be completed by',
         lines: [PresenterUtils.govukFormattedDateFromStringOrNull(this.sentReferral.referral.completionDeadline)],
-        isList: false,
       },
       {
         key: 'Maximum number of enforceable days',
         lines: [this.sentReferral.referral.usingRarDays ? String(this.sentReferral.referral.maximumRarDays) : 'N/A'],
-        isList: false,
       },
       {
         key: 'Further information for the provider',
         lines: [this.sentReferral.referral.furtherInformation || 'N/A'],
-        isList: false,
       },
     ]
   }
@@ -81,51 +78,44 @@ export default class ShowReferralPresenter {
 
   get serviceUserRisks(): SummaryListItem[] {
     return [
-      { key: 'Risk to known adult', lines: ['Medium'], isList: false },
-      { key: 'Risk to public', lines: ['Low'], isList: false },
-      { key: 'Risk to children', lines: ['Low'], isList: false },
-      { key: 'Risk to staff', lines: ['Low'], isList: false },
+      { key: 'Risk to known adult', lines: ['Medium'] },
+      { key: 'Risk to public', lines: ['Low'] },
+      { key: 'Risk to children', lines: ['Low'] },
+      { key: 'Risk to staff', lines: ['Low'] },
       {
         key: 'Additional risk information',
         lines: [this.sentReferral.referral.additionalRiskInformation],
-        isList: false,
       },
     ]
   }
 
   get serviceUserNeeds(): SummaryListItem[] {
     return [
-      { key: 'Criminogenic needs', lines: ['Thinking and attitudes', 'Accommodation'], isList: true },
+      { key: 'Criminogenic needs', lines: ['Thinking and attitudes', 'Accommodation'], listStyle: ListStyle.noMarkers },
       {
         key: 'Identify needs',
         lines: [this.sentReferral.referral.additionalNeedsInformation || 'N/A'],
-        isList: false,
       },
       {
         key: 'Other mobility, disability or accessibility needs',
         lines: [this.sentReferral.referral.accessibilityNeeds || 'N/A'],
-        isList: false,
       },
       {
         key: 'Interpreter required',
         lines: [this.sentReferral.referral.needsInterpreter ? 'Yes' : 'No'],
-        isList: false,
       },
-      { key: 'Interpreter language', lines: [this.sentReferral.referral.interpreterLanguage || 'N/A'], isList: false },
+      { key: 'Interpreter language', lines: [this.sentReferral.referral.interpreterLanguage || 'N/A'] },
       {
         key: 'Primary language',
         lines: [this.sentReferral.referral.serviceUser.preferredLanguage || 'N/A'],
-        isList: false,
       },
       {
         key: 'Caring or employment responsibilities',
         lines: [this.sentReferral.referral.hasAdditionalResponsibilities ? 'Yes' : 'No'],
-        isList: false,
       },
       {
         key: `Provide details of when ${this.sentReferral.referral.serviceUser.firstName} will not be able to attend sessions`,
         lines: [this.sentReferral.referral.whenUnavailable || 'N/A'],
-        isList: false,
       },
     ]
   }

--- a/server/routes/shared/endOfServiceReportAnswersPresenter.test.ts
+++ b/server/routes/shared/endOfServiceReportAnswersPresenter.test.ts
@@ -39,7 +39,6 @@ describe(EndOfServiceReportAnswersPresenter, () => {
 
       expect(presenter.interventionSummary).toEqual([
         {
-          isList: false,
           key: 'Service user’s name',
           lines: ['Alex River'],
         },

--- a/server/routes/shared/endOfServiceReportAnswersPresenter.ts
+++ b/server/routes/shared/endOfServiceReportAnswersPresenter.ts
@@ -26,7 +26,7 @@ export default class EndOfServiceReportAnswersPresenter {
 
   readonly interventionSummary: SummaryListItem[] = [
     // TODO IC-1322 Populate this fully
-    { key: 'Service user’s name', lines: [PresenterUtils.fullName(this.referral.referral.serviceUser)], isList: false },
+    { key: 'Service user’s name', lines: [PresenterUtils.fullName(this.referral.referral.serviceUser)] },
   ]
 
   readonly outcomes: OutcomePresenter[] = this.referral.referral.desiredOutcomesIds.map((desiredOutcomeId, index) => {

--- a/server/routes/shared/submittedPostSessionFeedbackPresenter.test.ts
+++ b/server/routes/shared/submittedPostSessionFeedbackPresenter.test.ts
@@ -36,17 +36,14 @@ describe(SubmittedPostSessionFeedbackPresenter, () => {
           {
             key: 'Caseworker',
             lines: ['Kay.Swerker'],
-            isList: false,
           },
           {
             key: 'Date',
             lines: ['01 Feb 2021'],
-            isList: false,
           },
           {
             key: 'Time',
             lines: ['13:00'],
-            isList: false,
           },
         ])
       })
@@ -64,12 +61,10 @@ describe(SubmittedPostSessionFeedbackPresenter, () => {
           {
             key: 'Date',
             lines: ['01 Feb 2021'],
-            isList: false,
           },
           {
             key: 'Time',
             lines: ['13:00'],
-            isList: false,
           },
         ])
       })

--- a/server/routes/shared/submittedPostSessionFeedbackPresenter.ts
+++ b/server/routes/shared/submittedPostSessionFeedbackPresenter.ts
@@ -25,12 +25,10 @@ export default class SubmittedPostSessionFeedbackPresenter {
       {
         key: 'Date',
         lines: [DateUtils.getDateStringFromDateTimeString(this.appointment.appointmentTime)],
-        isList: false,
       },
       {
         key: 'Time',
         lines: [DateUtils.getTimeStringFromDateTimeString(this.appointment.appointmentTime)],
-        isList: false,
       },
     ]
 
@@ -39,7 +37,6 @@ export default class SubmittedPostSessionFeedbackPresenter {
         {
           key: 'Caseworker',
           lines: [this.assignedCaseworker.username],
-          isList: false,
         },
         ...dateAndTimeSummary,
       ]

--- a/server/utils/summaryList.ts
+++ b/server/utils/summaryList.ts
@@ -1,5 +1,10 @@
+export enum ListStyle {
+  noMarkers,
+  bulleted,
+}
+
 export interface SummaryListItem {
   key: string
   lines: string[]
-  isList: boolean
+  listStyle?: ListStyle
 }

--- a/server/utils/viewUtils.test.ts
+++ b/server/utils/viewUtils.test.ts
@@ -1,3 +1,4 @@
+import { ListStyle } from './summaryList'
 import ViewUtils from './viewUtils'
 
 describe('ViewUtils', () => {
@@ -66,9 +67,10 @@ describe('ViewUtils', () => {
     it('returns a summary list args object for passing to the govukSummaryList macro', () => {
       expect(
         ViewUtils.summaryListArgs([
-          { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], isList: true },
-          { key: 'Gender', lines: ['Male'], isList: false },
-          { key: 'Address', lines: ['Flat 2', '27 Test Walk', 'SY16 1AQ'], isList: false },
+          { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], listStyle: ListStyle.noMarkers },
+          { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], listStyle: ListStyle.bulleted },
+          { key: 'Gender', lines: ['Male'] },
+          { key: 'Address', lines: ['Flat 2', '27 Test Walk', 'SY16 1AQ'] },
         ])
       ).toEqual({
         rows: [
@@ -78,6 +80,14 @@ describe('ViewUtils', () => {
             },
             value: {
               html: `<ul class="govuk-list"><li>Accommodation</li>\n<li>Social inclusion</li></ul>`,
+            },
+          },
+          {
+            key: {
+              text: 'Needs',
+            },
+            value: {
+              html: `<ul class="govuk-list govuk-list--bullet"><li>Accommodation</li>\n<li>Social inclusion</li></ul>`,
             },
           },
           {
@@ -105,8 +115,8 @@ describe('ViewUtils', () => {
   it('escapes special characters passed iin', () => {
     expect(
       ViewUtils.summaryListArgs([
-        { key: 'Needs', lines: ['Accommodation&', 'Social inclusion'], isList: true },
-        { key: 'Address', lines: ['Flat 2', "27 St James's Road", 'SY16 1AQ'], isList: false },
+        { key: 'Needs', lines: ['Accommodation&', 'Social inclusion'], listStyle: ListStyle.noMarkers },
+        { key: 'Address', lines: ['Flat 2', "27 St James's Road", 'SY16 1AQ'] },
       ])
     ).toEqual({
       rows: [

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -1,5 +1,5 @@
 import * as nunjucks from 'nunjucks'
-import { SummaryListItem } from './summaryList'
+import { ListStyle, SummaryListItem } from './summaryList'
 import { ErrorSummaryArgs, SummaryListArgs, TableArgs } from './govukFrontendTypes'
 
 export type SortableTableHeaders = { text: string; sort: 'ascending' | 'descending' | 'none' }[]
@@ -40,8 +40,9 @@ export default class ViewUtils {
             text: item.key,
           },
           value: (() => {
-            if (item.isList) {
-              const html = `<ul class="govuk-list">${item.lines
+            if (item.listStyle !== undefined) {
+              const itemClass = `govuk-list${item.listStyle === ListStyle.bulleted ? ' govuk-list--bullet' : ''}`
+              const html = `<ul class="${itemClass}">${item.lines
                 .map(line => `<li>${ViewUtils.escape(line)}</li>`)
                 .join('\n')}</ul>`
               return { html }


### PR DESCRIPTION
## What does this pull request do?

Updates the Find journey to display multiple service categories for a cohort intervention.

## What is the intent behind these changes?

To allow probation practioners to discover cohort interventions.

## Screenshot (under "service type" and "service types")

![Screenshot 2021-05-12 at 14 31 31](https://user-images.githubusercontent.com/53756884/117991968-72c43800-b336-11eb-9c4d-965f8932af6b.png)
