### PR TITLE
IC-1814: PP EOSR uses serviceCategoryIds instead of serviceCategory

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -79,10 +79,12 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.login()
 
     const serviceCategory = serviceCategoryFactory.build()
+    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
     const deliusServiceUser = deliusServiceUserFactory.build()
     const referral = sentReferralFactory.build({
       referral: {
-        serviceCategoryId: serviceCategory.id,
+        interventionId: intervention.id,
+        serviceCategoryIds: [serviceCategory.id],
         desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id],
         serviceUser: { crn: deliusServiceUser.otherIds.crn },
       },
@@ -103,6 +105,7 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.stubGetEndOfServiceReport(endOfServiceReport.id, endOfServiceReport)
     cy.stubGetSentReferral(referral.id, referral)
     cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+    cy.stubGetIntervention(intervention.id, intervention)
     cy.stubGetServiceUserByCRN(deliusServiceUser.otherIds.crn, deliusServiceUser)
 
     cy.visit(`/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`)

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -13,6 +13,7 @@ describe('Probation practitioner referrals dashboard', () => {
   })
 
   it("user logs in and sees 'My cases' screen with list of sent referrals", () => {
+    const serviceCategory = serviceCategoryFactory.build()
     const accommodationIntervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
     const womensServicesIntervention = interventionFactory.build({ contractType: { name: "womens' services" } })
 
@@ -23,6 +24,13 @@ describe('Probation practitioner referrals dashboard', () => {
         referral: {
           interventionId: accommodationIntervention.id,
           serviceUser: { firstName: 'George', lastName: 'Michael' },
+          serviceCategoryIds: [serviceCategory.id],
+          desiredOutcomes: [
+            {
+              serviceCategoryId: serviceCategory.id,
+              desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
+            },
+          ],
           desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
           complexityLevelId: '110f2405-d944-4c15-836c-0c6684e2aa78',
         },
@@ -38,7 +46,13 @@ describe('Probation practitioner referrals dashboard', () => {
         referral: {
           interventionId: womensServicesIntervention.id,
           serviceUser: { firstName: 'Jenny', lastName: 'Jones', crn: 'X123456' },
-          desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
+          serviceCategoryIds: [serviceCategory.id],
+          desiredOutcomes: [
+            {
+              serviceCategoryId: serviceCategory.id,
+              desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
+            },
+          ],
           complexityLevelId: '110f2405-d944-4c15-836c-0c6684e2aa78',
         },
       }),
@@ -77,15 +91,25 @@ describe('Probation practitioner referrals dashboard', () => {
   it('user views an end of service report', () => {
     cy.stubGetSentReferralsForUserToken([])
     cy.login()
-
-    const serviceCategory = serviceCategoryFactory.build()
-    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
+    const serviceCategory1 = serviceCategoryFactory.build()
+    const serviceCategory2 = serviceCategoryFactory.build({
+      desiredOutcomes: [
+        {
+          id: '2d63bedc-9658-40c4-9d31-da649396ace1',
+          description: 'Some other desired outcome',
+        },
+      ],
+    })
+    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory1, serviceCategory2] })
     const deliusServiceUser = deliusServiceUserFactory.build()
     const referral = sentReferralFactory.build({
       referral: {
         interventionId: intervention.id,
-        serviceCategoryIds: [serviceCategory.id],
-        desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id],
+        serviceCategoryIds: [serviceCategory1.id, serviceCategory2.id],
+        desiredOutcomes: [
+          { serviceCategoryId: serviceCategory1.id, desiredOutcomesIds: [serviceCategory1.desiredOutcomes[0].id] },
+          { serviceCategoryId: serviceCategory2.id, desiredOutcomesIds: [serviceCategory2.desiredOutcomes[0].id] },
+        ],
         serviceUser: { crn: deliusServiceUser.otherIds.crn },
       },
     })
@@ -93,10 +117,16 @@ describe('Probation practitioner referrals dashboard', () => {
       referralId: referral.id,
       outcomes: [
         {
-          desiredOutcome: serviceCategory.desiredOutcomes[0],
+          desiredOutcome: serviceCategory1.desiredOutcomes[0],
           achievementLevel: 'ACHIEVED',
-          progressionComments: 'Some progression comments',
-          additionalTaskComments: 'Some task comments',
+          progressionComments: 'Some progression comments for serviceCategory1',
+          additionalTaskComments: 'Some task comments for serviceCategory1',
+        },
+        {
+          desiredOutcome: serviceCategory2.desiredOutcomes[0],
+          achievementLevel: 'ACHIEVED',
+          progressionComments: 'Some progression comments for serviceCategory2',
+          additionalTaskComments: 'Some task comments for serviceCategory2',
         },
       ],
       furtherInformation: 'Some further information',
@@ -104,8 +134,9 @@ describe('Probation practitioner referrals dashboard', () => {
 
     cy.stubGetEndOfServiceReport(endOfServiceReport.id, endOfServiceReport)
     cy.stubGetSentReferral(referral.id, referral)
-    cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
     cy.stubGetIntervention(intervention.id, intervention)
+    cy.stubGetServiceCategory(serviceCategory1.id, serviceCategory1)
+    cy.stubGetServiceCategory(serviceCategory2.id, serviceCategory2)
     cy.stubGetServiceUserByCRN(deliusServiceUser.otherIds.crn, deliusServiceUser)
 
     cy.visit(`/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`)
@@ -113,9 +144,12 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.contains('End of service report')
     cy.contains('The service provider has created an end of service report')
     cy.contains('Achieved')
-    cy.contains(serviceCategory.desiredOutcomes[0].description)
-    cy.contains('Some progression comments')
-    cy.contains('Some task comments')
+    cy.contains(serviceCategory1.desiredOutcomes[0].description)
+    cy.contains('Some progression comments for serviceCategory1')
+    cy.contains('Some task comments for serviceCategory1')
+    cy.contains(serviceCategory2.desiredOutcomes[0].description)
+    cy.contains('Some progression comments for serviceCategory1')
+    cy.contains('Some task comments for serviceCategory1')
     cy.contains('Some further information')
   })
 })

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -842,7 +842,9 @@ describe('Service provider referrals dashboard', () => {
       referral: {
         interventionId: accommodationIntervention.id,
         serviceCategoryId: serviceCategory.id,
+        serviceCategoryIds: [serviceCategory.id],
         desiredOutcomesIds: selectedDesiredOutcomesIds,
+        desiredOutcomes: [{ serviceCategoryId: serviceCategory.id, desiredOutcomesIds: selectedDesiredOutcomesIds }],
         serviceUser: { firstName: 'Alex', lastName: 'River' },
       },
     }

--- a/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.test.ts
@@ -35,7 +35,7 @@ describe(EndOfServiceReportPresenter, () => {
 
   describe('text', () => {
     it('returns text to be displayed', () => {
-      const presenter = new EndOfServiceReportPresenter(referral, buildEndOfServiceReport(), serviceCategory)
+      const presenter = new EndOfServiceReportPresenter(referral, buildEndOfServiceReport(), [serviceCategory])
 
       expect(presenter.text).toEqual({
         introduction:
@@ -46,7 +46,7 @@ describe(EndOfServiceReportPresenter, () => {
 
   describe('answersPresenter', () => {
     it('returns a presenter', () => {
-      const presenter = new EndOfServiceReportPresenter(referral, buildEndOfServiceReport(), serviceCategory)
+      const presenter = new EndOfServiceReportPresenter(referral, buildEndOfServiceReport(), [serviceCategory])
 
       expect(presenter.answersPresenter).toBeDefined()
     })

--- a/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.test.ts
@@ -4,9 +4,6 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
 
 describe(EndOfServiceReportPresenter, () => {
-  const referral = sentReferralFactory.build({
-    referral: { desiredOutcomesIds: ['1', '3'], serviceUser: { firstName: 'Alex', lastName: 'River' } },
-  })
   const serviceCategory = serviceCategoryFactory.build({
     name: 'social inclusion',
     desiredOutcomes: [
@@ -14,6 +11,12 @@ describe(EndOfServiceReportPresenter, () => {
       { id: '2', description: 'Description of desired outcome 2' },
       { id: '3', description: 'Description of desired outcome 3' },
     ],
+  })
+  const referral = sentReferralFactory.build({
+    referral: {
+      desiredOutcomes: [{ serviceCategoryId: serviceCategory.id, desiredOutcomesIds: ['1', '3'] }],
+      serviceUser: { firstName: 'Alex', lastName: 'River' },
+    },
   })
   const buildEndOfServiceReport = () =>
     endOfServiceReportFactory.build({

--- a/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.ts
@@ -8,7 +8,7 @@ export default class EndOfServiceReportPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategory: ServiceCategory
+    private readonly serviceCategories: ServiceCategory[]
   ) {}
 
   readonly text = {
@@ -20,7 +20,7 @@ export default class EndOfServiceReportPresenter {
   readonly answersPresenter = new EndOfServiceReportAnswersPresenter(
     this.referral,
     this.endOfServiceReport,
-    this.serviceCategory,
+    this.serviceCategories[0],
     false
   )
 }

--- a/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/endOfServiceReportPresenter.ts
@@ -20,7 +20,7 @@ export default class EndOfServiceReportPresenter {
   readonly answersPresenter = new EndOfServiceReportAnswersPresenter(
     this.referral,
     this.endOfServiceReport,
-    this.serviceCategories[0],
+    this.serviceCategories,
     false
   )
 }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -158,7 +158,9 @@ describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:ses
       const referral = sentReferralFactory.build({
         referral: {
           serviceCategoryIds: [serviceCategory.id],
-          desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id],
+          desiredOutcomes: [
+            { serviceCategoryId: serviceCategory.id, desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id] },
+          ],
         },
       })
       const endOfServiceReport = endOfServiceReportFactory.build({

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -154,8 +154,12 @@ describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:ses
   describe('GET /probation-practitioner/end-of-service-report/:id', () => {
     it('renders a page with the contents of the end of service report', async () => {
       const serviceCategory = serviceCategoryFactory.build()
+      const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
       const referral = sentReferralFactory.build({
-        referral: { desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id] },
+        referral: {
+          serviceCategoryIds: [serviceCategory.id],
+          desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id],
+        },
       })
       const endOfServiceReport = endOfServiceReportFactory.build({
         outcomes: [
@@ -172,7 +176,7 @@ describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:ses
 
       interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
       interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+      interventionsService.getIntervention.mockResolvedValue(intervention)
       communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
 
       await request(app)
@@ -184,6 +188,28 @@ describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:ses
           expect(res.text).toContain('Some progression comments')
           expect(res.text).toContain('Some task comments')
           expect(res.text).toContain('Some further information')
+        })
+    })
+
+    it('throws error if not all service categories were obtainable', async () => {
+      const serviceCategory = serviceCategoryFactory.build()
+      const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
+      const referral = sentReferralFactory.build({
+        referral: {
+          serviceCategoryIds: [serviceCategory.id, 'someOtherId'],
+        },
+      })
+      const endOfServiceReport = endOfServiceReportFactory.build()
+      const deliusServiceUser = deliusServiceUserFactory.build()
+      interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+      interventionsService.getSentReferral.mockResolvedValue(referral)
+      interventionsService.getIntervention.mockResolvedValue(intervention)
+      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+      await request(app)
+        .get(`/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`)
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain('Expected service categories are missing in intervention')
         })
     })
   })

--- a/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.test.ts
@@ -4,9 +4,6 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
 
 describe(EndOfServiceReportCheckAnswersPresenter, () => {
-  const referral = sentReferralFactory.build({
-    referral: { desiredOutcomesIds: ['1', '3'], serviceUser: { firstName: 'Alex', lastName: 'River' } },
-  })
   const serviceCategory = serviceCategoryFactory.build({
     name: 'social inclusion',
     desiredOutcomes: [
@@ -14,6 +11,12 @@ describe(EndOfServiceReportCheckAnswersPresenter, () => {
       { id: '2', description: 'Description of desired outcome 2' },
       { id: '3', description: 'Description of desired outcome 3' },
     ],
+  })
+  const referral = sentReferralFactory.build({
+    referral: {
+      desiredOutcomes: [{ serviceCategoryId: serviceCategory.id, desiredOutcomesIds: ['1', '3'] }],
+      serviceUser: { firstName: 'Alex', lastName: 'River' },
+    },
   })
   const buildEndOfServiceReport = () =>
     endOfServiceReportFactory.build({

--- a/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportCheckAnswersPresenter.ts
@@ -22,7 +22,7 @@ export default class EndOfServiceReportCheckAnswersPresenter {
   readonly answersPresenter = new EndOfServiceReportAnswersPresenter(
     this.referral,
     this.endOfServiceReport,
-    this.serviceCategory,
+    [this.serviceCategory],
     true
   )
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1208,7 +1208,14 @@ describe('GET /service-provider/end-of-service-report/:id/check-answers', () => 
   it('renders a page with the contents of the end of service report', async () => {
     const serviceCategory = serviceCategoryFactory.build()
     const referral = sentReferralFactory.build({
-      referral: { desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id] },
+      referral: {
+        desiredOutcomes: [
+          {
+            serviceCategoryId: serviceCategory.id,
+            desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id],
+          },
+        ],
+      },
     })
     const endOfServiceReport = endOfServiceReportFactory.build({
       outcomes: [

--- a/server/routes/shared/endOfServiceReportAnswersPresenter.test.ts
+++ b/server/routes/shared/endOfServiceReportAnswersPresenter.test.ts
@@ -4,38 +4,64 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
 
 describe(EndOfServiceReportAnswersPresenter, () => {
-  const referral = sentReferralFactory.build({
-    referral: { desiredOutcomesIds: ['1', '3'], serviceUser: { firstName: 'Alex', lastName: 'River' } },
-  })
-  const serviceCategory = serviceCategoryFactory.build({
+  const serviceCategory1 = serviceCategoryFactory.build({
     name: 'social inclusion',
     desiredOutcomes: [
-      { id: '1', description: 'Description of desired outcome 1' },
-      { id: '2', description: 'Description of desired outcome 2' },
-      { id: '3', description: 'Description of desired outcome 3' },
+      { id: '1', description: 'Description of desired outcome 1 for social inclusion' },
+      { id: '2', description: 'Description of desired outcome 2 for social inclusion' },
+      { id: '3', description: 'Description of desired outcome 3 for social inclusion' },
     ],
   })
+  const serviceCategory2 = serviceCategoryFactory.build({
+    name: 'accommodation',
+    desiredOutcomes: [
+      { id: '4', description: 'Description of desired outcome 1 for accommodation' },
+      { id: '5', description: 'Description of desired outcome 2 for accommodation' },
+      { id: '6', description: 'Description of desired outcome 3 for accommodation' },
+    ],
+  })
+  const cohortReferral = sentReferralFactory.build({
+    referral: {
+      desiredOutcomes: [
+        { serviceCategoryId: serviceCategory1.id, desiredOutcomesIds: ['1', '3'] },
+        { serviceCategoryId: serviceCategory2.id, desiredOutcomesIds: ['5'] },
+      ],
+      serviceUser: { firstName: 'Alex', lastName: 'River' },
+    },
+  })
+
+  const serviceCategories = [serviceCategory1, serviceCategory2]
   const buildEndOfServiceReport = () =>
     endOfServiceReportFactory.build({
       outcomes: [
         {
-          desiredOutcome: serviceCategory.desiredOutcomes[0],
+          desiredOutcome: serviceCategory1.desiredOutcomes[0],
           achievementLevel: 'ACHIEVED',
           progressionComments: 'Example progression comments 1',
           additionalTaskComments: 'Example task comments 1',
         },
         {
-          desiredOutcome: serviceCategory.desiredOutcomes[2],
+          desiredOutcome: serviceCategory1.desiredOutcomes[2],
           achievementLevel: 'PARTIALLY_ACHIEVED',
           progressionComments: 'Example progression comments 2',
           additionalTaskComments: 'Example task comments 2',
+        },
+        {
+          desiredOutcome: serviceCategory2.desiredOutcomes[1],
+          achievementLevel: 'PARTIALLY_ACHIEVED',
+          progressionComments: 'Example progression comments 3',
+          additionalTaskComments: 'Example task comments 3',
         },
       ],
     })
 
   describe('interventionSummary', () => {
     it('returns a summary of the intervention', () => {
-      const presenter = new EndOfServiceReportAnswersPresenter(referral, buildEndOfServiceReport(), serviceCategory)
+      const presenter = new EndOfServiceReportAnswersPresenter(
+        cohortReferral,
+        buildEndOfServiceReport(),
+        serviceCategories
+      )
 
       expect(presenter.interventionSummary).toEqual([
         {
@@ -49,7 +75,7 @@ describe(EndOfServiceReportAnswersPresenter, () => {
   describe('outcomes', () => {
     it('replays the user’s outcome answers from the draft end of service report, with a link for changing the answer', () => {
       const endOfServiceReport = buildEndOfServiceReport()
-      const presenter = new EndOfServiceReportAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+      const presenter = new EndOfServiceReportAnswersPresenter(cohortReferral, endOfServiceReport, serviceCategories)
 
       expect(presenter.outcomes).toEqual([
         {
@@ -58,7 +84,7 @@ describe(EndOfServiceReportAnswersPresenter, () => {
           additionalTaskComments: 'Example task comments 1',
           changeHref: `/service-provider/end-of-service-report/${endOfServiceReport.id}/outcomes/1`,
           progressionComments: 'Example progression comments 1',
-          subtitle: 'Description of desired outcome 1',
+          subtitle: 'Description of desired outcome 1 for social inclusion',
           title: 'Outcome 1',
         },
         {
@@ -67,8 +93,17 @@ describe(EndOfServiceReportAnswersPresenter, () => {
           additionalTaskComments: 'Example task comments 2',
           changeHref: `/service-provider/end-of-service-report/${endOfServiceReport.id}/outcomes/2`,
           progressionComments: 'Example progression comments 2',
-          subtitle: 'Description of desired outcome 3',
+          subtitle: 'Description of desired outcome 3 for social inclusion',
           title: 'Outcome 2',
+        },
+        {
+          achievementLevelStyle: 'PARTIALLY_ACHIEVED',
+          achievementLevelText: 'Partially achieved',
+          additionalTaskComments: 'Example task comments 3',
+          changeHref: `/service-provider/end-of-service-report/${endOfServiceReport.id}/outcomes/3`,
+          progressionComments: 'Example progression comments 3',
+          subtitle: 'Description of desired outcome 2 for accommodation',
+          title: 'Outcome 3',
         },
       ])
     })
@@ -78,7 +113,7 @@ describe(EndOfServiceReportAnswersPresenter, () => {
         const endOfServiceReport = buildEndOfServiceReport()
         endOfServiceReport.outcomes[0].progressionComments = ''
 
-        const presenter = new EndOfServiceReportAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+        const presenter = new EndOfServiceReportAnswersPresenter(cohortReferral, endOfServiceReport, serviceCategories)
 
         expect(presenter.outcomes[0].progressionComments).toEqual('None')
       })
@@ -89,7 +124,7 @@ describe(EndOfServiceReportAnswersPresenter, () => {
         const endOfServiceReport = buildEndOfServiceReport()
         endOfServiceReport.outcomes[0].additionalTaskComments = ''
 
-        const presenter = new EndOfServiceReportAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+        const presenter = new EndOfServiceReportAnswersPresenter(cohortReferral, endOfServiceReport, serviceCategories)
 
         expect(presenter.outcomes[0].additionalTaskComments).toEqual('None')
       })
@@ -99,7 +134,7 @@ describe(EndOfServiceReportAnswersPresenter, () => {
   describe('furtherInformation', () => {
     it('replays the user’s further information answer from the draft end of service report, with a link for changing the answer', () => {
       const endOfServiceReport = buildEndOfServiceReport()
-      const presenter = new EndOfServiceReportAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+      const presenter = new EndOfServiceReportAnswersPresenter(cohortReferral, endOfServiceReport, serviceCategories)
 
       expect(presenter.furtherInformation).toEqual({
         changeHref: `/service-provider/end-of-service-report/${endOfServiceReport.id}/further-information`,
@@ -111,7 +146,7 @@ describe(EndOfServiceReportAnswersPresenter, () => {
       const endOfServiceReport = buildEndOfServiceReport()
       endOfServiceReport.furtherInformation = ''
 
-      const presenter = new EndOfServiceReportAnswersPresenter(referral, endOfServiceReport, serviceCategory)
+      const presenter = new EndOfServiceReportAnswersPresenter(cohortReferral, endOfServiceReport, serviceCategories)
 
       expect(presenter.furtherInformation.text).toEqual('None')
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compileOnSave": true,
   "compilerOptions": {
     "target": "es2018",
+    "lib": ["es2019"],
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "./dist",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -2,6 +2,7 @@
   "compileOnSave": true,
   "compilerOptions": {
     "target": "es2018",
+    "lib": ["es2019"],
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "./dist",


### PR DESCRIPTION
## What does this pull request do?

Change the PP EOSR journey to use serviceCategoryIds instead of serviceCategoryId and desiredOutcomes rather than desiredOutcomeIds

## What is the intent behind these changes?

Make the UI compatible with cohort referrals. Allows the PP user to see EOSR for cohort referrals.
