### PR TITLE
IC-1768: Add ContractType to Intervention model and update contract tests

### DIFF
--- a/server/models/intervention.ts
+++ b/server/models/intervention.ts
@@ -16,7 +16,7 @@ export default interface Intervention {
   description: string
   npsRegion: NPSRegion | null
   pccRegions: PCCRegion[]
-  serviceCategory: ServiceCategory
+  serviceCategory: ServiceCategory // deprecated
   serviceCategories: ServiceCategory[]
   serviceProvider: ServiceProvider
   eligibility: Eligibility

--- a/server/models/intervention.ts
+++ b/server/models/intervention.ts
@@ -10,6 +10,11 @@ export interface Eligibility {
   allowsMale: boolean
 }
 
+interface ContractType {
+  code: string
+  name: string
+}
+
 export default interface Intervention {
   id: string
   title: string
@@ -20,4 +25,5 @@ export default interface Intervention {
   serviceCategories: ServiceCategory[]
   serviceProvider: ServiceProvider
   eligibility: Eligibility
+  contractType: ContractType
 }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -6,9 +6,6 @@ import SentReferral from '../models/sentReferral'
 import ServiceUser from '../models/serviceUser'
 import config from '../config'
 import oauth2TokenFactory from '../../testutils/factories/oauth2Token'
-import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
-import serviceProviderFactory from '../../testutils/factories/serviceProvider'
-import eligibilityFactory from '../../testutils/factories/eligibility'
 import interventionFactory from '../../testutils/factories/intervention'
 import DeliusServiceUser from '../models/delius/deliusServiceUser'
 import actionPlanFactory from '../../testutils/factories/actionPlan'
@@ -1535,22 +1532,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
   describe('getInterventions', () => {
     it('returns a list of all interventions', async () => {
-      const intervention = {
-        id: '15237ae5-a017-4de6-a033-abf350f14d99',
-        title: 'Better solutions (anger management)',
-        description:
-          'To provide service users with key tools and strategies to address issues of anger management and temper control and explore the link between thoughts, emotions and behaviour. It provides the opportunity for service users to practice these strategies in a safe and closed environment.',
-        pccRegions: [
-          { id: 'cheshire', name: 'Cheshire' },
-          { id: 'cumbria', name: 'Cumbria' },
-          { id: 'lancashire', name: 'Lancashire' },
-          { id: 'merseyside', name: 'Merseyside' },
-        ],
-        serviceCategory: serviceCategoryFactory.build(),
-        serviceCategories: [serviceCategoryFactory.build()],
-        serviceProvider: serviceProviderFactory.build(),
-        eligibility: eligibilityFactory.allAdults().build(),
-      }
+      const interventions = interventionFactory.buildList(2)
 
       await provider.addInteraction({
         state: 'There are some interventions',
@@ -1562,12 +1544,12 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
         willRespondWith: {
           status: 200,
-          body: Matchers.like([intervention, intervention]),
+          body: Matchers.like(interventions),
           headers: { 'Content-Type': 'application/json' },
         },
       })
 
-      expect(await interventionsService.getInterventions(token, {})).toEqual([intervention, intervention])
+      expect(await interventionsService.getInterventions(token, {})).toEqual(interventions)
     })
 
     describe('allowsMale filter', () => {

--- a/testutils/factories/intervention.ts
+++ b/testutils/factories/intervention.ts
@@ -30,5 +30,9 @@ The service will use the following methods:
     serviceCategories: [serviceCategory],
     serviceProvider: serviceProviderFactory.build(),
     eligibility: eligibilityFactory.allAdults().build(),
+    contractType: {
+      code: 'ACC',
+      name: 'Accommodation',
+    },
   }
 })


### PR DESCRIPTION
## What does this pull request do?

Adds `contractType` to intervention model

## What is the intent behind these changes?

We'll be using this in place of the `serviceCategory`, now that we have
cohort referrals that have their own contract type - e.g. "Women's
services" could have multiple service categories (Accommodation, Social
Inclusion) but in dashboards we want to display "Women's services",
rather than a list of all the service categories.
