### PR TITLE
IC-1188: Make caring/employment text box a textarea

### DIFF
--- a/server/routes/referrals/needsAndRequirementsView.ts
+++ b/server/routes/referrals/needsAndRequirementsView.ts
@@ -111,11 +111,10 @@ export default class NeedsAndRequirementsView {
     }
   }
 
-  private get whenUnavailableInputArgs(): InputArgs {
+  private get whenUnavailableTextareaArgs(): InputArgs {
     return {
       id: 'when-unavailable',
       name: 'when-unavailable',
-      classes: 'govuk-!-width-one-third',
       label: {
         text: this.presenter.text.whenUnavailable.label,
       },
@@ -136,7 +135,7 @@ export default class NeedsAndRequirementsView {
         interpreterRadiosArgs: this.interpreterRadiosArgs.bind(this),
         interpreterLanguageInputArgs: this.interpreterLanguageInputArgs,
         responsibilitiesRadiosArgs: this.responsibilitiesRadiosArgs.bind(this),
-        whenUnavailableInputArgs: this.whenUnavailableInputArgs,
+        whenUnavailableTextareaArgs: this.whenUnavailableTextareaArgs,
       },
     ]
   }

--- a/server/views/referrals/needsAndRequirements.njk
+++ b/server/views/referrals/needsAndRequirements.njk
@@ -42,7 +42,7 @@
         {{ govukRadios(interpreterRadiosArgs(interpreterLanguageHtml)) }}
 
         {% set whenUnavailableHtml %}
-        {{ govukInput(whenUnavailableInputArgs) }}
+        {{ govukTextarea(whenUnavailableTextareaArgs) }}
         {% endset -%}
         {{ govukRadios(responsibilitiesRadiosArgs(whenUnavailableHtml)) }}
 


### PR DESCRIPTION
## What does this pull request do?

Switches caring/employment text input into larger textarea.

## What is the intent behind these changes?

This was determined to be too small after a few rounds of research, and the small input field couldn't capture the level of detail users tried to enter.

## Screenshot

## Before

![image](https://user-images.githubusercontent.com/19826940/118967084-2db98a80-b962-11eb-93f5-eda836413bc8.png)

## After
![image](https://user-images.githubusercontent.com/19826940/118967026-1aa6ba80-b962-11eb-851d-0bfb883a9ebf.png)



