### PR TITLE
IC-1693: Add service user details to "check answers" page

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -233,6 +233,16 @@ describe('Referral form', () => {
     cy.get('a').contains('Check your answers').click()
     cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/check-answers`)
 
+    cy.contains('X123456')
+    cy.contains('Mr')
+    cy.contains('River')
+    cy.contains('1 January 1980')
+    cy.contains('Male')
+    cy.contains('British')
+    cy.contains('English')
+    cy.contains('Agnostic')
+    cy.contains('Autism')
+
     cy.contains('Submit referral').click()
     cy.location('pathname').should('equal', `/referrals/${sentReferral.id}/confirmation`)
 

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -141,7 +141,7 @@ describe('Referral form', () => {
     cy.contains('X123456')
     cy.contains('Mr')
     cy.contains('River')
-    cy.contains('1980-01-01')
+    cy.contains('1 January 1980')
     cy.contains('Male')
     cy.contains('British')
     cy.contains('English')

--- a/server/routes/referrals/checkAnswersPresenter.test.ts
+++ b/server/routes/referrals/checkAnswersPresenter.test.ts
@@ -1,0 +1,48 @@
+import CheckAnswersPresenter from './checkAnswersPresenter'
+import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import { ListStyle } from '../../utils/summaryList'
+
+describe(CheckAnswersPresenter, () => {
+  describe('serviceUserDetailsSection', () => {
+    const referral = draftReferralFactory.build({
+      serviceUser: {
+        crn: 'X862134',
+        title: 'Mr',
+        firstName: 'Alex',
+        lastName: 'River',
+        dateOfBirth: '1980-01-01',
+        gender: 'Male',
+        ethnicity: 'British',
+        preferredLanguage: 'English',
+        religionOrBelief: 'Agnostic',
+        disabilities: ['Autism spectrum condition', 'sciatica'],
+      },
+    })
+    const serviceCategory = serviceCategoryFactory.build()
+    const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+
+    describe('title', () => {
+      it('returns the section title', () => {
+        expect(presenter.serviceUserDetailsSection.title).toEqual('Alex’s personal details')
+      })
+    })
+
+    describe('summary', () => {
+      it('returns the service user’s details', () => {
+        expect(presenter.serviceUserDetailsSection.summary).toEqual([
+          { key: 'CRN', lines: ['X862134'] },
+          { key: 'Title', lines: ['Mr'] },
+          { key: 'First name', lines: ['Alex'] },
+          { key: 'Last name', lines: ['River'] },
+          { key: 'Date of birth', lines: ['1 January 1980'] },
+          { key: 'Gender', lines: ['Male'] },
+          { key: 'Ethnicity', lines: ['British'] },
+          { key: 'Preferred language', lines: ['English'] },
+          { key: 'Religion or belief', lines: ['Agnostic'] },
+          { key: 'Disabilities', lines: ['Autism spectrum condition', 'sciatica'], listStyle: ListStyle.noMarkers },
+        ])
+      })
+    })
+  })
+})

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -1,12 +1,17 @@
 import DraftReferral from '../../models/draftReferral'
 import ServiceCategory from '../../models/serviceCategory'
+import { SummaryListItem } from '../../utils/summaryList'
+import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
 
 export default class CheckAnswersPresenter {
   constructor(private readonly referral: DraftReferral, private readonly serviceCategory: ServiceCategory) {}
 
-  // TODO IC-679 build this page properly - this
-  // is just a placeholder to show the data’s coming in
-  readonly serviceUserName = this.referral.serviceUser?.firstName ?? ''
+  get serviceUserDetailsSection(): { title: string; summary: SummaryListItem[] } {
+    return {
+      title: `${this.serviceUserName}’s personal details`,
+      summary: new ServiceUserDetailsPresenter(this.referral.serviceUser).summary,
+    }
+  }
 
-  readonly referralSectionHeading = `Information for the ${this.serviceCategory.name} referral`
+  private readonly serviceUserName = this.referral.serviceUser?.firstName ?? ''
 }

--- a/server/routes/referrals/checkAnswersView.ts
+++ b/server/routes/referrals/checkAnswersView.ts
@@ -1,9 +1,17 @@
 import CheckAnswersPresenter from './checkAnswersPresenter'
+import ViewUtils from '../../utils/viewUtils'
 
 export default class CheckAnswersView {
   constructor(private readonly presenter: CheckAnswersPresenter) {}
 
+  private readonly serviceUserDetailsSummaryListArgs = ViewUtils.summaryListArgs(
+    this.presenter.serviceUserDetailsSection.summary
+  )
+
   get renderArgs(): [string, Record<string, unknown>] {
-    return ['referrals/checkAnswers', { presenter: this.presenter }]
+    return [
+      'referrals/checkAnswers',
+      { presenter: this.presenter, serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs },
+    ]
   }
 }

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -1277,7 +1277,7 @@ describe('GET /referrals/:id/check-answers', () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const referral = draftReferralFactory
       .serviceCategorySelected(serviceCategory.id)
-      .build({ serviceUser: { firstName: 'Johnny' } })
+      .build({ serviceUser: { firstName: 'Johnny', religionOrBelief: 'Agnostic' } })
 
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
@@ -1290,6 +1290,8 @@ describe('GET /referrals/:id/check-answers', () => {
       .expect(res => {
         expect(res.text).toContain('Submit your referral')
         expect(res.text).toContain('Make sure you have checked your answers before submitting your referral')
+        expect(res.text).toContain('Johnny’s personal details')
+        expect(res.text).toContain('Agnostic')
       })
   })
 

--- a/server/routes/referrals/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.test.ts
@@ -51,7 +51,7 @@ describe(ServiceUserDetailsPresenter, () => {
         { key: 'Title', lines: ['Mr'] },
         { key: 'First name', lines: ['Alex'] },
         { key: 'Last name', lines: ['River'] },
-        { key: 'Date of birth', lines: ['1980-01-01'] },
+        { key: 'Date of birth', lines: ['1 January 1980'] },
         { key: 'Gender', lines: ['Male'] },
         { key: 'Ethnicity', lines: ['British'] },
         { key: 'Preferred language', lines: ['English'] },

--- a/server/routes/referrals/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.test.ts
@@ -47,16 +47,16 @@ describe(ServiceUserDetailsPresenter, () => {
       const presenter = new ServiceUserDetailsPresenter(serviceUser)
 
       expect(presenter.summary).toEqual([
-        { key: 'CRN', lines: [serviceUser.crn] },
-        { key: 'Title', lines: [serviceUser.title] },
-        { key: 'First name', lines: [serviceUser.firstName] },
-        { key: 'Last name', lines: [serviceUser.lastName] },
-        { key: 'Date of birth', lines: [serviceUser.dateOfBirth] },
-        { key: 'Gender', lines: [serviceUser.gender] },
-        { key: 'Ethnicity', lines: [serviceUser.ethnicity] },
-        { key: 'Preferred language', lines: [serviceUser.preferredLanguage] },
-        { key: 'Religion or belief', lines: [serviceUser.religionOrBelief] },
-        { key: 'Disabilities', lines: serviceUser.disabilities || [], listStyle: ListStyle.noMarkers },
+        { key: 'CRN', lines: ['X862134'] },
+        { key: 'Title', lines: ['Mr'] },
+        { key: 'First name', lines: ['Alex'] },
+        { key: 'Last name', lines: ['River'] },
+        { key: 'Date of birth', lines: ['1980-01-01'] },
+        { key: 'Gender', lines: ['Male'] },
+        { key: 'Ethnicity', lines: ['British'] },
+        { key: 'Preferred language', lines: ['English'] },
+        { key: 'Religion or belief', lines: ['Agnostic'] },
+        { key: 'Disabilities', lines: ['Autism spectrum condition', 'sciatica'], listStyle: ListStyle.noMarkers },
       ])
     })
 

--- a/server/routes/referrals/serviceUserDetailsPresenter.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.ts
@@ -1,4 +1,6 @@
 import ServiceUser from '../../models/serviceUser'
+import CalendarDay from '../../utils/calendarDay'
+import PresenterUtils from '../../utils/presenterUtils'
 import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 
 export default class ServiceUserDetailsPresenter {
@@ -11,11 +13,25 @@ export default class ServiceUserDetailsPresenter {
     { key: 'Title', lines: [this.serviceUser.title ?? ''] },
     { key: 'First name', lines: [this.serviceUser.firstName ?? ''] },
     { key: 'Last name', lines: [this.serviceUser.lastName ?? ''] },
-    { key: 'Date of birth', lines: [this.serviceUser.dateOfBirth ?? ''] },
+    { key: 'Date of birth', lines: [this.dateOfBirth] },
     { key: 'Gender', lines: [this.serviceUser.gender ?? ''] },
     { key: 'Ethnicity', lines: [this.serviceUser.ethnicity ?? ''] },
     { key: 'Preferred language', lines: [this.serviceUser.preferredLanguage ?? ''] },
     { key: 'Religion or belief', lines: [this.serviceUser.religionOrBelief ?? ''] },
     { key: 'Disabilities', lines: this.serviceUser.disabilities ?? [], listStyle: ListStyle.noMarkers },
   ]
+
+  private get dateOfBirth() {
+    if (this.serviceUser.dateOfBirth === null) {
+      return ''
+    }
+
+    const day = CalendarDay.parseIso8601Date(this.serviceUser.dateOfBirth)
+
+    if (day === null) {
+      return ''
+    }
+
+    return PresenterUtils.govukFormattedDate(day)
+  }
 }

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -269,20 +269,16 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(sentReferral, serviceCategory, deliusUser, null, null)
 
       expect(presenter.serviceUserDetails).toEqual([
-        { key: 'CRN', lines: [sentReferral.referral.serviceUser.crn] },
-        { key: 'Title', lines: [sentReferral.referral.serviceUser.title] },
-        { key: 'First name', lines: [sentReferral.referral.serviceUser.firstName] },
-        { key: 'Last name', lines: [sentReferral.referral.serviceUser.lastName] },
-        { key: 'Date of birth', lines: [sentReferral.referral.serviceUser.dateOfBirth] },
-        { key: 'Gender', lines: [sentReferral.referral.serviceUser.gender] },
-        { key: 'Ethnicity', lines: [sentReferral.referral.serviceUser.ethnicity] },
-        { key: 'Preferred language', lines: [sentReferral.referral.serviceUser.preferredLanguage] },
-        { key: 'Religion or belief', lines: [sentReferral.referral.serviceUser.religionOrBelief] },
-        {
-          key: 'Disabilities',
-          lines: sentReferral.referral.serviceUser.disabilities || [],
-          listStyle: ListStyle.noMarkers,
-        },
+        { key: 'CRN', lines: ['X123456'] },
+        { key: 'Title', lines: ['Mr'] },
+        { key: 'First name', lines: ['Jenny'] },
+        { key: 'Last name', lines: ['Jones'] },
+        { key: 'Date of birth', lines: ['1980-01-01'] },
+        { key: 'Gender', lines: ['Male'] },
+        { key: 'Ethnicity', lines: ['British'] },
+        { key: 'Preferred language', lines: ['English'] },
+        { key: 'Religion or belief', lines: ['Agnostic'] },
+        { key: 'Disabilities', lines: ['Autism spectrum condition', 'sciatica'], listStyle: ListStyle.noMarkers },
       ])
     })
   })

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -273,7 +273,7 @@ describe(ShowReferralPresenter, () => {
         { key: 'Title', lines: ['Mr'] },
         { key: 'First name', lines: ['Jenny'] },
         { key: 'Last name', lines: ['Jones'] },
-        { key: 'Date of birth', lines: ['1980-01-01'] },
+        { key: 'Date of birth', lines: ['1 January 1980'] },
         { key: 'Gender', lines: ['Male'] },
         { key: 'Ethnicity', lines: ['British'] },
         { key: 'Preferred language', lines: ['English'] },

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -14,6 +15,10 @@
       <h1 class="govuk-heading-xl">Submit your referral</h1>
 
       <p class="govuk-body-m">Make sure you have checked your answers before submitting your referral.</p>
+
+      <h2 class="govuk-heading-l">{{ presenter.serviceUserDetailsSection.title }}</h2>
+
+      {{ govukSummaryList(serviceUserDetailsSummaryListArgs) }}
 
       <form method="post" action="send">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">


### PR DESCRIPTION
## What does this pull request do?

Starts building out the "check your answers" page for the probation practioner "make a referral" journey, starting with the service user personal details.

## What is the intent behind these changes?

To allow a probation practitioner to check their answers before submitting a referral, in line with the GOV.UK Design System guidance.

## Screenshot

![localhost_3007_referrals_1_check-answers](https://user-images.githubusercontent.com/53756884/119463541-c45ac280-bd39-11eb-8d0a-0add2eed15ef.png)
