### PR TITLE
IC-1726: Use contract type on PP referral progress page

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -1,5 +1,4 @@
 import sentReferralFactory from '../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
 import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
 import actionPlanFactory from '../../testutils/factories/actionPlan'
@@ -16,11 +15,10 @@ describe('Probation Practitioner monitor journey', () => {
 
   describe('viewing the progress of an intervention', () => {
     it('displays the referral progress page with the status of each session', () => {
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
       const referralParams = {
         id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
-        referral: { interventionId: intervention.id, serviceCategoryId: serviceCategory.id },
+        referral: { interventionId: intervention.id },
       }
       const deliusServiceUser = deliusServiceUserFactory.build()
       const probationPractitioner = deliusUserFactory.build({
@@ -64,7 +62,6 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetIntervention(assignedReferral.referral.interventionId, intervention)
       cy.stubGetSentReferrals([assignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
-      cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
@@ -112,11 +109,10 @@ describe('Probation Practitioner monitor journey', () => {
 
   describe('Viewing session feedback', () => {
     it('allows users to click through to a page to view session feedback', () => {
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
       const referralParams = {
         id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
-        referral: { interventionId: intervention.id, serviceCategoryId: serviceCategory.id },
+        referral: { interventionId: intervention.id },
       }
 
       const deliusServiceUser = deliusServiceUserFactory.build()
@@ -139,7 +135,6 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetIntervention(assignedReferral.referral.interventionId, intervention)
       cy.stubGetSentReferrals([assignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
-      cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
@@ -180,12 +175,10 @@ describe('Probation Practitioner monitor journey', () => {
 
   describe('cancelling a referral', () => {
     it('displays a form to allow users to submit comments and cancel a referral', () => {
-      // TODO: Remove this when refactoring intervention progress view to not use serviceCategoryId
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
       const referralParams = {
         id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
-        referral: { interventionId: intervention.id, serviceCategoryId: serviceCategory.id },
+        referral: { interventionId: intervention.id },
       }
       const deliusServiceUser = deliusServiceUserFactory.build()
       const probationPractitioner = deliusUserFactory.build({
@@ -229,8 +222,6 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetIntervention(assignedReferral.referral.interventionId, intervention)
       cy.stubGetSentReferrals([assignedReferral])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
-      // TODO: Remove this when refactoring intervention progress view to not use serviceCategoryId
-      cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -1,6 +1,6 @@
 import InterventionProgressPresenter from './interventionProgressPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import interventionFactory from '../../../testutils/factories/intervention'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
@@ -9,8 +9,8 @@ describe(InterventionProgressPresenter, () => {
   describe('sessionTableRows', () => {
     it('returns an empty list if there are no appointments', () => {
       const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
       expect(presenter.sessionTableRows).toEqual([])
     })
@@ -18,8 +18,8 @@ describe(InterventionProgressPresenter, () => {
     describe('when a session exists but an appointment has not yet been scheduled', () => {
       it('populates the table with formatted session information, with no link text or href', () => {
         const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, [
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, [
           actionPlanAppointmentFactory.newlyCreated().build(),
         ])
         expect(presenter.sessionTableRows).toEqual([
@@ -42,8 +42,8 @@ describe(InterventionProgressPresenter, () => {
     describe('when an appointment has been scheduled', () => {
       it('populates the table with formatted session information, with the "Reschedule session" and "Give feedback" links displayed', () => {
         const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, [
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, [
           actionPlanAppointmentFactory.build({
             sessionNumber: 1,
             appointmentTime: '2020-12-07T13:00:00.000000Z',
@@ -71,8 +71,8 @@ describe(InterventionProgressPresenter, () => {
       describe('when the service user attended the session or was late', () => {
         it('populates the table with the "completed" status against that session and a link to view it', () => {
           const referral = sentReferralFactory.build({ actionPlanId: 'c59809e0-ab78-4723-bbef-bd34bc6df110' })
-          const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, [
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, [
             actionPlanAppointmentFactory.attended('yes').build({ sessionNumber: 1 }),
             actionPlanAppointmentFactory.attended('late').build({ sessionNumber: 2 }),
           ])
@@ -108,8 +108,8 @@ describe(InterventionProgressPresenter, () => {
       describe('when the service did not attend the session', () => {
         it('populates the table with the "failure to attend" status against that session and a link to view it', () => {
           const referral = sentReferralFactory.build({ actionPlanId: 'c59809e0-ab78-4723-bbef-bd34bc6df110' })
-          const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, [
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, [
             actionPlanAppointmentFactory.attended('no').build(),
           ])
           expect(presenter.sessionTableRows).toEqual([
@@ -135,8 +135,8 @@ describe(InterventionProgressPresenter, () => {
     describe('title', () => {
       it('returns a title to be displayed', () => {
         const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+        const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
+        const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
         expect(presenter.text).toMatchObject({
           title: 'Accommodation progress',
@@ -148,8 +148,8 @@ describe(InterventionProgressPresenter, () => {
   describe('referralCancellationHref', () => {
     it('returns the url including referral id for the referral cancellation page', () => {
       const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
       expect(presenter.referralCancellationHref).toEqual(
         `/probation-practitioner/referrals/${referral.id}/cancellation/reason`
@@ -160,15 +160,15 @@ describe(InterventionProgressPresenter, () => {
   describe('referralAssigned', () => {
     it('returns false when the referral has no assignee', () => {
       const referral = sentReferralFactory.unassigned().build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
       expect(presenter.referralAssigned).toEqual(false)
     })
     it('returns true when the referral has an assignee', () => {
       const referral = sentReferralFactory.assigned().build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
       expect(presenter.referralAssigned).toEqual(true)
     })
@@ -177,17 +177,17 @@ describe(InterventionProgressPresenter, () => {
   describe('referralEndRequested', () => {
     it('returns true when the referral has ended', () => {
       const referral = sentReferralFactory.endRequested().build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
       expect(presenter.referralEndRequested).toEqual(true)
     })
 
     it('returns false when the referral has not ended', () => {
       const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
+      const intervention = interventionFactory.build()
 
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
       expect(presenter.referralEndRequested).toEqual(false)
     })
@@ -196,17 +196,17 @@ describe(InterventionProgressPresenter, () => {
   describe('referralEndRequestedText', () => {
     it('returns the requested end date when an end has been requested', () => {
       const referral = sentReferralFactory.endRequested().build({ endRequestedAt: '2021-04-28T20:45:21.986389Z' })
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
       expect(presenter.referralEndRequestedText).toEqual('You requested to end this service on 28 Apr 2021.')
     })
 
     it('returns an empty string when an end has not been requested', () => {
       const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
+      const intervention = interventionFactory.build()
 
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
       expect(presenter.referralEndRequestedText).toEqual('')
     })
@@ -216,8 +216,8 @@ describe(InterventionProgressPresenter, () => {
     describe('when the referral has no end of service report', () => {
       it('returns false', () => {
         const referral = sentReferralFactory.build({ endOfServiceReport: null })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
         expect(presenter.hasEndOfServiceReport).toEqual(false)
       })
@@ -228,8 +228,8 @@ describe(InterventionProgressPresenter, () => {
           const referral = sentReferralFactory.build({
             endOfServiceReport: endOfServiceReportFactory.justCreated().build(),
           })
-          const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
           expect(presenter.hasEndOfServiceReport).toEqual(false)
         })
@@ -240,8 +240,8 @@ describe(InterventionProgressPresenter, () => {
           const referral = sentReferralFactory.build({
             endOfServiceReport: endOfServiceReportFactory.submitted().build(),
           })
-          const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
           expect(presenter.hasEndOfServiceReport).toEqual(true)
         })
@@ -252,8 +252,8 @@ describe(InterventionProgressPresenter, () => {
   describe('endOfServiceReportTableHeaders', () => {
     it('returns the headers for the end of service report table', () => {
       const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
       expect(presenter.endOfServiceReportTableHeaders).toEqual(['Caseworker', 'Status', 'Action'])
     })
@@ -266,8 +266,8 @@ describe(InterventionProgressPresenter, () => {
         assignedTo: hmppsAuthUserFactory.build({ username: 'john.bloggs' }),
         endOfServiceReport,
       })
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, [])
 
       expect(presenter.endOfServiceReportTableRows).toEqual([
         {

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -1,11 +1,11 @@
 import SentReferral from '../../models/sentReferral'
 import { ActionPlanAppointment } from '../../models/actionPlan'
-import ServiceCategory from '../../models/serviceCategory'
 import utils from '../../utils/utils'
 import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from '../shared/referralOverviewPagePresenter'
 import DateUtils from '../../utils/dateUtils'
 import sessionStatus, { SessionStatus } from '../../utils/sessionStatus'
 import SessionStatusPresenter from '../shared/sessionStatusPresenter'
+import Intervention from '../../models/intervention'
 
 interface ProgressSessionTableRow {
   sessionNumber: number
@@ -24,7 +24,7 @@ export default class InterventionProgressPresenter {
 
   constructor(
     private readonly referral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly intervention: Intervention,
     private readonly actionPlanAppointments: ActionPlanAppointment[]
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
@@ -53,7 +53,7 @@ export default class InterventionProgressPresenter {
   }
 
   readonly text = {
-    title: `${utils.convertToTitleCase(this.serviceCategory.name)} progress`,
+    title: `${utils.convertToTitleCase(this.intervention.contractType.name)} progress`,
   }
 
   readonly referralCancellationHref = `/probation-practitioner/referrals/${this.referral.id}/cancellation/reason`

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -87,13 +87,13 @@ describe('GET /probation-practitioner/dashboard', () => {
 
 describe('GET /probation-practitioner/referrals/:id/progress', () => {
   it('displays information about the intervention progress', async () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
     const serviceUser = deliusServiceUserFactory.build()
     const sentReferral = sentReferralFactory.assigned().build({
-      referral: { serviceCategoryId: serviceCategory.id },
+      referral: { interventionId: intervention.id },
     })
 
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -62,17 +62,17 @@ export default class ProbationPractitionerReferralsController {
       req.params.id
     )
     const serviceUserPromise = this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
-    const serviceCategoryPromise = this.interventionsService.getServiceCategory(
+    const interventionPromise = this.interventionsService.getIntervention(
       res.locals.user.token.accessToken,
-      sentReferral.referral.serviceCategoryId
+      sentReferral.referral.interventionId
     )
     const actionPlanPromise =
       sentReferral.actionPlanId === null
         ? Promise.resolve(null)
         : this.interventionsService.getActionPlan(res.locals.user.token.accessToken, sentReferral.actionPlanId)
 
-    const [serviceCategory, actionPlan, serviceUser] = await Promise.all([
-      serviceCategoryPromise,
+    const [intervention, actionPlan, serviceUser] = await Promise.all([
+      interventionPromise,
       actionPlanPromise,
       serviceUserPromise,
     ])
@@ -85,7 +85,7 @@ export default class ProbationPractitionerReferralsController {
       )
     }
 
-    const presenter = new InterventionProgressPresenter(sentReferral, serviceCategory, actionPlanAppointments)
+    const presenter = new InterventionProgressPresenter(sentReferral, intervention, actionPlanAppointments)
     const view = new InterventionProgressView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)


### PR DESCRIPTION
## What does this pull request do?

Use contract type on PP referral progress page rather than service category, now that we have multiple.

## What is the intent behind these changes?

To support cohort referrals
