### PR TITLE
Ic 1683: Adds "Select Service Categories" for cohort referrals on "Make a referral" screen

### DIFF
--- a/integration_tests/integration/make_a_referral/referralSectionVerifier.js
+++ b/integration_tests/integration/make_a_referral/referralSectionVerifier.js
@@ -41,8 +41,16 @@ class _ReferralSectionChecker {
     return this
   }
 
+  selectServiceCagories(activeLinks) {
+    cy.get("[data-cy=url]:contains('Select service categories for the Womans Service referral')").should(
+      hrefAttrChainer(activeLinks.selectServiceCategories),
+      'href'
+    )
+    return this
+  }
+
   cohortInterventionReferralDetails(activeLinks) {
-    cy.get("[data-cy=url]:contains('Confirm the relevant sentence for the intervention referral')").should(
+    cy.get("[data-cy=url]:contains('Confirm the relevant sentence for the Womans Service referral')").should(
       hrefAttrChainer(activeLinks.relevantSentence),
       'href'
     )
@@ -59,7 +67,7 @@ class _ReferralSectionChecker {
       .eq(1)
       .should(hrefAttrChainer(activeLinks.desiredOutcomes1), 'href')
     cy.get('[data-cy=url]')
-      .contains('Enter when the intervention service need to be completed')
+      .contains('Enter when the Womans Service referral need to be completed')
       .should(hrefAttrChainer(activeLinks.completedDate), 'href')
     cy.get('[data-cy=url]').contains('Enter enforceable days used').should(hrefAttrChainer(activeLinks.rarDays), 'href')
     cy.get('[data-cy=url]')

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -4,16 +4,18 @@ import referralFormSectionFactory from '../../../testutils/factories/referralFor
 import cohortReferralFormSectionFactory from '../../../testutils/factories/cohortReferralFormSection'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import ServiceCategory from '../../models/serviceCategory'
+import interventionFactory from '../../../testutils/factories/intervention'
 
 describe('ReferralFormPresenter', () => {
   describe('for a single referral', () => {
-    const serviceCategory = serviceCategoryFactory.build()
+    const nonCohortIntervention = interventionFactory.build({ serviceCategories: [serviceCategoryFactory.build()] })
+    const serviceCategory = nonCohortIntervention.serviceCategories[0]
     describe('for each referral form section', () => {
       describe('review service user information section', () => {
         describe('when no required values have been set', () => {
           it('should contain a "Not started" label and "server-user-details" url visible', () => {
             const referral = draftReferralFactory.unfilled().build({ serviceCategoryIds: [serviceCategory.id] })
-            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
             const expected = [
               referralFormSectionFactory.reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information').build(),
               referralFormSectionFactory
@@ -29,7 +31,7 @@ describe('ReferralFormPresenter', () => {
             const referral = draftReferralFactory
               .serviceUserSelected()
               .build({ serviceCategoryIds: [serviceCategory.id] })
-            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
             const expected = [
               referralFormSectionFactory.reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information').build(),
               referralFormSectionFactory
@@ -43,7 +45,7 @@ describe('ReferralFormPresenter', () => {
         describe('when "risk information" has been set', () => {
           it('should contain a "Not started" label and "needs-and-requirements" url visible', () => {
             const referral = draftReferralFactory.filledFormUpToRiskInformation([serviceCategory]).build()
-            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
             const expected = [
               referralFormSectionFactory
                 .reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information', 'needs-and-requirements')
@@ -59,7 +61,7 @@ describe('ReferralFormPresenter', () => {
         describe('when all required values have been set', () => {
           it('should contain a "Completed" label and service category details section can be started', () => {
             const referral = draftReferralFactory.filledFormUpToNeedsAndRequirements([serviceCategory]).build()
-            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
             const expected = [
               referralFormSectionFactory
                 .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
@@ -77,7 +79,7 @@ describe('ReferralFormPresenter', () => {
         describe('when "relevant sentence" has been set', () => {
           it('should contain a "Not Started" label and "complexity-level" url visible', () => {
             const referral = draftReferralFactory.filledFormUpToRelevantSentence([serviceCategory]).build()
-            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
             const expected = [
               referralFormSectionFactory
                 .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
@@ -101,7 +103,7 @@ describe('ReferralFormPresenter', () => {
               .filledFormUpToRelevantSentence([serviceCategory])
               .addSelectedDesiredOutcomes([serviceCategory])
               .build()
-            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
             const expected = [
               referralFormSectionFactory
                 .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
@@ -127,7 +129,7 @@ describe('ReferralFormPresenter', () => {
               .addSelectedDesiredOutcomes([serviceCategory])
               .addSelectedComplexityLevel([serviceCategory])
               .build({ serviceCategoryIds: [serviceCategory.id] })
-            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
             const expected = [
               referralFormSectionFactory
                 .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
@@ -150,7 +152,7 @@ describe('ReferralFormPresenter', () => {
         describe('when "date completed by" has been set', () => {
           it('should contain a "Not Started" label and "rar-days" url visible', () => {
             const referral = draftReferralFactory.filledFormUpToCompletionDate([serviceCategory]).build()
-            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
             const expected = [
               referralFormSectionFactory
                 .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
@@ -174,7 +176,7 @@ describe('ReferralFormPresenter', () => {
         describe('when "rar days" has been set', () => {
           it('should contain a "Not Started" label and "further-information" url visible', () => {
             const referral = draftReferralFactory.filledFormUpToRarDays([serviceCategory]).build()
-            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
             const expected = [
               referralFormSectionFactory
                 .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
@@ -199,7 +201,7 @@ describe('ReferralFormPresenter', () => {
         describe('when all required values have been set', () => {
           it('should contain a "Completed" label and allow user to submit answers', () => {
             const referral = draftReferralFactory.filledFormUpToFurtherInformation([serviceCategory]).build()
-            const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
             const expected = [
               referralFormSectionFactory
                 .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
@@ -231,7 +233,7 @@ describe('ReferralFormPresenter', () => {
             serviceCategoryIds: null,
           })
 
-          const presenter = new ReferralFormPresenter(referral, [serviceCategory])
+          const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
@@ -251,17 +253,85 @@ describe('ReferralFormPresenter', () => {
       serviceCategoryFactory.build({ name: 'accommodation' }),
       serviceCategoryFactory.build({ name: 'social inclusion' }),
     ]
-    describe('service category referral details section', () => {
-      describe('when "relevant sentence" has been set', () => {
-        it('should contain a "Not Started" label and only the first "complexity-level" url is visible', () => {
-          const referral = draftReferralFactory.filledFormUpToRelevantSentence(serviceCategories).build()
-          const presenter = new ReferralFormPresenter(referral, serviceCategories)
+    const cohortIntervention = interventionFactory.build({ serviceCategories })
+    describe('select service categories section', () => {
+      describe('when "needs and requirements" has been set', () => {
+        it('should contain a "Not Started" label', () => {
+          const referral = draftReferralFactory
+            .filledFormUpToNeedsAndRequirements(serviceCategories)
+            .build({ serviceCategoryIds: null })
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.NotStarted,
+                'service-categories'
+              )
+              .build(),
             cohortReferralFormSectionFactory
-              .cohortInterventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
+              .cohortInterventionDetails('Accommodation', ReferralFormStatus.CannotStartYet, null, null)
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
+    })
+    describe('service category referral details section', () => {
+      describe('when "selected service categories" has been set', () => {
+        it('should contain a "Not Started" label and "relevant-sentence" url is visible', () => {
+          const referral = draftReferralFactory
+            .filledFormUpToNeedsAndRequirements(serviceCategories)
+            .selectedServiceCategories(serviceCategories)
+            .build()
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+              .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.Completed,
+                'service-categories'
+              )
+              .build(),
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails('Accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
+                {
+                  title: 'accommodation',
+                  desiredOutcomesUrl: null,
+                  complexityLevelUrl: null,
+                },
+                { title: 'social inclusion', complexityLevelUrl: null, desiredOutcomesUrl: null },
+              ])
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
+      describe('when "relevant" has been set', () => {
+        it('should contain a "Not Started" label and only the first "complexity-level" url is visible', () => {
+          const referral = draftReferralFactory.filledFormUpToRelevantSentence(serviceCategories).build()
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+              .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.Completed,
+                'service-categories'
+              )
+              .build(),
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails('Accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
                 {
                   title: 'accommodation',
                   desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
@@ -270,24 +340,31 @@ describe('ReferralFormPresenter', () => {
                 { title: 'social inclusion', complexityLevelUrl: null, desiredOutcomesUrl: null },
               ])
               .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
       })
       describe('when "complexity level" has been set for the first service', () => {
-        it('should contain a "Not Started" label and only the first "desired-outcomes" url is visible', () => {
+        it('should contain a "Not Started" label and only the first "complexity-level" url is visible', () => {
           const referral = draftReferralFactory
             .filledFormUpToRelevantSentence(serviceCategories)
             .addSelectedDesiredOutcomes([serviceCategories[0]])
             .build()
-          const presenter = new ReferralFormPresenter(referral, serviceCategories)
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.Completed,
+                'service-categories'
+              )
+              .build(),
             cohortReferralFormSectionFactory
-              .cohortInterventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
+              .cohortInterventionDetails('Accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
                 {
                   title: 'accommodation',
                   desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
@@ -296,7 +373,7 @@ describe('ReferralFormPresenter', () => {
                 { title: 'social inclusion', complexityLevelUrl: null, desiredOutcomesUrl: null },
               ])
               .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
@@ -308,13 +385,20 @@ describe('ReferralFormPresenter', () => {
             .addSelectedDesiredOutcomes([serviceCategories[0]])
             .addSelectedComplexityLevel([serviceCategories[0]])
             .build()
-          const presenter = new ReferralFormPresenter(referral, serviceCategories)
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.Completed,
+                'service-categories'
+              )
+              .build(),
             cohortReferralFormSectionFactory
-              .cohortInterventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
+              .cohortInterventionDetails('Accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
                 {
                   title: 'accommodation',
                   desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
@@ -327,7 +411,7 @@ describe('ReferralFormPresenter', () => {
                 },
               ])
               .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
@@ -340,13 +424,20 @@ describe('ReferralFormPresenter', () => {
             .addSelectedDesiredOutcomes(serviceCategories)
             .addSelectedComplexityLevel([serviceCategories[0]])
             .build()
-          const presenter = new ReferralFormPresenter(referral, serviceCategories)
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.Completed,
+                'service-categories'
+              )
+              .build(),
             cohortReferralFormSectionFactory
-              .cohortInterventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
+              .cohortInterventionDetails('Accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
                 {
                   title: 'accommodation',
                   desiredOutcomesUrl: `service-category/${serviceCategories[0].id}/desired-outcomes`,
@@ -359,7 +450,7 @@ describe('ReferralFormPresenter', () => {
                 },
               ])
               .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
@@ -371,14 +462,21 @@ describe('ReferralFormPresenter', () => {
             .addSelectedDesiredOutcomes(serviceCategories)
             .addSelectedComplexityLevel(serviceCategories)
             .build()
-          const presenter = new ReferralFormPresenter(referral, serviceCategories)
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.Completed,
+                'service-categories'
+              )
+              .build(),
             cohortReferralFormSectionFactory
               .cohortInterventionDetails(
-                'accommodation',
+                'Accommodation',
                 ReferralFormStatus.NotStarted,
                 'relevant-sentence',
                 [
@@ -396,7 +494,7 @@ describe('ReferralFormPresenter', () => {
                 'completion-deadline'
               )
               .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
@@ -404,14 +502,21 @@ describe('ReferralFormPresenter', () => {
       describe('when "date completed by" has been set', () => {
         it('should contain a "Not Started" label and "rar-days" url visible', () => {
           const referral = draftReferralFactory.filledFormUpToCompletionDate(serviceCategories).build()
-          const presenter = new ReferralFormPresenter(referral, serviceCategories)
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.Completed,
+                'service-categories'
+              )
+              .build(),
             cohortReferralFormSectionFactory
               .cohortInterventionDetails(
-                'accommodation',
+                'Accommodation',
                 ReferralFormStatus.NotStarted,
                 'relevant-sentence',
                 [
@@ -430,7 +535,7 @@ describe('ReferralFormPresenter', () => {
                 'rar-days'
               )
               .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
@@ -438,14 +543,21 @@ describe('ReferralFormPresenter', () => {
       describe('when "rar days" has been set', () => {
         it('should contain a "Not Started" label and "further-information" url visible', () => {
           const referral = draftReferralFactory.filledFormUpToRarDays(serviceCategories).build()
-          const presenter = new ReferralFormPresenter(referral, serviceCategories)
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.Completed,
+                'service-categories'
+              )
+              .build(),
             cohortReferralFormSectionFactory
               .cohortInterventionDetails(
-                'accommodation',
+                'Accommodation',
                 ReferralFormStatus.NotStarted,
                 'relevant-sentence',
                 [
@@ -465,7 +577,7 @@ describe('ReferralFormPresenter', () => {
                 'further-information'
               )
               .build(),
-            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })
@@ -473,14 +585,21 @@ describe('ReferralFormPresenter', () => {
       describe('when all required values have been set', () => {
         it('should contain a "Completed" label and allow user to submit answers', () => {
           const referral = draftReferralFactory.filledFormUpToFurtherInformation(serviceCategories).build()
-          const presenter = new ReferralFormPresenter(referral, serviceCategories)
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
           const expected = [
             referralFormSectionFactory
               .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
               .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.Completed,
+                'service-categories'
+              )
+              .build(),
             cohortReferralFormSectionFactory
               .cohortInterventionDetails(
-                'accommodation',
+                'Accommodation',
                 ReferralFormStatus.Completed,
                 'relevant-sentence',
                 [
@@ -500,9 +619,7 @@ describe('ReferralFormPresenter', () => {
                 'further-information'
               )
               .build(),
-            referralFormSectionFactory
-              .checkAnswers(ReferralFormStatus.NotStarted)
-              .build({ tasks: [{ title: 'Check your answers', url: 'check-answers' }] }),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.NotStarted, 'check-answers', '4').build(),
           ]
           expect(presenter.sections).toEqual(expected)
         })

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -1,23 +1,62 @@
 /* eslint max-classes-per-file: 0 */
 import DraftReferral from '../../models/draftReferral'
-import ServiceCategory from '../../models/serviceCategory'
+import Intervention from '../../models/intervention'
 
 export default class ReferralFormPresenter {
-  private readonly taskValues: typeof ReferralFormPresenter.TaskValues.prototype
+  private readonly taskValues: TaskValues
 
-  private readonly sectionValues: typeof ReferralFormPresenter.SectionValues.prototype
+  private readonly sectionValues: SectionValues
 
-  constructor(private readonly referral: DraftReferral, private readonly serviceCategories: ServiceCategory[]) {
-    this.taskValues = new ReferralFormPresenter.TaskValues(referral)
-    this.sectionValues = new ReferralFormPresenter.SectionValues(this.taskValues)
+  private readonly formSectionBuilder: FormSectionBuilder
+
+  constructor(private readonly referral: DraftReferral, private readonly intervention: Intervention) {
+    this.taskValues = new TaskValues(referral)
+    this.sectionValues = new SectionValues(this.taskValues)
+    this.formSectionBuilder = new FormSectionBuilder(referral, intervention, this.taskValues, this.sectionValues)
   }
 
   get isCohortIntervention(): boolean {
-    return this.serviceCategories.length > 1
+    return this.intervention.serviceCategories.length > 1
   }
 
   get sections(): ReferralFormSectionPresenter[] {
-    const reviewServiceUserInformation: ReferralFormSingleListSectionPresenter = {
+    if (this.isCohortIntervention) {
+      return this.formSectionBuilder.buildCohortReferralSections()
+    }
+    return this.formSectionBuilder.buildSingleReferralSections()
+  }
+}
+
+class FormSectionBuilder {
+  constructor(
+    private referral: DraftReferral,
+    private intervention: Intervention,
+    private taskValues: TaskValues,
+    private sectionValues: SectionValues
+  ) {}
+
+  buildSingleReferralSections(): ReferralFormSectionPresenter[] {
+    const reviewServiceUserInformationSection = this.buildReviewServiceUserInformationSection()
+    const referralDetailsSection = this.buildSingleReferralDetailsSection(reviewServiceUserInformationSection)
+    const checkYourAnswersSection = this.buildCheckYourAnswersSection(referralDetailsSection, false)
+    return [reviewServiceUserInformationSection, referralDetailsSection, checkYourAnswersSection]
+  }
+
+  buildCohortReferralSections() {
+    const reviewServiceUserInformationSection = this.buildReviewServiceUserInformationSection()
+    const selectServiceCategoriesSection = this.buildSelectServiceCategoriesSection(reviewServiceUserInformationSection)
+    const referralDetailsSection = this.buildCohortReferralDetailsSection(selectServiceCategoriesSection)
+    const checkYourAnswersSection = this.buildCheckYourAnswersSection(referralDetailsSection, true)
+    return [
+      reviewServiceUserInformationSection,
+      selectServiceCategoriesSection,
+      referralDetailsSection,
+      checkYourAnswersSection,
+    ]
+  }
+
+  private buildReviewServiceUserInformationSection(): ReferralFormSingleListSectionPresenter {
+    return {
       type: 'single',
       title: 'Review service user’s information',
       number: '1',
@@ -37,122 +76,161 @@ export default class ReferralFormPresenter {
         },
       ],
     }
-    let referralDetails: ReferralFormSectionPresenter
-    if (this.isCohortIntervention) {
-      referralDetails = {
-        type: 'multi',
-        title: 'Add intervention referral details',
-        number: '2',
-        status: this.calculateStatus(
-          this.sectionValues.serviceCategoryReferralDetails,
-          reviewServiceUserInformation.status!
-        ),
-        taskListSections: [
-          {
-            tasks: [
-              {
-                title: `Confirm the relevant sentence for the intervention referral`,
-                url: this.calculateTaskUrl('relevant-sentence', this.taskValues.needsAndRequirements),
-              },
-            ],
-          },
-        ]
-          .concat(
-            this.serviceCategories.map((serviceCategory, index) => {
+  }
+
+  private buildSelectServiceCategoriesSection(
+    reviewServiceUserInformationSection: ReferralFormSingleListSectionPresenter
+  ): ReferralFormSingleListSectionPresenter {
+    return {
+      type: 'single',
+      title: 'Choose service categories',
+      number: '2',
+      status: this.calculateStatus(
+        this.sectionValues.cohortServiceCategories,
+        reviewServiceUserInformationSection.status
+      ),
+      tasks: [
+        {
+          title: `Select service categories for the ${this.intervention.contractType.name} referral`,
+          url: this.calculateTaskUrl('service-categories', this.taskValues.needsAndRequirements),
+        },
+      ],
+    }
+  }
+
+  private buildSingleReferralDetailsSection(
+    reviewServiceUserInformationSection: ReferralFormSingleListSectionPresenter
+  ): ReferralFormSingleListSectionPresenter {
+    return {
+      type: 'single',
+      title: `Add ${this.intervention.serviceCategories[0].name} referral details`,
+      number: '2',
+      status: this.calculateStatus(
+        this.sectionValues.serviceCategoryReferralDetails,
+        reviewServiceUserInformationSection.status!
+      ),
+      tasks: [
+        {
+          title: `Confirm the relevant sentence for the ${this.intervention.serviceCategories[0].name} referral`,
+          url: this.calculateTaskUrl('relevant-sentence', this.taskValues.needsAndRequirements),
+        },
+        {
+          title: 'Select desired outcomes',
+          url: this.calculateTaskUrl(
+            this.referral.serviceCategoryIds && this.referral.serviceCategoryIds.length > 0
+              ? `service-category/${this.referral.serviceCategoryIds[0]}/desired-outcomes`
+              : null,
+            this.taskValues.relevantSentence
+          ),
+        },
+        {
+          title: 'Select required complexity level',
+          url: this.calculateTaskUrl(
+            this.referral.serviceCategoryIds && this.referral.serviceCategoryIds.length > 0
+              ? `service-category/${this.referral.serviceCategoryIds[0]}/complexity-level`
+              : null,
+            this.taskValues.allDesiredOutcomes
+          ),
+        },
+        {
+          title: `Enter when the ${this.intervention.serviceCategories[0].name} service need to be completed`,
+          url: this.calculateTaskUrl('completion-deadline', this.taskValues.allComplexityLevels),
+        },
+        {
+          title: 'Enter enforceable days used',
+          url: this.calculateTaskUrl('rar-days', this.taskValues.completionDeadline),
+        },
+        {
+          title: 'Further information for service provider',
+          url: this.calculateTaskUrl('further-information', this.taskValues.rarDays),
+        },
+      ],
+    }
+  }
+
+  private buildCohortReferralDetailsSection(
+    selectServiceCategoriesSection: ReferralFormSingleListSectionPresenter
+  ): ReferralFormMultiListSectionPresenter {
+    return {
+      type: 'multi',
+      title: `Add ${this.intervention.contractType.name} referral details`,
+      number: '3',
+      status: this.calculateStatus(
+        this.sectionValues.serviceCategoryReferralDetails,
+        selectServiceCategoriesSection.status!
+      ),
+      taskListSections: [
+        {
+          tasks: [
+            {
+              title: `Confirm the relevant sentence for the ${this.intervention.contractType.name} referral`,
+              url: this.calculateTaskUrl('relevant-sentence', this.taskValues.cohortServiceCategories),
+            },
+          ],
+        },
+      ]
+        .concat(
+          this.intervention.serviceCategories
+            .filter(serviceCat => {
+              if (this.referral.serviceCategoryIds !== null) {
+                return this.referral.serviceCategoryIds.some(id => id === serviceCat.id)
+              }
+              return false
+            })
+            .map((serviceCat, index) => {
               return {
-                title: serviceCategory.name,
+                title: serviceCat.name,
                 tasks: [
                   {
                     title: `Select desired outcomes`,
                     url: this.calculateTaskUrl(
-                      `service-category/${serviceCategory.id}/desired-outcomes`,
+                      `service-category/${serviceCat.id}/desired-outcomes`,
                       index === 0
                         ? this.taskValues.relevantSentence
-                        : this.taskValues.complexityLevel(this.serviceCategories[index - 1].id)
+                        : this.taskValues.complexityLevel(this.intervention.serviceCategories[index - 1].id)
                     ),
                   },
                   {
                     title: `Select required complexity level`,
                     url: this.calculateTaskUrl(
-                      `service-category/${serviceCategory.id}/complexity-level`,
-                      this.taskValues.desiredOutcomes(serviceCategory.id)
+                      `service-category/${serviceCat.id}/complexity-level`,
+                      this.taskValues.desiredOutcomes(serviceCat.id)
                     ),
                   },
                 ],
               }
             })
-          )
-          .concat([
-            {
-              tasks: [
-                {
-                  title: `Enter when the intervention service need to be completed`,
-                  url: this.calculateTaskUrl('completion-deadline', this.taskValues.allComplexityLevels),
-                },
-                {
-                  title: 'Enter enforceable days used',
-                  url: this.calculateTaskUrl('rar-days', this.taskValues.completionDeadline),
-                },
-                {
-                  title: 'Further information for service provider',
-                  url: this.calculateTaskUrl('further-information', this.taskValues.rarDays),
-                },
-              ],
-            },
-          ]),
-      }
-    } else {
-      referralDetails = {
-        type: 'single',
-        title: `Add ${this.serviceCategories[0].name} referral details`,
-        number: '2',
-        status: this.calculateStatus(
-          this.sectionValues.serviceCategoryReferralDetails,
-          reviewServiceUserInformation.status!
-        ),
-        tasks: [
+        )
+        .concat([
           {
-            title: `Confirm the relevant sentence for the ${this.serviceCategories[0].name} referral`,
-            url: this.calculateTaskUrl('relevant-sentence', this.taskValues.needsAndRequirements),
+            tasks: [
+              {
+                title: `Enter when the ${this.intervention.contractType.name} referral need to be completed`,
+                url: this.calculateTaskUrl('completion-deadline', this.taskValues.allComplexityLevels),
+              },
+              {
+                title: 'Enter enforceable days used',
+                url: this.calculateTaskUrl('rar-days', this.taskValues.completionDeadline),
+              },
+              {
+                title: 'Further information for service provider',
+                url: this.calculateTaskUrl('further-information', this.taskValues.rarDays),
+              },
+            ],
           },
-          {
-            title: 'Select desired outcomes',
-            url: this.calculateTaskUrl(
-              this.referral.serviceCategoryIds && this.referral.serviceCategoryIds.length > 0
-                ? `service-category/${this.referral.serviceCategoryIds[0]}/desired-outcomes`
-                : null,
-              this.taskValues.relevantSentence
-            ),
-          },
-          {
-            title: 'Select required complexity level',
-            url: this.calculateTaskUrl(
-              this.referral.serviceCategoryIds && this.referral.serviceCategoryIds.length > 0
-                ? `service-category/${this.referral.serviceCategoryIds[0]}/complexity-level`
-                : null,
-              this.taskValues.allDesiredOutcomes
-            ),
-          },
-          {
-            title: `Enter when the ${this.serviceCategories[0].name} service need to be completed`,
-            url: this.calculateTaskUrl('completion-deadline', this.taskValues.allComplexityLevels),
-          },
-          {
-            title: 'Enter enforceable days used',
-            url: this.calculateTaskUrl('rar-days', this.taskValues.completionDeadline),
-          },
-          {
-            title: 'Further information for service provider',
-            url: this.calculateTaskUrl('further-information', this.taskValues.rarDays),
-          },
-        ],
-      }
+        ]),
     }
-    const checkYourAnswers: ReferralFormSingleListSectionPresenter = {
+  }
+
+  private buildCheckYourAnswersSection(
+    referralDetailsSection: ReferralFormSectionPresenter,
+    isCohort: boolean
+  ): ReferralFormSingleListSectionPresenter {
+    return {
       type: 'single',
       title: 'Check your answers',
-      number: '3',
-      status: this.calculateStatus(this.sectionValues.checkYourAnswers, referralDetails.status),
+      number: isCohort ? '4' : '3',
+      status: this.calculateStatus(this.sectionValues.checkYourAnswers, referralDetailsSection.status),
       tasks: [
         {
           title: 'Check your answers',
@@ -160,17 +238,6 @@ export default class ReferralFormPresenter {
         },
       ],
     }
-    return [reviewServiceUserInformation, referralDetails, checkYourAnswers]
-  }
-
-  private calculateTaskUrl(url: string | null, displayCriteria: DraftReferralValues): string | null {
-    const everyFieldHasValues = displayCriteria.every(field => {
-      if (field === null) {
-        return false
-      }
-      return Array.isArray(field) ? field.length !== 0 : true
-    })
-    return everyFieldHasValues ? url : null
   }
 
   private calculateStatus(
@@ -192,112 +259,129 @@ export default class ReferralFormPresenter {
     return ReferralFormStatus.NotStarted
   }
 
-  private static SectionValues = class {
-    constructor(private taskValues: typeof ReferralFormPresenter.TaskValues.prototype) {}
+  private calculateTaskUrl(url: string | null, displayCriteria: DraftReferralValues): string | null {
+    const everyFieldHasValues = displayCriteria.every(field => {
+      if (field === null) {
+        return false
+      }
+      return Array.isArray(field) ? field.length !== 0 : true
+    })
+    return everyFieldHasValues ? url : null
+  }
+}
+class SectionValues {
+  constructor(private taskValues: TaskValues) {}
 
-    get reviewServiceUserInformation(): DraftReferralValues {
-      return (
-        this.taskValues.serviceUserDetails && this.taskValues.riskInformation && this.taskValues.needsAndRequirements
-      )
-    }
-
-    get serviceCategoryReferralDetails(): DraftReferralValues {
-      return (
-        this.taskValues.relevantSentence &&
-        this.taskValues.allDesiredOutcomes &&
-        this.taskValues.allComplexityLevels &&
-        this.taskValues.completionDeadline &&
-        this.taskValues.rarDays &&
-        this.taskValues.furtherInformation
-      )
-    }
-
-    get checkYourAnswers(): DraftReferralValues {
-      return this.taskValues.checkAnswers
-    }
+  get reviewServiceUserInformation(): DraftReferralValues {
+    return this.taskValues.serviceUserDetails && this.taskValues.riskInformation && this.taskValues.needsAndRequirements
   }
 
-  private static TaskValues = class {
-    constructor(private referral: DraftReferral) {}
+  get cohortServiceCategories(): DraftReferralValues {
+    return this.taskValues.cohortServiceCategories
+  }
 
-    // TODO: IC-1676. We need a field to confirm that the user has "checked" service user details.
-    get serviceUserDetails(): DraftReferralValues {
-      return []
-    }
+  get serviceCategoryReferralDetails(): DraftReferralValues {
+    return (
+      this.taskValues.relevantSentence &&
+      this.taskValues.allDesiredOutcomes &&
+      this.taskValues.allComplexityLevels &&
+      this.taskValues.completionDeadline &&
+      this.taskValues.rarDays &&
+      this.taskValues.furtherInformation
+    )
+  }
 
-    get riskInformation(): DraftReferralValues {
-      return [this.referral.additionalRiskInformation]
-    }
+  get checkYourAnswers(): DraftReferralValues {
+    return this.taskValues.checkAnswers
+  }
+}
+class TaskValues {
+  constructor(private referral: DraftReferral) {}
 
-    get needsAndRequirements(): DraftReferralValues {
-      return [
-        this.referral.additionalNeedsInformation,
-        this.referral.accessibilityNeeds,
-        this.referral.needsInterpreter,
-        this.referral.hasAdditionalResponsibilities,
-      ]
-    }
+  // TODO: IC-1676. We need a field to confirm that the user has "checked" service user details.
+  get serviceUserDetails(): DraftReferralValues {
+    return []
+  }
 
-    get relevantSentence(): DraftReferralValues {
-      return [this.referral.relevantSentenceId]
-    }
+  get riskInformation(): DraftReferralValues {
+    return [this.referral.additionalRiskInformation]
+  }
 
-    get allComplexityLevels(): DraftReferralValues {
-      if (this.referral.serviceCategoryIds === null || this.referral.serviceCategoryIds.length === 0) {
-        return [null]
-      }
-      const complexityLevelIds = this.referral.serviceCategoryIds.map(serviceCategoryId => {
-        return this.complexityLevel(serviceCategoryId)
-      })
-      return complexityLevelIds.reduce((acc, list) => acc.concat(list), [])
-    }
+  get needsAndRequirements(): DraftReferralValues {
+    return [
+      this.referral.additionalNeedsInformation,
+      this.referral.accessibilityNeeds,
+      this.referral.needsInterpreter,
+      this.referral.hasAdditionalResponsibilities,
+    ]
+  }
 
-    complexityLevel(serviceCategoryId: string): DraftReferralValues {
-      const complexityLevelId = this.referral.complexityLevels?.find(
-        complexityLevel => complexityLevel.serviceCategoryId === serviceCategoryId
-      )?.complexityLevelId
-      if (complexityLevelId === undefined) {
-        return [null]
-      }
-      return [complexityLevelId]
-    }
+  get relevantSentence(): DraftReferralValues {
+    return [this.referral.relevantSentenceId]
+  }
 
-    get allDesiredOutcomes(): DraftReferralValues {
-      if (this.referral.serviceCategoryIds === null || this.referral.serviceCategoryIds.length === 0) {
-        return [null]
-      }
-      const desiredOutcomesIds = this.referral.serviceCategoryIds.map(serviceCategoryId => {
-        return this.desiredOutcomes(serviceCategoryId)
-      })
-      return desiredOutcomesIds.reduce((acc, list) => acc.concat(list), [])
-    }
-
-    desiredOutcomes(serviceCategoryId: string): DraftReferralValues {
-      const desiredOutcomeIds = this.referral.desiredOutcomes?.find(
-        desiredOutcome => desiredOutcome.serviceCategoryId === serviceCategoryId
-      )?.desiredOutcomesIds
-      if (desiredOutcomeIds === undefined) {
-        return [null]
-      }
-      return desiredOutcomeIds
-    }
-
-    get completionDeadline(): DraftReferralValues {
-      return [this.referral.completionDeadline]
-    }
-
-    get rarDays(): DraftReferralValues {
-      return [this.referral.usingRarDays]
-    }
-
-    get furtherInformation(): DraftReferralValues {
-      return [this.referral.furtherInformation]
-    }
-
-    // null is used to ensure that section is never in a `completed` status. This is because there are no fields to confirm a user has checked the answers.
-    get checkAnswers(): DraftReferralValues {
+  get cohortServiceCategories(): DraftReferralValues {
+    if (this.referral.serviceCategoryIds === null) {
       return [null]
     }
+    return this.referral.serviceCategoryIds
+  }
+
+  get allComplexityLevels(): DraftReferralValues {
+    if (this.referral.serviceCategoryIds === null || this.referral.serviceCategoryIds.length === 0) {
+      return [null]
+    }
+    const complexityLevelIds = this.referral.serviceCategoryIds.map(serviceCategoryId => {
+      return this.complexityLevel(serviceCategoryId)
+    })
+    return complexityLevelIds.reduce((acc, list) => acc.concat(list), [])
+  }
+
+  complexityLevel(serviceCategoryId: string): DraftReferralValues {
+    const complexityLevelId = this.referral.complexityLevels?.find(
+      complexityLevel => complexityLevel.serviceCategoryId === serviceCategoryId
+    )?.complexityLevelId
+    if (complexityLevelId === undefined) {
+      return [null]
+    }
+    return [complexityLevelId]
+  }
+
+  get allDesiredOutcomes(): DraftReferralValues {
+    if (this.referral.serviceCategoryIds === null || this.referral.serviceCategoryIds.length === 0) {
+      return [null]
+    }
+    const desiredOutcomesIds = this.referral.serviceCategoryIds.map(serviceCategoryId => {
+      return this.desiredOutcomes(serviceCategoryId)
+    })
+    return desiredOutcomesIds.reduce((acc, list) => acc.concat(list), [])
+  }
+
+  desiredOutcomes(serviceCategoryId: string): DraftReferralValues {
+    const desiredOutcomeIds = this.referral.desiredOutcomes?.find(
+      desiredOutcome => desiredOutcome.serviceCategoryId === serviceCategoryId
+    )?.desiredOutcomesIds
+    if (desiredOutcomeIds === undefined) {
+      return [null]
+    }
+    return desiredOutcomeIds
+  }
+
+  get completionDeadline(): DraftReferralValues {
+    return [this.referral.completionDeadline]
+  }
+
+  get rarDays(): DraftReferralValues {
+    return [this.referral.usingRarDays]
+  }
+
+  get furtherInformation(): DraftReferralValues {
+    return [this.referral.furtherInformation]
+  }
+
+  // null is used to ensure that section is never in a `completed` status. This is because there are no fields to confirm a user has checked the answers.
+  get checkAnswers(): DraftReferralValues {
+    return [null]
   }
 }
 export type ReferralFormSectionPresenter =

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -893,7 +893,7 @@ describe('GET /referrals/:id/service-categories', () => {
       .get('/referrals/1/service-categories')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('What service types are you referring Alex to?')
+        expect(res.text).toContain('What service categories are you referring Alex to?')
       })
   })
 })

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -142,15 +142,14 @@ export default class ReferralsController {
       this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
     ])
-    const { serviceCategories } = intervention
     if (
-      serviceCategories.length === 1 &&
+      intervention.serviceCategories.length === 1 &&
       (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length === 0)
     ) {
       throw new Error('No service category selected')
     }
 
-    const presenter = new ReferralFormPresenter(referral, serviceCategories)
+    const presenter = new ReferralFormPresenter(referral, intervention)
     const view = new ReferralFormView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/referrals/updateServiceCategoriesPresenter.test.ts
+++ b/server/routes/referrals/updateServiceCategoriesPresenter.test.ts
@@ -10,7 +10,7 @@ describe(UpdateServiceCategoriesPresenter, () => {
 
       const presenter = new UpdateServiceCategoriesPresenter(referral, serviceCategoriesFromIntervention)
 
-      expect(presenter.text.title).toEqual('What service types are you referring Alex to?')
+      expect(presenter.text.title).toEqual('What service categories are you referring Alex to?')
     })
   })
 

--- a/server/routes/referrals/updateServiceCategoriesPresenter.ts
+++ b/server/routes/referrals/updateServiceCategoriesPresenter.ts
@@ -11,7 +11,7 @@ export default class UpdateServiceCategoriesPresenter {
   ) {}
 
   readonly text = {
-    title: `What service types are you referring ${this.referral.serviceUser.firstName} to?`,
+    title: `What service categories are you referring ${this.referral.serviceUser.firstName} to?`,
   }
 
   readonly errorMessage = PresenterUtils.errorMessage(this.error, 'service-category-ids')

--- a/testutils/factories/cohortReferralFormSection.ts
+++ b/testutils/factories/cohortReferralFormSection.ts
@@ -6,40 +6,44 @@ import {
 
 class CohortReferralFormSectionFactory extends Factory<ReferralFormMultiListSectionPresenter> {
   cohortInterventionDetails(
-    serviceCategoryName: string,
+    contractName: string,
     referralFormStatus: ReferralFormStatus = ReferralFormStatus.CannotStartYet,
     relevantSentenceUrl: string | null = null,
-    cohortUrls: { title: string; desiredOutcomesUrl: string | null; complexityLevelUrl: string | null }[] = [],
+    cohortUrls: { title: string; desiredOutcomesUrl: string | null; complexityLevelUrl: string | null }[] | null = [],
     completionDateUrl: string | null = null,
     rarDaysUrl: string | null = null,
     furtherInformationUrl: string | null = null
   ) {
     return this.params({
       type: 'multi',
-      title: `Add intervention referral details`,
-      number: '2',
+      title: `Add ${contractName} referral details`,
+      number: '3',
       status: referralFormStatus,
       taskListSections: [
         {
-          tasks: [{ title: `Confirm the relevant sentence for the intervention referral`, url: relevantSentenceUrl }],
+          tasks: [
+            { title: `Confirm the relevant sentence for the ${contractName} referral`, url: relevantSentenceUrl },
+          ],
         },
       ]
         .concat(
-          cohortUrls.map(cohortUrl => {
-            return {
-              title: cohortUrl.title,
-              tasks: [
-                { title: 'Select desired outcomes', url: cohortUrl.desiredOutcomesUrl },
-                { title: 'Select required complexity level', url: cohortUrl.complexityLevelUrl },
-              ],
-            }
-          })
+          cohortUrls === null
+            ? []
+            : cohortUrls.map(cohortUrl => {
+                return {
+                  title: cohortUrl.title,
+                  tasks: [
+                    { title: 'Select desired outcomes', url: cohortUrl.desiredOutcomesUrl },
+                    { title: 'Select required complexity level', url: cohortUrl.complexityLevelUrl },
+                  ],
+                }
+              })
         )
         .concat([
           {
             tasks: [
               {
-                title: `Enter when the intervention service need to be completed`,
+                title: `Enter when the ${contractName} referral need to be completed`,
                 url: completionDateUrl,
               },
               { title: 'Enter enforceable days used', url: rarDaysUrl },

--- a/testutils/factories/referralFormSection.ts
+++ b/testutils/factories/referralFormSection.ts
@@ -23,6 +23,20 @@ class ReferralFormSectionFactory extends Factory<ReferralFormSingleListSectionPr
     })
   }
 
+  selectedServiceCategories(
+    contractName: string,
+    referralFormStatus: ReferralFormStatus = ReferralFormStatus.NotStarted,
+    serviceCategoriesUrl: string | null = null
+  ) {
+    return this.params({
+      type: 'single',
+      title: 'Choose service categories',
+      number: '2',
+      status: referralFormStatus,
+      tasks: [{ title: `Select service categories for the ${contractName} referral`, url: serviceCategoriesUrl }],
+    })
+  }
+
   interventionDetails(
     serviceCategoryName: string,
     referralFormStatus: ReferralFormStatus = ReferralFormStatus.CannotStartYet,
@@ -54,12 +68,13 @@ class ReferralFormSectionFactory extends Factory<ReferralFormSingleListSectionPr
 
   checkAnswers(
     referralFormStatus: ReferralFormStatus = ReferralFormStatus.CannotStartYet,
-    checkAnswersUrl: string | null = null
+    checkAnswersUrl: string | null = null,
+    sectionNumber = '3'
   ) {
     return this.params({
       type: 'single',
       title: 'Check your answers',
-      number: '3',
+      number: sectionNumber,
       status: referralFormStatus,
       tasks: [{ title: 'Check your answers', url: checkAnswersUrl }],
     })


### PR DESCRIPTION
## What does this pull request do?

Adds "Select Service Categories" for cohort referrals on "Make a referral" screen
## What is the intent behind these changes?

Provide ability for SP user to select the service categories required for draft referral.


![image](https://user-images.githubusercontent.com/83066216/119829549-43dfc180-bef3-11eb-8e57-a51c06f1634a.png)
