### PR TITLE
🐛 Include main script in the production build

### DIFF
--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -18,5 +18,5 @@
     "strict": true
   },
   "exclude": ["node_modules", "**/*.test.*", "**/testutils", "**/*mock*"],
-  "include": ["server/**/*.js", "server/**/*.ts"]
+  "include": ["server.ts", "server/**/*.js", "server/**/*.ts"]
 }


### PR DESCRIPTION


## What does this pull request do?

Previously missed in f28e6017d3749bdda1c1a0bdc9e6b3d3832ada94, resulting in:

**Error: Cannot find module '/app/dist/server.js'**:
```
$ kubectl get pods --namespace=hmpps-interventions-dev
NAME                                           READY   STATUS             RESTARTS   AGE
data-dictionary-67d9dfcbcf-bnht4               1/1     Running            0          21h
hmpps-interventions-service-69756c5c48-n5mzp   1/1     Running            0          21h
hmpps-interventions-service-69756c5c48-qb88r   1/1     Running            0          21h
hmpps-interventions-ui-5fdd94bb5b-cx6hm        0/1     CrashLoopBackOff   13         46m
hmpps-interventions-ui-5fdd94bb5b-w9xnk        0/1     CrashLoopBackOff   13         46m
hmpps-interventions-ui-6b5987bc58-c9z9g        1/1     Running            0          17h

$ kubectl logs hmpps-interventions-ui-5fdd94bb5b-cx6hm --namespace=hmpps-interventions-dev

> hmpps-interventions-ui@0.0.1 start /app
> node $NODE_OPTIONS dist/server.js

internal/modules/cjs/loader.js:888
  throw err;
  ^

Error: Cannot find module '/app/dist/server.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:885:15)
    at Function.Module._load (internal/modules/cjs/loader.js:730:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! hmpps-interventions-ui@0.0.1 start: `node $NODE_OPTIONS dist/server.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the hmpps-interventions-ui@0.0.1 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

## What is the intent behind these changes?

Fix deployment
