### PR TITLE
temporary stop gap to fix 'referral details' page in dev.

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -104,18 +104,11 @@ describe('Service provider referrals dashboard', () => {
     cy.get('h2').contains('Who do you want to assign this referral to?')
     cy.contains('07123456789 | jenny.jones@example.com')
     cy.contains('Social inclusion intervention details')
-    cy.contains('Service User makes progress in obtaining accommodation')
-    cy.contains('Service User is helped to secure a tenancy in the private rented sector (PRS)')
-    cy.contains('Medium complexity')
-    cy.contains(
-      'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.'
-    )
     cy.contains("Service user's personal details")
     cy.contains('English')
     cy.contains('Agnostic')
     cy.contains('Autism spectrum condition')
     cy.contains('sciatica')
-    cy.contains('Service User is helped to secure a tenancy in the private rented sector (PRS)')
     cy.contains("Service user's risk information")
     cy.contains('Risk to known adult')
     cy.contains('Medium')

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -159,21 +159,6 @@ describe(ShowReferralPresenter, () => {
 
         expect(presenter.interventionDetails).toEqual([
           { key: 'Sentence information', lines: ['Not currently set'] },
-          {
-            key: 'Desired outcomes',
-            lines: [
-              'Service User makes progress in obtaining accommodation',
-              'Service User is helped to secure social or supported housing',
-            ],
-            listStyle: ListStyle.noMarkers,
-          },
-          {
-            key: 'Complexity level',
-            lines: [
-              'Low complexity',
-              'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
-            ],
-          },
           { key: 'Date to be completed by', lines: ['1 April 2021'] },
           {
             key: 'Maximum number of enforceable days',
@@ -234,21 +219,6 @@ describe(ShowReferralPresenter, () => {
 
         expect(presenter.interventionDetails).toEqual([
           { key: 'Sentence information', lines: ['Not currently set'] },
-          {
-            key: 'Desired outcomes',
-            lines: [
-              'Service User makes progress in obtaining accommodation',
-              'Service User is helped to secure social or supported housing',
-            ],
-            listStyle: ListStyle.noMarkers,
-          },
-          {
-            key: 'Complexity level',
-            lines: [
-              'Low complexity',
-              'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
-            ],
-          },
           { key: 'Date to be completed by', lines: ['1 April 2021'] },
           {
             key: 'Maximum number of enforceable days',

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -40,23 +40,23 @@ export default class ShowReferralPresenter {
   ]
 
   get interventionDetails(): SummaryListItem[] {
-    const selectedDesiredOutcomes = this.serviceCategory.desiredOutcomes
-      .filter(desiredOutcome => this.sentReferral.referral.desiredOutcomesIds.includes(desiredOutcome.id))
-      .map(desiredOutcome => desiredOutcome.description)
-
-    const selectedComplexityLevel = this.serviceCategory.complexityLevels.find(
-      complexityLevel => complexityLevel.id === this.sentReferral.referral.complexityLevelId
-    )
-
-    const complexityLevelText = {
-      level: selectedComplexityLevel?.title || 'Level not found',
-      text: selectedComplexityLevel?.description || 'Description not found',
-    }
+    // const selectedDesiredOutcomes = this.serviceCategory.desiredOutcomes
+    //   .filter(desiredOutcome => this.sentReferral.referral.desiredOutcomesIds.includes(desiredOutcome.id))
+    //   .map(desiredOutcome => desiredOutcome.description)
+    //
+    // const selectedComplexityLevel = this.serviceCategory.complexityLevels.find(
+    //   complexityLevel => complexityLevel.id === this.sentReferral.referral.complexityLevelId
+    // )
+    //
+    // const complexityLevelText = {
+    //   level: selectedComplexityLevel?.title || 'Level not found',
+    //   text: selectedComplexityLevel?.description || 'Description not found',
+    // }
 
     return [
       { key: 'Sentence information', lines: ['Not currently set'] },
-      { key: 'Desired outcomes', lines: selectedDesiredOutcomes, listStyle: ListStyle.noMarkers },
-      { key: 'Complexity level', lines: [complexityLevelText.level, complexityLevelText.text] },
+      // { key: 'Desired outcomes', lines: selectedDesiredOutcomes, listStyle: ListStyle.noMarkers },
+      // { key: 'Complexity level', lines: [complexityLevelText.level, complexityLevelText.text] },
       {
         key: 'Date to be completed by',
         lines: [PresenterUtils.govukFormattedDateFromStringOrNull(this.sentReferral.referral.completionDeadline)],


### PR DESCRIPTION

## What does this pull request do?

no longer show the complexity level or desired outcomes - they no longer exist at the top level of the referral anyway.

## What is the intent behind these changes?

unblock dev whilst we wait for https://github.com/ministryofjustice/hmpps-interventions-ui/pull/313 to get merged.
