### PR TITLE
IC-1727: Use contract type name on SP dashboard and referral progress page

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -96,8 +96,6 @@ describe('Service provider referrals dashboard', () => {
 
     cy.stubGetIntervention(personalWellbeingIntervention.id, personalWellbeingIntervention)
     cy.stubGetIntervention(socialInclusionIntervention.id, socialInclusionIntervention)
-    cy.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory)
-    cy.stubGetServiceCategory(socialInclusionServiceCategory.id, socialInclusionServiceCategory)
     sentReferrals.forEach(referral => cy.stubGetSentReferral(referral.id, referral))
     cy.stubGetSentReferrals(sentReferrals)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -1,18 +1,20 @@
 import DashboardPresenter from './dashboardPresenter'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import interventionFactory from '../../../testutils/factories/intervention'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 
 describe(DashboardPresenter, () => {
   describe('tableRows', () => {
     it('returns the table’s rows', () => {
-      const accommodationServiceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-      const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+      const interventions = [
+        interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } }),
+        interventionFactory.build({ id: '2', contractType: { name: "women's services" } }),
+      ]
       const sentReferrals = [
         sentReferralFactory.build({
           sentAt: '2021-01-26T13:00:00.000000Z',
           referenceNumber: 'ABCABCA1',
           referral: {
-            serviceCategoryId: accommodationServiceCategory.id,
+            interventionId: '1',
             serviceUser: { firstName: 'George', lastName: 'Michael' },
           },
         }),
@@ -20,16 +22,13 @@ describe(DashboardPresenter, () => {
           sentAt: '2020-09-13T13:00:00.000000Z',
           referenceNumber: 'ABCABCA2',
           referral: {
-            serviceCategoryId: socialInclusionServiceCategory.id,
+            interventionId: '2',
             serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
           },
         }),
       ]
 
-      const presenter = new DashboardPresenter(sentReferrals, [
-        accommodationServiceCategory,
-        socialInclusionServiceCategory,
-      ])
+      const presenter = new DashboardPresenter(sentReferrals, interventions)
 
       expect(presenter.tableRows).toEqual([
         [
@@ -44,7 +43,7 @@ describe(DashboardPresenter, () => {
           { text: '13 Sep 2020', sortValue: '2020-09-13', href: null },
           { text: 'ABCABCA2', sortValue: null, href: null },
           { text: 'Jenny Jones', sortValue: 'jones, jenny', href: null },
-          { text: 'Social inclusion', sortValue: null, href: null },
+          { text: "Women's services", sortValue: null, href: null },
           { text: '', sortValue: null, href: null },
           { text: 'View', sortValue: null, href: `/service-provider/referrals/${sentReferrals[1].id}/details` },
         ],
@@ -53,14 +52,14 @@ describe(DashboardPresenter, () => {
 
     describe('when a referral has been assigned to a caseworker', () => {
       it('includes the caseworker’s username', () => {
-        const serviceCategory = serviceCategoryFactory.build()
+        const intervention = interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } })
         const sentReferrals = [
           sentReferralFactory
             .assigned()
-            .build({ assignedTo: { username: 'john.smith' }, referral: { serviceCategoryId: serviceCategory.id } }),
+            .build({ assignedTo: { username: 'john.smith' }, referral: { interventionId: intervention.id } }),
         ]
 
-        const presenter = new DashboardPresenter(sentReferrals, [serviceCategory])
+        const presenter = new DashboardPresenter(sentReferrals, [intervention])
 
         expect(presenter.tableRows[0][4]).toMatchObject({ text: 'john.smith' })
       })
@@ -69,12 +68,12 @@ describe(DashboardPresenter, () => {
     describe('the View link', () => {
       describe('when a referral has been assigned to a caseworker', () => {
         it('links to the intervention progress page', () => {
-          const serviceCategory = serviceCategoryFactory.build()
+          const intervention = interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } })
           const sentReferrals = [
-            sentReferralFactory.assigned().build({ referral: { serviceCategoryId: serviceCategory.id } }),
+            sentReferralFactory.assigned().build({ referral: { interventionId: intervention.id } }),
           ]
 
-          const presenter = new DashboardPresenter(sentReferrals, [serviceCategory])
+          const presenter = new DashboardPresenter(sentReferrals, [intervention])
 
           expect(presenter.tableRows[0][5]).toMatchObject({
             href: `/service-provider/referrals/${sentReferrals[0].id}/progress`,

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -1,12 +1,12 @@
+import Intervention from '../../models/intervention'
 import SentReferral from '../../models/sentReferral'
-import ServiceCategory from '../../models/serviceCategory'
 import CalendarDay from '../../utils/calendarDay'
 import PresenterUtils from '../../utils/presenterUtils'
 import utils from '../../utils/utils'
 import { SortableTableHeaders, SortableTableRow } from '../../utils/viewUtils'
 
 export default class DashboardPresenter {
-  constructor(private readonly referrals: SentReferral[], private readonly serviceCategories: ServiceCategory[]) {}
+  constructor(private readonly referrals: SentReferral[], private readonly interventions: Intervention[]) {}
 
   readonly tableHeadings: SortableTableHeaders = [
     { text: 'Date received', sort: 'none' },
@@ -18,12 +18,14 @@ export default class DashboardPresenter {
   ]
 
   readonly tableRows: SortableTableRow[] = this.referrals.map(referral => {
-    const { serviceCategoryId } = referral.referral
-    const serviceCategory = this.serviceCategories.find(aServiceCategory => aServiceCategory.id === serviceCategoryId)
-    if (serviceCategory === undefined) {
-      throw new Error(`Expected serviceCategories to contain service category with ID ${serviceCategoryId}`)
+    const interventionForReferral = this.interventions.find(
+      intervention => intervention.id === referral.referral.interventionId
+    )
+    if (interventionForReferral === undefined) {
+      throw new Error(
+        `Couldn't populate row as referral's intervention ID ${referral.referral.interventionId} not passed in collection`
+      )
     }
-
     const sentAtDay = CalendarDay.britishDayForDate(new Date(referral.sentAt))
     const { serviceUser } = referral.referral
 
@@ -39,7 +41,7 @@ export default class DashboardPresenter {
         sortValue: PresenterUtils.fullNameSortValue(serviceUser),
         href: null,
       },
-      { text: utils.convertToProperCase(serviceCategory.name), sortValue: null, href: null },
+      { text: utils.convertToProperCase(interventionForReferral.contractType.name), sortValue: null, href: null },
       { text: referral.assignedTo?.username ?? '', sortValue: null, href: null },
       { text: 'View', sortValue: null, href: DashboardPresenter.hrefForViewing(referral) },
     ]

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -1,6 +1,6 @@
 import InterventionProgressPresenter from './interventionProgressPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import interventionFactory from '../../../testutils/factories/intervention'
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
@@ -9,15 +9,15 @@ describe(InterventionProgressPresenter, () => {
   describe('referralEnded', () => {
     it('returns true when the referral has ended', () => {
       const referral = sentReferralFactory.endRequested().build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
       expect(presenter.referralEnded).toEqual(true)
     })
     it('returns false when the referral has not ended', () => {
       const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
       expect(presenter.referralEnded).toEqual(false)
     })
@@ -26,8 +26,8 @@ describe(InterventionProgressPresenter, () => {
   describe('referralEndedFields', () => {
     it('returns ended fields when the referral has ended', () => {
       const referral = sentReferralFactory.endRequested().build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
       expect(presenter.referralEndedFields.endRequestedComments).toEqual(referral.endRequestedComments)
       expect(presenter.referralEndedFields.endRequestedReason).toEqual(referral.endRequestedReason)
@@ -35,8 +35,8 @@ describe(InterventionProgressPresenter, () => {
     })
     it('returns null values when the referral has not ended', () => {
       const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
       expect(presenter.referralEndedFields.endRequestedComments).toBeNull()
       expect(presenter.referralEndedFields.endRequestedReason).toBeNull()
@@ -47,8 +47,8 @@ describe(InterventionProgressPresenter, () => {
   describe('createActionPlanFormAction', () => {
     it('returns the relative URL for creating a draft action plan', () => {
       const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
       expect(presenter.createActionPlanFormAction).toEqual(`/service-provider/referrals/${referral.id}/action-plan`)
     })
@@ -57,8 +57,8 @@ describe(InterventionProgressPresenter, () => {
   describe('sessionTableRows', () => {
     it('returns an empty list if there are no appointments', () => {
       const referral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+      const intervention = interventionFactory.build()
+      const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
       expect(presenter.sessionTableRows).toEqual([])
     })
@@ -66,9 +66,9 @@ describe(InterventionProgressPresenter, () => {
     describe('when a session exists but an appointment has not yet been scheduled', () => {
       it('populates the table with formatted session information, with the "Edit session details" link displayed', () => {
         const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
+        const intervention = interventionFactory.build()
         const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [
+        const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [
           actionPlanAppointmentFactory.newlyCreated().build(),
         ])
         expect(presenter.sessionTableRows).toEqual([
@@ -94,8 +94,8 @@ describe(InterventionProgressPresenter, () => {
       it('populates the table with formatted session information, with the "Reschedule session" and "Give feedback" links displayed', () => {
         const referral = sentReferralFactory.build()
         const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [
           actionPlanAppointmentFactory.build({
             sessionNumber: 1,
             appointmentTime: '2020-12-07T13:00:00.000000Z',
@@ -131,8 +131,8 @@ describe(InterventionProgressPresenter, () => {
         it('populates the table with the "completed" status against that session and a link to view it', () => {
           const referral = sentReferralFactory.build()
           const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
-          const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [
             actionPlanAppointmentFactory.attended('yes').build({ sessionNumber: 1 }),
             actionPlanAppointmentFactory.attended('late').build({ sessionNumber: 2 }),
           ])
@@ -176,8 +176,8 @@ describe(InterventionProgressPresenter, () => {
         it('populates the table with the "failure to attend" status against that session and a link to view it', () => {
           const referral = sentReferralFactory.build()
           const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
-          const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [
             actionPlanAppointmentFactory.attended('no').build(),
           ])
 
@@ -207,8 +207,8 @@ describe(InterventionProgressPresenter, () => {
     describe('title', () => {
       it('returns a title to be displayed', () => {
         const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+        const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
         expect(presenter.text).toMatchObject({
           title: 'Accommodation',
@@ -220,8 +220,8 @@ describe(InterventionProgressPresenter, () => {
       describe('when there is no action plan', () => {
         it('returns “Not submitted”', () => {
           const referral = sentReferralFactory.build()
-          const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Not submitted' })
         })
@@ -230,9 +230,9 @@ describe(InterventionProgressPresenter, () => {
       describe('when the action plan has not been submitted', () => {
         it('returns “Not submitted”', () => {
           const referral = sentReferralFactory.build()
-          const serviceCategory = serviceCategoryFactory.build()
+          const intervention = interventionFactory.build()
           const actionPlan = actionPlanFactory.notSubmitted().build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [])
+          const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [])
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Not submitted' })
         })
@@ -241,9 +241,9 @@ describe(InterventionProgressPresenter, () => {
       describe('when the action plan has been submitted', () => {
         it('returns “Submitted”', () => {
           const referral = sentReferralFactory.build()
-          const serviceCategory = serviceCategoryFactory.build()
+          const intervention = interventionFactory.build()
           const actionPlan = actionPlanFactory.submitted().build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [])
+          const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [])
 
           expect(presenter.text).toMatchObject({ actionPlanStatus: 'Submitted' })
         })
@@ -254,8 +254,8 @@ describe(InterventionProgressPresenter, () => {
       describe('when there is no end of service report', () => {
         it('returns “Not submitted”', () => {
           const referral = sentReferralFactory.build({ endOfServiceReport: null })
-          const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
           expect(presenter.text).toMatchObject({ endOfServiceReportStatus: 'Not submitted' })
         })
@@ -265,8 +265,8 @@ describe(InterventionProgressPresenter, () => {
         it('returns “Not submitted”', () => {
           const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
           const referral = sentReferralFactory.build({ endOfServiceReport })
-          const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
           expect(presenter.text).toMatchObject({ endOfServiceReportStatus: 'Not submitted' })
         })
@@ -276,8 +276,8 @@ describe(InterventionProgressPresenter, () => {
         it('returns “Submitted”', () => {
           const endOfServiceReport = endOfServiceReportFactory.submitted().build()
           const referral = sentReferralFactory.build({ endOfServiceReport })
-          const serviceCategory = serviceCategoryFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
           expect(presenter.text).toMatchObject({ endOfServiceReportStatus: 'Submitted' })
         })
@@ -289,8 +289,8 @@ describe(InterventionProgressPresenter, () => {
     describe('when there is no action plan', () => {
       it('returns the inactive style', () => {
         const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
         expect(presenter.actionPlanStatusStyle).toEqual('inactive')
       })
@@ -299,9 +299,9 @@ describe(InterventionProgressPresenter, () => {
     describe('when the action plan has not been submitted', () => {
       it('returns the active style', () => {
         const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
+        const intervention = interventionFactory.build()
         const actionPlan = actionPlanFactory.notSubmitted().build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [])
+        const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [])
 
         expect(presenter.actionPlanStatusStyle).toEqual('inactive')
       })
@@ -310,9 +310,9 @@ describe(InterventionProgressPresenter, () => {
     describe('when the action plan has been submitted', () => {
       it('returns the active style', () => {
         const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
+        const intervention = interventionFactory.build()
         const actionPlan = actionPlanFactory.submitted().build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [])
+        const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [])
 
         expect(presenter.actionPlanStatusStyle).toEqual('active')
       })
@@ -323,8 +323,8 @@ describe(InterventionProgressPresenter, () => {
     describe('when there is no action plan', () => {
       it('returns true', () => {
         const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
         expect(presenter.allowActionPlanCreation).toEqual(true)
       })
@@ -333,9 +333,9 @@ describe(InterventionProgressPresenter, () => {
     describe('when there is an action plan', () => {
       it('returns false', () => {
         const referral = sentReferralFactory.build()
-        const serviceCategory = serviceCategoryFactory.build()
+        const intervention = interventionFactory.build()
         const actionPlan = actionPlanFactory.notSubmitted().build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [])
+        const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [])
 
         expect(presenter.allowActionPlanCreation).toEqual(false)
       })
@@ -345,17 +345,17 @@ describe(InterventionProgressPresenter, () => {
   describe('referralAssigned', () => {
     it('returns false when the referral has no assignee', () => {
       const referral = sentReferralFactory.unassigned().build()
-      const serviceCategory = serviceCategoryFactory.build()
+      const intervention = interventionFactory.build()
       const actionPlan = actionPlanFactory.submitted().build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [])
 
       expect(presenter.referralAssigned).toEqual(false)
     })
     it('returns true when the referral has an assignee', () => {
       const referral = sentReferralFactory.assigned().build()
-      const serviceCategory = serviceCategoryFactory.build()
+      const intervention = interventionFactory.build()
       const actionPlan = actionPlanFactory.submitted().build()
-      const presenter = new InterventionProgressPresenter(referral, serviceCategory, actionPlan, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [])
 
       expect(presenter.referralAssigned).toEqual(true)
     })
@@ -365,8 +365,8 @@ describe(InterventionProgressPresenter, () => {
     describe('when there is no end of service report', () => {
       it('returns the inactive style', () => {
         const referral = sentReferralFactory.build({ endOfServiceReport: null })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
         expect(presenter.endOfServiceReportStatusStyle).toEqual('inactive')
       })
@@ -376,8 +376,8 @@ describe(InterventionProgressPresenter, () => {
       it('returns the active style', () => {
         const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
         const referral = sentReferralFactory.build({ endOfServiceReport })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
         expect(presenter.endOfServiceReportStatusStyle).toEqual('inactive')
       })
@@ -387,8 +387,8 @@ describe(InterventionProgressPresenter, () => {
       it('returns the active style', () => {
         const endOfServiceReport = endOfServiceReportFactory.submitted().build()
         const referral = sentReferralFactory.build({ endOfServiceReport })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
         expect(presenter.endOfServiceReportStatusStyle).toEqual('active')
       })
@@ -399,8 +399,8 @@ describe(InterventionProgressPresenter, () => {
     describe('when there is no end of service report', () => {
       it('returns true', () => {
         const referral = sentReferralFactory.build({ endOfServiceReport: null })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
         expect(presenter.allowEndOfServiceReportCreation).toEqual(true)
       })
@@ -410,8 +410,8 @@ describe(InterventionProgressPresenter, () => {
       it('returns false', () => {
         const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
         const referral = sentReferralFactory.build({ endOfServiceReport })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, serviceCategory, null, [])
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
         expect(presenter.allowEndOfServiceReportCreation).toEqual(false)
       })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -1,11 +1,11 @@
 import ActionPlan, { ActionPlanAppointment } from '../../models/actionPlan'
 import SentReferral from '../../models/sentReferral'
-import ServiceCategory from '../../models/serviceCategory'
 import utils from '../../utils/utils'
 import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from '../shared/referralOverviewPagePresenter'
 import DateUtils from '../../utils/dateUtils'
 import sessionStatus, { SessionStatus } from '../../utils/sessionStatus'
 import SessionStatusPresenter from '../shared/sessionStatusPresenter'
+import Intervention from '../../models/intervention'
 
 interface EndedFields {
   endRequestedAt: string | null
@@ -25,7 +25,7 @@ export default class InterventionProgressPresenter {
 
   constructor(
     private readonly referral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly intervention: Intervention,
     private readonly actionPlan: ActionPlan | null,
     private readonly actionPlanAppointments: ActionPlanAppointment[]
   ) {
@@ -43,7 +43,7 @@ export default class InterventionProgressPresenter {
   readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
 
   readonly text = {
-    title: utils.convertToTitleCase(this.serviceCategory.name),
+    title: utils.convertToTitleCase(this.intervention.contractType.name),
     actionPlanStatus: this.actionPlanSubmitted ? 'Submitted' : 'Not submitted',
     endOfServiceReportStatus: this.endOfServiceReportSubmitted ? 'Submitted' : 'Not submitted',
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -43,27 +43,30 @@ afterEach(() => {
 
 describe('GET /service-provider/dashboard', () => {
   it('displays a list of all sent referrals', async () => {
-    const accommodationServiceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-    const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+    const accommodationIntervention = interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } })
+    const womensServicesIntervention = interventionFactory.build({
+      id: '2',
+      contractType: { name: "women's services" },
+    })
 
     const sentReferrals = [
       sentReferralFactory.build({
         referral: {
-          serviceCategoryId: accommodationServiceCategory.id,
+          interventionId: accommodationIntervention.id,
           serviceUser: { firstName: 'George', lastName: 'Michael' },
         },
       }),
       sentReferralFactory.build({
         referral: {
-          serviceCategoryId: socialInclusionServiceCategory.id,
+          interventionId: womensServicesIntervention.id,
           serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
         },
       }),
     ]
 
     interventionsService.getReferralsSentToServiceProvider.mockResolvedValue(sentReferrals)
-    interventionsService.getServiceCategory.mockImplementation(async (token, id) => {
-      const result = [accommodationServiceCategory, socialInclusionServiceCategory].find(category => category.id === id)
+    interventionsService.getIntervention.mockImplementation(async (token, id) => {
+      const result = [accommodationIntervention, womensServicesIntervention].find(category => category.id === id)
       return result!
     })
 
@@ -74,7 +77,7 @@ describe('GET /service-provider/dashboard', () => {
         expect(res.text).toContain('George Michael')
         expect(res.text).toContain('Accommodation')
         expect(res.text).toContain('Jenny Jones')
-        expect(res.text).toContain('Social inclusion')
+        expect(res.text).toContain('Women&#39;s services')
       })
   })
 })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -150,13 +150,13 @@ describe('GET /service-provider/referrals/:id/details', () => {
 
 describe('GET /service-provider/referrals/:id/progress', () => {
   it('displays information about the intervention progress', async () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
     const deliusServiceUser = deliusServiceUserFactory.build()
     const sentReferral = sentReferralFactory.assigned().build({
-      referral: { serviceCategoryId: serviceCategory.id },
+      referral: { interventionId: intervention.id },
     })
 
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -133,17 +133,17 @@ export default class ServiceProviderReferralsController {
       req.params.id
     )
     const serviceUserPromise = this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
-    const serviceCategoryPromise = this.interventionsService.getServiceCategory(
+    const interventionPromise = this.interventionsService.getIntervention(
       res.locals.user.token.accessToken,
-      sentReferral.referral.serviceCategoryId
+      sentReferral.referral.interventionId
     )
     const actionPlanPromise =
       sentReferral.actionPlanId === null
         ? Promise.resolve(null)
         : this.interventionsService.getActionPlan(res.locals.user.token.accessToken, sentReferral.actionPlanId)
 
-    const [serviceCategory, actionPlan, serviceUser] = await Promise.all([
-      serviceCategoryPromise,
+    const [intervention, actionPlan, serviceUser] = await Promise.all([
+      interventionPromise,
       actionPlanPromise,
       serviceUserPromise,
     ])
@@ -156,12 +156,7 @@ export default class ServiceProviderReferralsController {
       )
     }
 
-    const presenter = new InterventionProgressPresenter(
-      sentReferral,
-      serviceCategory,
-      actionPlan,
-      actionPlanAppointments
-    )
+    const presenter = new InterventionProgressPresenter(sentReferral, intervention, actionPlan, actionPlanAppointments)
     const view = new InterventionProgressView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -71,16 +71,13 @@ export default class ServiceProviderReferralsController {
       serviceProvider.id
     )
 
-    const dedupedServiceCategoryIds = Array.from(
-      new Set(referrals.map(referral => referral.referral.serviceCategoryId))
-    )
-    const serviceCategories = await Promise.all(
-      dedupedServiceCategoryIds.map(id =>
-        this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
-      )
+    const dedupedInterventionIds = Array.from(new Set(referrals.map(referral => referral.referral.interventionId)))
+
+    const interventions = await Promise.all(
+      dedupedInterventionIds.map(id => this.interventionsService.getIntervention(res.locals.user.token.accessToken, id))
     )
 
-    const presenter = new DashboardPresenter(referrals, serviceCategories)
+    const presenter = new DashboardPresenter(referrals, interventions)
     const view = new DashboardView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, null)


### PR DESCRIPTION
## What does this pull request do?

Uses contract type name on SP dashboard & referral progress page rather than service category.

## What is the intent behind these changes?

To support cohort referrals.
