### PR TITLE
IC-1771 Display each selected service category for the referral in the SP details page.

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -35,8 +35,6 @@ describe('Service provider referrals dashboard', () => {
           serviceUser: { firstName: 'George', lastName: 'Michael' },
           serviceCategoryId: accommodationServiceCategory.id,
           serviceCategoryIds: [accommodationServiceCategory.id, socialInclusionServiceCategory.id],
-          // desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
-          // complexityLevelId: '110f2405-d944-4c15-836c-0c6684e2aa78',
         },
       }),
       sentReferralFactory.build({
@@ -47,8 +45,16 @@ describe('Service provider referrals dashboard', () => {
           serviceUser: { firstName: 'Jenny', lastName: 'Jones', crn: 'X123456' },
           serviceCategoryId: socialInclusionServiceCategory.id,
           serviceCategoryIds: [accommodationServiceCategory.id, socialInclusionServiceCategory.id],
-          // desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
-          // complexityLevelId: '110f2405-d944-4c15-836c-0c6684e2aa78',
+          complexityLevels: [
+            {
+              serviceCategoryId: accommodationServiceCategory.id,
+              complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+            },
+            {
+              serviceCategoryId: socialInclusionServiceCategory.id,
+              complexityLevelId: '110f2405-d944-4c15-836c-0c6684e2aa78',
+            },
+          ],
         },
       }),
     ]
@@ -117,6 +123,15 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('07123456789 | jenny.jones@example.com')
     cy.contains('Intervention details')
     cy.contains('Personal wellbeing')
+
+    cy.contains('Accommodation service')
+    cy.contains('LOW COMPLEXITY')
+    cy.contains('Service User has some capacity and means to secure')
+
+    cy.contains('Social inclusion service')
+    cy.contains('MEDIUM COMPLEXITY')
+    cy.contains('Service User is at risk of homelessness/is homeless')
+
     cy.contains("Service user's personal details")
     cy.contains('English')
     cy.contains('Agnostic')

--- a/server/models/intervention.ts
+++ b/server/models/intervention.ts
@@ -10,7 +10,7 @@ export interface Eligibility {
   allowsMale: boolean
 }
 
-interface ContractType {
+export interface ContractType {
   code: string
   name: string
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -15,6 +15,7 @@ import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
+import interventionFactory from '../../../testutils/factories/intervention'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -80,10 +81,8 @@ describe('GET /service-provider/dashboard', () => {
 
 describe('GET /service-provider/referrals/:id/details', () => {
   it('displays information about the referral and service user', async () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-    const sentReferral = sentReferralFactory.unassigned().build({
-      referral: { serviceCategoryId: serviceCategory.id, serviceUser: { firstName: 'Jenny', lastName: 'Jones' } },
-    })
+    const intervention = interventionFactory.build()
+    const sentReferral = sentReferralFactory.unassigned().build()
     const deliusUser = deliusUserFactory.build({
       firstName: 'Bernard',
       surname: 'Beaks',
@@ -103,7 +102,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
       },
     })
 
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
@@ -123,13 +122,13 @@ describe('GET /service-provider/referrals/:id/details', () => {
 
   describe('when the referral has been assigned to a caseworker', () => {
     it('mentions the assigned caseworker', async () => {
-      const serviceCategory = serviceCategoryFactory.build()
+      const intervention = interventionFactory.build()
       const sentReferral = sentReferralFactory.assigned().build()
       const deliusUser = deliusUserFactory.build()
       const deliusServiceUser = deliusServiceUserFactory.build()
       const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
 
-      interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+      interventionsService.getIntervention.mockResolvedValue(intervention)
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
       communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
       communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -91,10 +91,10 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       req.params.id
     )
-    const [serviceCategory, sentBy, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(
+    const [intervention, sentBy, serviceUser] = await Promise.all([
+      this.interventionsService.getIntervention(
         res.locals.user.token.accessToken,
-        sentReferral.referral.serviceCategoryId
+        sentReferral.referral.interventionId
       ),
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
@@ -124,7 +124,7 @@ export default class ServiceProviderReferralsController {
       }
     }
 
-    const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, sentBy, assignee, formError)
+    const presenter = new ShowReferralPresenter(sentReferral, intervention, sentBy, assignee, formError)
     const view = new ShowReferralView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -4,10 +4,22 @@ import deliusUserFactory from '../../../testutils/factories/deliusUser'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 import { ListStyle } from '../../utils/summaryList'
 import interventionFactory from '../../../testutils/factories/intervention'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import { TagArgs } from '../../utils/govukFrontendTypes'
 
 describe(ShowReferralPresenter, () => {
   const intervention = interventionFactory.build()
   const { serviceCategory } = intervention
+
+  const cohortServiceCategories = [
+    serviceCategoryFactory.build({ name: 'Lifestyle and associates' }),
+    serviceCategoryFactory.build({ name: 'Emotional wellbeing' }),
+  ]
+  const cohortIntervention = interventionFactory.build({
+    contractType: { code: 'PWB', name: 'Personal wellbeing' },
+    serviceCategories: cohortServiceCategories,
+    serviceCategory: cohortServiceCategories[0],
+  })
 
   const referralParams = {
     referral: {
@@ -175,6 +187,44 @@ describe(ShowReferralPresenter, () => {
           },
         ])
       })
+    })
+  })
+
+  describe('serviceCategorySection', () => {
+    const referral = sentReferralFactory.build({
+      referral: {
+        createdAt: '2020-12-07T20:45:21.986389Z',
+        completionDeadline: '2021-04-01',
+        serviceProvider: {
+          name: 'Harmony Living',
+        },
+        serviceCategoryIds: cohortServiceCategories.map(it => it.id),
+        serviceCategoryId: cohortServiceCategories[0].id,
+        complexityLevels: cohortServiceCategories.map(it => {
+          return { serviceCategoryId: it.id, complexityLevelId: it.complexityLevels[0].id }
+        }),
+      },
+    })
+
+    it('returns a section for each selected service category on the referral', () => {
+      const presenter = new ShowReferralPresenter(referral, cohortIntervention, deliusUser, null, null)
+      expect(
+        presenter.serviceCategorySection(cohortServiceCategories[0], (args: TagArgs): string => {
+          return args.text!
+        })
+      ).toEqual([
+        {
+          key: 'Complexity level',
+          lines: [
+            'LOW COMPLEXITY',
+            'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
+          ],
+        },
+        {
+          key: 'Desired outcomes',
+          lines: ['Outcomes not found'],
+        },
+      ])
     })
   })
 

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -1,56 +1,20 @@
 import ShowReferralPresenter from './showReferralPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import deliusUserFactory from '../../../testutils/factories/deliusUser'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 import { ListStyle } from '../../utils/summaryList'
+import interventionFactory from '../../../testutils/factories/intervention'
 
 describe(ShowReferralPresenter, () => {
-  const serviceCategory = serviceCategoryFactory.build({
-    name: 'accommodation',
-    complexityLevels: [
-      {
-        id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
-        title: 'Low complexity',
-        description:
-          'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
-      },
-      {
-        id: '110f2405-d944-4c15-836c-0c6684e2aa78',
-        title: 'Medium complexity',
-        description:
-          'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
-      },
-      {
-        id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
-        title: 'High complexity',
-        description:
-          'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
-      },
-    ],
-    desiredOutcomes: [
-      {
-        id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
-        description:
-          'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
-      },
-      {
-        id: '65924ac6-9724-455b-ad30-906936291421',
-        description: 'Service User makes progress in obtaining accommodation',
-      },
-      {
-        id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-        description: 'Service User is helped to secure social or supported housing',
-      },
-      {
-        id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-        description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
-      },
-    ],
-  })
+  const intervention = interventionFactory.build()
+  const { serviceCategory } = intervention
 
   const referralParams = {
-    referral: { serviceCategoryId: serviceCategory.id, serviceUser: { firstName: 'Jenny', lastName: 'Jones' } },
+    referral: {
+      serviceCategoryId: serviceCategory.id,
+      serviceCategoryIds: [serviceCategory.id],
+      serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+    },
   }
   const deliusUser = deliusUserFactory.build({
     firstName: 'Bernard',
@@ -62,27 +26,18 @@ describe(ShowReferralPresenter, () => {
   describe('assignmentFormAction', () => {
     it('returns the relative URL for the check assignment page', () => {
       const referral = sentReferralFactory.build(referralParams)
-      const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, null, null)
+      const presenter = new ShowReferralPresenter(referral, intervention, deliusUser, null, null)
 
       expect(presenter.assignmentFormAction).toEqual(`/service-provider/referrals/${referral.id}/assignment/check`)
     })
   })
 
   describe('text', () => {
-    describe('interventionDetailsSummaryHeading', () => {
-      it('returns text to be displayed including service category name', () => {
-        const sentReferral = sentReferralFactory.assigned().build(referralParams)
-        const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, null, null)
-
-        expect(presenter.text.interventionDetailsSummaryHeading).toEqual('Accommodation intervention details')
-      })
-    })
-
     describe('assignedTo', () => {
       describe('when the referral doesn’t have an assigned caseworker', () => {
         it('returns null', () => {
           const referral = sentReferralFactory.unassigned().build()
-          const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, null, null)
+          const presenter = new ShowReferralPresenter(referral, intervention, deliusUser, null, null)
 
           expect(presenter.text.assignedTo).toBeNull()
         })
@@ -91,7 +46,7 @@ describe(ShowReferralPresenter, () => {
       describe('when the referral has an assigned caseworker', () => {
         it('returns the name of the assignee', () => {
           const referral = sentReferralFactory.unassigned().build()
-          const presenter = new ShowReferralPresenter(referral, serviceCategory, deliusUser, hmppsAuthUser, null)
+          const presenter = new ShowReferralPresenter(referral, intervention, deliusUser, hmppsAuthUser, null)
 
           expect(presenter.text.assignedTo).toEqual('John Smith')
         })
@@ -102,7 +57,7 @@ describe(ShowReferralPresenter, () => {
   describe('probationPractitionerDetails', () => {
     it('returns a summary list of probation practitioner details', () => {
       const sentReferral = sentReferralFactory.build(referralParams)
-      const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, null, null)
+      const presenter = new ShowReferralPresenter(sentReferral, intervention, deliusUser, null, null)
 
       expect(presenter.probationPractitionerDetails).toEqual([
         { key: 'Name', lines: ['Bernard Beaks'] },
@@ -149,15 +104,10 @@ describe(ShowReferralPresenter, () => {
       })
 
       it('returns a summary list of intervention details', () => {
-        const presenter = new ShowReferralPresenter(
-          referralWithAllOptionalFields,
-          serviceCategory,
-          deliusUser,
-          null,
-          null
-        )
+        const presenter = new ShowReferralPresenter(referralWithAllOptionalFields, intervention, deliusUser, null, null)
 
         expect(presenter.interventionDetails).toEqual([
+          { key: 'Service type', lines: ['Accommodation'] },
           { key: 'Sentence information', lines: ['Not currently set'] },
           { key: 'Date to be completed by', lines: ['1 April 2021'] },
           {
@@ -209,15 +159,10 @@ describe(ShowReferralPresenter, () => {
       })
 
       it("returns a summary list of intervention details with a message for fields that haven't been set", () => {
-        const presenter = new ShowReferralPresenter(
-          referralWithNoOptionalFields,
-          serviceCategory,
-          deliusUser,
-          null,
-          null
-        )
+        const presenter = new ShowReferralPresenter(referralWithNoOptionalFields, intervention, deliusUser, null, null)
 
         expect(presenter.interventionDetails).toEqual([
+          { key: 'Service type', lines: ['Accommodation'] },
           { key: 'Sentence information', lines: ['Not currently set'] },
           { key: 'Date to be completed by', lines: ['1 April 2021'] },
           {
@@ -236,7 +181,7 @@ describe(ShowReferralPresenter, () => {
   describe('serviceUserPersonalDetails', () => {
     it("returns a summary list of the service user's personal details", () => {
       const sentReferral = sentReferralFactory.build(referralParams)
-      const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, null, null)
+      const presenter = new ShowReferralPresenter(sentReferral, intervention, deliusUser, null, null)
 
       expect(presenter.serviceUserDetails).toEqual([
         { key: 'CRN', lines: [sentReferral.referral.serviceUser.crn] },
@@ -260,7 +205,7 @@ describe(ShowReferralPresenter, () => {
   describe('serviceUserRisks', () => {
     it("returns a summary list of the service user's risk information", () => {
       const sentReferral = sentReferralFactory.build(referralParams)
-      const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, null, null)
+      const presenter = new ShowReferralPresenter(sentReferral, intervention, deliusUser, null, null)
 
       expect(presenter.serviceUserRisks).toEqual([
         { key: 'Risk to known adult', lines: ['Medium'] },
@@ -312,7 +257,7 @@ describe(ShowReferralPresenter, () => {
 
         const presenter = new ShowReferralPresenter(
           referralWithAllConditionalFields,
-          serviceCategory,
+          intervention,
           deliusUser,
           null,
           null
@@ -389,7 +334,7 @@ describe(ShowReferralPresenter, () => {
 
         const presenter = new ShowReferralPresenter(
           referralWithNoConditionalFields,
-          serviceCategory,
+          intervention,
           deliusUser,
           null,
           null

--- a/server/routes/serviceProviderReferrals/showReferralView.ts
+++ b/server/routes/serviceProviderReferrals/showReferralView.ts
@@ -1,6 +1,11 @@
 import ShowReferralPresenter from './showReferralPresenter'
 import ViewUtils from '../../utils/viewUtils'
-import { InputArgs } from '../../utils/govukFrontendTypes'
+import { InputArgs, SummaryListArgs, TagArgs } from '../../utils/govukFrontendTypes'
+
+interface ServiceCategorySection {
+  name: string
+  summaryListArgs: (tagMacro: (args: TagArgs) => string) => SummaryListArgs
+}
 
 export default class ShowReferralView {
   constructor(private readonly presenter: ShowReferralPresenter) {}
@@ -28,6 +33,17 @@ export default class ShowReferralView {
     }
   }
 
+  private get serviceCategorySections(): ServiceCategorySection[] {
+    return this.presenter.referralServiceCategories.map(serviceCategory => {
+      return {
+        name: serviceCategory.name,
+        summaryListArgs: (tagMacro: (args: TagArgs) => string) => {
+          return ViewUtils.summaryListArgs(this.presenter.serviceCategorySection(serviceCategory, tagMacro))
+        },
+      }
+    })
+  }
+
   private readonly backLinkArgs = {
     text: 'Back',
     href: '/service-provider/dashboard',
@@ -44,6 +60,7 @@ export default class ShowReferralView {
         serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs,
         serviceUserRisksSummaryListArgs: this.serviceUserRisksSummaryListArgs,
         serviceUserNeedsSummaryListArgs: this.serviceUserNeedsSummaryListArgs,
+        serviceCategorySections: this.serviceCategorySections,
         emailInputArgs: this.emailInputArgs,
         backLinkArgs: this.backLinkArgs,
       },

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -5,6 +5,8 @@ import { FormValidationError } from './formValidationError'
 import Duration from './duration'
 import utils from './utils'
 import AuthUserDetails from '../models/hmppsAuth/authUserDetails'
+import ComplexityLevel from '../models/complexityLevel'
+import { TagArgs } from './govukFrontendTypes'
 
 interface DateTimeComponentInputPresenter {
   value: string
@@ -283,5 +285,35 @@ export default class PresenterUtils {
     }
 
     return notFoundMessage
+  }
+
+  static complexityLevelTagArgs(complexityLevel: ComplexityLevel): TagArgs {
+    const title = complexityLevel.title.toUpperCase()
+
+    if (title.includes('LOW')) {
+      return {
+        text: title,
+        classes: 'govuk-tag--green',
+      }
+    }
+
+    if (title.includes('MEDIUM')) {
+      return {
+        text: title,
+        classes: 'govuk-tag--blue',
+      }
+    }
+
+    if (title.includes('HIGH')) {
+      return {
+        text: title,
+        classes: 'govuk-tag--red',
+      }
+    }
+
+    return {
+      text: 'UNKNOWN',
+      classes: 'govuk-tag--grey',
+    }
   }
 }

--- a/server/views/serviceProviderReferrals/referralDetails.njk
+++ b/server/views/serviceProviderReferrals/referralDetails.njk
@@ -16,7 +16,7 @@
       {{ govukSummaryList(interventionDetailsSummaryListArgs) }}
 
       {%  for section in serviceCategorySections %}
-        <h2 class="govuk-heading-m">{{ section.name }} Service</h2>
+        <h2 class="govuk-heading-m">{{ section.name | capitalize }} service</h2>
         {{ govukSummaryList(section.summaryListArgs(govukTag)) }}
       {% endfor %}
 

--- a/server/views/serviceProviderReferrals/referralDetails.njk
+++ b/server/views/serviceProviderReferrals/referralDetails.njk
@@ -1,4 +1,5 @@
 {% extends "../partials/referralNavigationTemplate.njk" %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% block referralPageSection %}
       {% if presenter.text.assignedTo == null %}
@@ -11,8 +12,14 @@
         <p class="govuk-body">This intervention is assigned to <strong>{{ presenter.text.assignedTo }}</strong>.</p>
       {% endif %}
 
-      <h2 class="govuk-heading-m">{{ presenter.text.interventionDetailsSummaryHeading }}</h2>
+      <h2 class="govuk-heading-m">Intervention details</h2>
       {{ govukSummaryList(interventionDetailsSummaryListArgs) }}
+
+      {%  for section in serviceCategorySections %}
+        <h2 class="govuk-heading-m">{{ section.name }} Service</h2>
+        {{ govukSummaryList(section.summaryListArgs(govukTag)) }}
+      {% endfor %}
+
       <h2 class="govuk-heading-m">Service user's personal details</h2>
       {{ govukSummaryList(serviceUserDetailsSummaryListArgs) }}
       <h2 class="govuk-heading-m">Service user's risk information</h2>


### PR DESCRIPTION
## What does this pull request do?

This change adds a field for "Service type" and a new section for each selected
service category. The selected complexity level is shown for each service category.
The desired outcomes are currently not shown. This will come in a later commit.

<img width="445" alt="Screenshot 2021-05-24 at 17 32 44" src="https://user-images.githubusercontent.com/63233073/119378315-0e9a6000-bcb6-11eb-8ed0-c8a46f36fb4e.png">

## What is the intent behind these changes?

Accurate referral details page for cohort referrals.
