### PR TITLE
Add needs and requirements to referral check-answers page

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -253,6 +253,11 @@ describe('Referral form', () => {
     cy.contains('Agnostic')
     cy.contains('Autism')
 
+    cy.contains('Alex is currently sleeping on her aunt’s sofa')
+    cy.contains('She uses a wheelchair')
+    cy.contains('Yes. Spanish')
+    cy.contains('Yes. She works Mondays 9am - midday')
+
     cy.contains('Submit referral').click()
     cy.location('pathname').should('equal', `/referrals/${sentReferral.id}/confirmation`)
 

--- a/server/routes/referrals/checkAnswersPresenter.test.ts
+++ b/server/routes/referrals/checkAnswersPresenter.test.ts
@@ -4,22 +4,24 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import { ListStyle } from '../../utils/summaryList'
 
 describe(CheckAnswersPresenter, () => {
+  const parameterisedDraftReferralFactory = draftReferralFactory.params({
+    serviceUser: {
+      crn: 'X862134',
+      title: 'Mr',
+      firstName: 'Alex',
+      lastName: 'River',
+      dateOfBirth: '1980-01-01',
+      gender: 'Male',
+      ethnicity: 'British',
+      preferredLanguage: 'English',
+      religionOrBelief: 'Agnostic',
+      disabilities: ['Autism spectrum condition', 'sciatica'],
+    },
+  })
+  const serviceCategory = serviceCategoryFactory.build()
+
   describe('serviceUserDetailsSection', () => {
-    const referral = draftReferralFactory.build({
-      serviceUser: {
-        crn: 'X862134',
-        title: 'Mr',
-        firstName: 'Alex',
-        lastName: 'River',
-        dateOfBirth: '1980-01-01',
-        gender: 'Male',
-        ethnicity: 'British',
-        preferredLanguage: 'English',
-        religionOrBelief: 'Agnostic',
-        disabilities: ['Autism spectrum condition', 'sciatica'],
-      },
-    })
-    const serviceCategory = serviceCategoryFactory.build()
+    const referral = parameterisedDraftReferralFactory.build()
     const presenter = new CheckAnswersPresenter(referral, serviceCategory)
 
     describe('title', () => {
@@ -42,6 +44,105 @@ describe(CheckAnswersPresenter, () => {
           { key: 'Religion or belief', lines: ['Agnostic'] },
           { key: 'Disabilities', lines: ['Autism spectrum condition', 'sciatica'], listStyle: ListStyle.noMarkers },
         ])
+      })
+    })
+  })
+
+  describe('needsAndRequirementsSection', () => {
+    describe('title', () => {
+      const referral = parameterisedDraftReferralFactory.build()
+      const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+
+      it('returns the section title', () => {
+        expect(presenter.needsAndRequirementsSection.title).toEqual('Alex’s needs and requirements')
+      })
+    })
+
+    describe('summary', () => {
+      describe('additional needs information', () => {
+        const referral = parameterisedDraftReferralFactory.build({
+          additionalNeedsInformation: 'Some additional needs information',
+        })
+        const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+
+        it('returns the value from the referral', () => {
+          expect(presenter.needsAndRequirementsSection.summary[0]).toEqual({
+            key: 'Additional information about Alex’s needs (optional)',
+            lines: ['Some additional needs information'],
+          })
+        })
+      })
+
+      describe('accessibility needs', () => {
+        const referral = parameterisedDraftReferralFactory.build({
+          accessibilityNeeds: 'Some accessibility needs information',
+        })
+        const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+
+        it('returns the value from the referral', () => {
+          expect(presenter.needsAndRequirementsSection.summary[1]).toEqual({
+            key: 'Does Alex have any other mobility, disability or accessibility needs? (optional)',
+            lines: ['Some accessibility needs information'],
+          })
+        })
+      })
+
+      describe('needs interpreter', () => {
+        it('includes the answer', () => {
+          const referral = parameterisedDraftReferralFactory.build({
+            needsInterpreter: false,
+          })
+          const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+
+          expect(presenter.needsAndRequirementsSection.summary[2]).toEqual({
+            key: 'Does Alex need an interpreter?',
+            lines: ['No'],
+          })
+        })
+
+        describe('when an interpreter is needed', () => {
+          const referral = parameterisedDraftReferralFactory.build({
+            needsInterpreter: true,
+            interpreterLanguage: 'Spanish',
+          })
+          const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+
+          it('also includes the language', () => {
+            expect(presenter.needsAndRequirementsSection.summary[2]).toEqual({
+              key: 'Does Alex need an interpreter?',
+              lines: ['Yes. Spanish'],
+            })
+          })
+        })
+      })
+
+      describe('has additional responsibilities', () => {
+        it('includes the answer', () => {
+          const referral = parameterisedDraftReferralFactory.build({
+            hasAdditionalResponsibilities: false,
+          })
+          const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+
+          expect(presenter.needsAndRequirementsSection.summary[3]).toEqual({
+            key: 'Does Alex have caring or employment responsibilities?',
+            lines: ['No'],
+          })
+        })
+
+        describe('when they have additional responsibilities', () => {
+          const referral = parameterisedDraftReferralFactory.build({
+            hasAdditionalResponsibilities: true,
+            whenUnavailable: 'Alex can’t attend on Fridays',
+          })
+          const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+
+          it('includes information about when they’re unavailable', () => {
+            expect(presenter.needsAndRequirementsSection.summary[3]).toEqual({
+              key: 'Does Alex have caring or employment responsibilities?',
+              lines: ['Yes. Alex can’t attend on Fridays'],
+            })
+          })
+        })
       })
     })
   })

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -2,6 +2,7 @@ import DraftReferral from '../../models/draftReferral'
 import ServiceCategory from '../../models/serviceCategory'
 import { SummaryListItem } from '../../utils/summaryList'
 import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
+import NeedsAndRequirementsPresenter from './needsAndRequirementsPresenter'
 
 export default class CheckAnswersPresenter {
   constructor(private readonly referral: DraftReferral, private readonly serviceCategory: ServiceCategory) {}
@@ -11,6 +12,49 @@ export default class CheckAnswersPresenter {
       title: `${this.serviceUserName}’s personal details`,
       summary: new ServiceUserDetailsPresenter(this.referral.serviceUser).summary,
     }
+  }
+
+  get needsAndRequirementsSection(): { title: string; summary: SummaryListItem[] } {
+    const needsAndRequirementsPresenter = new NeedsAndRequirementsPresenter(this.referral)
+
+    return {
+      title: `${this.serviceUserName}’s needs and requirements`,
+      summary: [
+        {
+          key: needsAndRequirementsPresenter.text.additionalNeedsInformation.label,
+          lines: [needsAndRequirementsPresenter.fields.additionalNeedsInformation],
+        },
+        {
+          key: needsAndRequirementsPresenter.text.accessibilityNeeds.label,
+          lines: [needsAndRequirementsPresenter.fields.accessibilityNeeds],
+        },
+        {
+          key: needsAndRequirementsPresenter.text.needsInterpreter.label,
+          lines: [
+            this.conditionalValue(
+              needsAndRequirementsPresenter.fields.needsInterpreter,
+              needsAndRequirementsPresenter.fields.interpreterLanguage
+            ),
+          ],
+        },
+        {
+          key: needsAndRequirementsPresenter.text.hasAdditionalResponsibilities.label,
+          lines: [
+            this.conditionalValue(
+              needsAndRequirementsPresenter.fields.hasAdditionalResponsibilities,
+              needsAndRequirementsPresenter.fields.whenUnavailable
+            ),
+          ],
+        },
+      ],
+    }
+  }
+
+  private conditionalValue(isSelected: boolean | null, dependentAnswerText: string) {
+    if (isSelected) {
+      return `Yes. ${dependentAnswerText}`
+    }
+    return 'No'
   }
 
   private readonly serviceUserName = this.referral.serviceUser?.firstName ?? ''

--- a/server/routes/referrals/checkAnswersView.ts
+++ b/server/routes/referrals/checkAnswersView.ts
@@ -8,10 +8,18 @@ export default class CheckAnswersView {
     this.presenter.serviceUserDetailsSection.summary
   )
 
+  private readonly needsAndRequirementsSummaryListArgs = ViewUtils.summaryListArgs(
+    this.presenter.needsAndRequirementsSection.summary
+  )
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/checkAnswers',
-      { presenter: this.presenter, serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs },
+      {
+        presenter: this.presenter,
+        serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs,
+        needsAndRequirementsSummaryListArgs: this.needsAndRequirementsSummaryListArgs,
+      },
     ]
   }
 }

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -20,6 +20,10 @@
 
       {{ govukSummaryList(serviceUserDetailsSummaryListArgs) }}
 
+      <h2 class="govuk-heading-l">{{ presenter.needsAndRequirementsSection.title }}</h2>
+
+      {{ govukSummaryList(needsAndRequirementsSummaryListArgs) }}
+
       <form method="post" action="send">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukButton({ text: "Submit referral" }) }}


### PR DESCRIPTION
## What does this pull request do?

Adds the answers from the "needs and requirements" questions to the probation practitioner "check your answers" referral page.

## What is the intent behind these changes?

To allow a probation practitioner to check all the information they've provided before submitting the referral.

## Screenshot

![localhost_3007_referrals_1_check-answers (1)](https://user-images.githubusercontent.com/53756884/119784228-e84b0f00-bec5-11eb-870d-985aa26a6811.png)
