### PR TITLE
IC-1726: Refactor PP dashboard to use contract type over service category

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -4,6 +4,7 @@ import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
 import actionPlanFactory from '../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../testutils/factories/actionPlanAppointment'
+import interventionFactory from '../../testutils/factories/intervention'
 
 describe('Probation Practitioner monitor journey', () => {
   beforeEach(() => {
@@ -16,9 +17,10 @@ describe('Probation Practitioner monitor journey', () => {
   describe('viewing the progress of an intervention', () => {
     it('displays the referral progress page with the status of each session', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
       const referralParams = {
         id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
-        referral: { serviceCategoryId: serviceCategory.id },
+        referral: { interventionId: intervention.id, serviceCategoryId: serviceCategory.id },
       }
       const deliusServiceUser = deliusServiceUserFactory.build()
       const probationPractitioner = deliusUserFactory.build({
@@ -59,9 +61,7 @@ describe('Probation Practitioner monitor journey', () => {
         actionPlanId: actionPlan.id,
       })
 
-      // Necessary until we add the Monitor dashboard
-      cy.stubGetDraftReferralsForUser([])
-
+      cy.stubGetIntervention(assignedReferral.referral.interventionId, intervention)
       cy.stubGetSentReferrals([assignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
       cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
@@ -113,10 +113,12 @@ describe('Probation Practitioner monitor journey', () => {
   describe('Viewing session feedback', () => {
     it('allows users to click through to a page to view session feedback', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
       const referralParams = {
         id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
-        referral: { serviceCategoryId: serviceCategory.id },
+        referral: { interventionId: intervention.id, serviceCategoryId: serviceCategory.id },
       }
+
       const deliusServiceUser = deliusServiceUserFactory.build()
       const probationPractitioner = deliusUserFactory.build({
         firstName: 'John',
@@ -134,8 +136,7 @@ describe('Probation Practitioner monitor journey', () => {
         actionPlanId: actionPlan.id,
       })
 
-      cy.stubGetDraftReferralsForUser([])
-
+      cy.stubGetIntervention(assignedReferral.referral.interventionId, intervention)
       cy.stubGetSentReferrals([assignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
       cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
@@ -180,9 +181,10 @@ describe('Probation Practitioner monitor journey', () => {
   describe('cancelling a referral', () => {
     it('displays a form to allow users to submit comments and cancel a referral', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
       const referralParams = {
         id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
-        referral: { serviceCategoryId: serviceCategory.id },
+        referral: { interventionId: intervention.id, serviceCategoryId: serviceCategory.id },
       }
       const deliusServiceUser = deliusServiceUserFactory.build()
       const probationPractitioner = deliusUserFactory.build({
@@ -223,9 +225,7 @@ describe('Probation Practitioner monitor journey', () => {
         actionPlanId: actionPlan.id,
       })
 
-      // Necessary until we add the Monitor dashboard
-      cy.stubGetDraftReferralsForUser([])
-
+      cy.stubGetIntervention(assignedReferral.referral.interventionId, intervention)
       cy.stubGetSentReferrals([assignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
       cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -2,6 +2,7 @@ import sentReferralFactory from '../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
 import endOfServiceReportFactory from '../../testutils/factories/endOfServiceReport'
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
+import interventionFactory from '../../testutils/factories/intervention'
 
 describe('Probation practitioner referrals dashboard', () => {
   beforeEach(() => {
@@ -12,15 +13,15 @@ describe('Probation practitioner referrals dashboard', () => {
   })
 
   it("user logs in and sees 'My cases' screen with list of sent referrals", () => {
-    const accommodationServiceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-    const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+    const accommodationIntervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
+    const womensServicesIntervention = interventionFactory.build({ contractType: { name: "womens' services" } })
 
     const sentReferrals = [
       sentReferralFactory.build({
         sentAt: '2021-01-26T13:00:00.000000Z',
         referenceNumber: 'ABCABCA1',
         referral: {
-          serviceCategoryId: accommodationServiceCategory.id,
+          interventionId: accommodationIntervention.id,
           serviceUser: { firstName: 'George', lastName: 'Michael' },
           desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
           complexityLevelId: '110f2405-d944-4c15-836c-0c6684e2aa78',
@@ -35,7 +36,7 @@ describe('Probation practitioner referrals dashboard', () => {
         },
         referenceNumber: 'ABCABCA2',
         referral: {
-          serviceCategoryId: socialInclusionServiceCategory.id,
+          interventionId: womensServicesIntervention.id,
           serviceUser: { firstName: 'Jenny', lastName: 'Jones', crn: 'X123456' },
           desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
           complexityLevelId: '110f2405-d944-4c15-836c-0c6684e2aa78',
@@ -43,8 +44,8 @@ describe('Probation practitioner referrals dashboard', () => {
       }),
     ]
 
-    cy.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory)
-    cy.stubGetServiceCategory(socialInclusionServiceCategory.id, socialInclusionServiceCategory)
+    cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
+    cy.stubGetIntervention(womensServicesIntervention.id, womensServicesIntervention)
     cy.stubGetSentReferrals(sentReferrals)
 
     cy.login()
@@ -57,7 +58,7 @@ describe('Probation practitioner referrals dashboard', () => {
         {
           Referral: 'ABCABCA1',
           'Service user': 'George Michael',
-          'Service Category': 'accommodation',
+          'Service Category': 'Accommodation',
           Provider: 'Harmony Living',
           Caseworker: 'Unassigned',
           Action: 'View',
@@ -65,7 +66,7 @@ describe('Probation practitioner referrals dashboard', () => {
         {
           Referral: 'ABCABCA2',
           'Service user': 'Jenny Jones',
-          'Service Category': 'social inclusion',
+          'Service Category': "Womens' services",
           Provider: 'Harmony Living',
           Caseworker: 'A. Caseworker',
           Action: 'View',

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.test.ts
@@ -1,13 +1,16 @@
+import interventionFactory from '../../../testutils/factories/intervention'
 import SentReferralFactory from '../../../testutils/factories/sentReferral'
-import ServiceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import MyCasesPresenter from './myCasesPresenter'
 
 describe('MyCasesPresenter', () => {
-  const serviceCategories = [ServiceCategoryFactory.build({ id: '1' }), ServiceCategoryFactory.build({ id: '2' })]
+  const interventions = [
+    interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } }),
+    interventionFactory.build({ id: '2', contractType: { name: "womens' services" } }),
+  ]
   const referrals = [
     SentReferralFactory.assigned().build({
       referral: {
-        serviceCategoryId: '1',
+        interventionId: '1',
         serviceUser: {
           firstName: 'rob',
           lastName: 'shah-brookes',
@@ -16,7 +19,7 @@ describe('MyCasesPresenter', () => {
     }),
     SentReferralFactory.unassigned().build({
       referral: {
-        serviceCategoryId: '2',
+        interventionId: '2',
         serviceUser: {
           firstName: 'HARDIP',
           lastName: 'fraiser',
@@ -25,7 +28,7 @@ describe('MyCasesPresenter', () => {
     }),
     SentReferralFactory.assigned().build({
       referral: {
-        serviceCategoryId: '1',
+        interventionId: '1',
         serviceUser: {
           firstName: 'Jenny',
           lastName: 'Catherine',
@@ -36,23 +39,23 @@ describe('MyCasesPresenter', () => {
 
   describe('tableRows', () => {
     it('returns a list of table rows with appropriate sort values', () => {
-      const presenter = new MyCasesPresenter(referrals, serviceCategories)
+      const presenter = new MyCasesPresenter(referrals, interventions)
 
       expect(presenter.tableRows).toEqual([
         expect.arrayContaining([
           { text: 'Rob Shah-Brookes', sortValue: 'shah-brookes, rob', href: null },
           { text: 'UserABC', sortValue: 'AUserABC', href: null },
-          { text: 'accommodation', sortValue: 'accommodation', href: null },
+          { text: 'Accommodation', sortValue: 'accommodation', href: null },
         ]),
         expect.arrayContaining([
           { text: 'Hardip Fraiser', sortValue: 'fraiser, hardip', href: null },
           { text: 'Unassigned', sortValue: 'Unassigned', href: null },
-          { text: 'accommodation', sortValue: 'accommodation', href: null },
+          { text: "Womens' services", sortValue: "womens' services", href: null },
         ]),
         expect.arrayContaining([
           { text: 'Jenny Catherine', sortValue: 'catherine, jenny', href: null },
           { text: 'UserABC', sortValue: 'AUserABC', href: null },
-          { text: 'accommodation', sortValue: 'accommodation', href: null },
+          { text: 'Accommodation', sortValue: 'accommodation', href: null },
         ]),
       ])
     })

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
@@ -1,11 +1,12 @@
+import Intervention from '../../models/intervention'
 import SentReferral from '../../models/sentReferral'
-import ServiceCategory from '../../models/serviceCategory'
 import PresenterUtils from '../../utils/presenterUtils'
+import utils from '../../utils/utils'
 import { SortableTableHeaders, SortableTableRow } from '../../utils/viewUtils'
 import DashboardNavPresenter from './dashboardNavPresenter'
 
 export default class MyCasesPresenter {
-  constructor(private readonly sentReferrals: SentReferral[], private readonly serviceCategories: ServiceCategory[]) {}
+  constructor(private readonly sentReferrals: SentReferral[], private readonly interventions: Intervention[]) {}
 
   readonly navItemsPresenter = new DashboardNavPresenter('My cases')
 
@@ -19,10 +20,11 @@ export default class MyCasesPresenter {
   ]
 
   readonly tableRows: SortableTableRow[] = this.sentReferrals.map(referral => {
-    const { serviceCategoryId } = referral.referral
-    const serviceCategory = this.serviceCategories.find(aServiceCategory => aServiceCategory.id === serviceCategoryId)
-    if (serviceCategory === undefined) {
-      throw new Error(`Expected serviceCategories to contain service category with ID ${serviceCategoryId}`)
+    const interventionForReferral = this.interventions.find(
+      intervention => intervention.id === referral.referral.interventionId
+    )
+    if (interventionForReferral === undefined) {
+      throw new Error(`Expected referral to be linked to an intervention with ID ${referral.referral.interventionId}`)
     }
 
     // i really want the actual names here, but that's an API call for each row - how can we improve this?
@@ -40,8 +42,8 @@ export default class MyCasesPresenter {
         href: null,
       },
       {
-        text: serviceCategory.name,
-        sortValue: serviceCategory.name,
+        text: utils.convertToProperCase(interventionForReferral.contractType.name),
+        sortValue: interventionForReferral.contractType.name,
         href: null,
       },
       {

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -13,6 +13,7 @@ import endOfServiceReportFactory from '../../../testutils/factories/endOfService
 
 import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
 import CommunityApiService from '../../services/communityApiService'
+import authUtils from '../../utils/authUtils'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -38,16 +39,6 @@ afterEach(() => {
 describe('GET /probation-practitioner/find', () => {
   interventionsService.getDraftReferralsForUser.mockResolvedValue([])
 
-  it('displays a dashboard page', async () => {
-    await request(app)
-      .get('/probation-practitioner/find')
-      .expect(200)
-      .expect(res => {
-        expect(res.text).toContain('Refer and monitor an intervention')
-        expect(res.text).toContain('Find interventions')
-      })
-  })
-
   it('displays a list in-progress referrals', async () => {
     const referral = draftReferralFactory.serviceUserSelected().build()
 
@@ -57,7 +48,34 @@ describe('GET /probation-practitioner/find', () => {
       .get('/probation-practitioner/find')
       .expect(200)
       .expect(res => {
+        expect(res.text).toContain('Refer and monitor an intervention')
+        expect(res.text).toContain('Find interventions')
         expect(res.text).toContain('Alex River')
+      })
+  })
+})
+
+describe('GET /probation-practitioner/dashboard', () => {
+  it('displays a dashboard page', async () => {
+    const socialInclusionServiceCategory = serviceCategoryFactory.build({
+      name: 'Social inclusion',
+      id: '62e042a7-c44f-4d82-a679-4f435167e44a',
+    })
+
+    const sentSocialInclusionReferral = sentReferralFactory.build({
+      referral: { serviceCategoryId: socialInclusionServiceCategory.id },
+    })
+
+    authUtils.getProbationPractitionerUserId = jest.fn()
+    interventionsService.getReferralsSentByProbationPractitioner.mockResolvedValue([sentSocialInclusionReferral])
+    interventionsService.getServiceCategory.mockResolvedValue(socialInclusionServiceCategory)
+
+    await request(app)
+      .get('/probation-practitioner/dashboard')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Alex River')
+        expect(res.text).toContain('Social inclusion')
       })
   })
 })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -14,6 +14,7 @@ import endOfServiceReportFactory from '../../../testutils/factories/endOfService
 import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
 import CommunityApiService from '../../services/communityApiService'
 import authUtils from '../../utils/authUtils'
+import interventionFactory from '../../../testutils/factories/intervention'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -57,25 +58,29 @@ describe('GET /probation-practitioner/find', () => {
 
 describe('GET /probation-practitioner/dashboard', () => {
   it('displays a dashboard page', async () => {
-    const socialInclusionServiceCategory = serviceCategoryFactory.build({
-      name: 'Social inclusion',
-      id: '62e042a7-c44f-4d82-a679-4f435167e44a',
-    })
-
-    const sentSocialInclusionReferral = sentReferralFactory.build({
-      referral: { serviceCategoryId: socialInclusionServiceCategory.id },
-    })
+    const intervention = interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } })
+    const referrals = [
+      sentReferralFactory.assigned().build({
+        referral: {
+          interventionId: '1',
+          serviceUser: {
+            firstName: 'Alex',
+            lastName: 'River',
+          },
+        },
+      }),
+    ]
 
     authUtils.getProbationPractitionerUserId = jest.fn()
-    interventionsService.getReferralsSentByProbationPractitioner.mockResolvedValue([sentSocialInclusionReferral])
-    interventionsService.getServiceCategory.mockResolvedValue(socialInclusionServiceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
+    interventionsService.getReferralsSentByProbationPractitioner.mockResolvedValue(referrals)
 
     await request(app)
       .get('/probation-practitioner/dashboard')
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Alex River')
-        expect(res.text).toContain('Social inclusion')
+        expect(res.text).toContain('Accommodation')
       })
   })
 })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -36,14 +36,12 @@ export default class ProbationPractitionerReferralsController {
       userId
     )
 
-    const dedupedServiceCategoryIds = Array.from(new Set(cases.map(referral => referral.referral.serviceCategoryId)))
-    const serviceCategories = await Promise.all(
-      dedupedServiceCategoryIds.map(id =>
-        this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
-      )
+    const dedupedInterventionIds = Array.from(new Set(cases.map(referral => referral.referral.interventionId)))
+    const interventions = await Promise.all(
+      dedupedInterventionIds.map(id => this.interventionsService.getIntervention(res.locals.user.token.accessToken, id))
     )
 
-    const presenter = new MyCasesPresenter(cases, serviceCategories)
+    const presenter = new MyCasesPresenter(cases, interventions)
     const view = new MyCasesView(presenter)
     ControllerUtils.renderWithLayout(res, view, null)
   }


### PR DESCRIPTION
## What does this pull request do?

Refactors PP dashboard to use contract type over service category

## What is the intent behind these changes?

Now that we're displaying cohort referrals in the system, we want to use the contract type name e.g. Personal Wellbeing, Womens' services in the dashboard, rather than a list of all the service categories on a cohort referral.
