### PR TITLE
IC-1727: Use `serviceCategoryIds` and `desiredOutcomes` new fields in SP Action Plan creation journey

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -252,7 +252,7 @@ describe('Service provider referrals dashboard', () => {
       referral: {
         interventionId: accommodationIntervention.id,
         serviceCategoryIds: [serviceCategory.id],
-        desiredOutcomesIds: selectedDesiredOutcomesIds,
+        desiredOutcomes: [{ serviceCategoryId: serviceCategory.id, desiredOutcomesIds: selectedDesiredOutcomesIds }],
       },
     }
     const deliusServiceUser = deliusServiceUserFactory.build()

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -252,7 +252,6 @@ describe('Service provider referrals dashboard', () => {
       referral: {
         interventionId: accommodationIntervention.id,
         serviceCategoryIds: [serviceCategory.id],
-        serviceCategoryId: serviceCategory.id, // TODO IC-1668: Remove this once action plan switched to cohort structure
         desiredOutcomesIds: selectedDesiredOutcomesIds,
       },
     }

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
@@ -29,7 +29,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
     referral: {
       serviceCategoryIds: [serviceCategory.id],
       serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
-      desiredOutcomesIds: selectedDesiredOutcomesIds,
+      desiredOutcomes: [{ serviceCategoryId: serviceCategory.id, desiredOutcomesIds: selectedDesiredOutcomesIds }],
     },
   })
 

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
@@ -27,7 +27,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
   const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
   const sentReferral = sentReferralFactory.assigned().build({
     referral: {
-      serviceCategoryId: serviceCategory.id,
+      serviceCategoryIds: [serviceCategory.id],
       serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
       desiredOutcomesIds: selectedDesiredOutcomesIds,
     },

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -16,7 +16,9 @@ export default class AddActionPlanActivitiesPresenter {
 
   readonly saveAndContinueFormAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activities`
 
-  private readonly desiredOutcomesIds = this.sentReferral.referral.desiredOutcomesIds
+  private readonly desiredOutcomesIds = this.sentReferral.referral.desiredOutcomes.flatMap(
+    desiredOutcome => desiredOutcome.desiredOutcomesIds
+  )
 
   readonly errorSummary = (() => {
     const errorSummary = this.errors.reduce((accumIndexedSummary, error) => {

--- a/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.test.ts
+++ b/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.test.ts
@@ -23,7 +23,9 @@ describe(FinaliseActionPlanActivitiesForm, () => {
     const referral = sentReferralFactory.build({
       referral: {
         serviceCategoryId: serviceCategory.id,
-        desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id],
+        desiredOutcomes: [
+          { serviceCategoryId: serviceCategory.id, desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id] },
+        ],
       },
     })
 

--- a/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.ts
+++ b/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.ts
@@ -16,9 +16,12 @@ export default class FinaliseActionPlanActivitiesForm {
   }
 
   get errors(): { desiredOutcomeId: string; error: FormValidationError }[] {
-    const desiredOutcomeIdsWithoutActivities = this.referral.referral.desiredOutcomesIds.filter(
-      desiredOutcomeId => !this.actionPlan.activities.some(activity => activity.desiredOutcome.id === desiredOutcomeId)
-    )
+    const desiredOutcomeIdsWithoutActivities = this.referral.referral.desiredOutcomes
+      .flatMap(desiredOutcome => desiredOutcome.desiredOutcomesIds)
+      .filter(
+        desiredOutcomeId =>
+          !this.actionPlan.activities.some(activity => activity.desiredOutcome.id === desiredOutcomeId)
+      )
 
     return desiredOutcomeIdsWithoutActivities.map(desiredOutcomeId => {
       const desiredOutcome = this.serviceCategory.desiredOutcomes.find(outcome => desiredOutcomeId === outcome.id)

--- a/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.test.ts
@@ -27,7 +27,7 @@ describe(ReviewActionPlanPresenter, () => {
   const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
   const sentReferral = sentReferralFactory.assigned().build({
     referral: {
-      serviceCategoryId: serviceCategory.id,
+      serviceCategoryIds: [serviceCategory.id],
       serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
       desiredOutcomesIds: selectedDesiredOutcomesIds,
     },

--- a/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.test.ts
@@ -29,7 +29,7 @@ describe(ReviewActionPlanPresenter, () => {
     referral: {
       serviceCategoryIds: [serviceCategory.id],
       serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
-      desiredOutcomesIds: selectedDesiredOutcomesIds,
+      desiredOutcomes: [{ serviceCategoryId: serviceCategory.id, desiredOutcomesIds: selectedDesiredOutcomesIds }],
     },
   })
 

--- a/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.ts
+++ b/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.ts
@@ -13,7 +13,9 @@ export default class ReviewActionPlanPresenter {
 
   readonly submitFormAction = `/service-provider/action-plan/${this.actionPlan.id}/submit`
 
-  private readonly desiredOutcomesIds = this.sentReferral.referral.desiredOutcomesIds
+  private readonly desiredOutcomesIds = this.sentReferral.referral.desiredOutcomes.flatMap(
+    desiredOutcome => desiredOutcome.desiredOutcomesIds
+  )
 
   readonly text = {
     title: `${utils.convertToProperCase(this.serviceCategory.name)} - create action plan`,

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -270,7 +270,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/add-activities', () =>
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes: [desiredOutcome] })
     const referral = sentReferralFactory.assigned().build({
       referral: {
-        serviceCategoryId: serviceCategory.id,
+        serviceCategoryIds: [serviceCategory.id],
         serviceUser: { firstName: 'Alex', lastName: 'River' },
         desiredOutcomesIds: [desiredOutcome.id],
       },
@@ -300,7 +300,7 @@ describe('POST /service-provider/action-plan/:id/add-activity', () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const referral = sentReferralFactory.assigned().build({
       referral: {
-        serviceCategoryId: serviceCategory.id,
+        serviceCategoryIds: [serviceCategory.id],
         serviceUser: { firstName: 'Alex', lastName: 'River' },
       },
     })
@@ -334,7 +334,7 @@ describe('POST /service-provider/action-plan/:id/add-activity', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes: [desiredOutcome] })
       const referral = sentReferralFactory.assigned().build({
         referral: {
-          serviceCategoryId: serviceCategory.id,
+          serviceCategoryIds: [serviceCategory.id],
           serviceUser: { firstName: 'Alex', lastName: 'River' },
           desiredOutcomesIds: [desiredOutcome.id],
         },
@@ -380,7 +380,7 @@ describe('POST /service-provider/action-plan/:id/add-activities', () => {
   const serviceCategory = serviceCategoryFactory.build({ desiredOutcomes })
   const referral = sentReferralFactory.build({
     referral: {
-      serviceCategoryId: serviceCategory.id,
+      serviceCategoryIds: [serviceCategory.id],
       desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id],
     },
   })
@@ -430,7 +430,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/number-of-sessions', (
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const referral = sentReferralFactory.assigned().build({
       referral: {
-        serviceCategoryId: serviceCategory.id,
+        serviceCategoryIds: [serviceCategory.id],
         serviceUser: { firstName: 'Alex', lastName: 'River' },
       },
     })
@@ -471,7 +471,7 @@ describe('POST /service-provider/action-plan/:actionPlanId/number-of-sessions', 
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const referral = sentReferralFactory.assigned().build({
         referral: {
-          serviceCategoryId: serviceCategory.id,
+          serviceCategoryIds: [serviceCategory.id],
           serviceUser: { firstName: 'Alex', lastName: 'River' },
         },
       })
@@ -502,7 +502,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/review', () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes: [desiredOutcome] })
     const referral = sentReferralFactory.assigned().build({
       referral: {
-        serviceCategoryId: serviceCategory.id,
+        serviceCategoryIds: [serviceCategory.id],
         serviceUser: { firstName: 'Alex', lastName: 'River' },
         desiredOutcomesIds: [desiredOutcome.id],
       },
@@ -548,7 +548,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/confirmation', () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const referral = sentReferralFactory.assigned().build({
       referral: {
-        serviceCategoryId: serviceCategory.id,
+        serviceCategoryIds: [serviceCategory.id],
         serviceUser: { firstName: 'Alex', lastName: 'River' },
       },
     })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -272,7 +272,12 @@ describe('GET /service-provider/action-plan/:actionPlanId/add-activities', () =>
       referral: {
         serviceCategoryIds: [serviceCategory.id],
         serviceUser: { firstName: 'Alex', lastName: 'River' },
-        desiredOutcomesIds: [desiredOutcome.id],
+        desiredOutcomes: [
+          {
+            serviceCategoryId: serviceCategory.id,
+            desiredOutcomesIds: [desiredOutcome.id],
+          },
+        ],
       },
     })
     const draftActionPlan = actionPlanFactory.justCreated(referral.id).build({
@@ -336,7 +341,12 @@ describe('POST /service-provider/action-plan/:id/add-activity', () => {
         referral: {
           serviceCategoryIds: [serviceCategory.id],
           serviceUser: { firstName: 'Alex', lastName: 'River' },
-          desiredOutcomesIds: [desiredOutcome.id],
+          desiredOutcomes: [
+            {
+              serviceCategoryId: serviceCategory.id,
+              desiredOutcomesIds: [desiredOutcome.id],
+            },
+          ],
         },
       })
       const draftActionPlan = actionPlanFactory.justCreated(referral.id).build()
@@ -381,7 +391,12 @@ describe('POST /service-provider/action-plan/:id/add-activities', () => {
   const referral = sentReferralFactory.build({
     referral: {
       serviceCategoryIds: [serviceCategory.id],
-      desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id],
+      desiredOutcomes: [
+        {
+          serviceCategoryId: serviceCategory.id,
+          desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id],
+        },
+      ],
     },
   })
 
@@ -504,7 +519,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/review', () => {
       referral: {
         serviceCategoryIds: [serviceCategory.id],
         serviceUser: { firstName: 'Alex', lastName: 'River' },
-        desiredOutcomesIds: [desiredOutcome.id],
+        desiredOutcomes: [{ serviceCategoryId: serviceCategory.id, desiredOutcomesIds: [desiredOutcome.id] }],
       },
     })
     const draftActionPlan = actionPlanFactory.readyToSubmit(referral.id).build({

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -249,7 +249,7 @@ export default class ServiceProviderReferralsController {
     const [serviceCategory, serviceUser] = await Promise.all([
       this.interventionsService.getServiceCategory(
         res.locals.user.token.accessToken,
-        sentReferral.referral.serviceCategoryId
+        sentReferral.referral.serviceCategoryIds[0]
       ),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
@@ -283,7 +283,7 @@ export default class ServiceProviderReferralsController {
     const [serviceCategory, serviceUser] = await Promise.all([
       this.interventionsService.getServiceCategory(
         res.locals.user.token.accessToken,
-        sentReferral.referral.serviceCategoryId
+        sentReferral.referral.serviceCategoryIds[0]
       ),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
@@ -304,7 +304,7 @@ export default class ServiceProviderReferralsController {
 
     const serviceCategory = await this.interventionsService.getServiceCategory(
       res.locals.user.token.accessToken,
-      sentReferral.referral.serviceCategoryId
+      sentReferral.referral.serviceCategoryIds[0]
     )
 
     const form = new FinaliseActionPlanActivitiesForm(sentReferral, actionPlan, serviceCategory)
@@ -331,7 +331,7 @@ export default class ServiceProviderReferralsController {
     const [serviceCategory, serviceUser] = await Promise.all([
       this.interventionsService.getServiceCategory(
         res.locals.user.token.accessToken,
-        sentReferral.referral.serviceCategoryId
+        sentReferral.referral.serviceCategoryIds[0]
       ),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
@@ -362,7 +362,7 @@ export default class ServiceProviderReferralsController {
     const [serviceCategory, serviceUser] = await Promise.all([
       this.interventionsService.getServiceCategory(
         res.locals.user.token.accessToken,
-        sentReferral.referral.serviceCategoryId
+        sentReferral.referral.serviceCategoryIds[0]
       ),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
@@ -396,7 +396,7 @@ export default class ServiceProviderReferralsController {
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
     const serviceCategory = await this.interventionsService.getServiceCategory(
       token,
-      referral.referral.serviceCategoryId
+      referral.referral.serviceCategoryIds[0]
     )
 
     const presenter = new AddActionPlanNumberOfSessionsPresenter(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compileOnSave": true,
   "compilerOptions": {
     "target": "es2018",
+    "lib": ["es2019"],
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "./dist",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -2,6 +2,7 @@
   "compileOnSave": true,
   "compilerOptions": {
     "target": "es2018",
+    "lib": ["es2019"],
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "./dist",


### PR DESCRIPTION
## What does this pull request do?

Use `serviceCategoryIds` and `desiredOutcomes` new fields in SP Action Plan creation journey, over the old `serviceCategoryId` and `desiredOutcomesIds` fields.

This doesn't mean that we can create a proper action plan for cohort services yet - I think it will be possible, but will ignore any service category on the referral other than the first one, but it should work for single-service referrals.

## What is the intent behind these changes?

- This will pave the way for functionality to create an action plan for cohort services.
- The development environment was failing for this journey due to those fields not being present in the response from the API.
