### PR TITLE
IC-1727: Use contract type in SP referral assignment pages

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -170,7 +170,6 @@ describe('Service provider referrals dashboard', () => {
     const referralParams = {
       referral: {
         interventionId: intervention.id,
-        serviceCategoryId: intervention.serviceCategories[0].id,
         serviceCategoryIds: [intervention.serviceCategories[0].id],
       },
     }
@@ -180,7 +179,6 @@ describe('Service provider referrals dashboard', () => {
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
 
     cy.stubGetIntervention(intervention.id, intervention)
-    cy.stubGetServiceCategory(intervention.serviceCategories[0].id, intervention.serviceCategories[0])
     cy.stubGetSentReferral(referral.id, referral)
     cy.stubGetSentReferrals([referral])
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
@@ -199,7 +197,7 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('Save and continue').click()
 
     cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/check`)
-    cy.get('h1').contains('Confirm the accommodation referral assignment')
+    cy.get('h1').contains('Confirm the Accommodation referral assignment')
     cy.contains('John Smith')
 
     const assignedReferral = sentReferralFactory

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.test.ts
@@ -1,15 +1,15 @@
 import AssignmentConfirmationPresenter from './assignmentConfirmationPresenter'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import interventionFactory from '../../../testutils/factories/intervention'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 
 describe(AssignmentConfirmationPresenter, () => {
   describe('dashboardHref', () => {
     it('returns the relative URL of the service provider referrals dashboard', () => {
       const sentReferral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
+      const intervention = interventionFactory.build()
       const assignee = hmppsAuthUserFactory.build()
-      const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
+      const presenter = new AssignmentConfirmationPresenter(sentReferral, intervention, assignee)
 
       expect(presenter.dashboardHref).toEqual('/service-provider/dashboard')
     })
@@ -22,9 +22,9 @@ describe(AssignmentConfirmationPresenter, () => {
           referenceNumber: 'CEF345',
           referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
         })
-        const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const intervention = interventionFactory.build({ contractType: { name: 'social inclusion' } })
         const assignee = hmppsAuthUserFactory.build({ firstName: 'Bernard', lastName: 'Beaks' })
-        const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
+        const presenter = new AssignmentConfirmationPresenter(sentReferral, intervention, assignee)
 
         expect(presenter.summary).toEqual([
           {
@@ -53,9 +53,9 @@ describe(AssignmentConfirmationPresenter, () => {
           referenceNumber: 'CEF345',
           referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
         })
-        const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const intervention = interventionFactory.build({ contractType: { name: 'social inclusion' } })
         const assignee = hmppsAuthUserFactory.build({ firstName: 'Bernard', lastName: '' })
-        const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
+        const presenter = new AssignmentConfirmationPresenter(sentReferral, intervention, assignee)
 
         expect(presenter.summary).toEqual([
           {
@@ -84,9 +84,9 @@ describe(AssignmentConfirmationPresenter, () => {
           referenceNumber: 'CEF345',
           referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
         })
-        const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const intervention = interventionFactory.build({ contractType: { name: 'social inclusion' } })
         const assignee = hmppsAuthUserFactory.build({ firstName: '', lastName: 'Beaks' })
-        const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
+        const presenter = new AssignmentConfirmationPresenter(sentReferral, intervention, assignee)
 
         expect(presenter.summary).toEqual([
           {
@@ -115,9 +115,9 @@ describe(AssignmentConfirmationPresenter, () => {
           referenceNumber: 'CEF345',
           referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
         })
-        const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const intervention = interventionFactory.build({ contractType: { name: 'social inclusion' } })
         const assignee = hmppsAuthUserFactory.build({ firstName: '', lastName: '' })
-        const presenter = new AssignmentConfirmationPresenter(sentReferral, serviceCategory, assignee)
+        const presenter = new AssignmentConfirmationPresenter(sentReferral, intervention, assignee)
 
         expect(presenter.summary).toEqual([
           {

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
@@ -1,14 +1,14 @@
 import SentReferral from '../../models/sentReferral'
-import ServiceCategory from '../../models/serviceCategory'
 import { SummaryListItem } from '../../utils/summaryList'
 import PresenterUtils from '../../utils/presenterUtils'
 import utils from '../../utils/utils'
 import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
+import Intervention from '../../models/intervention'
 
 export default class AssignmentConfirmationPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly intervention: Intervention,
     private readonly assignee: AuthUserDetails
   ) {}
 
@@ -25,7 +25,7 @@ export default class AssignmentConfirmationPresenter {
     },
     {
       key: 'Service type',
-      lines: [utils.convertToProperCase(this.serviceCategory.name)],
+      lines: [utils.convertToProperCase(this.intervention.contractType.name)],
     },
     {
       key: 'Assigned to',

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
@@ -1,15 +1,15 @@
 import CheckAssignmentPresenter from './checkAssignmentPresenter'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
+import interventionFactory from '../../../testutils/factories/intervention'
 
 describe(CheckAssignmentPresenter, () => {
   describe('text', () => {
     it('returns text to be displayed', () => {
       const user = hmppsAuthUserFactory.build()
-      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-      const presenter = new CheckAssignmentPresenter('', user, '', serviceCategory)
+      const intervention = interventionFactory.build({ contractType: { name: 'Social inclusion' } })
+      const presenter = new CheckAssignmentPresenter('', user, '', intervention)
 
-      expect(presenter.text).toEqual({ title: 'Confirm the social inclusion referral assignment' })
+      expect(presenter.text).toEqual({ title: 'Confirm the Social inclusion referral assignment' })
     })
   })
 
@@ -17,8 +17,8 @@ describe(CheckAssignmentPresenter, () => {
     describe('when the selected caseworker has a first and last name', () => {
       it('returns a summary of the selected caseworker with both names', () => {
         const user = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', serviceCategory)
+        const intervention = interventionFactory.build()
+        const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: ['John Smith'] },
@@ -30,8 +30,8 @@ describe(CheckAssignmentPresenter, () => {
     describe('when the selected caseworker has only a first name', () => {
       it('returns a summary of the selected caseworker with just the first name', () => {
         const user = hmppsAuthUserFactory.build({ firstName: 'John', lastName: '' })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', serviceCategory)
+        const intervention = interventionFactory.build()
+        const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: ['John '] },
@@ -43,8 +43,8 @@ describe(CheckAssignmentPresenter, () => {
     describe('when the selected caseworker has only a last name', () => {
       it('returns a summary of the selected caseworker with just the last name', () => {
         const user = hmppsAuthUserFactory.build({ firstName: '', lastName: 'smith' })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'smith@harmonyliving.org.uk', serviceCategory)
+        const intervention = interventionFactory.build()
+        const presenter = new CheckAssignmentPresenter('', user, 'smith@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: [' Smith'] },
@@ -56,8 +56,8 @@ describe(CheckAssignmentPresenter, () => {
     describe('when the selected caseworker has neither a first or last name', () => {
       it('returns a summary with an empty string for the caseworker name', () => {
         const user = hmppsAuthUserFactory.build({ firstName: '', lastName: '' })
-        const serviceCategory = serviceCategoryFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'unknown@harmonyliving.org.uk', serviceCategory)
+        const intervention = interventionFactory.build()
+        const presenter = new CheckAssignmentPresenter('', user, 'unknown@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: [''] },
@@ -70,8 +70,8 @@ describe(CheckAssignmentPresenter, () => {
   describe('hiddenFields', () => {
     it('returns a hidden field for the email address', () => {
       const user = hmppsAuthUserFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', serviceCategory)
+      const intervention = interventionFactory.build()
+      const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', intervention)
       expect(presenter.hiddenFields).toEqual({ email: 'john@harmonyliving.org.uk' })
     })
   })
@@ -79,8 +79,8 @@ describe(CheckAssignmentPresenter, () => {
   describe('formAction', () => {
     it('returns a URL for submitting the assignment', () => {
       const user = hmppsAuthUserFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new CheckAssignmentPresenter('1', user, '', serviceCategory)
+      const intervention = interventionFactory.build()
+      const presenter = new CheckAssignmentPresenter('1', user, '', intervention)
       expect(presenter.formAction).toEqual('/service-provider/referrals/1/assignment')
     })
   })

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
@@ -1,18 +1,19 @@
-import ServiceCategory from '../../models/serviceCategory'
 import { SummaryListItem } from '../../utils/summaryList'
 import PresenterUtils from '../../utils/presenterUtils'
 import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
+import Intervention from '../../models/intervention'
+import utils from '../../utils/utils'
 
 export default class CheckAssignmentPresenter {
   constructor(
     private readonly referralId: string,
     private readonly assignee: AuthUserDetails,
     private readonly email: string,
-    private readonly serviceCategory: ServiceCategory
+    private readonly intervention: Intervention
   ) {}
 
   readonly text = {
-    title: `Confirm the ${this.serviceCategory.name} referral assignment`,
+    title: `Confirm the ${utils.convertToProperCase(this.intervention.contractType.name)} referral assignment`,
   }
 
   readonly summary: SummaryListItem[] = [

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -171,11 +171,11 @@ describe('GET /service-provider/referrals/:id/progress', () => {
 
 describe('GET /service-provider/referrals/:id/assignment/check', () => {
   it('displays the name of the selected caseworker', async () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-    const referral = sentReferralFactory.build({ referral: { serviceCategoryId: serviceCategory.id } })
+    const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
+    const referral = sentReferralFactory.build({ referral: { interventionId: intervention.id } })
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
 
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(referral)
     hmppsAuthService.getSPUserByEmailAddress.mockResolvedValue(hmppsAuthUser)
 
@@ -184,7 +184,7 @@ describe('GET /service-provider/referrals/:id/assignment/check', () => {
       .query({ email: 'john@harmonyliving.org.uk' })
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Confirm the accommodation referral assignment')
+        expect(res.text).toContain('Confirm the Accommodation referral assignment')
         expect(res.text).toContain('John Smith')
         expect(res.text).toContain('john@harmonyliving.org.uk')
       })
@@ -207,13 +207,13 @@ describe('GET /service-provider/referrals/:id/assignment/check', () => {
 
 describe('POST /service-provider/referrals/:id/assignment', () => {
   it('assigns the referral to the selected caseworker', async () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
     const referral = sentReferralFactory.build({
-      referral: { serviceCategoryId: serviceCategory.id, serviceUser: { firstName: 'Alex', lastName: 'River' } },
+      referral: { interventionId: intervention.id, serviceUser: { firstName: 'Alex', lastName: 'River' } },
     })
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
 
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(referral)
     hmppsAuthService.getSPUserByEmailAddress.mockResolvedValue(hmppsAuthUser)
     interventionsService.assignSentReferral.mockResolvedValue(referral)
@@ -238,17 +238,17 @@ describe('POST /service-provider/referrals/:id/assignment', () => {
 
 describe('GET /service-provider/referrals/:id/assignment/confirmation', () => {
   it('displays details of the assigned caseworker and the referral', async () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
     const referral = sentReferralFactory.assigned().build({
       referral: {
-        serviceCategoryId: serviceCategory.id,
+        interventionId: intervention.id,
         serviceUser: { firstName: 'Alex', lastName: 'River' },
       },
       assignedTo: { username: 'john.smith' },
     })
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
 
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(referral)
     hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -187,15 +187,12 @@ export default class ServiceProviderReferralsController {
     }
 
     const referral = await this.interventionsService.getSentReferral(res.locals.user.token.accessToken, req.params.id)
-    const [serviceCategory, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(
-        res.locals.user.token.accessToken,
-        referral.referral.serviceCategoryId
-      ),
+    const [intervention, serviceUser] = await Promise.all([
+      this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn),
     ])
 
-    const presenter = new CheckAssignmentPresenter(referral.id, assignee, email, serviceCategory)
+    const presenter = new CheckAssignmentPresenter(referral.id, assignee, email, intervention)
     const view = new CheckAssignmentView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
@@ -226,16 +223,13 @@ export default class ServiceProviderReferralsController {
       throw new Error('Can’t view confirmation of assignment, as referral isn’t assigned.')
     }
 
-    const [assignee, serviceCategory, serviceUser] = await Promise.all([
+    const [assignee, intervention, serviceUser] = await Promise.all([
       this.hmppsAuthService.getSPUserByUsername(res.locals.user.token.accessToken, referral.assignedTo.username),
-      this.interventionsService.getServiceCategory(
-        res.locals.user.token.accessToken,
-        referral.referral.serviceCategoryId
-      ),
+      this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn),
     ])
 
-    const presenter = new AssignmentConfirmationPresenter(referral, serviceCategory, assignee)
+    const presenter = new AssignmentConfirmationPresenter(referral, intervention, assignee)
     const view = new AssignmentConfirmationView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)


### PR DESCRIPTION
## What does this pull request do?

Use contract type in SP referral assignment pages, rather than service category, now that we have cohort services that may
have multiple.

This commit also updates tests to ensure we're presenting the service type in sentence case, rather than lower case, as advised by the content team.

## What is the intent behind these changes?

To update the journey to support cohort referrals.
