### PR TITLE
fix service type on relevant sentence page and remove unnessecary checks for selected service category id

### DIFF
--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -780,16 +780,13 @@ describe('GET /referrals/:id/relevant-sentence', () => {
   let serviceUserCRN: string
 
   beforeEach(() => {
-    const serviceCategory = serviceCategoryFactory.build({
-      id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
-      name: 'social inclusion',
-    })
-    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+    const intervention = interventionFactory.build()
+    const referral = draftReferralFactory.justCreated().build({ interventionId: intervention.id })
 
     serviceUserCRN = referral.serviceUser.crn
 
     interventionsService.getDraftReferral.mockResolvedValue(referral)
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     communityApiService.getActiveConvictionsByCRN.mockResolvedValue(deliusConvictionFactory.buildList(2))
   })
 
@@ -798,20 +795,20 @@ describe('GET /referrals/:id/relevant-sentence', () => {
       .get('/referrals/1/relevant-sentence')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Select the relevant sentence for the social inclusion referral')
+        expect(res.text).toContain('Select the relevant sentence for the accommodation referral')
       })
 
     expect(communityApiService.getActiveConvictionsByCRN).toHaveBeenCalledWith(serviceUserCRN)
   })
 
-  it('renders an error when the request for a service category fails', async () => {
-    interventionsService.getServiceCategory.mockRejectedValue(new Error('Failed to get service category'))
+  it('renders an error when the request for the intervention fails', async () => {
+    interventionsService.getIntervention.mockRejectedValue(new Error('Failed to get intervention'))
 
     await request(app)
       .get('/referrals/1/relevant-sentence')
       .expect(500)
       .expect(res => {
-        expect(res.text).toContain('Failed to get service category')
+        expect(res.text).toContain('Failed to get intervention')
       })
   })
 
@@ -829,14 +826,16 @@ describe('GET /referrals/:id/relevant-sentence', () => {
 
 describe('POST /referrals/:id/relevant-sentence', () => {
   beforeEach(() => {
-    const serviceCategory = serviceCategoryFactory.build({ id: 'b33c19d1-7414-4014-b543-e543e59c5b39' })
+    const intervention = interventionFactory.build()
+    const serviceCategory = serviceCategoryFactory.build({
+      id: 'b33c19d1-7414-4014-b543-e543e59c5b39',
+      name: 'social inclusion',
+    })
     const referral = draftReferralFactory
       .serviceCategorySelected(serviceCategory.id)
-      .serviceCategoriesSelected([serviceCategory.id])
-      .build()
-
+      .build({ interventionId: intervention.id })
     interventionsService.getDraftReferral.mockResolvedValue(referral)
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
   })
 
   it('updates the referral on the backend and redirects to the next question', async () => {

--- a/server/routes/referrals/relevantSentencePresenter.test.ts
+++ b/server/routes/referrals/relevantSentencePresenter.test.ts
@@ -1,18 +1,18 @@
 import RelevantSentencePresenter from './relevantSentencePresenter'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import interventionFactory from '../../../testutils/factories/intervention'
 
 describe(RelevantSentencePresenter, () => {
-  const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-  const draftReferral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+  const intervention = interventionFactory.build({ contractType: { name: 'personal wellbeing' } })
+  const draftReferral = draftReferralFactory.justCreated().build({ interventionId: intervention.id })
 
   describe('title', () => {
-    it('includes the service category name', () => {
+    it('includes the service type name', () => {
       const convictions = [deliusConvictionFactory.build()]
-      const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
+      const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
-      expect(presenter.title).toEqual('Select the relevant sentence for the social inclusion referral')
+      expect(presenter.title).toEqual('Select the relevant sentence for the personal wellbeing referral')
     })
   })
 
@@ -64,7 +64,7 @@ describe(RelevantSentencePresenter, () => {
 
         const convictions = [deliusConvictionFactory.build({ offences })]
 
-        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
         expect(presenter.relevantSentenceFields[0].category).toEqual('Common and other types of assault')
       })
@@ -117,7 +117,7 @@ describe(RelevantSentencePresenter, () => {
 
         const convictions = [deliusConvictionFactory.build({ offences })]
 
-        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
         expect(presenter.relevantSentenceFields[0].subcategory).toEqual('Common assault and battery')
       })
@@ -139,7 +139,7 @@ describe(RelevantSentencePresenter, () => {
           }),
         ]
 
-        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
         expect(presenter.relevantSentenceFields[0].endOfSentenceDate).toEqual('15 September 2025')
       })
@@ -149,7 +149,7 @@ describe(RelevantSentencePresenter, () => {
       it('uses the conviction ID', () => {
         const convictions = [deliusConvictionFactory.build({ convictionId: 123456789 })]
 
-        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
         expect(presenter.relevantSentenceFields[0].value).toEqual(123456789)
       })
@@ -160,7 +160,7 @@ describe(RelevantSentencePresenter, () => {
         it('sets the `checked` value to `false`', () => {
           const convictions = deliusConvictionFactory.buildList(2)
 
-          const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
+          const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
           expect(presenter.relevantSentenceFields[0].checked).toBe(false)
           expect(presenter.relevantSentenceFields[1].checked).toBe(false)
@@ -173,7 +173,7 @@ describe(RelevantSentencePresenter, () => {
 
             const convictions = [deliusConvictionFactory.build(), convictionWithSelectedSentence]
 
-            const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
+            const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
             expect(presenter.relevantSentenceFields[0].checked).toBe(false)
             expect(presenter.relevantSentenceFields[1].checked).toBe(true)
@@ -187,7 +187,7 @@ describe(RelevantSentencePresenter, () => {
 
           const convictions = [deliusConvictionFactory.build(), convictionWithSelectedSentence]
 
-          const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions, null, {
+          const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions, null, {
             'relevant-sentence-id': convictionWithSelectedSentence.convictionId,
           })
 
@@ -206,7 +206,7 @@ describe(RelevantSentencePresenter, () => {
 
             const convictions = [convictionWithSentenceAlreadyOnReferral, convictionWithSentenceChosenByUser]
 
-            const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions, null, {
+            const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions, null, {
               'relevant-sentence-id': convictionWithSentenceChosenByUser.convictionId,
             })
 
@@ -223,7 +223,7 @@ describe(RelevantSentencePresenter, () => {
 
     describe('when no error is passed in', () => {
       it('returns null', () => {
-        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
         expect(presenter.errorSummary).toBeNull()
       })
@@ -231,7 +231,7 @@ describe(RelevantSentencePresenter, () => {
 
     describe('when an error is passed in', () => {
       it('returns error information', () => {
-        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions, {
+        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions, {
           errors: [
             {
               formFields: ['relevant-sentence-id'],
@@ -253,7 +253,7 @@ describe(RelevantSentencePresenter, () => {
 
     describe('when no error is passed in', () => {
       it('returns null', () => {
-        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions)
+        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
         expect(presenter.errorMessage).toBeNull()
       })
@@ -261,7 +261,7 @@ describe(RelevantSentencePresenter, () => {
 
     describe('when an error is passed in', () => {
       it('returns error information', () => {
-        const presenter = new RelevantSentencePresenter(draftReferral, serviceCategory, convictions, {
+        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions, {
           errors: [
             {
               formFields: ['relevant-sentence-id'],

--- a/server/routes/referrals/relevantSentencePresenter.ts
+++ b/server/routes/referrals/relevantSentencePresenter.ts
@@ -1,19 +1,19 @@
-import ServiceCategory from '../../models/serviceCategory'
 import DeliusConviction from '../../models/delius/deliusConviction'
 import DraftReferral from '../../models/draftReferral'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import Intervention from '../../models/intervention'
 
 export default class RelevantSentencePresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly intervention: Intervention,
     private readonly convictions: DeliusConviction[],
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
-  readonly title = `Select the relevant sentence for the ${this.serviceCategory.name.toLocaleLowerCase()} referral`
+  readonly title = `Select the relevant sentence for the ${this.intervention.contractType.name.toLocaleLowerCase()} referral`
 
   readonly errorMessage = PresenterUtils.errorMessage(this.error, 'relevant-sentence-id')
 


### PR DESCRIPTION
## What does this pull request do?

fix service type on relevant sentence page and remove unnessecary checks for selected service category id

## What is the intent behind these changes?

cohort improvements/fixes
