### PR TITLE
IC-1604: Add page for selecting desired outcomes on cohort referrals

### DIFF
--- a/mocks.ts
+++ b/mocks.ts
@@ -113,14 +113,21 @@ export default async function setUpMocks(): Promise<void> {
   ])
   */
 
-  const accommodationServiceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-  const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+  const accommodationServiceCategory = serviceCategoryFactory.build({
+    name: 'accommodation',
+    id: '5fd9e664-0a73-4476-9f05-a330f556f34a',
+  })
+  const socialInclusionServiceCategory = serviceCategoryFactory.build({
+    name: 'social inclusion',
+    id: '62e042a7-c44f-4d82-a679-4f435167e44a',
+  })
   const intervention = interventionFactory.build({
     serviceCategories: [accommodationServiceCategory, socialInclusionServiceCategory],
   })
 
   const draftReferral = draftReferralFactory
-    .serviceCategorySelected()
+    .serviceCategorySelected(accommodationServiceCategory.id)
+    .serviceCategoriesSelected([accommodationServiceCategory.id, socialInclusionServiceCategory.id])
     .serviceUserDetailsSet()
     .build({
       id: '98a42c61-c30f-4beb-8062-04033c376e2d',
@@ -151,5 +158,11 @@ export default async function setUpMocks(): Promise<void> {
 
     interventionsMocks.stubGetIntervention(draftReferral.interventionId, intervention),
     interventionsMocks.stubGetDraftReferral(draftReferral.id, draftReferral),
+    [accommodationServiceCategory, socialInclusionServiceCategory].forEach(async serviceCategory => {
+      await interventionsMocks.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+      await interventionsMocks.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, serviceCategory.id, {
+        ...draftReferral,
+      })
+    }),
   ])
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -220,7 +220,10 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/:id/desired-outcomes', (req, res) => referralsController.viewDesiredOutcomes(req, res))
   post('/referrals/:id/desired-outcomes', (req, res) => referralsController.updateDesiredOutcomes(req, res))
   get('/referrals/:referralId/service-category/:serviceCategoryId/desired-outcomes', (req, res) =>
-    referralsController.viewCohortDesiredOutcomes(req, res)
+    referralsController.selectCohortDesiredOutcomes(req, res)
+  )
+  post('/referrals/:referralId/service-category/:serviceCategoryId/desired-outcomes', (req, res) =>
+    referralsController.selectCohortDesiredOutcomes(req, res)
   )
   get('/referrals/:id/needs-and-requirements', (req, res) => referralsController.viewNeedsAndRequirements(req, res))
   post('/referrals/:id/needs-and-requirements', (req, res) => referralsController.updateNeedsAndRequirements(req, res))

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -219,6 +219,9 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals/:id/relevant-sentence', (req, res) => referralsController.updateRelevantSentence(req, res))
   get('/referrals/:id/desired-outcomes', (req, res) => referralsController.viewDesiredOutcomes(req, res))
   post('/referrals/:id/desired-outcomes', (req, res) => referralsController.updateDesiredOutcomes(req, res))
+  get('/referrals/:referralId/service-category/:serviceCategoryId/desired-outcomes', (req, res) =>
+    referralsController.viewCohortDesiredOutcomes(req, res)
+  )
   get('/referrals/:id/needs-and-requirements', (req, res) => referralsController.viewNeedsAndRequirements(req, res))
   post('/referrals/:id/needs-and-requirements', (req, res) => referralsController.updateNeedsAndRequirements(req, res))
   get('/referrals/:id/risk-information', (req, res) => referralsController.viewRiskInformation(req, res))

--- a/server/routes/referrals/desiredOutcomesForm.test.ts
+++ b/server/routes/referrals/desiredOutcomesForm.test.ts
@@ -1,89 +1,36 @@
-import { Request } from 'express'
+import TestUtils from '../../../testutils/testUtils'
 import DesiredOutcomesForm from './desiredOutcomesForm'
 
 describe(DesiredOutcomesForm, () => {
-  describe('isValid', () => {
-    it('returns true when the desired-outcomes-ids property is present and not empty in the body', async () => {
-      const form = await DesiredOutcomesForm.createForm({
-        body: {
+  describe('data', () => {
+    describe('when desired outcomes ids are passed', () => {
+      it('returns params for update', async () => {
+        const request = TestUtils.createRequest({
           'desired-outcomes-ids': ['29843fdf-8b88-4b08-a0f9-dfbd3208fd2e', '43557c7a-c286-49c2-a994-d0a821295c7a'],
-        },
-      } as Request)
+        })
+        const data = await new DesiredOutcomesForm(request).data()
 
-      expect(form.isValid).toBe(true)
-    })
-
-    it('returns false when the desired-outcomes-ids property is absent in the body', async () => {
-      const form = await DesiredOutcomesForm.createForm({
-        body: {},
-      } as Request)
-
-      expect(form.isValid).toBe(false)
-    })
-
-    it('returns false when the desired-outcomes-ids property is null in the body', async () => {
-      const form = await DesiredOutcomesForm.createForm({
-        body: { 'desired-outcomes-ids': null },
-      } as Request)
-
-      expect(form.isValid).toBe(false)
-    })
-  })
-
-  describe('error', () => {
-    it('returns null when the desired-outcomes-ids property is present in the body', async () => {
-      const form = await DesiredOutcomesForm.createForm({
-        body: {
-          'desired-outcomes-ids': ['29843fdf-8b88-4b08-a0f9-dfbd3208fd2e', '43557c7a-c286-49c2-a994-d0a821295c7a'],
-        },
-      } as Request)
-
-      expect(form.error).toBe(null)
-    })
-
-    it('returns an error object when the desired-outcomes-ids property is absent in the body', async () => {
-      const form = await DesiredOutcomesForm.createForm({
-        body: {},
-      } as Request)
-
-      expect(form.error).toEqual({
-        errors: [
-          {
-            errorSummaryLinkedField: 'desired-outcomes-ids',
-            formFields: ['desired-outcomes-ids'],
-            message: 'Select desired outcomes',
-          },
-        ],
+        expect(data.paramsForUpdate?.desiredOutcomesIds).toEqual([
+          '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
+          '43557c7a-c286-49c2-a994-d0a821295c7a',
+        ])
       })
     })
 
-    it('returns an error object when the desired-outcomes-ids property is null in the body', async () => {
-      const form = await DesiredOutcomesForm.createForm({
-        body: { 'desired-outcomes-ids': null },
-      } as Request)
-
-      expect(form.error).toEqual({
-        errors: [
-          {
-            errorSummaryLinkedField: 'desired-outcomes-ids',
-            formFields: ['desired-outcomes-ids'],
-            message: 'Select desired outcomes',
+    describe('when desired outcomes ids are empty', () => {
+      it('returns an error', async () => {
+        const request = TestUtils.createRequest({
+          body: {
+            'desired-outcomes-ids': [],
           },
-        ],
-      })
-    })
-  })
+        })
+        const data = await new DesiredOutcomesForm(request).data()
 
-  describe('paramsForUpdate', () => {
-    it('returns the params to be sent to the backend, when the data in the body is valid', async () => {
-      const form = await DesiredOutcomesForm.createForm({
-        body: {
-          'desired-outcomes-ids': ['29843fdf-8b88-4b08-a0f9-dfbd3208fd2e', '43557c7a-c286-49c2-a994-d0a821295c7a'],
-        },
-      } as Request)
-
-      expect(form.paramsForUpdate).toEqual({
-        desiredOutcomesIds: ['29843fdf-8b88-4b08-a0f9-dfbd3208fd2e', '43557c7a-c286-49c2-a994-d0a821295c7a'],
+        expect(data.error?.errors).toContainEqual({
+          errorSummaryLinkedField: 'desired-outcomes-ids',
+          formFields: ['desired-outcomes-ids'],
+          message: 'Select desired outcomes',
+        })
       })
     })
   })

--- a/server/routes/referrals/desiredOutcomesForm.ts
+++ b/server/routes/referrals/desiredOutcomesForm.ts
@@ -9,6 +9,7 @@ import FormUtils from '../../utils/formUtils'
 export default class DesiredOutcomesForm {
   constructor(private readonly request: Request) {}
 
+  // TODO: return Partial<ReferralDesiredOutcomes> when we update the code for single-service referrals to use the new PATCH function.
   async data(): Promise<FormData<Partial<DraftReferral>>> {
     const validationResult = await FormUtils.runValidations({
       request: this.request,

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -992,6 +992,70 @@ describe('GET /referrals/:referralId/service-category/:service-category-id/desir
   })
 })
 
+describe('POST /referrals/:referralId/service-category/:service-category-id/desired-outcomes/', () => {
+  const desiredOutcomes = [
+    {
+      id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+      description:
+        'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+    },
+    {
+      id: '65924ac6-9724-455b-ad30-906936291421',
+      description: 'Service User makes progress in obtaining accommodation',
+    },
+    {
+      id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
+      description: 'Service User is helped to secure social or supported housing',
+    },
+    {
+      id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
+      description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+    },
+  ]
+
+  beforeEach(() => {
+    const serviceCategory = serviceCategoryFactory.build({ desiredOutcomes, name: 'social inclusion' })
+    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+  })
+
+  it('updates the referral on the backend and redirects to back to the form page', async () => {
+    await request(app)
+      .post('/referrals/1/service-category/b33c19d1-7414-4014-b543-e543e59c5b39/desired-outcomes')
+      .type('form')
+      .send({ 'desired-outcomes-ids[]': [desiredOutcomes[0].id, desiredOutcomes[1].id] })
+      .expect(302)
+      .expect('Location', '/referrals/1/form')
+
+    expect(interventionsService.setDesiredOutcomesForServiceCategory).toHaveBeenCalledWith('token', '1', {
+      serviceCategoryId: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+      desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id],
+    })
+  })
+
+  it('updates the referral on the backend and returns a 500 if the API call fails with a non-validation error', async () => {
+    interventionsService.setDesiredOutcomesForServiceCategory.mockRejectedValue({
+      message: 'Some backend error message',
+    })
+
+    await request(app)
+      .post('/referrals/1/service-category/b33c19d1-7414-4014-b543-e543e59c5b39/desired-outcomes')
+      .type('form')
+      .send({ 'desired-outcomes-ids[]': [desiredOutcomes[0].id, desiredOutcomes[1].id] })
+      .expect(500)
+      .expect(res => {
+        expect(res.text).toContain('Some backend error message')
+      })
+
+    expect(interventionsService.setDesiredOutcomesForServiceCategory).toHaveBeenCalledWith('token', '1', {
+      serviceCategoryId: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+      desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id],
+    })
+  })
+})
+
 describe('GET /referrals/:id/rar-days', () => {
   beforeEach(() => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -947,6 +947,51 @@ describe('POST /referrals/:id/desired-outcomes', () => {
   })
 })
 
+describe('GET /referrals/:referralId/service-category/:service-category-id/desired-outcomes', () => {
+  beforeEach(() => {
+    const socialInclusionServiceCategory = serviceCategoryFactory.build({
+      id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+      name: 'social inclusion',
+    })
+    const accommodationServiceCategory = serviceCategoryFactory.build({
+      id: 'd69b80d5-0005-4f08-b5d8-404999c9e843',
+      name: 'accommodation',
+    })
+
+    const referral = draftReferralFactory
+      .serviceCategoriesSelected([socialInclusionServiceCategory.id, accommodationServiceCategory.id])
+      .build()
+
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(socialInclusionServiceCategory)
+  })
+
+  it('renders a form page', async () => {
+    await request(app)
+      .get('/referrals/1/service-category/b33c19d1-7414-4014-b543-e543e59c5b39/desired-outcomes')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('What are the desired outcomes for the social inclusion service?')
+      })
+
+    expect(interventionsService.getServiceCategory.mock.calls[0]).toEqual([
+      'token',
+      'b33c19d1-7414-4014-b543-e543e59c5b39',
+    ])
+  })
+
+  it('renders an error when the request for a service category fails', async () => {
+    interventionsService.getServiceCategory.mockRejectedValue(new Error('Failed to get service category'))
+
+    await request(app)
+      .get('/referrals/1/service-category/b33c19d1-7414-4014-b543-e543e59c5b39/desired-outcomes')
+      .expect(500)
+      .expect(res => {
+        expect(res.text).toContain('Failed to get service category')
+      })
+  })
+})
+
 describe('GET /referrals/:id/rar-days', () => {
   beforeEach(() => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -430,25 +430,25 @@ export default class ReferralsController {
   }
 
   async updateDesiredOutcomes(req: Request, res: Response): Promise<void> {
-    const form = await DesiredOutcomesForm.createForm(req)
+    const data = await new DesiredOutcomesForm(req).data()
 
-    let error: FormValidationError | null = null
+    let formError: FormValidationError | null = null
 
-    if (form.isValid) {
+    if (!data.error) {
       try {
         await this.interventionsService.patchDraftReferral(
           res.locals.user.token.accessToken,
           req.params.id,
-          form.paramsForUpdate
+          data.paramsForUpdate
         )
       } catch (e) {
-        error = createFormValidationErrorOrRethrow(e)
+        formError = createFormValidationErrorOrRethrow(e)
       }
     } else {
-      error = form.error
+      formError = data.error
     }
 
-    if (!error) {
+    if (!formError) {
       res.redirect(`/referrals/${req.params.id}/complexity-level`)
     } else {
       const referral = await this.interventionsService.getDraftReferral(
@@ -465,7 +465,7 @@ export default class ReferralsController {
         this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
       ])
 
-      const presenter = new DesiredOutcomesPresenter(referral, serviceCategory, error, req.body)
+      const presenter = new DesiredOutcomesPresenter(referral, serviceCategory, formError, req.body)
       const view = new DesiredOutcomesView(presenter)
 
       res.status(400)

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -14,7 +14,6 @@ import ServiceCategory from '../models/serviceCategory'
 import ActionPlan, { ActionPlanAppointment, AppointmentAttendance, AppointmentBehaviour } from '../models/actionPlan'
 import DraftReferral from '../models/draftReferral'
 import SentReferral from '../models/sentReferral'
-import ReferralDesiredOutcomes from '../models/referralDesiredOutcomes'
 
 export type InterventionsServiceError = SanitisedError & { validationErrors?: InterventionsServiceValidationError[] }
 
@@ -157,7 +156,8 @@ export default class InterventionsService {
   async setDesiredOutcomesForServiceCategory(
     token: string,
     referralId: string,
-    desiredOutcomes: Partial<ReferralDesiredOutcomes>
+    // TODO: switch below to Partial<ReferralDesiredOutcomes> when we update the code for single-service referrals to use the new PATCH function.
+    desiredOutcomes: Partial<DraftReferral>
   ): Promise<DraftReferral> {
     const restClient = this.createRestClient(token)
 


### PR DESCRIPTION
## What does this pull request do?

Adds a page for selecting desired outcomes on cohort referrals.

This isn't currently linked to in the referral form, as there's going to be a bit of logic that will be covered in IC-1598 9 (once the complexity level page has also been added).

## What is the intent behind these changes?

To allow PPs to select desired outcomes for specific service categories on cohort referrals.

## Screenshot (mocked data - hence the wrong desired outcome text)

![image](https://user-images.githubusercontent.com/19826940/118002180-4a8d0700-b33f-11eb-83b1-c292013d9150.png)

