### PR TITLE
IC-1766: Tag pacts after deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,22 @@ jobs:
       - run: npm run scripts:typecheck
       - run: npm run lint
 
+  tag_pact_version:
+    environment:
+      PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
+      PACT_BROKER_USERNAME: "interventions"
+    executor: hmpps/node
+    parameters:
+      tag:
+        type: string
+    steps:
+      - run:
+          name: Tag contract version with deployment
+          command: |
+            npx --package='@pact-foundation/pact-node' pact-broker create-version-tag \
+              --pacticipant="Interventions UI" --version="$CIRCLE_SHA1" --tag="<< parameters.tag >>" \
+              --broker-base-url="$PACT_BROKER_BASE_URL" --broker-username="$PACT_BROKER_USERNAME" --broker-password="$PACT_BROKER_PASSWORD"
+
   assemble:
     executor:
       name: hmpps/node
@@ -161,6 +177,11 @@ workflows:
             - vulnerability_scan_and_monitor
           context:
             - hmpps-common-vars
+      - tag_pact_version:
+          name: "tag_pact_version_dev"
+          tag: "deployed:dev"
+          requires: [deploy_dev]
+          context: [hmpps-common-vars]
       - approve_research:
           type: approval
           requires:
@@ -191,6 +212,11 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-interventions-ui-preprod
+      - tag_pact_version:
+          name: "tag_pact_version_preprod"
+          tag: "deployed:preprod"
+          requires: [deploy_preprod]
+          context: [hmpps-common-vars]
       - hmpps/deploy_env:
           name: deploy_prod
           env: "prod"
@@ -202,6 +228,11 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-interventions-ui-prod
+      - tag_pact_version:
+          name: "tag_pact_version_prod"
+          tag: "deployed:prod"
+          requires: [deploy_prod]
+          context: [hmpps-common-vars]
 
   nightly:
     triggers:


### PR DESCRIPTION
## What does this pull request do?

Tag pacts after deploy. This will tag the "UI"'s git SHA with the `deployed:environment` tag

## What is the intent behind these changes?

Tagging contracts on deployments is [recommended][1] practice.

It enables us running verification against a specific deployed version of the contracts

[1]: https://docs.pact.io/pact_broker/tags#after-deploying-to-an-environment