### PR TITLE
IC-1541: Display user-facing error when trying to set a conflicting time & date for an appointment

### DIFF
--- a/server/routes/serviceProviderReferrals/editSessionPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/editSessionPresenter.test.ts
@@ -11,6 +11,76 @@ describe(EditSessionPresenter, () => {
     })
   })
 
+  describe('errorSummary', () => {
+    describe('when a server error is passed in', () => {
+      it('displays the message from the server error', () => {
+        const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 1 })
+        const presenter = new EditSessionPresenter(
+          appointment,
+          {
+            errors: [
+              {
+                errorSummaryLinkedField: 'date-day',
+                formFields: ['date-day'],
+                message: 'The session date must be a real date',
+              },
+            ],
+          },
+          null,
+          {
+            errors: [
+              {
+                formFields: ['session-input'],
+                errorSummaryLinkedField: 'session-input',
+                message:
+                  'The proposed date and time you selected clashes with another appointment. Please select a different date and time.',
+              },
+            ],
+          }
+        )
+
+        expect(presenter.errorSummary).toEqual([
+          {
+            field: 'session-input',
+            message:
+              'The proposed date and time you selected clashes with another appointment. Please select a different date and time.',
+          },
+        ])
+      })
+    })
+
+    describe('when a standard validation error is passed in', () => {
+      it('displays the message from the server error', () => {
+        const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 1 })
+        const presenter = new EditSessionPresenter(
+          appointment,
+          {
+            errors: [
+              {
+                errorSummaryLinkedField: 'date-day',
+                formFields: ['date-day'],
+                message: 'The session date must be a real date',
+              },
+            ],
+          },
+          null,
+          null
+        )
+
+        expect(presenter.errorSummary).toEqual([{ field: 'date-day', message: 'The session date must be a real date' }])
+      })
+    })
+
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
+        const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 1 })
+        const presenter = new EditSessionPresenter(appointment)
+
+        expect(presenter.errorSummary).toEqual(null)
+      })
+    })
+  })
+
   describe('fields', () => {
     describe('with a newly-created appointment', () => {
       it('returns empty fields', () => {

--- a/server/routes/serviceProviderReferrals/editSessionPresenter.ts
+++ b/server/routes/serviceProviderReferrals/editSessionPresenter.ts
@@ -8,8 +8,9 @@ import { FormValidationError } from '../../utils/formValidationError'
 export default class EditSessionPresenter {
   constructor(
     private readonly appointment: ActionPlanAppointment,
-    private readonly error: FormValidationError | null = null,
-    private readonly userInputData: Record<string, unknown> | null = null
+    private readonly validationError: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null,
+    private readonly serverError: FormValidationError | null = null
   ) {}
 
   readonly text = {
@@ -18,7 +19,11 @@ export default class EditSessionPresenter {
 
   private readonly utils = new PresenterUtils(this.userInputData)
 
-  readonly errorSummary = PresenterUtils.errorSummary(this.error)
+  readonly errorSummary = this.serverError
+    ? PresenterUtils.errorSummary(this.serverError)
+    : PresenterUtils.errorSummary(this.validationError)
+
+  readonly serverErrorMessage = PresenterUtils.errorMessage(this.serverError, 'session-input')
 
   readonly fields = {
     date: this.utils.dateValue(
@@ -26,19 +31,19 @@ export default class EditSessionPresenter {
         ? null
         : CalendarDay.britishDayForDate(new Date(this.appointment.appointmentTime)),
       'date',
-      this.error
+      this.validationError
     ),
     time: this.utils.twelveHourTimeValue(
       this.appointment.appointmentTime === null
         ? null
         : ClockTime.britishTimeForDate(new Date(this.appointment.appointmentTime)),
       'time',
-      this.error
+      this.validationError
     ),
     duration: this.utils.durationValue(
       this.appointment.durationInMinutes === null ? null : Duration.fromUnits(0, this.appointment.durationInMinutes, 0),
       'duration',
-      this.error
+      this.validationError
     ),
   }
 }

--- a/server/routes/serviceProviderReferrals/editSessionView.ts
+++ b/server/routes/serviceProviderReferrals/editSessionView.ts
@@ -14,11 +14,23 @@ export default class EditSessionView {
         timeInputArgs: this.timeInputArgs,
         durationDateInputArgs: this.durationDateInputArgs,
         errorSummaryArgs: this.errorSummaryArgs,
+        serverError: this.serverError,
       },
     ]
   }
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+
+  get serverError(): { message: string; classes: string } | null {
+    if (this.presenter.serverErrorMessage === null) {
+      return null
+    }
+
+    return {
+      message: this.presenter.serverErrorMessage,
+      classes: 'govuk-form-group--error',
+    }
+  }
 
   get dateInputArgs(): DateInputArgs {
     return {

--- a/server/views/serviceProviderReferrals/editSession.njk
+++ b/server/views/serviceProviderReferrals/editSession.njk
@@ -12,18 +12,28 @@
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form method="post" novalidate>
-        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
 
-        {% if errorSummaryArgs !== null %}
-          {{ govukErrorSummary(errorSummaryArgs) }}
-        {% endif %}
+      <form method="post" novalidate="novalidate">
+
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
         <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
 
-        {{ govukDateInput(dateInputArgs) }}
-        {{ appTimeInput(timeInputArgs) }}
-        {{ govukDateInput(durationDateInputArgs) }}
+        <div id='session-input' {% if serverError != null %}class="{{serverError.classes}}"{% endif %}>
+          {% if serverError !== null %}
+            <span class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span>
+                {{ serverError.message }}
+              </span>
+            {% endif %}
+
+          {{ govukDateInput(dateInputArgs) }}
+          {{ appTimeInput(timeInputArgs) }}
+          {{ govukDateInput(durationDateInputArgs) }}
+        </div>
 
         {{ govukButton({ text: "Save and continue" }) }}
       </form>


### PR DESCRIPTION
## What does this pull request do?

Displays an error to the user when editing an appointment and trying to set the time & date to that of another pre-scheduled appointment. In this case, we'll get a 409 status code from the Community API.

I'm not 100% convinced by my approach here - I initially tried using our existing `formError` pattern to pass in this error, but as we're not targeting a single `input` field here, like we do elsewhere (we're targeting a collection of `input` fields, so we can't use the existing macros - see screenshot), I've had to handle this slightly differently, hence the addition of the `serverError` argument to the `EditSessionPresenter`.

## What is the intent behind these changes?

Without this change, the UI takes the user back to the intervention progress page, as if it's been a successful edit, even though the Community API has rejected this update.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/118825363-84678b80-b8b2-11eb-8474-f3a2aa0b38a7.png)

