### PR TITLE
IC-1811: Changed ordering of 'Find Inteventions' search menu

### DIFF
--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -28,10 +28,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
       <form method="get">
+        {{ govukCheckboxes(pccRegionCheckboxArgs) }}
         {{ govukCheckboxes(genderCheckboxArgs) }}
         {{ govukCheckboxes(ageCheckboxArgs) }}
-        {{ govukCheckboxes(pccRegionCheckboxArgs) }}
-
         {{ govukButton({ text: "Filter results" }) }}
       </form>
 


### PR DESCRIPTION
## What does this pull request do?

Changes order of items in search menu in Find Interventions page

## What is the intent behind these changes?

To make sure that regions are shown first


![image](https://user-images.githubusercontent.com/83066216/119987342-d4ce9f80-bfbc-11eb-8ec0-f9deddb00a1c.png)
