### PR TITLE
Switch to local network access to the service

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,7 +20,7 @@ env:
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/
-  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+  INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true
   REDIS_TLS_ENABLED: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,7 +20,7 @@ env:
   HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: https://offender-prprod.aks-live-1.studio-hosting.service.justice.gov.uk
-  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
+  INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true
   REDIS_TLS_ENABLED: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,7 +18,7 @@ env:
   HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.probation.service.justice.gov.uk
   OFFENDER_ASSESSMENTS_API_URL: https://offender-prod.aks-live-1.studio-hosting.service.justice.gov.uk
-  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk
+  INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
   TOKEN_VERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true
   REDIS_TLS_ENABLED: true

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -17,7 +17,7 @@ env:
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/
-  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-research.apps.live-1.cloud-platform.service.justice.gov.uk
+  INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true
   REDIS_TLS_ENABLED: true


### PR DESCRIPTION
## What does this pull request do?

Switch to local network access to the service to avoid our requests being considered as malicious attempts

## What is the intent behind these changes?

The Web Application Firewall is blocking legitimate UI-to-service requests

- We don't want to turn the WAF off
- We don't know how to configure the WAF or debug why it's blocking
- We do have the apps running in the same namespace

Same namespace means they are on the same isolated network, meaning the ui can directly call service with its service name as host; this eliminates the need to go out and back in via the ingress

However, it loses TLS, but that is most likely fine due to it being on an isolated network anyway
