### PR TITLE
IC-1777: Add production helm values

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
@@ -1,6 +1,4 @@
-{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "app.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -29,8 +27,7 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          - path: /
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
-{{- end }}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,9 +10,7 @@ image:
   port: 3000
 
 ingress:
-  enabled: true
   host: hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk
-  path: /
 
 env_details:
   contains_live_data: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,9 +10,7 @@ image:
   port: 3000
 
 ingress:
-  enabled: true
   host: hmpps-interventions-ui-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
-  path: /
 
 env_details:
   contains_live_data: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,0 +1,24 @@
+replicaCount: 3
+
+image:
+  repository: quay.io/hmpps/hmpps-interventions-ui
+  tag: latest
+  pullPolicy: IfNotPresent
+  port: 3000
+
+ingress:
+  host: refer-monitor-intervention.service.justice.gov.uk
+  cert_secret: tls-certificate
+
+env_details:
+  contains_live_data: true
+
+env:
+  DEPLOYMENT_ENV: prod
+  HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
+  COMMUNITY_API_URL: https://community-api-secure.probation.service.justice.gov.uk
+  OFFENDER_ASSESSMENTS_API_URL: https://offender-prod.aks-live-1.studio-hosting.service.justice.gov.uk
+  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk
+  TOKEN_VERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
+  TOKEN_VERIFICATION_ENABLED: true
+  REDIS_TLS_ENABLED: true

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -7,9 +7,7 @@ image:
   port: 3000
 
 ingress:
-  enabled: true
   host: hmpps-interventions-ui-research.apps.live-1.cloud-platform.service.justice.gov.uk
-  path: /
 
 env_details:
   contains_live_data: false


### PR DESCRIPTION
## What does this pull request do?

IC-1777: Adds production helm values. It doesn't deploy to production yet, just adds the necessary configuration. Can be manually deployed by

```
$ cd helm_deploy/
$ helm upgrade hmpps-interventions-ui hmpps-interventions-ui \
  --wait --values=values-prod.yaml --namespace=hmpps-interventions-prod \
  --set "image.tag={get latest image from quay.io}"
```

"get latest image from quay.io" == check https://quay.io/repository/hmpps/hmpps-interventions-ui?tag=latest&tab=tags

Also removes the ingress path and flag, they are always the same

## What is the intent behind these changes?

Prepare for production deployment