### PR TITLE
Fix desired outcomes and complexity level selected values for cohort referrals

### DIFF
--- a/server/routes/referrals/complexityLevelPresenter.test.ts
+++ b/server/routes/referrals/complexityLevelPresenter.test.ts
@@ -36,9 +36,14 @@ describe('ComplexityLevelPresenter', () => {
       expect(expectedHints).toEqual(complexityLevelIds)
     })
 
-    describe('when the referral already has a selected complexity level', () => {
-      it('sets checked to true for the referral’s selected complexity level', () => {
-        draftReferral.complexityLevelId = serviceCategory.complexityLevels[1].id
+    describe('when the referral already has a selected complexity level for the service category', () => {
+      it('sets checked to true for the referral’s selected complexity level for the service category', () => {
+        draftReferral.complexityLevels = [
+          {
+            serviceCategoryId: serviceCategory.id,
+            complexityLevelId: serviceCategory.complexityLevels[1].id,
+          },
+        ]
         const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory)
 
         expect(presenter.complexityDescriptions.map(description => description.checked)).toEqual([false, true, false])
@@ -55,9 +60,14 @@ describe('ComplexityLevelPresenter', () => {
       })
     })
 
-    describe('when the referral already has a selected complexity level and there is user input data', () => {
+    describe('when the referral already has a selected complexity level for the service category and there is user input data', () => {
       it('sets checked to true for the complexity level that the user chose', () => {
-        draftReferral.complexityLevelId = serviceCategory.complexityLevels[0].id
+        draftReferral.complexityLevels = [
+          {
+            serviceCategoryId: serviceCategory.id,
+            complexityLevelId: serviceCategory.complexityLevels[0].id,
+          },
+        ]
         const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory, null, {
           'complexity-level-id': serviceCategory.complexityLevels[1].id,
         })

--- a/server/routes/referrals/complexityLevelPresenter.ts
+++ b/server/routes/referrals/complexityLevelPresenter.ts
@@ -30,7 +30,14 @@ export default class ComplexityLevelPresenter {
   })
 
   private get selectedComplexityLevelId() {
-    return this.userInputData ? this.userInputData['complexity-level-id'] : this.referral.complexityLevelId
+    if (this.userInputData) {
+      return this.userInputData['complexity-level-id']
+    }
+
+    return (
+      this.referral.complexityLevels?.find(val => val.serviceCategoryId === this.serviceCategory.id)
+        ?.complexityLevelId ?? null
+    )
   }
 
   readonly title = `What is the complexity level for the ${this.serviceCategory.name} service?`

--- a/server/routes/referrals/desiredOutcomesPresenter.test.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.test.ts
@@ -101,9 +101,14 @@ describe('DesiredOutcomesPresenter', () => {
     })
   })
 
-  describe('when the referral already has selected desired outcomes', () => {
-    it('sets checked to true for the referral’s selected desired outcomes', () => {
-      draftReferral.desiredOutcomesIds = [serviceCategory.desiredOutcomes[0].id, serviceCategory.desiredOutcomes[1].id]
+  describe('when the referral already has selected desired outcomes for the service category', () => {
+    it('sets checked to true for the referral’s selected desired outcomes for the service category', () => {
+      draftReferral.desiredOutcomes = [
+        {
+          serviceCategoryId: serviceCategory.id,
+          desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id, serviceCategory.desiredOutcomes[1].id],
+        },
+      ]
       const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory)
 
       expect(presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.checked)).toEqual([
@@ -143,9 +148,14 @@ describe('DesiredOutcomesPresenter', () => {
     })
   })
 
-  describe('when the referral already has a selected desired outcomes and there is user input data', () => {
+  describe('when the referral already has a selected desired outcomes for the service category and there is user input data', () => {
     it('sets checked to true for the desired outcomes that the user chose', () => {
-      draftReferral.desiredOutcomesIds = [serviceCategory.desiredOutcomes[0].id]
+      draftReferral.desiredOutcomes = [
+        {
+          serviceCategoryId: serviceCategory.id,
+          desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id, serviceCategory.desiredOutcomes[1].id],
+        },
+      ]
       const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory, null, {
         'desired-outcomes-ids': [serviceCategory.desiredOutcomes[1].id, serviceCategory.desiredOutcomes[2].id],
       })
@@ -160,7 +170,12 @@ describe('DesiredOutcomesPresenter', () => {
 
     describe('when the user input data doesn’t contain a desired-outcomes-ids key', () => {
       it('doesn’t set any of the desired outcomes as checked', () => {
-        draftReferral.desiredOutcomesIds = [serviceCategory.desiredOutcomes[0].id]
+        draftReferral.desiredOutcomes = [
+          {
+            serviceCategoryId: serviceCategory.id,
+            desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id],
+          },
+        ]
         const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory, null, {})
 
         expect(presenter.desiredOutcomes.map(desiredOutcome => desiredOutcome.checked)).toEqual([

--- a/server/routes/referrals/desiredOutcomesPresenter.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.ts
@@ -32,7 +32,10 @@ export default class DesiredOutcomesPresenter {
       return this.userInputData['desired-outcomes-ids'] ?? []
     }
 
-    return this.referral.desiredOutcomesIds ?? []
+    return (
+      this.referral.desiredOutcomes?.find(val => val.serviceCategoryId === this.serviceCategory.id)
+        ?.desiredOutcomesIds ?? []
+    )
   }
 
   readonly title = `What are the desired outcomes for the ${this.serviceCategory.name} service?`


### PR DESCRIPTION
## What does this pull request do?

Updates the desired outcomes and complexity level pages on the probation practitioner "make a referral" journey, to correctly display any already-selected value. This was previously only working for single-service referrals.

## What is the intent behind these changes?

To bring the cohort referral journey in line with the single-service journey.
