### PR TITLE
IC-1605: Add page for selecting complexity levels on Cohort referrals

### DIFF
--- a/mocks.ts
+++ b/mocks.ts
@@ -163,6 +163,9 @@ export default async function setUpMocks(): Promise<void> {
       await interventionsMocks.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, {
         ...draftReferral,
       })
+      await interventionsMocks.stubSetComplexityLevelForServiceCategory(draftReferral.id, {
+        ...draftReferral,
+      })
     }),
   ])
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -211,6 +211,9 @@ export default function routes(router: Router, services: Services): Router {
   post('/referrals/:id/service-categories', (req, res) => referralsController.updateServiceCategories(req, res))
   get('/referrals/:id/complexity-level', (req, res) => referralsController.viewComplexityLevel(req, res))
   post('/referrals/:id/complexity-level', (req, res) => referralsController.updateComplexityLevel(req, res))
+  get('/referrals/:referralId/service-category/:serviceCategoryId/complexity-level', (req, res) =>
+    referralsController.viewCohortComplexityLevel(req, res)
+  )
   get('/referrals/:id/completion-deadline', (req, res) => referralsController.viewCompletionDeadline(req, res))
   post('/referrals/:id/completion-deadline', (req, res) => referralsController.updateCompletionDeadline(req, res))
   get('/referrals/:id/further-information', (req, res) => referralsController.viewFurtherInformation(req, res))

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -214,6 +214,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/referrals/:referralId/service-category/:serviceCategoryId/complexity-level', (req, res) =>
     referralsController.viewCohortComplexityLevel(req, res)
   )
+  post('/referrals/:referralId/service-category/:serviceCategoryId/complexity-level', (req, res) =>
+    referralsController.updateCohortComplexityLevel(req, res)
+  )
   get('/referrals/:id/completion-deadline', (req, res) => referralsController.viewCompletionDeadline(req, res))
   post('/referrals/:id/completion-deadline', (req, res) => referralsController.updateCompletionDeadline(req, res))
   get('/referrals/:id/further-information', (req, res) => referralsController.viewFurtherInformation(req, res))

--- a/server/routes/referrals/complexityLevelForm.test.ts
+++ b/server/routes/referrals/complexityLevelForm.test.ts
@@ -1,82 +1,34 @@
-import { Request } from 'express'
+import TestUtils from '../../../testutils/testUtils'
 import ComplexityLevelForm from './complexityLevelForm'
 
 describe(ComplexityLevelForm, () => {
-  describe('isValid', () => {
-    it('returns true when the complexity-level-id property is present in the body', async () => {
-      const form = await ComplexityLevelForm.createForm({
-        body: { 'complexity-level-id': '43557c7a-c286-49c2-a994-d0a821295c7a' },
-      } as Request)
+  describe('data', () => {
+    describe('when a complexity level id is passed', () => {
+      it('returns params for update', async () => {
+        const request = TestUtils.createRequest({
+          'complexity-level-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
+        })
+        const data = await new ComplexityLevelForm(request).data()
 
-      expect(form.isValid).toBe(true)
-    })
-
-    it('returns false when the complexity-level-id property is absent in the body', async () => {
-      const form = await ComplexityLevelForm.createForm({
-        body: {},
-      } as Request)
-
-      expect(form.isValid).toBe(false)
-    })
-
-    it('returns false when the complexity-level-id property is null in the body', async () => {
-      const form = await ComplexityLevelForm.createForm({
-        body: { 'complexity-level-id': null },
-      } as Request)
-
-      expect(form.isValid).toBe(false)
-    })
-  })
-
-  describe('error', () => {
-    it('returns null when the complexity-level-id property is present in the body', async () => {
-      const form = await ComplexityLevelForm.createForm({
-        body: { 'complexity-level-id': '43557c7a-c286-49c2-a994-d0a821295c7a' },
-      } as Request)
-
-      expect(form.error).toBe(null)
-    })
-
-    it('returns an error object when the complexity-level-id property is absent in the body', async () => {
-      const form = await ComplexityLevelForm.createForm({
-        body: {},
-      } as Request)
-
-      expect(form.error).toEqual({
-        errors: [
-          {
-            errorSummaryLinkedField: 'complexity-level-id',
-            formFields: ['complexity-level-id'],
-            message: 'Select a complexity level',
-          },
-        ],
+        expect(data.paramsForUpdate?.complexityLevelId).toEqual('29843fdf-8b88-4b08-a0f9-dfbd3208fd2e')
       })
     })
 
-    it('returns an error object when the complexity-level-id property is null in the body', async () => {
-      const form = await ComplexityLevelForm.createForm({
-        body: { 'complexity-level-id': null },
-      } as Request)
-
-      expect(form.error).toEqual({
-        errors: [
-          {
-            errorSummaryLinkedField: 'complexity-level-id',
-            formFields: ['complexity-level-id'],
-            message: 'Select a complexity level',
+    describe('when complexity level id is empty', () => {
+      it('returns an error', async () => {
+        const request = TestUtils.createRequest({
+          body: {
+            complexityLevelId: '',
           },
-        ],
+        })
+        const data = await new ComplexityLevelForm(request).data()
+
+        expect(data.error?.errors).toContainEqual({
+          errorSummaryLinkedField: 'complexity-level-id',
+          formFields: ['complexity-level-id'],
+          message: 'Select a complexity level',
+        })
       })
-    })
-  })
-
-  describe('paramsForUpdate', () => {
-    it('returns the params to be sent to the backend, when the data in the body is valid', async () => {
-      const form = await ComplexityLevelForm.createForm({
-        body: { 'complexity-level-id': '43557c7a-c286-49c2-a994-d0a821295c7a' },
-      } as Request)
-
-      expect(form.paramsForUpdate).toEqual({ complexityLevelId: '43557c7a-c286-49c2-a994-d0a821295c7a' })
     })
   })
 })

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -629,6 +629,51 @@ describe('POST /referrals/:id/complexity-level', () => {
   })
 })
 
+describe('GET /referrals/:referralId/service-category/:service-category-id/complexity-level', () => {
+  beforeEach(() => {
+    const socialInclusionServiceCategory = serviceCategoryFactory.build({
+      id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+      name: 'social inclusion',
+    })
+    const accommodationServiceCategory = serviceCategoryFactory.build({
+      id: 'd69b80d5-0005-4f08-b5d8-404999c9e843',
+      name: 'accommodation',
+    })
+
+    const referral = draftReferralFactory
+      .serviceCategoriesSelected([socialInclusionServiceCategory.id, accommodationServiceCategory.id])
+      .build()
+
+    interventionsService.getDraftReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(socialInclusionServiceCategory)
+  })
+
+  it('renders a form page', async () => {
+    await request(app)
+      .get('/referrals/1/service-category/b33c19d1-7414-4014-b543-e543e59c5b39/complexity-level')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('What is the complexity level for the social inclusion service?')
+      })
+
+    expect(interventionsService.getServiceCategory).toHaveBeenCalledWith(
+      'token',
+      'b33c19d1-7414-4014-b543-e543e59c5b39'
+    )
+  })
+
+  it('renders an error when the request for a service category fails', async () => {
+    interventionsService.getServiceCategory.mockRejectedValue(new Error('Failed to get service category'))
+
+    await request(app)
+      .get('/referrals/1/service-category/b33c19d1-7414-4014-b543-e543e59c5b39/complexity-level')
+      .expect(500)
+      .expect(res => {
+        expect(res.text).toContain('Failed to get service category')
+      })
+  })
+})
+
 describe('GET /referrals/:id/further-information', () => {
   beforeEach(() => {
     const serviceCategory = serviceCategoryFactory.build()

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -244,25 +244,25 @@ export default class ReferralsController {
   }
 
   async updateComplexityLevel(req: Request, res: Response): Promise<void> {
-    const form = await ComplexityLevelForm.createForm(req)
+    const data = await new ComplexityLevelForm(req).data()
 
-    let error: FormValidationError | null = null
+    let formError: FormValidationError | null = null
 
-    if (form.isValid) {
+    if (!data.error) {
       try {
         await this.interventionsService.patchDraftReferral(
           res.locals.user.token.accessToken,
           req.params.id,
-          form.paramsForUpdate
+          data.paramsForUpdate
         )
       } catch (e) {
-        error = createFormValidationErrorOrRethrow(e)
+        formError = createFormValidationErrorOrRethrow(e)
       }
     } else {
-      error = form.error
+      formError = data.error
     }
 
-    if (!error) {
+    if (!formError) {
       res.redirect(`/referrals/${req.params.id}/completion-deadline`)
     } else {
       const referral = await this.interventionsService.getDraftReferral(
@@ -279,7 +279,7 @@ export default class ReferralsController {
         this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
       ])
 
-      const presenter = new ComplexityLevelPresenter(referral, serviceCategory, error, req.body)
+      const presenter = new ComplexityLevelPresenter(referral, serviceCategory, formError, req.body)
       const view = new ComplexityLevelView(presenter)
 
       res.status(400)


### PR DESCRIPTION
## Note: when reviewing, ignore commits before 32c38fa924, which are part of #300 

## What does this pull request do?

Adds a page for selecting complexity levels on cohort referrals.

This isn't currently linked to in the referral form, but that will come next.

We'll also use this to replace the existing page for selecting a complexity level on single-service referrals.

## What is the intent behind these changes?

To allow PPs to select complexity levels on Cohort Referrals

## Screenshot

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/19826940/118254149-ac19b680-b4a2-11eb-8184-d17d607db9a7.png">

