### PR TITLE
Add serviceCategories property to GET /interventions

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1317,6 +1317,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           { id: 'merseyside', name: 'Merseyside' },
         ],
         serviceCategory: serviceCategoryFactory.build(),
+        serviceCategories: [serviceCategoryFactory.build()],
         serviceProvider: serviceProviderFactory.build(),
         eligibility: eligibilityFactory.allAdults().build(),
       }


### PR DESCRIPTION
## What does this pull request do?

Updates contracts to add the `serviceCategories` property to the response of `GET /interventions`.

I probably should have done this as part of b9af1b9, where I added it to the `GET /intervention/:id` response.

## What is the intent behind these changes?

To allow us to add service categories information on the intervention search results page.