### PR TITLE
IC-1640: Added warning to SP user if the referral still needs to be c…

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -689,6 +689,26 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetServiceUserByCRN(crn, deliusServiceUser)
     })
     it('allows users to know if, when and why an intervention was cancelled', () => {
+      const endedReferral = sentReferralFactory
+        .endRequested()
+        .concluded()
+        .build({
+          ...referralParams,
+        })
+      cy.stubGetSentReferral(endedReferral.id, endedReferral)
+      cy.stubGetSentReferrals([endedReferral])
+      cy.login()
+      cy.visit(`/service-provider/referrals/${endedReferral.id}/progress`)
+      cy.contains('Intervention ended')
+      cy.contains(
+        'The probation practitioner ended this intervention on 28 Apr 2021 with reason: Service user was recalled'
+      )
+      cy.contains('Please note that an end of service report must still be submitted within 10 working days.').should(
+        'not.exist'
+      )
+      cy.contains("Additional information: you'll be seeing alex again soon i'm sure!")
+    })
+    it('allows users to know that they should still concluded non concluded but ended referrals', () => {
       const endedReferral = sentReferralFactory.endRequested().build({
         ...referralParams,
       })
@@ -696,11 +716,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetSentReferrals([endedReferral])
       cy.login()
       cy.visit(`/service-provider/referrals/${endedReferral.id}/progress`)
-      cy.contains('Intervention cancelled')
-      cy.contains(
-        'The probation practitioner cancelled this intervention on 28 Apr 2021 with reason: Service user was recalled'
-      )
-      cy.contains("Additional information: you'll be seeing alex again soon i'm sure!")
+      cy.contains('Please note that an end of service report must still be submitted within 10 working days.')
     })
     it('allows users to click through to a page to view session feedback', () => {
       const assignedReferral = sentReferralFactory.assigned().build({

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -22,6 +22,7 @@ describe(InterventionProgressPresenter, () => {
       expect(presenter.referralEnded).toEqual(false)
     })
   })
+
   describe('referralEndedFields', () => {
     it('returns ended fields when the referral has ended', () => {
       const referral = sentReferralFactory.endRequested().build()

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -70,6 +70,10 @@ export default class InterventionProgressPresenter {
     }
   }
 
+  get isConcluded(): boolean {
+    return this.referral.concludedAt !== null
+  }
+
   readonly hasSessions = this.actionPlanAppointments.length !== 0
 
   readonly sessionTableHeaders = ['Session details', 'Date and time', 'Status', 'Action']

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -16,13 +16,14 @@ export default class InterventionProgressView {
   get cancelledReferralNotificationBannerArgs(): NotificationBannerArgs {
     let cancellationReasonHTML = ''
     let cancellationCommentsHTML = ''
+    let notConcludedWarningHTML = ''
     if (this.presenter.referralEndedFields.endRequestedAt && this.presenter.referralEndedFields.endRequestedReason) {
       const formattedEndDate = DateUtils.getDateStringFromDateTimeString(
         this.presenter.referralEndedFields.endRequestedAt
       )
       cancellationReasonHTML = `
         <p>
-            The probation practitioner cancelled this intervention on ${formattedEndDate} 
+            The probation practitioner ended this intervention on ${formattedEndDate} 
             with reason: ${ViewUtils.escape(this.presenter.referralEndedFields.endRequestedReason)}.
         </p>`
     }
@@ -32,9 +33,15 @@ export default class InterventionProgressView {
             Additional information: ${ViewUtils.escape(this.presenter.referralEndedFields.endRequestedComments)}
         </p>`
     }
-    const html = `<div>${cancellationReasonHTML}${cancellationCommentsHTML}</div>`
+    if (!this.presenter.isConcluded) {
+      notConcludedWarningHTML = `
+            <p>
+                Please note that an end of service report must still be submitted within 10 working days.
+            </p>`
+    }
+    const html = `<div>${cancellationReasonHTML}${notConcludedWarningHTML}${cancellationCommentsHTML}</div>`
     return {
-      titleText: 'Intervention cancelled',
+      titleText: 'Intervention ended',
       html,
       classes: 'govuk-notification-banner--warning',
     }

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -84,6 +84,12 @@ class SentReferralFactory extends Factory<SentReferral> {
       endRequestedComments: "you'll be seeing alex again soon i'm sure!",
     })
   }
+
+  concluded() {
+    return this.endRequested().params({
+      concludedAt: '2021-04-28T20:45:21.986389Z',
+    })
+  }
 }
 
 export default SentReferralFactory.define(({ sequence }) => ({


### PR DESCRIPTION
…oncluded when it has ended

## What does this pull request do?

Adds a notification warning to the SP user if the referral has been ended but the referral has still to be concluded.
The additional message reads: "Please note that an end of service report must still be submitted within 10 working days."
In addition the wording of `cancelled` has been changed to `ended`.

![image](https://user-images.githubusercontent.com/83066216/118270218-a084ba80-b4b7-11eb-8b94-182251dc6b5e.png)


## What is the intent behind these changes?

To inform the SP user about the status of an ended referral