### PR TITLE
IC-1726: Display contract type in referral cancellation journey

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -180,6 +180,7 @@ describe('Probation Practitioner monitor journey', () => {
 
   describe('cancelling a referral', () => {
     it('displays a form to allow users to submit comments and cancel a referral', () => {
+      // TODO: Remove this when refactoring intervention progress view to not use serviceCategoryId
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
       const referralParams = {
@@ -228,6 +229,7 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetIntervention(assignedReferral.referral.interventionId, intervention)
       cy.stubGetSentReferrals([assignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
+      // TODO: Remove this when refactoring intervention progress view to not use serviceCategoryId
       cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -192,12 +192,12 @@ describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:ses
 describe('GET /probation-practitioner/referrals/:id/cancellation/reason', () => {
   it('renders a page where the PP can add comments and cancel a referral', async () => {
     const referral = sentReferralFactory.assigned().build()
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const intervention = interventionFactory.build()
     const serviceUser = deliusServiceUserFactory.build()
 
     interventionsService.getSentReferral.mockResolvedValue(referral)
     communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getReferralCancellationReasons.mockResolvedValue([
       { code: 'MIS', description: 'Referral was made by mistake' },
       { code: 'MOV', description: 'Service user has moved out of delivery area' },
@@ -219,12 +219,12 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/reason', () => 
 describe('POST /probation-practitioner/referrals/:id/cancellation/check-your-answers', () => {
   it('passes through params to a page where the PP can confirm whether or not to cancel a referral', async () => {
     const referral = sentReferralFactory.assigned().build()
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const intervention = interventionFactory.build()
     const serviceUser = deliusServiceUserFactory.build()
 
     interventionsService.getSentReferral.mockResolvedValue(referral)
     communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
 
     await request(app)
       .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/check-your-answers`)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -122,16 +122,16 @@ export default class ProbationPractitionerReferralsController {
     const { accessToken } = user.token
 
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
-    const serviceCategory = await this.interventionsService.getServiceCategory(
+    const intervention = await this.interventionsService.getIntervention(
       accessToken,
-      sentReferral.referral.serviceCategoryId
+      sentReferral.referral.interventionId
     )
     const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
     const cancellationReasons = await this.interventionsService.getReferralCancellationReasons(accessToken)
 
     const presenter = new ReferralCancellationReasonPresenter(
       sentReferral,
-      serviceCategory,
+      intervention,
       serviceUser,
       cancellationReasons
     )
@@ -154,15 +154,15 @@ export default class ProbationPractitionerReferralsController {
       res.status(400)
       formError = data.error
 
-      const serviceCategory = await this.interventionsService.getServiceCategory(
+      const intervention = await this.interventionsService.getIntervention(
         accessToken,
-        sentReferral.referral.serviceCategoryId
+        sentReferral.referral.interventionId
       )
       const cancellationReasons = await this.interventionsService.getReferralCancellationReasons(accessToken)
 
       const presenter = new ReferralCancellationReasonPresenter(
         sentReferral,
-        serviceCategory,
+        intervention,
         serviceUser,
         cancellationReasons,
         formError
@@ -203,13 +203,13 @@ export default class ProbationPractitionerReferralsController {
     const { accessToken } = user.token
 
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
-    const serviceCategory = await this.interventionsService.getServiceCategory(
+    const intervention = await this.interventionsService.getIntervention(
       accessToken,
-      sentReferral.referral.serviceCategoryId
+      sentReferral.referral.interventionId
     )
     const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
 
-    const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, serviceCategory)
+    const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, intervention)
     const view = new ReferralCancellationConfirmationView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.test.ts
@@ -1,13 +1,13 @@
+import interventionFactory from '../../../testutils/factories/intervention'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import ReferralCancellationConfirmationPresenter from './referralCancellationConfirmationPresenter'
 
 describe(ReferralCancellationConfirmationPresenter, () => {
   describe('text', () => {
     it('contains a panel title and what happens next text', () => {
       const sentReferral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, serviceCategory)
+      const intervention = interventionFactory.build()
+      const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, intervention)
 
       expect(presenter.text).toMatchObject({
         confirmationText: 'This referral has been cancelled',
@@ -20,8 +20,8 @@ describe(ReferralCancellationConfirmationPresenter, () => {
   describe('serviceUserSummary', () => {
     it('displays information about the referral and service user', () => {
       const sentReferral = sentReferralFactory.build({ referenceNumber: 'AB1234' })
-      const serviceCategory = serviceCategoryFactory.build({ name: 'Accommodation' })
-      const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, serviceCategory)
+      const intervention = interventionFactory.build({ contractType: { name: 'personal wellbeing' } })
+      const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, intervention)
 
       expect(presenter.serviceUserSummary).toEqual([
         {
@@ -34,7 +34,7 @@ describe(ReferralCancellationConfirmationPresenter, () => {
         },
         {
           key: 'Type of referral',
-          lines: ['Accommodation'],
+          lines: ['Personal wellbeing'],
         },
       ])
     })

--- a/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationConfirmationPresenter.ts
@@ -1,11 +1,11 @@
-import ServiceCategory from '../../models/serviceCategory'
 import SentReferral from '../../models/sentReferral'
 import PresenterUtils from '../../utils/presenterUtils'
 import { SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
+import Intervention from '../../models/intervention'
 
 export default class ReferralCancellationConfirmationPresenter {
-  constructor(private readonly referral: SentReferral, private readonly serviceCategory: ServiceCategory) {}
+  constructor(private readonly referral: SentReferral, private readonly intervention: Intervention) {}
 
   readonly text = {
     confirmationText: 'This referral has been cancelled',
@@ -26,7 +26,7 @@ export default class ReferralCancellationConfirmationPresenter {
     },
     {
       key: 'Type of referral',
-      lines: [utils.convertToProperCase(this.serviceCategory.name)],
+      lines: [utils.convertToProperCase(this.intervention.contractType.name)],
     },
   ]
 }

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
@@ -1,6 +1,6 @@
 import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import interventionFactory from '../../../testutils/factories/intervention'
 import serviceProviderFactory from '../../../testutils/factories/serviceProvider'
 import CancellationReason from '../../models/cancellationReason'
 import ReferralCancellationReasonPresenter from './referralCancellationReasonPresenter'
@@ -11,12 +11,12 @@ describe(ReferralCancellationReasonPresenter, () => {
       const serviceProvider = serviceProviderFactory.build({ name: 'Harmony Living' })
       const sentReferral = sentReferralFactory.build({ referral: { serviceProvider } })
       const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex', surname: 'River' })
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
       const cancellationReasons: CancellationReason[] = []
 
       const presenter = new ReferralCancellationReasonPresenter(
         sentReferral,
-        serviceCategory,
+        intervention,
         serviceUser,
         cancellationReasons
       )
@@ -32,7 +32,7 @@ describe(ReferralCancellationReasonPresenter, () => {
     it('returns an array of fields to be passed as radio button args', () => {
       const sentReferral = sentReferralFactory.build()
       const serviceUser = deliusServiceUserFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
+      const intervention = interventionFactory.build()
       const cancellationReasons: CancellationReason[] = [
         { code: 'MIS', description: 'Referral was made by mistake' },
         { code: 'MOV', description: 'Service user has moved out of delivery area' },
@@ -40,7 +40,7 @@ describe(ReferralCancellationReasonPresenter, () => {
 
       const presenter = new ReferralCancellationReasonPresenter(
         sentReferral,
-        serviceCategory,
+        intervention,
         serviceUser,
         cancellationReasons
       )
@@ -55,14 +55,14 @@ describe(ReferralCancellationReasonPresenter, () => {
   describe('errorSummary', () => {
     const sentReferral = sentReferralFactory.build()
     const serviceUser = deliusServiceUserFactory.build()
-    const serviceCategory = serviceCategoryFactory.build()
+    const intervention = interventionFactory.build()
     const cancellationReasons: CancellationReason[] = []
 
     describe('when there is an error', () => {
       it('returns a summary of the error', () => {
         const presenter = new ReferralCancellationReasonPresenter(
           sentReferral,
-          serviceCategory,
+          intervention,
           serviceUser,
           cancellationReasons,
           {
@@ -86,7 +86,7 @@ describe(ReferralCancellationReasonPresenter, () => {
       it('returns null', () => {
         const presenter = new ReferralCancellationReasonPresenter(
           sentReferral,
-          serviceCategory,
+          intervention,
           serviceUser,
           cancellationReasons
         )
@@ -99,14 +99,14 @@ describe(ReferralCancellationReasonPresenter, () => {
   describe('errorMessage', () => {
     const sentReferral = sentReferralFactory.build()
     const serviceUser = deliusServiceUserFactory.build()
-    const serviceCategory = serviceCategoryFactory.build()
+    const intervention = interventionFactory.build()
     const cancellationReasons: CancellationReason[] = []
 
     describe('when there is an error', () => {
       it('returns the error message', () => {
         const presenter = new ReferralCancellationReasonPresenter(
           sentReferral,
-          serviceCategory,
+          intervention,
           serviceUser,
           cancellationReasons,
           {
@@ -128,7 +128,7 @@ describe(ReferralCancellationReasonPresenter, () => {
       it('returns null', () => {
         const presenter = new ReferralCancellationReasonPresenter(
           sentReferral,
-          serviceCategory,
+          intervention,
           serviceUser,
           cancellationReasons
         )

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
@@ -1,15 +1,15 @@
 import a from 'indefinite'
 import DeliusServiceUser from '../../models/delius/deliusServiceUser'
 import CancellationReason from '../../models/cancellationReason'
-import ServiceCategory from '../../models/serviceCategory'
 import SentReferral from '../../models/sentReferral'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import Intervention from '../../models/intervention'
 
 export default class ReferralCancellationReasonPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly intervention: Intervention,
     private readonly serviceUser: DeliusServiceUser,
     private readonly cancellationReasons: CancellationReason[],
     private readonly error: FormValidationError | null = null
@@ -18,7 +18,7 @@ export default class ReferralCancellationReasonPresenter {
   readonly text = {
     title: 'Referral cancellation',
     information: `You are about to cancel ${this.serviceUser.firstName} ${this.serviceUser.surname}'s referral for ${a(
-      this.serviceCategory.name
+      this.intervention.contractType.name
     )} intervention with ${this.sentReferral.referral.serviceProvider.name}.`,
     additionalCommentsLabel: 'Additional comments (optional):',
   }


### PR DESCRIPTION
## What does this pull request do?

Replaces service category with contract type name in PP referral cancellation pages.

## What is the intent behind these changes?

To make the page work with cohort services and not try to display multiple service categories.
