### PR TITLE
IC-1605: Add contracts and method for setting complexity level per service category on cohort referrals

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -61,6 +61,10 @@ module.exports = on => {
       return interventionsService.stubSetDesiredOutcomesForServiceCategory(arg.referralId, arg.responseJson)
     },
 
+    stubSetComplexityLevelForServiceCategory: arg => {
+      return interventionsService.stubSetComplexityLevelForServiceCategory(arg.referralId, arg.responseJson)
+    },
+
     stubGetServiceCategory: arg => {
       return interventionsService.stubGetServiceCategory(arg.id, arg.responseJson)
     },

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -58,7 +58,7 @@ module.exports = on => {
     },
 
     stubSetDesiredOutcomesForServiceCategory: arg => {
-      return interventionsService.stubPatchDraftReferral(arg.referralId, arg.serviceCategoryId, arg.responseJson)
+      return interventionsService.stubSetDesiredOutcomesForServiceCategory(arg.referralId, arg.responseJson)
     },
 
     stubGetServiceCategory: arg => {

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -10,8 +10,8 @@ Cypress.Commands.add('stubPatchDraftReferral', (id, responseJson) => {
   cy.task('stubPatchDraftReferral', { id, responseJson })
 })
 
-Cypress.Commands.add('setDesiredOutcomesForServiceCategory', (referralId, serviceCategoryId, responseJson) => {
-  cy.task('stubPatchDraftReferral', { referralId, serviceCategoryId, responseJson })
+Cypress.Commands.add('setDesiredOutcomesForServiceCategory', (referralId, responseJson) => {
+  cy.task('stubSetDesiredOutcomesForServiceCategory', { referralId, responseJson })
 })
 
 Cypress.Commands.add('stubGetServiceCategory', (id, responseJson) => {

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -14,6 +14,10 @@ Cypress.Commands.add('setDesiredOutcomesForServiceCategory', (referralId, respon
   cy.task('stubSetDesiredOutcomesForServiceCategory', { referralId, responseJson })
 })
 
+Cypress.Commands.add('setComplexityLevelForServiceCategory', (referralId, responseJson) => {
+  cy.task('stubSetComplexityLevelForServiceCategory', { referralId, responseJson })
+})
+
 Cypress.Commands.add('stubGetServiceCategory', (id, responseJson) => {
   cy.task('stubGetServiceCategory', { id, responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -71,6 +71,25 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubSetComplexityLevelForServiceCategory = async (
+    referralId: string,
+    responseJson: Record<string, unknown>
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/draft-referral/${referralId}/complexity-levels`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
   stubGetServiceCategory = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -54,7 +54,6 @@ export default class InterventionsServiceMocks {
 
   stubSetDesiredOutcomesForServiceCategory = async (
     referralId: string,
-    serviceCategoryId: string,
     responseJson: Record<string, unknown>
   ): Promise<unknown> => {
     return this.wiremock.stubFor({

--- a/mocks.ts
+++ b/mocks.ts
@@ -160,7 +160,7 @@ export default async function setUpMocks(): Promise<void> {
     interventionsMocks.stubGetDraftReferral(draftReferral.id, draftReferral),
     [accommodationServiceCategory, socialInclusionServiceCategory].forEach(async serviceCategory => {
       await interventionsMocks.stubGetServiceCategory(serviceCategory.id, serviceCategory)
-      await interventionsMocks.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, serviceCategory.id, {
+      await interventionsMocks.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, {
         ...draftReferral,
       })
     }),

--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -1,3 +1,4 @@
+import ReferralComplexityLevel from './referralComplexityLevel'
 import ReferralDesiredOutcomes from './referralDesiredOutcomes'
 import ServiceProvider from './serviceProvider'
 import ServiceUser from './serviceUser'
@@ -11,7 +12,8 @@ export interface ReferralFields {
   interventionId: string
   serviceCategoryId: string
   serviceCategoryIds: string[]
-  complexityLevelId: string
+  complexityLevelId: string // deprecated in favour of complexityLevels
+  complexityLevels: ReferralComplexityLevel[]
   furtherInformation: string
   relevantSentenceId: number
   desiredOutcomesIds: string[] // deprecated in favour of desiredOutcomes

--- a/server/models/referralComplexityLevel.ts
+++ b/server/models/referralComplexityLevel.ts
@@ -1,0 +1,4 @@
+export default interface ReferralComplexityLevel {
+  serviceCategoryId: string
+  complexityLevelId: string
+}

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1144,10 +1144,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
           desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
         },
-        {
-          serviceCategoryId: '3c7d6bc9-540a-4aef-a3fe-dfdff7a3c124',
-          desiredOutcomesIds: ['263821e1-3ad1-44ee-8ec5-c1a925f7a828', '0694fcc9-833f-4756-8d93-28199c0ec58a'],
-        },
       ],
       additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
       accessibilityNeeds: 'She uses a wheelchair',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1009,6 +1009,56 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('setComplexityLevelForServiceCategory', () => {
+    it('returns the updated referral when selecting a complexity level on a cohort referral', async () => {
+      await provider.addInteraction({
+        state: `There is an existing draft cohort referral with ID of 06716f8e-f507-42d4-bdcc-44c90e18dbd7, and it has had multiple service categories selected`,
+        uponReceiving: 'a PATCH request to set the complexity level for a service category on a referral',
+        withRequest: {
+          method: 'PATCH',
+          path: `/draft-referral/06716f8e-f507-42d4-bdcc-44c90e18dbd7/complexity-level`,
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: {
+            serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+            complexityLevelId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: '06716f8e-f507-42d4-bdcc-44c90e18dbd7',
+            complexityLevels: Matchers.like([
+              {
+                serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+                complexityLevelId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+              },
+            ]),
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const referral = await interventionsService.setComplexityLevelForServiceCategory(
+        token,
+        '06716f8e-f507-42d4-bdcc-44c90e18dbd7',
+        {
+          serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+          complexityLevelId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+        }
+      )
+
+      expect(referral.id).toBe('06716f8e-f507-42d4-bdcc-44c90e18dbd7')
+      expect(referral.complexityLevels![0].serviceCategoryId).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
+      expect(referral.complexityLevels![0].complexityLevelId).toEqual('301ead30-30a4-4c7c-8296-2768abfb59b5')
+    })
+  })
+
   describe('getServiceCategory', () => {
     const complexityLevels = [
       {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -224,6 +224,46 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
     })
 
+    describe('for a cohort referral that has had a complexity level selected', () => {
+      it('returns a referral for the given ID, with the a complexity level selected', async () => {
+        await provider.addInteraction({
+          state: `There is an existing draft cohort referral with ID of 06716f8e-f507-42d4-bdcc-44c90e18dbd7, and it has had a complexity level selected for multiple service categories`,
+          uponReceiving: 'a request for that referral',
+          withRequest: {
+            method: 'GET',
+            path: '/draft-referral/06716f8e-f507-42d4-bdcc-44c90e18dbd7',
+            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like({
+              id: '06716f8e-f507-42d4-bdcc-44c90e18dbd7',
+              complexityLevels: [
+                {
+                  serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+                  complexityLevelId: 'c9a7744a-8e6f-45ac-b7be-a88fea39efc0',
+                },
+                {
+                  serviceCategoryId: '3c7d6bc9-540a-4aef-a3fe-dfdff7a3c124',
+                  complexityLevelId: 'c6943b29-45e4-413d-9c5a-e8c84bcf29ec',
+                },
+              ],
+            }),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        const referral = await interventionsService.getDraftReferral(token, '06716f8e-f507-42d4-bdcc-44c90e18dbd7')
+
+        expect(referral.id).toBe('06716f8e-f507-42d4-bdcc-44c90e18dbd7')
+        expect(referral.complexityLevels![0].serviceCategoryId).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
+        expect(referral.complexityLevels![0].complexityLevelId).toEqual('c9a7744a-8e6f-45ac-b7be-a88fea39efc0')
+
+        expect(referral.complexityLevels![1].serviceCategoryId).toEqual('3c7d6bc9-540a-4aef-a3fe-dfdff7a3c124')
+        expect(referral.complexityLevels![1].complexityLevelId).toEqual('c6943b29-45e4-413d-9c5a-e8c84bcf29ec')
+      })
+    })
+
     describe('for a referral that has had a service user selected', () => {
       beforeEach(async () => {
         await provider.addInteraction({
@@ -1166,6 +1206,12 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
       serviceCategoryIds: ['428ee70f-3001-4399-95a6-ad25eaaede16'],
       complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+      complexityLevels: [
+        {
+          serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+          complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+        },
+      ],
       furtherInformation: 'Some information about the service user',
       relevantSentenceId: 2600295124,
       desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -194,6 +194,36 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
     })
 
+    describe('for a single-service referral that has had a complexity level selected', () => {
+      beforeEach(async () => {
+        await provider.addInteraction({
+          state:
+            'There is an existing draft referral with ID of 037cc90b-beaa-4a32-9ab7-7f79136e1d27, and it has had a complexity level selected',
+          uponReceiving: 'a request for that referral',
+          withRequest: {
+            method: 'GET',
+            path: '/draft-referral/037cc90b-beaa-4a32-9ab7-7f79136e1d27',
+            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like({
+              id: '037cc90b-beaa-4a32-9ab7-7f79136e1d27',
+              complexityLevelId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+            }),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+      })
+
+      it('returns a referral for the given ID, with the desired outcomes selected', async () => {
+        const referral = await interventionsService.getDraftReferral(token, '037cc90b-beaa-4a32-9ab7-7f79136e1d27')
+
+        expect(referral.id).toBe('037cc90b-beaa-4a32-9ab7-7f79136e1d27')
+        expect(referral.complexityLevelId).toEqual('301ead30-30a4-4c7c-8296-2768abfb59b5')
+      })
+    })
+
     describe('for a referral that has had a service user selected', () => {
       beforeEach(async () => {
         await provider.addInteraction({

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -172,6 +172,25 @@ export default class InterventionsService {
     }
   }
 
+  async setComplexityLevelForServiceCategory(
+    token: string,
+    referralId: string,
+    // TODO: switch below to Partial<ReferralComplexityLevel> when we update the code for single-service referrals to use the new PATCH function.
+    complexityLevel: Partial<DraftReferral>
+  ): Promise<DraftReferral> {
+    const restClient = this.createRestClient(token)
+
+    try {
+      return (await restClient.patch({
+        path: `/draft-referral/${referralId}/complexity-level`,
+        headers: { Accept: 'application/json' },
+        data: complexityLevel,
+      })) as DraftReferral
+    } catch (e) {
+      throw this.createServiceError(e)
+    }
+  }
+
   async getServiceCategory(token: string, id: string): Promise<ServiceCategory> {
     const restClient = this.createRestClient(token)
 

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -122,6 +122,7 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   serviceCategoryId: null,
   serviceCategoryIds: [],
   complexityLevelId: null,
+  complexityLevels: null,
   furtherInformation: null,
   relevantSentenceId: null,
   desiredOutcomesIds: null,

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -17,6 +17,12 @@ const exampleReferralFields = () => {
     serviceCategoryId,
     serviceCategoryIds: [serviceCategoryId],
     complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+    complexityLevels: [
+      {
+        serviceCategoryId,
+        complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+      },
+    ],
     furtherInformation: 'Some information about the service user',
     relevantSentenceId: 2600295124,
     desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],


### PR DESCRIPTION
## What does this pull request do?

Adds contracts and method for setting complexity level per service category on cohort referrals.

## What is the intent behind these changes?

This change allows us to associate a complexity level with a given service category, like we do with Desired Outcomes, as now that cohort referrals have been brought into the mix, there's the possibility of a referral having multiple service categories selected on it.
