### PR TITLE
IC-1711/IC-1712: Added desired outcomes and complexity levels on 'Mak…

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The integration tests require a different docker-compose stack and a different a
 
 `npm run int-test(-ui)`
 
+Note: You may need to run `npm run build` if you make none test code changes while the cypress tests are active
+
 ### Building a static page (designers)
 
 To view the existing static pages, and for more instructions about how to edit them, go to `http://localhost:3000/static-pages`. If you get asked to log in when you try to go to this page, then you might need to re-enter this URL after logging in.

--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -7,5 +7,6 @@ $path: "/assets/images/"
 @import './components/header-bar'
 @import './components/notification-banner'
 @import './components/find-filters'
+@import './components/task-list'
 
 @import './local'

--- a/assets/sass/components/_task-list.scss
+++ b/assets/sass/components/_task-list.scss
@@ -1,0 +1,17 @@
+.moj-task-list__items-multi {
+  margin-bottom: 10px;
+}
+
+.moj-task-list__items-nested {
+  margin-bottom: 10px;
+  margin-left: 60px !important;
+  margin-top: 10px;
+}
+
+.moj-task-list__items-nested li:last-child {
+  border-bottom: 0;
+}
+
+.moj-task-list__items-last-of-section {
+  margin-bottom: 60px;
+}

--- a/integration_tests/integration/make_a_referral/referralSectionVerifier.js
+++ b/integration_tests/integration/make_a_referral/referralSectionVerifier.js
@@ -1,0 +1,75 @@
+// eslint-disable-next-line max-classes-per-file
+export default class ReferralSectionVerifier {
+  static get verifySection() {
+    return new _ReferralSectionChecker()
+  }
+}
+function hrefAttrChainer(isActive) {
+  return isActive ? 'have.attr' : 'not.have.attr'
+}
+class _ReferralSectionChecker {
+  reviewServiceUserInformation(activeLinks) {
+    cy.get('[data-cy=url]')
+      .contains('Confirm service user’s personal details')
+      .should(hrefAttrChainer(activeLinks.confirmServiceUserDetails), 'href')
+    cy.get('[data-cy=url]')
+      .contains('Service user’s risk information')
+      .should(hrefAttrChainer(activeLinks.riskInformation), 'href')
+    cy.get('[data-cy=url]')
+      .contains('Service user’s needs and requirements')
+      .should(hrefAttrChainer(activeLinks.needsAndRequirements), 'href')
+    return this
+  }
+
+  interventionReferralDetails(activeLinks) {
+    cy.get('[data-cy=url]')
+      .contains('Confirm the relevant sentence for the accommodation referral')
+      .should(hrefAttrChainer(activeLinks.relevantSentence), 'href')
+    cy.get('[data-cy=url]')
+      .contains('Select required complexity level')
+      .should(hrefAttrChainer(activeLinks.requiredComplexityLevel), 'href')
+    cy.get('[data-cy=url]')
+      .contains('Select desired outcomes')
+      .should(hrefAttrChainer(activeLinks.desiredOutcomes), 'href')
+    cy.get('[data-cy=url]')
+      .contains('Enter when the accommodation service need to be completed')
+      .should(hrefAttrChainer(activeLinks.completedDate), 'href')
+    cy.get('[data-cy=url]').contains('Enter enforceable days used').should(hrefAttrChainer(activeLinks.rarDays), 'href')
+    cy.get('[data-cy=url]')
+      .contains('Further information for service provider')
+      .should(hrefAttrChainer(activeLinks.furtherInformation), 'href')
+    return this
+  }
+
+  cohortInterventionReferralDetails(activeLinks) {
+    cy.get("[data-cy=url]:contains('Confirm the relevant sentence for the intervention referral')").should(
+      hrefAttrChainer(activeLinks.relevantSentence),
+      'href'
+    )
+    cy.get("[data-cy=url]:contains('Select required complexity level')")
+      .eq(0)
+      .should(hrefAttrChainer(activeLinks.requiredComplexityLevel1), 'href')
+    cy.get("[data-cy=url]:contains('Select desired outcomes')")
+      .eq(0)
+      .should(hrefAttrChainer(activeLinks.desiredOutcomes1), 'href')
+    cy.get("[data-cy=url]:contains('Select required complexity level')")
+      .eq(1)
+      .should(hrefAttrChainer(activeLinks.requiredComplexityLevel2), 'href')
+    cy.get("[data-cy=url]:contains('Select desired outcomes')")
+      .eq(1)
+      .should(hrefAttrChainer(activeLinks.desiredOutcomes1), 'href')
+    cy.get('[data-cy=url]')
+      .contains('Enter when the intervention service need to be completed')
+      .should(hrefAttrChainer(activeLinks.completedDate), 'href')
+    cy.get('[data-cy=url]').contains('Enter enforceable days used').should(hrefAttrChainer(activeLinks.rarDays), 'href')
+    cy.get('[data-cy=url]')
+      .contains('Further information for service provider')
+      .should(hrefAttrChainer(activeLinks.furtherInformation), 'href')
+    return this
+  }
+
+  checkYourAnswers(activeLinks) {
+    cy.get('[data-cy=url]').contains('Check your answers').should(hrefAttrChainer(activeLinks.checkAnswers), 'href')
+    return this
+  }
+}

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -3,8 +3,67 @@ import sentReferralFactory from '../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
 import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
+import interventionFactory from '../../testutils/factories/intervention'
+// eslint-disable-next-line import/no-named-as-default,import/no-named-as-default-member
+import ReferralSectionVerifier from './make_a_referral/referralSectionVerifier'
 
 describe('Referral form', () => {
+  const deliusServiceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+  const convictionWithSentenceToSelect = deliusConvictionFactory.build({
+    convictionId: 123456789,
+    active: true,
+    offences: [
+      {
+        mainOffence: true,
+        detail: {
+          mainCategoryDescription: 'Burglary',
+          subCategoryDescription: 'Theft act, 1968',
+        },
+      },
+      {
+        mainOffence: false,
+        detail: {
+          mainCategoryDescription: 'Common and other types of assault',
+          subCategoryDescription: 'Common assault and battery',
+        },
+      },
+    ],
+    sentence: {
+      sentenceId: 2500284169,
+      description: 'Absolute/Conditional Discharge',
+      expectedSentenceEndDate: '2025-11-15',
+      sentenceType: {
+        code: 'SC',
+        description: 'CJA - Indeterminate Public Prot.',
+      },
+    },
+  })
+  const convictions = [convictionWithSentenceToSelect, deliusConvictionFactory.build()]
+  const accommodationServiceCategory = serviceCategoryFactory.build({
+    name: 'accommodation',
+    desiredOutcomes: [
+      {
+        id: '1',
+        description: 'Service User makes progress in obtaining accommodation',
+      },
+      {
+        id: '2',
+        description: 'Service User is prevented from becoming homeless',
+      },
+    ],
+    complexityLevels: [
+      {
+        id: '1',
+        title: 'Low complexity',
+        description: 'Info about low complexity',
+      },
+      {
+        id: '2',
+        title: 'High complexity',
+        description: 'Info about high complexity',
+      },
+    ],
+  })
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubLogin')
@@ -12,256 +71,523 @@ describe('Referral form', () => {
     cy.task('stubProbationPractitionerAuthUser')
   })
 
-  it('User starts a referral, fills in the form, and submits it', () => {
-    const deliusServiceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-    const serviceCategory = serviceCategoryFactory.build({
-      name: 'accommodation',
-      desiredOutcomes: [
-        {
-          id: '1',
-          description: 'Service User makes progress in obtaining accommodation',
+  describe('for single referrals', () => {
+    it('User starts a referral, fills in the form, and submits it', () => {
+      const draftReferral = draftReferralFactory.serviceUserSelected().build({
+        serviceCategoryIds: [accommodationServiceCategory.id],
+        serviceProvider: {
+          name: 'Harmony Living',
         },
-        {
-          id: '2',
-          description: 'Service User is prevented from becoming homeless',
-        },
-      ],
-      complexityLevels: [
-        {
-          id: '1',
-          title: 'Low complexity',
-          description: 'Info about low complexity',
-        },
-        {
-          id: '2',
-          title: 'High complexity',
-          description: 'Info about high complexity',
-        },
-      ],
-    })
+      })
 
-    const draftReferral = draftReferralFactory.serviceUserSelected().build({
-      serviceCategoryId: serviceCategory.id,
-      serviceCategoryIds: [serviceCategory.id],
-      serviceProvider: {
-        name: 'Harmony Living',
-      },
-    })
-
-    const completedServiceUserDetailsDraftReferral = draftReferralFactory.serviceUserDetailsSet().build({
-      serviceCategoryId: serviceCategory.id,
-      serviceCategoryIds: [serviceCategory.id],
-      serviceProvider: {
-        name: 'Harmony Living',
-      },
-    })
-
-    const completedDraftReferral = {
-      ...completedServiceUserDetailsDraftReferral,
-      completionDeadline: '2021-04-01',
-      complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
-      furtherInformation: 'Some information about the service user',
-      relevantSentenceId: 12345678910,
-      desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
-      additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
-      accessibilityNeeds: 'She uses a wheelchair',
-      needsInterpreter: true,
-      interpreterLanguage: 'Spanish',
-      hasAdditionalResponsibilities: true,
-      whenUnavailable: 'She works Mondays 9am - midday',
-      additionalRiskInformation: 'A danger to the elderly',
-      usingRarDays: true,
-      maximumRarDays: 10,
-    }
-
-    const convictionWithSentenceToSelect = deliusConvictionFactory.build({
-      convictionId: 123456789,
-      active: true,
-      offences: [
-        {
-          mainOffence: true,
-          detail: {
-            mainCategoryDescription: 'Burglary',
-            subCategoryDescription: 'Theft act, 1968',
+      const completedServiceUserDetailsDraftReferral = draftReferralFactory
+        .filledFormUpToNeedsAndRequirements([accommodationServiceCategory])
+        .build({
+          serviceCategoryIds: [accommodationServiceCategory.id],
+          interventionId: draftReferral.interventionId,
+          serviceProvider: {
+            name: 'Harmony Living',
           },
-        },
-        {
-          mainOffence: false,
-          detail: {
-            mainCategoryDescription: 'Common and other types of assault',
-            subCategoryDescription: 'Common assault and battery',
+        })
+
+      const completedDraftReferral = draftReferralFactory
+        .filledFormUpToFurtherInformation([accommodationServiceCategory])
+        .build({
+          serviceCategoryIds: [accommodationServiceCategory.id],
+          interventionId: draftReferral.interventionId,
+          serviceProvider: {
+            name: 'Harmony Living',
           },
-        },
-      ],
-      sentence: {
-        sentenceId: 2500284169,
-        description: 'Absolute/Conditional Discharge',
-        expectedSentenceEndDate: '2025-11-15',
-        sentenceType: {
-          code: 'SC',
-          description: 'CJA - Indeterminate Public Prot.',
-        },
-      },
-    })
+        })
 
-    const convictions = [convictionWithSentenceToSelect, deliusConvictionFactory.build()]
+      const sentReferral = sentReferralFactory.fromFields(completedDraftReferral).build()
 
-    const sentReferral = sentReferralFactory.fromFields(completedDraftReferral).build()
+      const intervention = interventionFactory.build()
 
-    cy.stubGetServiceUserByCRN('X123456', deliusServiceUser)
-    cy.stubCreateDraftReferral(draftReferral)
-    cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
-    cy.stubGetSentReferrals([])
-    cy.stubGetDraftReferralsForUser([])
-    cy.stubGetDraftReferral(draftReferral.id, draftReferral)
-    cy.stubPatchDraftReferral(draftReferral.id, draftReferral)
-    cy.stubSendDraftReferral(draftReferral.id, sentReferral)
-    cy.stubGetSentReferral(sentReferral.id, sentReferral)
-    cy.stubGetActiveConvictionsByCRN('X123456', convictions)
-    cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
-    cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
+      cy.stubGetServiceUserByCRN('X123456', deliusServiceUser)
+      cy.stubCreateDraftReferral(draftReferral)
+      cy.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory)
+      cy.stubGetSentReferrals([])
+      cy.stubGetDraftReferralsForUser([])
+      cy.stubGetDraftReferral(draftReferral.id, draftReferral)
+      cy.stubPatchDraftReferral(draftReferral.id, draftReferral)
+      cy.stubSendDraftReferral(draftReferral.id, sentReferral)
+      cy.stubGetSentReferral(sentReferral.id, sentReferral)
+      cy.stubGetActiveConvictionsByCRN('X123456', convictions)
+      cy.stubGetIntervention(draftReferral.interventionId, intervention)
+      cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
+      cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
 
-    cy.login()
+      cy.login()
 
-    const randomInterventionId = '99ee16d3-130a-4d8f-97c5-f1a42119a382'
+      const randomInterventionId = '99ee16d3-130a-4d8f-97c5-f1a42119a382'
 
-    cy.visit(`/intervention/${randomInterventionId}/refer`)
+      cy.visit(`/intervention/${randomInterventionId}/refer`)
 
-    cy.contains('Service user CRN').type('X123456')
+      cy.contains('Service user CRN').type('X123456')
 
-    cy.contains('Continue').click()
+      cy.contains('Continue').click()
 
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
 
-    cy.get('[data-cy=status]').eq(0).contains('NOT STARTED', { matchCase: false })
-    cy.get('[data-cy=status]').eq(1).contains('CANNOT START YET', { matchCase: false })
-    cy.get('[data-cy=status]').eq(2).contains('CANNOT START YET', { matchCase: false })
+      cy.get('[data-cy=status]').eq(0).contains('NOT STARTED', { matchCase: false })
+      cy.get('[data-cy=status]').eq(1).contains('CANNOT START YET', { matchCase: false })
+      cy.get('[data-cy=status]').eq(2).contains('CANNOT START YET', { matchCase: false })
+      ReferralSectionVerifier.verifySection
+        .reviewServiceUserInformation({
+          confirmServiceUserDetails: true,
+          riskInformation: true,
+          needsAndRequirements: false,
+        })
+        .interventionReferralDetails({
+          relevantSentence: false,
+          requiredComplexityLevel: false,
+          desiredOutcomes: false,
+          completedDate: false,
+          rarDays: false,
+          furtherInformation: false,
+        })
+        .checkYourAnswers({ checkAnswers: false })
 
-    cy.contains('Confirm service user’s personal details').click()
+      cy.contains('Confirm service user’s personal details').click()
 
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/service-user-details`)
-    cy.get('h1').contains("Alex's information")
-    cy.contains('X123456')
-    cy.contains('Mr')
-    cy.contains('River')
-    cy.contains('1 January 1980')
-    cy.contains('Male')
-    cy.contains('British')
-    cy.contains('English')
-    cy.contains('Agnostic')
-    cy.contains('Autism')
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/service-user-details`)
+      cy.get('h1').contains("Alex's information")
+      cy.contains('X123456')
+      cy.contains('Mr')
+      cy.contains('River')
+      cy.contains('1 January 1980')
+      cy.contains('Male')
+      cy.contains('British')
+      cy.contains('English')
+      cy.contains('Agnostic')
+      cy.contains('Autism')
 
-    cy.contains('Save and continue').click()
+      cy.contains('Save and continue').click()
 
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/risk-information`)
-    cy.contains('Save and continue').click()
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/risk-information`)
+      cy.contains('Save and continue').click()
 
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/needs-and-requirements`)
-    cy.get('h1').contains('Alex’s needs and requirements')
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/needs-and-requirements`)
+      cy.get('h1').contains('Alex’s needs and requirements')
 
-    cy.contains('Additional information about Alex’s needs').type('Alex is currently sleeping on his aunt’s sofa')
-    cy.contains('Does Alex have any other mobility, disability or accessibility needs?').type('He uses a wheelchair')
-    cy.withinFieldsetThatContains('Does Alex need an interpreter?', () => {
+      cy.contains('Additional information about Alex’s needs').type('Alex is currently sleeping on his aunt’s sofa')
+      cy.contains('Does Alex have any other mobility, disability or accessibility needs?').type('He uses a wheelchair')
+      cy.withinFieldsetThatContains('Does Alex need an interpreter?', () => {
+        cy.contains('Yes').click()
+      })
+      cy.contains('What language?').type('Spanish')
+      cy.withinFieldsetThatContains('Does Alex have caring or employment responsibilities?', () => {
+        cy.contains('Yes').click()
+      })
+      cy.contains('Provide details of when Alex will not be able to attend sessions').type(
+        'He works Mondays 9am - midday'
+      )
+      cy.stubGetDraftReferral(draftReferral.id, completedServiceUserDetailsDraftReferral)
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
+
+      cy.get('[data-cy=status]').eq(0).contains('COMPLETED', { matchCase: false })
+      cy.get('[data-cy=status]').eq(1).contains('NOT STARTED', { matchCase: false })
+      cy.get('[data-cy=status]').eq(2).contains('CANNOT START YET', { matchCase: false })
+      ReferralSectionVerifier.verifySection
+        .reviewServiceUserInformation({
+          confirmServiceUserDetails: true,
+          riskInformation: true,
+          needsAndRequirements: true,
+        })
+        .interventionReferralDetails({
+          relevantSentence: true,
+          requiredComplexityLevel: false,
+          desiredOutcomes: false,
+          completedDate: false,
+          rarDays: false,
+          furtherInformation: false,
+        })
+        .checkYourAnswers({ checkAnswers: false })
+
+      cy.contains('Confirm service user’s personal details').should('have.attr', 'href')
+
+      cy.contains('Confirm the relevant sentence for the accommodation referral').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/relevant-sentence`)
+      cy.get('h1').contains('Select the relevant sentence for the accommodation referral')
+
+      cy.contains('Burglary').click()
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should(
+        'equal',
+        `/referrals/${draftReferral.id}/service-category/${draftReferral.serviceCategoryIds[0]}/desired-outcomes`
+      )
+
+      cy.get('h1').contains('What are the desired outcomes for the accommodation service?')
+
+      cy.contains('Service User makes progress in obtaining accommodation').click()
+      cy.contains('Service User is prevented from becoming homeless').click()
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should(
+        'equal',
+        `/referrals/${draftReferral.id}/service-category/${draftReferral.serviceCategoryIds[0]}/complexity-level`
+      )
+      cy.get('h1').contains('What is the complexity level for the accommodation service?')
+      cy.contains('Low complexity').click()
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/completion-deadline`)
+      cy.get('h1').contains('What date does the accommodation service need to be completed by?')
+      cy.contains('Day').type('15')
+      cy.contains('Month').type('8')
+      cy.contains('Year').type('2021')
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/rar-days`)
+      cy.get('h1').contains('Are you using RAR days for the accommodation service?')
       cy.contains('Yes').click()
+      cy.contains('What is the maximum number of RAR days for the accommodation service?').type('10')
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/further-information`)
+      cy.get('h1').contains('Do you have further information for the accommodation service provider? (optional)')
+      cy.get('textarea').type('Some information about Alex')
+
+      // stub completed draft referral to mark section as completed
+      cy.stubGetDraftReferral(draftReferral.id, completedDraftReferral)
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
+
+      cy.get('[data-cy=status]').eq(0).contains('COMPLETED', { matchCase: false })
+      cy.get('[data-cy=status]').eq(1).contains('COMPLETED', { matchCase: false })
+      cy.get('[data-cy=status]').eq(2).contains('NOT STARTED', { matchCase: false })
+      ReferralSectionVerifier.verifySection
+        .reviewServiceUserInformation({
+          confirmServiceUserDetails: true,
+          riskInformation: true,
+          needsAndRequirements: true,
+        })
+        .interventionReferralDetails({
+          relevantSentence: true,
+          requiredComplexityLevel: true,
+          desiredOutcomes: true,
+          completedDate: true,
+          rarDays: true,
+          furtherInformation: true,
+        })
+        .checkYourAnswers({ checkAnswers: true })
+
+      cy.get('a').contains('Check your answers').click()
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/check-answers`)
+
+      cy.contains('X123456')
+      cy.contains('Mr')
+      cy.contains('River')
+      cy.contains('1 January 1980')
+      cy.contains('Male')
+      cy.contains('British')
+      cy.contains('English')
+      cy.contains('Agnostic')
+      cy.contains('Autism')
+
+      cy.contains('Alex is currently sleeping on her aunt’s sofa')
+      cy.contains('She uses a wheelchair')
+      cy.contains('Yes. Spanish')
+      cy.contains('Yes. She works Mondays 9am - midday')
+
+      cy.contains('Submit referral').click()
+      cy.location('pathname').should('equal', `/referrals/${sentReferral.id}/confirmation`)
+
+      cy.contains('We’ve sent your referral to Harmony Living')
+      cy.contains(sentReferral.referenceNumber)
     })
-    cy.contains('What language?').type('Spanish')
-    cy.withinFieldsetThatContains('Does Alex have caring or employment responsibilities?', () => {
+  })
+  describe('for cohort referrals, when user tries to make a referral', () => {
+    it('should be able to complete a cohort referral', () => {
+      const socialInclusionServiceCategory = serviceCategoryFactory.build({
+        name: 'social inclusion',
+        desiredOutcomes: [
+          {
+            id: '3',
+            description: 'Service User develops and sustains social networks to reduce initial social isolation.',
+          },
+          {
+            id: '4',
+            description: 'Service User secures early post-release engagement with community based services.',
+          },
+          {
+            id: '5',
+            description:
+              'Service User develops resilience and perseverance to cope with challenges and barriers on return to the community.',
+          },
+        ],
+        complexityLevels: [
+          {
+            id: '3',
+            title: 'Low complexity',
+            description: 'Info about low complexity',
+          },
+          {
+            id: '4',
+            title: 'High complexity',
+            description: 'Info about high complexity',
+          },
+        ],
+      })
+      const intervention = interventionFactory.build({
+        serviceCategories: [accommodationServiceCategory, socialInclusionServiceCategory],
+      })
+      const draftReferral = draftReferralFactory.serviceUserSelected().build({
+        serviceCategoryIds: [accommodationServiceCategory.id, socialInclusionServiceCategory.id],
+        interventionId: intervention.id,
+        serviceProvider: {
+          name: 'Harmony Living',
+        },
+      })
+
+      const completedServiceUserDetailsDraftReferral = draftReferralFactory
+        .filledFormUpToNeedsAndRequirements([accommodationServiceCategory, socialInclusionServiceCategory])
+        .build({
+          serviceCategoryIds: [accommodationServiceCategory.id, socialInclusionServiceCategory.id],
+          interventionId: intervention.id,
+          serviceProvider: {
+            name: 'Harmony Living',
+          },
+        })
+
+      const completedDraftReferral = draftReferralFactory
+        .filledFormUpToFurtherInformation([accommodationServiceCategory, socialInclusionServiceCategory])
+        .build({
+          serviceCategoryIds: [accommodationServiceCategory.id, socialInclusionServiceCategory.id],
+          interventionId: intervention.id,
+          serviceProvider: {
+            name: 'Harmony Living',
+          },
+        })
+
+      const sentReferral = sentReferralFactory.fromFields(completedDraftReferral).build()
+
+      cy.stubGetServiceUserByCRN('X123456', deliusServiceUser)
+      cy.stubCreateDraftReferral(draftReferral)
+      cy.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory)
+      cy.stubGetServiceCategory(socialInclusionServiceCategory.id, socialInclusionServiceCategory)
+      cy.stubGetSentReferrals([])
+      cy.stubGetDraftReferralsForUser([])
+      cy.stubGetDraftReferral(draftReferral.id, draftReferral)
+      cy.stubPatchDraftReferral(draftReferral.id, draftReferral)
+      cy.stubSendDraftReferral(draftReferral.id, sentReferral)
+      cy.stubGetSentReferral(sentReferral.id, sentReferral)
+      cy.stubGetActiveConvictionsByCRN('X123456', convictions)
+      cy.stubGetIntervention(draftReferral.interventionId, intervention)
+      cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
+      cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
+
+      cy.login()
+
+      const randomInterventionId = '99ee16d3-130a-4d8f-97c5-f1a42119a382'
+
+      cy.visit(`/intervention/${randomInterventionId}/refer`)
+
+      cy.contains('Service user CRN').type('X123456')
+
+      cy.contains('Continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
+      cy.get('[data-cy=status]').eq(0).contains('NOT STARTED', { matchCase: false })
+      cy.get('[data-cy=status]').eq(1).contains('CANNOT START YET', { matchCase: false })
+      cy.get('[data-cy=status]').eq(2).contains('CANNOT START YET', { matchCase: false })
+      ReferralSectionVerifier.verifySection
+        .reviewServiceUserInformation({
+          confirmServiceUserDetails: true,
+          riskInformation: true,
+          needsAndRequirements: false,
+        })
+        .cohortInterventionReferralDetails({
+          relevantSentence: false,
+          requiredComplexityLevel1: false,
+          desiredOutcomes1: false,
+          requiredComplexityLevel2: false,
+          desiredOutcomes2: false,
+          completedDate: false,
+          rarDays: false,
+          furtherInformation: false,
+        })
+        .checkYourAnswers({ checkAnswers: false })
+
+      cy.contains('Confirm service user’s personal details').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/service-user-details`)
+      cy.get('h1').contains("Alex's information")
+      cy.contains('X123456')
+      cy.contains('Mr')
+      cy.contains('River')
+      cy.contains('1 January 1980')
+      cy.contains('Male')
+      cy.contains('British')
+      cy.contains('English')
+      cy.contains('Agnostic')
+      cy.contains('Autism')
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/risk-information`)
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/needs-and-requirements`)
+      cy.get('h1').contains('Alex’s needs and requirements')
+
+      cy.contains('Additional information about Alex’s needs').type('Alex is currently sleeping on his aunt’s sofa')
+      cy.contains('Does Alex have any other mobility, disability or accessibility needs?').type('He uses a wheelchair')
+      cy.withinFieldsetThatContains('Does Alex need an interpreter?', () => {
+        cy.contains('Yes').click()
+      })
+      cy.contains('What language?').type('Spanish')
+      cy.withinFieldsetThatContains('Does Alex have caring or employment responsibilities?', () => {
+        cy.contains('Yes').click()
+      })
+      cy.contains('Provide details of when Alex will not be able to attend sessions').type(
+        'He works Mondays 9am - midday'
+      )
+      cy.stubGetDraftReferral(draftReferral.id, completedServiceUserDetailsDraftReferral)
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
+
+      cy.get('[data-cy=status]').eq(0).contains('COMPLETED', { matchCase: false })
+      cy.get('[data-cy=status]').eq(1).contains('NOT STARTED', { matchCase: false })
+      cy.get('[data-cy=status]').eq(2).contains('CANNOT START YET', { matchCase: false })
+      ReferralSectionVerifier.verifySection
+        .reviewServiceUserInformation({
+          confirmServiceUserDetails: true,
+          riskInformation: true,
+          needsAndRequirements: true,
+        })
+        .cohortInterventionReferralDetails({
+          relevantSentence: true,
+          requiredComplexityLevel1: false,
+          desiredOutcomes1: false,
+          requiredComplexityLevel2: false,
+          desiredOutcomes2: false,
+          completedDate: false,
+          rarDays: false,
+          furtherInformation: false,
+        })
+        .checkYourAnswers({ checkAnswers: false })
+
+      cy.contains('Confirm the relevant sentence for the intervention referral').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/relevant-sentence`)
+      cy.get('h1').contains('Select the relevant sentence for the accommodation referral')
+
+      cy.contains('Burglary').click()
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should(
+        'equal',
+        `/referrals/${draftReferral.id}/service-category/${draftReferral.serviceCategoryIds[0]}/desired-outcomes`
+      )
+      cy.get('h1').contains('What are the desired outcomes for the accommodation service?')
+
+      cy.contains('Service User makes progress in obtaining accommodation').click()
+      cy.contains('Service User is prevented from becoming homeless').click()
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should(
+        'equal',
+        `/referrals/${draftReferral.id}/service-category/${draftReferral.serviceCategoryIds[0]}/complexity-level`
+      )
+
+      cy.get('h1').contains('What is the complexity level for the accommodation service?')
+      cy.contains('Low complexity').click()
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should(
+        'equal',
+        `/referrals/${draftReferral.id}/service-category/${draftReferral.serviceCategoryIds[1]}/desired-outcomes`
+      )
+      cy.get('h1').contains('What are the desired outcomes for the social inclusion service?')
+      cy.contains('Service User develops and sustains social networks to reduce initial social isolation.').click()
+      cy.contains('Service User secures early post-release engagement with community based services.').click()
+      cy.contains(
+        'Service User develops resilience and perseverance to cope with challenges and barriers on return to the community.'
+      ).click()
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should(
+        'equal',
+        `/referrals/${draftReferral.id}/service-category/${draftReferral.serviceCategoryIds[1]}/complexity-level`
+      )
+
+      cy.get('h1').contains('What is the complexity level for the social inclusion service?')
+      cy.contains('Low complexity').click()
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/completion-deadline`)
+      cy.get('h1').contains('What date does the accommodation service need to be completed by?')
+      cy.contains('Day').type('15')
+      cy.contains('Month').type('8')
+      cy.contains('Year').type('2021')
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/rar-days`)
+      cy.get('h1').contains('Are you using RAR days for the accommodation service?')
       cy.contains('Yes').click()
+      cy.contains('What is the maximum number of RAR days for the accommodation service?').type('10')
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/further-information`)
+      cy.get('h1').contains('Do you have further information for the accommodation service provider? (optional)')
+      cy.get('textarea').type('Some information about Alex')
+
+      // stub completed draft referral to mark section as completed
+      cy.stubGetDraftReferral(draftReferral.id, completedDraftReferral)
+
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
+
+      cy.get('[data-cy=status]').eq(0).contains('COMPLETED', { matchCase: false })
+      cy.get('[data-cy=status]').eq(1).contains('COMPLETED', { matchCase: false })
+      cy.get('[data-cy=status]').eq(2).contains('NOT STARTED', { matchCase: false })
+      ReferralSectionVerifier.verifySection.reviewServiceUserInformation({
+        confirmServiceUserDetails: true,
+        riskInformation: true,
+        needsAndRequirements: true,
+      })
+      ReferralSectionVerifier.verifySection.cohortInterventionReferralDetails({
+        relevantSentence: true,
+        requiredComplexityLevel1: true,
+        desiredOutcomes1: true,
+        requiredComplexityLevel2: true,
+        desiredOutcomes2: true,
+        completedDate: true,
+        rarDays: true,
+        furtherInformation: true,
+      })
+      ReferralSectionVerifier.verifySection.checkYourAnswers({ checkAnswers: true })
+
+      cy.get('a').contains('Check your answers').click()
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/check-answers`)
+
+      cy.contains('Submit referral').click()
+      cy.location('pathname').should('equal', `/referrals/${sentReferral.id}/confirmation`)
+
+      cy.contains('We’ve sent your referral to Harmony Living')
+      cy.contains(sentReferral.referenceNumber)
     })
-    cy.contains('Provide details of when Alex will not be able to attend sessions').type(
-      'He works Mondays 9am - midday'
-    )
-    cy.stubGetDraftReferral(draftReferral.id, completedServiceUserDetailsDraftReferral)
-    cy.contains('Save and continue').click()
-
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
-
-    cy.get('[data-cy=status]').eq(0).contains('COMPLETED', { matchCase: false })
-    cy.get('[data-cy=status]').eq(1).contains('NOT STARTED', { matchCase: false })
-    cy.get('[data-cy=status]').eq(2).contains('CANNOT START YET', { matchCase: false })
-
-    cy.contains('Select the relevant sentence for the accommodation referral').click()
-
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/relevant-sentence`)
-    cy.get('h1').contains('Select the relevant sentence for the accommodation referral')
-
-    cy.contains('Burglary').click()
-
-    cy.contains('Save and continue').click()
-
-    cy.location('pathname').should(
-      'equal',
-      `/referrals/${draftReferral.id}/service-category/${draftReferral.serviceCategoryIds[0]}/desired-outcomes`
-    )
-    cy.get('h1').contains('What are the desired outcomes for the accommodation service?')
-
-    cy.contains('Service User makes progress in obtaining accommodation').click()
-    cy.contains('Service User is prevented from becoming homeless').click()
-
-    cy.contains('Save and continue').click()
-
-    cy.location('pathname').should(
-      'equal',
-      `/referrals/${draftReferral.id}/service-category/${draftReferral.serviceCategoryIds[0]}/complexity-level`
-    )
-    cy.get('h1').contains('What is the complexity level for the accommodation service?')
-    cy.contains('Low complexity').click()
-
-    cy.contains('Save and continue').click()
-
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/completion-deadline`)
-    cy.get('h1').contains('What date does the accommodation service need to be completed by?')
-    cy.contains('Day').type('15')
-    cy.contains('Month').type('8')
-    cy.contains('Year').type('2021')
-
-    cy.contains('Save and continue').click()
-
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/rar-days`)
-    cy.get('h1').contains('Are you using RAR days for the accommodation service?')
-    cy.contains('Yes').click()
-    cy.contains('What is the maximum number of RAR days for the accommodation service?').type('10')
-
-    cy.contains('Save and continue').click()
-
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/further-information`)
-    cy.get('h1').contains('Do you have further information for the accommodation service provider? (optional)')
-    cy.get('textarea').type('Some information about Alex')
-
-    // stub completed draft referral to mark section as completed
-    cy.stubGetDraftReferral(draftReferral.id, completedDraftReferral)
-
-    cy.contains('Save and continue').click()
-
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/form`)
-
-    cy.get('[data-cy=status]').eq(0).contains('COMPLETED', { matchCase: false })
-    cy.get('[data-cy=status]').eq(1).contains('COMPLETED', { matchCase: false })
-    cy.get('[data-cy=status]').eq(2).contains('NOT STARTED', { matchCase: false })
-
-    cy.get('a').contains('Check your answers').click()
-    cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/check-answers`)
-
-    cy.contains('X123456')
-    cy.contains('Mr')
-    cy.contains('River')
-    cy.contains('1 January 1980')
-    cy.contains('Male')
-    cy.contains('British')
-    cy.contains('English')
-    cy.contains('Agnostic')
-    cy.contains('Autism')
-
-    cy.contains('Alex is currently sleeping on her aunt’s sofa')
-    cy.contains('She uses a wheelchair')
-    cy.contains('Yes. Spanish')
-    cy.contains('Yes. She works Mondays 9am - midday')
-
-    cy.contains('Submit referral').click()
-    cy.location('pathname').should('equal', `/referrals/${sentReferral.id}/confirmation`)
-
-    cy.contains('We’ve sent your referral to Harmony Living')
-    cy.contains(sentReferral.referenceNumber)
   })
 })

--- a/mocks.ts
+++ b/mocks.ts
@@ -128,7 +128,7 @@ export default async function setUpMocks(): Promise<void> {
   const draftReferral = draftReferralFactory
     .serviceCategorySelected(accommodationServiceCategory.id)
     .serviceCategoriesSelected([accommodationServiceCategory.id, socialInclusionServiceCategory.id])
-    .serviceUserDetailsSet()
+    .filledFormUpToNeedsAndRequirements()
     .build({
       id: '98a42c61-c30f-4beb-8062-04033c376e2d',
       serviceUser: {

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -1,65 +1,243 @@
 import ReferralFormPresenter, { ReferralFormStatus } from './referralFormPresenter'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import referralFormSectionFactory from '../../../testutils/factories/referralFormSection'
+import cohortReferralFormSectionFactory from '../../../testutils/factories/cohortReferralFormSection'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import ServiceCategory from '../../models/serviceCategory'
 
 describe('ReferralFormPresenter', () => {
-  describe('sections', () => {
-    describe('review service user information section', () => {
-      describe('when no required values have been set', () => {
-        it('should contain a "Not started" label and "server-user-details" url visible', () => {
-          const referral = draftReferralFactory.build()
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
-          const expected = [
-            referralFormSectionFactory.reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information').build(),
-            referralFormSectionFactory
-              .interventionDetails('social inclusion', ReferralFormStatus.CannotStartYet)
-              .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
-          ]
-          expect(presenter.sections).toEqual(expected)
+  describe('for a single referral', () => {
+    const serviceCategory = serviceCategoryFactory.build()
+    describe('for each referral form section', () => {
+      describe('review service user information section', () => {
+        describe('when no required values have been set', () => {
+          it('should contain a "Not started" label and "server-user-details" url visible', () => {
+            const referral = draftReferralFactory.unfilled().build({ serviceCategoryIds: [serviceCategory.id] })
+            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const expected = [
+              referralFormSectionFactory.reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information').build(),
+              referralFormSectionFactory
+                .interventionDetails('accommodation', ReferralFormStatus.CannotStartYet)
+                .build(),
+              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            ]
+            expect(presenter.sections).toEqual(expected)
+          })
+        })
+        describe('when "Service user details" has been set', () => {
+          it('should contain a "Not started" label and "risk-information" url visible', () => {
+            const referral = draftReferralFactory
+              .serviceUserSelected()
+              .build({ serviceCategoryIds: [serviceCategory.id] })
+            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const expected = [
+              referralFormSectionFactory.reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information').build(),
+              referralFormSectionFactory
+                .interventionDetails('accommodation', ReferralFormStatus.CannotStartYet)
+                .build(),
+              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            ]
+            expect(presenter.sections).toEqual(expected)
+          })
+        })
+        describe('when "risk information" has been set', () => {
+          it('should contain a "Not started" label and "needs-and-requirements" url visible', () => {
+            const referral = draftReferralFactory.filledFormUpToRiskInformation([serviceCategory]).build()
+            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const expected = [
+              referralFormSectionFactory
+                .reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information', 'needs-and-requirements')
+                .build(),
+              referralFormSectionFactory
+                .interventionDetails('accommodation', ReferralFormStatus.CannotStartYet)
+                .build(),
+              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            ]
+            expect(presenter.sections).toEqual(expected)
+          })
+        })
+        describe('when all required values have been set', () => {
+          it('should contain a "Completed" label and service category details section can be started', () => {
+            const referral = draftReferralFactory.filledFormUpToNeedsAndRequirements([serviceCategory]).build()
+            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const expected = [
+              referralFormSectionFactory
+                .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+                .build(),
+              referralFormSectionFactory
+                .interventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence')
+                .build(),
+              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            ]
+            expect(presenter.sections).toEqual(expected)
+          })
         })
       })
-      describe('when "Service user details" has been set', () => {
-        it('should contain a "Not started" label and "risk-information" url visible', () => {
-          const referral = draftReferralFactory.serviceUserSelected().build()
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
-          const expected = [
-            referralFormSectionFactory.reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information').build(),
-            referralFormSectionFactory
-              .interventionDetails('social inclusion', ReferralFormStatus.CannotStartYet)
-              .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
-          ]
-          expect(presenter.sections).toEqual(expected)
+      describe('service category referral details section', () => {
+        describe('when "relevant sentence" has been set', () => {
+          it('should contain a "Not Started" label and "complexity-level" url visible', () => {
+            const referral = draftReferralFactory.filledFormUpToRelevantSentence([serviceCategory]).build()
+            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const expected = [
+              referralFormSectionFactory
+                .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+                .build(),
+              referralFormSectionFactory
+                .interventionDetails(
+                  'accommodation',
+                  ReferralFormStatus.NotStarted,
+                  'relevant-sentence',
+                  `service-category/${serviceCategory.id}/desired-outcomes`
+                )
+                .build(),
+              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            ]
+            expect(presenter.sections).toEqual(expected)
+          })
+        })
+        describe('when "desired outcomes" has been set', () => {
+          it('should contain a "Not Started" label and "desired-outcomes" url visible', () => {
+            const referral = draftReferralFactory
+              .filledFormUpToRelevantSentence([serviceCategory])
+              .addSelectedDesiredOutcomes([serviceCategory])
+              .build()
+            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const expected = [
+              referralFormSectionFactory
+                .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+                .build(),
+              referralFormSectionFactory
+                .interventionDetails(
+                  'accommodation',
+                  ReferralFormStatus.NotStarted,
+                  'relevant-sentence',
+                  `service-category/${serviceCategory.id}/desired-outcomes`,
+                  `service-category/${serviceCategory.id}/complexity-level`
+                )
+                .build(),
+              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            ]
+            expect(presenter.sections).toEqual(expected)
+          })
+        })
+        describe('when "complexity level" has been set', () => {
+          it('should contain a "Not Started" label and "completion-deadline" url visible', () => {
+            const referral = draftReferralFactory
+              .filledFormUpToRelevantSentence([serviceCategory])
+              .addSelectedDesiredOutcomes([serviceCategory])
+              .addSelectedComplexityLevel([serviceCategory])
+              .build({ serviceCategoryIds: [serviceCategory.id] })
+            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const expected = [
+              referralFormSectionFactory
+                .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+                .build(),
+              referralFormSectionFactory
+                .interventionDetails(
+                  'accommodation',
+                  ReferralFormStatus.NotStarted,
+                  'relevant-sentence',
+                  `service-category/${serviceCategory.id}/desired-outcomes`,
+                  `service-category/${serviceCategory.id}/complexity-level`,
+                  'completion-deadline'
+                )
+                .build(),
+              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            ]
+            expect(presenter.sections).toEqual(expected)
+          })
+        })
+        describe('when "date completed by" has been set', () => {
+          it('should contain a "Not Started" label and "rar-days" url visible', () => {
+            const referral = draftReferralFactory.filledFormUpToCompletionDate([serviceCategory]).build()
+            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const expected = [
+              referralFormSectionFactory
+                .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+                .build(),
+              referralFormSectionFactory
+                .interventionDetails(
+                  'accommodation',
+                  ReferralFormStatus.NotStarted,
+                  'relevant-sentence',
+                  `service-category/${serviceCategory.id}/desired-outcomes`,
+                  `service-category/${serviceCategory.id}/complexity-level`,
+                  'completion-deadline',
+                  'rar-days'
+                )
+                .build(),
+              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            ]
+            expect(presenter.sections).toEqual(expected)
+          })
+        })
+        describe('when "rar days" has been set', () => {
+          it('should contain a "Not Started" label and "further-information" url visible', () => {
+            const referral = draftReferralFactory.filledFormUpToRarDays([serviceCategory]).build()
+            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const expected = [
+              referralFormSectionFactory
+                .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+                .build(),
+              referralFormSectionFactory
+                .interventionDetails(
+                  'accommodation',
+                  ReferralFormStatus.NotStarted,
+                  'relevant-sentence',
+                  `service-category/${serviceCategory.id}/desired-outcomes`,
+                  `service-category/${serviceCategory.id}/complexity-level`,
+                  'completion-deadline',
+                  'rar-days',
+                  'further-information'
+                )
+                .build(),
+              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            ]
+            expect(presenter.sections).toEqual(expected)
+          })
+        })
+        describe('when all required values have been set', () => {
+          it('should contain a "Completed" label and allow user to submit answers', () => {
+            const referral = draftReferralFactory.filledFormUpToFurtherInformation([serviceCategory]).build()
+            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const expected = [
+              referralFormSectionFactory
+                .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+                .build(),
+              referralFormSectionFactory
+                .interventionDetails(
+                  'accommodation',
+                  ReferralFormStatus.Completed,
+                  'relevant-sentence',
+                  `service-category/${serviceCategory.id}/desired-outcomes`,
+                  `service-category/${serviceCategory.id}/complexity-level`,
+                  'completion-deadline',
+                  'rar-days',
+                  'further-information'
+                )
+                .build(),
+              referralFormSectionFactory
+                .checkAnswers(ReferralFormStatus.NotStarted)
+                .build({ tasks: [{ title: 'Check your answers', url: 'check-answers' }] }),
+            ]
+            expect(presenter.sections).toEqual(expected)
+          })
         })
       })
-      describe('when "risk information" has been set', () => {
-        it('should contain a "Not started" label and "needs-and-requirements" url visible', () => {
-          const referral = draftReferralFactory.serviceUserSelected().riskInformation().build()
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
-          const expected = [
-            referralFormSectionFactory
-              .reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information', 'needs-and-requirements')
-              .build(),
-            referralFormSectionFactory
-              .interventionDetails('social inclusion', ReferralFormStatus.CannotStartYet)
-              .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
-          ]
-          expect(presenter.sections).toEqual(expected)
-        })
-      })
-      describe('when all required values have been set', () => {
-        it('should contain a "Completed" label and service category details section can be started', () => {
-          const referral = draftReferralFactory.serviceUserSelected().riskInformation().needsAndRequirements().build()
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+      describe('when "serviceCategoryIds" have not been set on the referral', () => {
+        // TODO IC-1686: add more detail when adding links for cohort services to referral form
+        it('should display an empty link for selecting desired outcomes and complexity level', () => {
+          const referral = draftReferralFactory.filledFormUpToRelevantSentence([serviceCategory]).build({
+            serviceCategoryIds: null,
+          })
+
+          const presenter = new ReferralFormPresenter(referral, [serviceCategory])
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
             referralFormSectionFactory
-              .interventionDetails('social inclusion', ReferralFormStatus.NotStarted, 'relevant-sentence')
+              .interventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', null, null)
               .build(),
             referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
           ]
@@ -67,92 +245,154 @@ describe('ReferralFormPresenter', () => {
         })
       })
     })
+  })
+  describe('for a cohort referral', () => {
+    const serviceCategories: ServiceCategory[] = [
+      serviceCategoryFactory.build({ name: 'accommodation' }),
+      serviceCategoryFactory.build({ name: 'social inclusion' }),
+    ]
     describe('service category referral details section', () => {
       describe('when "relevant sentence" has been set', () => {
-        it('should contain a "Not Started" label and "relevant-sentence" url visible', () => {
-          const serviceCategory = serviceCategoryFactory.build()
-
-          const referral = draftReferralFactory
-            .serviceUserSelected()
-            .riskInformation()
-            .needsAndRequirements()
-            .serviceCategoriesSelected([serviceCategory.id])
-            .relevantSentence()
-            .build()
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+        it('should contain a "Not Started" label and only the first "complexity-level" url is visible', () => {
+          const referral = draftReferralFactory.filledFormUpToRelevantSentence(serviceCategories).build()
+          const presenter = new ReferralFormPresenter(referral, serviceCategories)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
-            referralFormSectionFactory
-              .interventionDetails(
-                'social inclusion',
-                ReferralFormStatus.NotStarted,
-                'relevant-sentence',
-                `service-category/${serviceCategory.id}/desired-outcomes`
-              )
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
+                {
+                  title: 'accommodation',
+                  desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
+                  complexityLevelUrl: null,
+                },
+                { title: 'social inclusion', complexityLevelUrl: null, desiredOutcomesUrl: null },
+              ])
               .build(),
             referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
       })
-      describe('when "desired outcomes" has been set', () => {
-        it('should contain a "Not Started" label and "complexity-level" url visible', () => {
-          const serviceCategory = serviceCategoryFactory.build()
-
+      describe('when "complexity level" has been set for the first service', () => {
+        it('should contain a "Not Started" label and only the first "desired-outcomes" url is visible', () => {
           const referral = draftReferralFactory
-            .serviceUserSelected()
-            .riskInformation()
-            .needsAndRequirements()
-            .serviceCategoriesSelected([serviceCategory.id])
-            .relevantSentence()
-            .desiredOutcomes()
+            .filledFormUpToRelevantSentence(serviceCategories)
+            .addSelectedDesiredOutcomes([serviceCategories[0]])
             .build()
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const presenter = new ReferralFormPresenter(referral, serviceCategories)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
-            referralFormSectionFactory
-              .interventionDetails(
-                'social inclusion',
-                ReferralFormStatus.NotStarted,
-                'relevant-sentence',
-                `service-category/${serviceCategory.id}/desired-outcomes`,
-                `service-category/${serviceCategory.id}/complexity-level`
-              )
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
+                {
+                  title: 'accommodation',
+                  desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
+                  complexityLevelUrl: `service-category/${serviceCategories[0].id}/complexity-level`,
+                },
+                { title: 'social inclusion', complexityLevelUrl: null, desiredOutcomesUrl: null },
+              ])
               .build(),
             referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
       })
-      describe('when "complexity level" has been set', () => {
+      describe('when "desired outcomes" has been set for the first service', () => {
+        it('should contain a "Not Started" label and the second "complexity-level" url is visible', () => {
+          const referral = draftReferralFactory
+            .filledFormUpToRelevantSentence(serviceCategories)
+            .addSelectedDesiredOutcomes([serviceCategories[0]])
+            .addSelectedComplexityLevel([serviceCategories[0]])
+            .build()
+          const presenter = new ReferralFormPresenter(referral, serviceCategories)
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+              .build(),
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
+                {
+                  title: 'accommodation',
+                  desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
+                  complexityLevelUrl: `service-category/${serviceCategories[0].id}/complexity-level`,
+                },
+                {
+                  title: 'social inclusion',
+                  desiredOutcomesUrl: `service-category/${serviceCategories[1].id}/desired-outcomes`,
+                  complexityLevelUrl: null,
+                },
+              ])
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
+
+      describe('when "complexity level" has been set for the second service', () => {
+        it('should contain a "Not Started" label and the second "desired-outcomes" url is visible', () => {
+          const referral = draftReferralFactory
+            .filledFormUpToRelevantSentence(serviceCategories)
+            .addSelectedDesiredOutcomes(serviceCategories)
+            .addSelectedComplexityLevel([serviceCategories[0]])
+            .build()
+          const presenter = new ReferralFormPresenter(referral, serviceCategories)
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+              .build(),
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
+                {
+                  title: 'accommodation',
+                  desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
+                  complexityLevelUrl: `service-category/${serviceCategories[0].id}/complexity-level`,
+                },
+                {
+                  title: 'social inclusion',
+                  desiredOutcomesUrl: `service-category/${serviceCategories[1].id}/desired-outcomes`,
+                  complexityLevelUrl: `service-category/${serviceCategories[1].id}/complexity-level`,
+                },
+              ])
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
+      describe('when "desired outcomes" has been set for second service', () => {
         it('should contain a "Not Started" label and "completion-deadline" url visible', () => {
-          const serviceCategory = serviceCategoryFactory.build()
-
           const referral = draftReferralFactory
-            .serviceUserSelected()
-            .riskInformation()
-            .needsAndRequirements()
-            .serviceCategoriesSelected([serviceCategory.id])
-            .relevantSentence()
-            .desiredOutcomes()
-            .complexityLevel()
+            .filledFormUpToRelevantSentence(serviceCategories)
+            .addSelectedDesiredOutcomes(serviceCategories)
+            .addSelectedComplexityLevel(serviceCategories)
             .build()
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const presenter = new ReferralFormPresenter(referral, serviceCategories)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
-            referralFormSectionFactory
-              .interventionDetails(
-                'social inclusion',
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails(
+                'accommodation',
                 ReferralFormStatus.NotStarted,
                 'relevant-sentence',
-                `service-category/${serviceCategory.id}/desired-outcomes`,
-                `service-category/${serviceCategory.id}/complexity-level`,
+                [
+                  {
+                    title: 'accommodation',
+                    desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
+                    complexityLevelUrl: `service-category/${serviceCategories[0].id}/complexity-level`,
+                  },
+                  {
+                    title: 'social inclusion',
+                    desiredOutcomesUrl: `service-category/${serviceCategories[1].id}/desired-outcomes`,
+                    complexityLevelUrl: `service-category/${serviceCategories[1].id}/complexity-level`,
+                  },
+                ],
                 'completion-deadline'
               )
               .build(),
@@ -163,30 +403,29 @@ describe('ReferralFormPresenter', () => {
       })
       describe('when "date completed by" has been set', () => {
         it('should contain a "Not Started" label and "rar-days" url visible', () => {
-          const serviceCategory = serviceCategoryFactory.build()
-
-          const referral = draftReferralFactory
-            .serviceUserSelected()
-            .riskInformation()
-            .needsAndRequirements()
-            .serviceCategoriesSelected([serviceCategory.id])
-            .relevantSentence()
-            .desiredOutcomes()
-            .complexityLevel()
-            .completionDate()
-            .build()
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const referral = draftReferralFactory.filledFormUpToCompletionDate(serviceCategories).build()
+          const presenter = new ReferralFormPresenter(referral, serviceCategories)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
-            referralFormSectionFactory
-              .interventionDetails(
-                'social inclusion',
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails(
+                'accommodation',
                 ReferralFormStatus.NotStarted,
                 'relevant-sentence',
-                `service-category/${serviceCategory.id}/desired-outcomes`,
-                `service-category/${serviceCategory.id}/complexity-level`,
+                [
+                  {
+                    title: 'accommodation',
+                    desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
+                    complexityLevelUrl: `service-category/${serviceCategories[0].id}/complexity-level`,
+                  },
+                  {
+                    title: 'social inclusion',
+                    desiredOutcomesUrl: `service-category/${serviceCategories[1].id}/desired-outcomes`,
+                    complexityLevelUrl: `service-category/${serviceCategories[1].id}/complexity-level`,
+                  },
+                ],
                 'completion-deadline',
                 'rar-days'
               )
@@ -198,31 +437,29 @@ describe('ReferralFormPresenter', () => {
       })
       describe('when "rar days" has been set', () => {
         it('should contain a "Not Started" label and "further-information" url visible', () => {
-          const serviceCategory = serviceCategoryFactory.build()
-
-          const referral = draftReferralFactory
-            .serviceUserSelected()
-            .riskInformation()
-            .needsAndRequirements()
-            .serviceCategoriesSelected([serviceCategory.id])
-            .relevantSentence()
-            .desiredOutcomes()
-            .complexityLevel()
-            .completionDate()
-            .rarDays()
-            .build()
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const referral = draftReferralFactory.filledFormUpToRarDays(serviceCategories).build()
+          const presenter = new ReferralFormPresenter(referral, serviceCategories)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
-            referralFormSectionFactory
-              .interventionDetails(
-                'social inclusion',
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails(
+                'accommodation',
                 ReferralFormStatus.NotStarted,
                 'relevant-sentence',
-                `service-category/${serviceCategory.id}/desired-outcomes`,
-                `service-category/${serviceCategory.id}/complexity-level`,
+                [
+                  {
+                    title: 'accommodation',
+                    desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
+                    complexityLevelUrl: `service-category/${serviceCategories[0].id}/complexity-level`,
+                  },
+                  {
+                    title: 'social inclusion',
+                    desiredOutcomesUrl: `service-category/${serviceCategories[1].id}/desired-outcomes`,
+                    complexityLevelUrl: `service-category/${serviceCategories[1].id}/complexity-level`,
+                  },
+                ],
                 'completion-deadline',
                 'rar-days',
                 'further-information'
@@ -235,32 +472,29 @@ describe('ReferralFormPresenter', () => {
       })
       describe('when all required values have been set', () => {
         it('should contain a "Completed" label and allow user to submit answers', () => {
-          const serviceCategory = serviceCategoryFactory.build()
-
-          const referral = draftReferralFactory
-            .serviceUserSelected()
-            .riskInformation()
-            .needsAndRequirements()
-            .serviceCategoriesSelected([serviceCategory.id])
-            .relevantSentence()
-            .desiredOutcomes()
-            .complexityLevel()
-            .completionDate()
-            .rarDays()
-            .furtherInformation()
-            .build()
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
+          const referral = draftReferralFactory.filledFormUpToFurtherInformation(serviceCategories).build()
+          const presenter = new ReferralFormPresenter(referral, serviceCategories)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
-            referralFormSectionFactory
-              .interventionDetails(
-                'social inclusion',
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails(
+                'accommodation',
                 ReferralFormStatus.Completed,
                 'relevant-sentence',
-                `service-category/${serviceCategory.id}/desired-outcomes`,
-                `service-category/${serviceCategory.id}/complexity-level`,
+                [
+                  {
+                    title: 'accommodation',
+                    desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
+                    complexityLevelUrl: `service-category/${serviceCategories[0].id}/complexity-level`,
+                  },
+                  {
+                    title: 'social inclusion',
+                    desiredOutcomesUrl: `service-category/${serviceCategories[1].id}/desired-outcomes`,
+                    complexityLevelUrl: `service-category/${serviceCategories[1].id}/complexity-level`,
+                  },
+                ],
                 'completion-deadline',
                 'rar-days',
                 'further-information'
@@ -269,25 +503,6 @@ describe('ReferralFormPresenter', () => {
             referralFormSectionFactory
               .checkAnswers(ReferralFormStatus.NotStarted)
               .build({ tasks: [{ title: 'Check your answers', url: 'check-answers' }] }),
-          ]
-          expect(presenter.sections).toEqual(expected)
-        })
-      })
-
-      describe('when "serviceCategoryIds" have not been set on the referral', () => {
-        // TODO IC-1686: add more detail when adding links for cohort services to referral form
-        it('should display an empty link for selecting desired outcomes and complexity level', () => {
-          const referral = draftReferralFactory.serviceUserSelected().riskInformation().needsAndRequirements().build()
-
-          const presenter = new ReferralFormPresenter(referral, 'social inclusion')
-          const expected = [
-            referralFormSectionFactory
-              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
-              .build(),
-            referralFormSectionFactory
-              .interventionDetails('social inclusion', ReferralFormStatus.NotStarted, 'relevant-sentence', null, null)
-              .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })

--- a/server/views/referrals/form.njk
+++ b/server/views/referrals/form.njk
@@ -17,20 +17,26 @@
         {% for section in presenter.sections %}
           {% if section.type === 'multi' %}
             <li>
+              <strong data-cy="status" class="{{ classForStatus(section.status) }} moj-task-list__task-completed">
+                  {{ section.status }}
+              </strong>
               <h2 class="moj-task-list__section">
                 <span class="moj-task-list__section-number">{{ section.number }}.</span>
                 {{ section.title }}
               </h2>
             </li>
-
             {% for taskListSection in section.taskListSections %}
-              <li class="govuk-!-margin-left-5">
-                {% set nested = true %}
+              <li>
+                {% set last = loop.last %}
+                {% set multi = true %}
+                {% set nested = (taskListSection.title !== undefined) %}
                 {% include "./partials/taskListSection.njk" %}
               </li>
             {% endfor %}
           {% elif section.type === 'single' %}
             <li>
+              {% set last = false %}
+              {% set multi = false %}
               {% set taskListSection = section %}
               {% set nested = false %}
               {% include "./partials/taskListSection.njk" %}

--- a/server/views/referrals/partials/taskListSection.njk
+++ b/server/views/referrals/partials/taskListSection.njk
@@ -4,22 +4,28 @@ it to get a right-floated tag. There’s a broader question of whether
 we’ve mis-implemented the MoJ task list pattern, in which tags are
 only used on individual completed tasks. Needs some design review.
 #}
-<strong data-cy="status" class="{{ classForStatus(taskListSection.status) }} moj-task-list__task-completed">
-  {{ taskListSection.status }}
-</strong>
+{% if taskListSection.status !== undefined %}
+    <strong data-cy="status" class="{{ classForStatus(taskListSection.status) }} moj-task-list__task-completed">
+      {{ taskListSection.status }}
+    </strong>
+{% endif %}
 
-<h2 class="moj-task-list__section">
-  <span class="moj-task-list__section-number {{ "govuk-!-padding-right-2" if nested }}">{{ taskListSection.number }}.</span>
+{% if taskListSection.title !== undefined %}
+<h2 class="moj-task-list__section {{ "govuk-!-margin-left-9" if nested }}">
+    {% if taskListSection.number !== undefined %}
+      <span class="moj-task-list__section-number {{ "govuk-!-padding-right-2" if nested }}">{{ taskListSection.number }}.</span>
+    {% endif %}
   {{ taskListSection.title }}
 </h2>
+{% endif %}
 
-<ul class="moj-task-list__items">
+<ul class="moj-task-list__items {{"moj-task-list__items-multi " if multi}} {{"moj-task-list__items-last-of-section " if last}} {{ "moj-task-list__items-nested" if nested }}">
   {% for task in taskListSection.tasks %}
     <li class="moj-task-list__item">
       {% if task.url !== null %}
-        <a class="moj-task-list__task-name" href="{{ task.url }}">{{ task.title }}</a>
+        <a data-cy="url" class="moj-task-list__task-name" href="{{ task.url }}">{{ task.title }}</a>
       {% else %}
-        <span class="app-task-list__task-name">{{ task.title }}</span>
+        <span data-cy="url" class="app-task-list__task-name">{{ task.title }}</span>
       {% endif %}
     </li>
   {% endfor %}

--- a/testutils/factories/cohortReferralFormSection.ts
+++ b/testutils/factories/cohortReferralFormSection.ts
@@ -1,0 +1,62 @@
+import { Factory } from 'fishery'
+import {
+  ReferralFormMultiListSectionPresenter,
+  ReferralFormStatus,
+} from '../../server/routes/referrals/referralFormPresenter'
+
+class CohortReferralFormSectionFactory extends Factory<ReferralFormMultiListSectionPresenter> {
+  cohortInterventionDetails(
+    serviceCategoryName: string,
+    referralFormStatus: ReferralFormStatus = ReferralFormStatus.CannotStartYet,
+    relevantSentenceUrl: string | null = null,
+    cohortUrls: { title: string; desiredOutcomesUrl: string | null; complexityLevelUrl: string | null }[] = [],
+    completionDateUrl: string | null = null,
+    rarDaysUrl: string | null = null,
+    furtherInformationUrl: string | null = null
+  ) {
+    return this.params({
+      type: 'multi',
+      title: `Add intervention referral details`,
+      number: '2',
+      status: referralFormStatus,
+      taskListSections: [
+        {
+          tasks: [{ title: `Confirm the relevant sentence for the intervention referral`, url: relevantSentenceUrl }],
+        },
+      ]
+        .concat(
+          cohortUrls.map(cohortUrl => {
+            return {
+              title: cohortUrl.title,
+              tasks: [
+                { title: 'Select desired outcomes', url: cohortUrl.desiredOutcomesUrl },
+                { title: 'Select required complexity level', url: cohortUrl.complexityLevelUrl },
+              ],
+            }
+          })
+        )
+        .concat([
+          {
+            tasks: [
+              {
+                title: `Enter when the intervention service need to be completed`,
+                url: completionDateUrl,
+              },
+              { title: 'Enter enforceable days used', url: rarDaysUrl },
+              { title: 'Further information for service provider', url: furtherInformationUrl },
+            ],
+          },
+        ]),
+    })
+  }
+}
+type MultiFormType = 'multi'
+const multiSectionForm: MultiFormType = 'multi'
+
+export default CohortReferralFormSectionFactory.define(() => ({
+  type: multiSectionForm,
+  title: '',
+  number: '1',
+  status: ReferralFormStatus.CannotStartYet,
+  taskListSections: [],
+}))

--- a/testutils/factories/referralFormSection.ts
+++ b/testutils/factories/referralFormSection.ts
@@ -1,7 +1,10 @@
 import { Factory } from 'fishery'
-import { ReferralFormSectionPresenter, ReferralFormStatus } from '../../server/routes/referrals/referralFormPresenter'
+import {
+  ReferralFormSingleListSectionPresenter,
+  ReferralFormStatus,
+} from '../../server/routes/referrals/referralFormPresenter'
 
-class ReferralFormSectionFactory extends Factory<ReferralFormSectionPresenter> {
+class ReferralFormSectionFactory extends Factory<ReferralFormSingleListSectionPresenter> {
   reviewServiceUser(
     referralFormStatus: ReferralFormStatus = ReferralFormStatus.NotStarted,
     riskInformationUrl: string | null = null,
@@ -36,14 +39,14 @@ class ReferralFormSectionFactory extends Factory<ReferralFormSectionPresenter> {
       number: '2',
       status: referralFormStatus,
       tasks: [
-        { title: 'Select the relevant sentence for the social inclusion referral', url: relevantSentenceUrl },
+        { title: `Confirm the relevant sentence for the ${serviceCategoryName} referral`, url: relevantSentenceUrl },
         { title: 'Select desired outcomes', url: desiredOutcomesUrl },
         { title: 'Select required complexity level', url: complexityLevelUrl },
         {
-          title: 'What date does the social inclusion service need to be completed by?',
+          title: `Enter when the ${serviceCategoryName} service need to be completed`,
           url: completionDateUrl,
         },
-        { title: 'Enter RAR days used', url: rarDaysUrl },
+        { title: 'Enter enforceable days used', url: rarDaysUrl },
         { title: 'Further information for service provider', url: furtherInformationUrl },
       ],
     })
@@ -62,12 +65,13 @@ class ReferralFormSectionFactory extends Factory<ReferralFormSectionPresenter> {
     })
   }
 }
-type SectionFormType = 'single' | 'multi'
+type SectionFormType = 'single'
 const singleSectionForm: SectionFormType = 'single'
+
 export default ReferralFormSectionFactory.define(() => ({
   type: singleSectionForm,
   title: '',
   number: '1',
-  tasks: [],
   status: ReferralFormStatus.CannotStartYet,
+  tasks: [],
 }))


### PR DESCRIPTION
…e a referral' form for cohort referrals

## What does this pull request do?

Adjusts the "Make a referral" page to be able to process cohort referrals to show desired outcomes and complexity level links.

It also adjusts the behaviour of "save and continue" for complexity level page if the referral is a cohort referral.

Before the user has selected service categories the nested desired outcomes and complexity will not be visible. However for this PR it is assumed that the service category ids will have been selected already. Single referrals will still look like the existing screen does.

It was not possible to separate this into two separate commits for desired outcome and complexity level which is why they are combined together.

**note**: I've confirmed with @rwk-moj if it's acceptable to not completely adhere to the line separators as depicted in the examples he provided. He says it's okay but he will need to approve it first. The reason is because a pure css solution isn't possible given that sections aren't separated but instead each row is a new \<li\> within the same \<ol\>. In order to replicate the image I'd either have to change the HTML elements or write some messy nun-jucks code 

## What is the intent behind these changes?

Provide ability for the user to view the status of cohort referrals



![image](https://user-images.githubusercontent.com/83066216/118844210-b1bc3580-b8c2-11eb-9038-1fb1ebf196c8.png)
