### PR TITLE
Move application security scan to be daily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,10 +117,6 @@ workflows:
       - build
       - integration_test
       - hmpps/helm_lint
-      - assemble
-      - appsec_scan:
-          requires: [assemble]
-          context: [veracode-credentials]
       - vulnerability_scan:
           name: vulnerability_scan_and_monitor
           monitor: true
@@ -206,6 +202,10 @@ workflows:
                 - main
     jobs:
       - hmpps/npm_security_audit
+      - assemble
+      - appsec_scan:
+          requires: [assemble]
+          context: [veracode-credentials]
       - vulnerability_scan:
           name: vulnerability_scan_and_monitor
           monitor: true


### PR DESCRIPTION
## What does this pull request do?

Move the Veracode scan to be daily

We are using a "policy scan", which is not meant to be ran concurrently and provider informational output. In short, not meant to be running on every commit

Once we have a "pipeline scan", we can integrate that into the PR checks

## What is the intent behind these changes?

Avoid concurrency failures like
```
[2021.05.13 10:42:09.156] * App not in state where new builds are allowed.
[2021.05.13 10:42:09.156] 
[2021.05.13 10:42:10.270] 
[2021.05.13 10:42:10.270] * A scan is in progress or has failed to complete successfully. Wait for the current scan to complete or delete the failed scan from the Veracode Platform and try again.
Exited with code exit status 2
CircleCI received exit code 2
```