### PR TITLE
Show category-specific data on check your answers

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -302,6 +302,12 @@ describe('Referral form', () => {
       cy.contains('Yes. Spanish')
       cy.contains('Yes. She works Mondays 9am - midday')
 
+      cy.contains('Accommodation referral details')
+      cy.contains('Low complexity')
+      cy.contains('Info about low complexity')
+      cy.contains('Service User makes progress in obtaining accommodation')
+      cy.contains('Service User is prevented from becoming homeless')
+
       cy.contains('Submit referral').click()
       cy.location('pathname').should('equal', `/referrals/${sentReferral.id}/confirmation`)
 

--- a/server/routes/referrals/checkAnswersPresenter.test.ts
+++ b/server/routes/referrals/checkAnswersPresenter.test.ts
@@ -22,7 +22,7 @@ describe(CheckAnswersPresenter, () => {
 
   describe('serviceUserDetailsSection', () => {
     const referral = parameterisedDraftReferralFactory.build()
-    const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+    const presenter = new CheckAnswersPresenter(referral, [serviceCategory])
 
     describe('title', () => {
       it('returns the section title', () => {
@@ -51,7 +51,7 @@ describe(CheckAnswersPresenter, () => {
   describe('needsAndRequirementsSection', () => {
     describe('title', () => {
       const referral = parameterisedDraftReferralFactory.build()
-      const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+      const presenter = new CheckAnswersPresenter(referral, [serviceCategory])
 
       it('returns the section title', () => {
         expect(presenter.needsAndRequirementsSection.title).toEqual('Alex’s needs and requirements')
@@ -63,7 +63,7 @@ describe(CheckAnswersPresenter, () => {
         const referral = parameterisedDraftReferralFactory.build({
           additionalNeedsInformation: 'Some additional needs information',
         })
-        const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+        const presenter = new CheckAnswersPresenter(referral, [serviceCategory])
 
         it('returns the value from the referral', () => {
           expect(presenter.needsAndRequirementsSection.summary[0]).toEqual({
@@ -77,7 +77,7 @@ describe(CheckAnswersPresenter, () => {
         const referral = parameterisedDraftReferralFactory.build({
           accessibilityNeeds: 'Some accessibility needs information',
         })
-        const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+        const presenter = new CheckAnswersPresenter(referral, [serviceCategory])
 
         it('returns the value from the referral', () => {
           expect(presenter.needsAndRequirementsSection.summary[1]).toEqual({
@@ -92,7 +92,7 @@ describe(CheckAnswersPresenter, () => {
           const referral = parameterisedDraftReferralFactory.build({
             needsInterpreter: false,
           })
-          const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+          const presenter = new CheckAnswersPresenter(referral, [serviceCategory])
 
           expect(presenter.needsAndRequirementsSection.summary[2]).toEqual({
             key: 'Does Alex need an interpreter?',
@@ -105,7 +105,7 @@ describe(CheckAnswersPresenter, () => {
             needsInterpreter: true,
             interpreterLanguage: 'Spanish',
           })
-          const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+          const presenter = new CheckAnswersPresenter(referral, [serviceCategory])
 
           it('also includes the language', () => {
             expect(presenter.needsAndRequirementsSection.summary[2]).toEqual({
@@ -121,7 +121,7 @@ describe(CheckAnswersPresenter, () => {
           const referral = parameterisedDraftReferralFactory.build({
             hasAdditionalResponsibilities: false,
           })
-          const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+          const presenter = new CheckAnswersPresenter(referral, [serviceCategory])
 
           expect(presenter.needsAndRequirementsSection.summary[3]).toEqual({
             key: 'Does Alex have caring or employment responsibilities?',
@@ -134,13 +134,90 @@ describe(CheckAnswersPresenter, () => {
             hasAdditionalResponsibilities: true,
             whenUnavailable: 'Alex can’t attend on Fridays',
           })
-          const presenter = new CheckAnswersPresenter(referral, serviceCategory)
+          const presenter = new CheckAnswersPresenter(referral, [serviceCategory])
 
           it('includes information about when they’re unavailable', () => {
             expect(presenter.needsAndRequirementsSection.summary[3]).toEqual({
               key: 'Does Alex have caring or employment responsibilities?',
               lines: ['Yes. Alex can’t attend on Fridays'],
             })
+          })
+        })
+      })
+    })
+  })
+
+  describe('referralDetailsSections', () => {
+    const accommodationServiceCategory = serviceCategoryFactory.build({
+      name: 'Accommodation',
+      complexityLevels: [
+        { id: '1', title: 'Low complexity', description: 'Low complexity accommodation description' },
+        { id: '2', title: 'High complexity', description: 'High complexity accommodation description' },
+      ],
+      desiredOutcomes: [
+        {
+          id: '1',
+          description: 'Accommodation desired outcome example 1',
+        },
+        {
+          id: '2',
+          description: 'Accommodation desired outcome example 2',
+        },
+        {
+          id: '3',
+          description: 'Accommodation desired outcome example 3',
+        },
+      ],
+    })
+    const eteServiceCategory = serviceCategoryFactory.build({
+      name: 'Education, training and employment',
+      complexityLevels: [
+        { id: '3', title: 'Low complexity', description: 'Low complexity ETE description' },
+        { id: '4', title: 'High complexity', description: 'High complexity ETE description' },
+      ],
+    })
+    const referral = parameterisedDraftReferralFactory.build({
+      serviceCategoryIds: [accommodationServiceCategory.id, eteServiceCategory.id],
+      complexityLevels: [
+        { serviceCategoryId: accommodationServiceCategory.id, complexityLevelId: '1' },
+        { serviceCategoryId: eteServiceCategory.id, complexityLevelId: '4' },
+      ],
+      desiredOutcomes: [
+        { serviceCategoryId: accommodationServiceCategory.id, desiredOutcomesIds: ['1', '3'] },
+        { serviceCategoryId: eteServiceCategory.id, desiredOutcomesIds: ['2'] },
+      ],
+    })
+    const presenter = new CheckAnswersPresenter(referral, [accommodationServiceCategory, eteServiceCategory])
+
+    it('contains a section for each service category in the referral', () => {
+      expect(presenter.referralDetailsSections).toMatchObject([
+        { title: 'Accommodation referral details' },
+        { title: 'Education, training and employment referral details' },
+      ])
+    })
+
+    describe('a section', () => {
+      const section = presenter.referralDetailsSections[0]
+
+      describe('complexity level', () => {
+        it('includes the chosen complexity level’s title and description', () => {
+          const item = section.summary[0]
+
+          expect(item).toEqual({
+            key: 'Complexity level',
+            lines: ['Low complexity', '', 'Low complexity accommodation description'],
+          })
+        })
+      })
+
+      describe('desired outcomes', () => {
+        it('includes the chosen desired outcomes’ descriptions', () => {
+          const item = section.summary[1]
+
+          expect(item).toEqual({
+            key: 'Desired outcomes',
+            lines: ['Accommodation desired outcome example 1', 'Accommodation desired outcome example 3'],
+            listStyle: ListStyle.bulleted,
           })
         })
       })

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -1,11 +1,14 @@
 import DraftReferral from '../../models/draftReferral'
 import ServiceCategory from '../../models/serviceCategory'
-import { SummaryListItem } from '../../utils/summaryList'
+import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
 import NeedsAndRequirementsPresenter from './needsAndRequirementsPresenter'
+import ComplexityLevelPresenter from './complexityLevelPresenter'
+import DesiredOutcomesPresenter from './desiredOutcomesPresenter'
+import utils from '../../utils/utils'
 
 export default class CheckAnswersPresenter {
-  constructor(private readonly referral: DraftReferral, private readonly serviceCategory: ServiceCategory) {}
+  constructor(private readonly referral: DraftReferral, private readonly serviceCategories: ServiceCategory[]) {}
 
   get serviceUserDetailsSection(): { title: string; summary: SummaryListItem[] } {
     return {
@@ -55,6 +58,41 @@ export default class CheckAnswersPresenter {
       return `Yes. ${dependentAnswerText}`
     }
     return 'No'
+  }
+
+  get referralDetailsSections(): { title: string; summary: SummaryListItem[] }[] {
+    if (this.referral.serviceCategoryIds === null) {
+      throw new Error('Service categories haven’t been selected')
+    }
+
+    return this.referral.serviceCategoryIds.map(serviceCategoryId => {
+      const serviceCategory = this.serviceCategories.find(aCategory => aCategory.id === serviceCategoryId)
+
+      if (serviceCategory === undefined) {
+        throw new Error(`Couldn’t find service category with ID ${serviceCategoryId}`)
+      }
+
+      const complexityLevelPresenter = new ComplexityLevelPresenter(this.referral, serviceCategory)
+      const checkedComplexityOption = complexityLevelPresenter.complexityDescriptions.find(val => val.checked)
+
+      const desiredOutcomesPresenter = new DesiredOutcomesPresenter(this.referral, serviceCategory)
+      const checkedDesiredOutcomesOptions = desiredOutcomesPresenter.desiredOutcomes.filter(val => val.checked)
+
+      return {
+        title: `${utils.convertToProperCase(serviceCategory.name)} referral details`,
+        summary: [
+          {
+            key: 'Complexity level',
+            lines: [checkedComplexityOption?.title ?? '', '', checkedComplexityOption?.hint ?? ''],
+          },
+          {
+            key: 'Desired outcomes',
+            lines: checkedDesiredOutcomesOptions.map(option => option.text),
+            listStyle: ListStyle.bulleted,
+          },
+        ],
+      }
+    })
   }
 
   private readonly serviceUserName = this.referral.serviceUser?.firstName ?? ''

--- a/server/routes/referrals/checkAnswersView.ts
+++ b/server/routes/referrals/checkAnswersView.ts
@@ -12,6 +12,11 @@ export default class CheckAnswersView {
     this.presenter.needsAndRequirementsSection.summary
   )
 
+  private readonly referralDetailsSections = this.presenter.referralDetailsSections.map(section => ({
+    title: section.title,
+    summaryListArgs: ViewUtils.summaryListArgs(section.summary),
+  }))
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/checkAnswers',
@@ -19,6 +24,7 @@ export default class CheckAnswersView {
         presenter: this.presenter,
         serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs,
         needsAndRequirementsSummaryListArgs: this.needsAndRequirementsSummaryListArgs,
+        referralDetailsSections: this.referralDetailsSections,
       },
     ]
   }

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -24,6 +24,12 @@
 
       {{ govukSummaryList(needsAndRequirementsSummaryListArgs) }}
 
+      {% for section in referralDetailsSections %}
+        <h2 class="govuk-heading-l">{{ section.title }}</h2>
+
+        {{ govukSummaryList(section.summaryListArgs) }}
+      {% endfor %}
+
       <form method="post" action="send">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukButton({ text: "Submit referral" }) }}


### PR DESCRIPTION
## What does this pull request do?

When a probation practitioner checks their answers before submitting a
referral, replay the chosen complexity level and desired outcomes for
each chosen service category.

## What is the intent behind these changes?

To allow a probation practitioner to check their answers before submitting a referral.

## Screenshot

![Screenshot_2021-06-01 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/120305886-30ed3880-c2c9-11eb-8a4f-2962562d2331.png)
