### PR TITLE
Extract business logic to a class for reuse

### DIFF
--- a/server/decorators/interventionDecorator.test.ts
+++ b/server/decorators/interventionDecorator.test.ts
@@ -1,0 +1,23 @@
+import InterventionDecorator from './interventionDecorator'
+import interventionFactory from '../../testutils/factories/intervention'
+import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
+
+describe(InterventionDecorator, () => {
+  describe('isCohortIntervention', () => {
+    it('returns false when the intervention has a single service category', () => {
+      const intervention = interventionFactory.build({ serviceCategories: [serviceCategoryFactory.build()] })
+      const decorator = new InterventionDecorator(intervention)
+
+      expect(decorator.isCohortIntervention).toEqual(false)
+    })
+
+    it('returns true when the intervention has multiple service categories', () => {
+      const intervention = interventionFactory.build({
+        serviceCategories: [serviceCategoryFactory.build(), serviceCategoryFactory.build()],
+      })
+      const decorator = new InterventionDecorator(intervention)
+
+      expect(decorator.isCohortIntervention).toEqual(true)
+    })
+  })
+})

--- a/server/decorators/interventionDecorator.ts
+++ b/server/decorators/interventionDecorator.ts
@@ -1,0 +1,9 @@
+import Intervention from '../models/intervention'
+
+export default class InterventionDecorator {
+  constructor(private readonly intervention: Intervention) {}
+
+  get isCohortIntervention(): boolean {
+    return this.intervention.serviceCategories.length > 1
+  }
+}

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -1,4 +1,5 @@
 /* eslint max-classes-per-file: 0 */
+import InterventionDecorator from '../../decorators/interventionDecorator'
 import DraftReferral from '../../models/draftReferral'
 import Intervention from '../../models/intervention'
 
@@ -15,12 +16,8 @@ export default class ReferralFormPresenter {
     this.formSectionBuilder = new FormSectionBuilder(referral, intervention, this.taskValues, this.sectionValues)
   }
 
-  get isCohortIntervention(): boolean {
-    return this.intervention.serviceCategories.length > 1
-  }
-
   get sections(): ReferralFormSectionPresenter[] {
-    if (this.isCohortIntervention) {
+    if (new InterventionDecorator(this.intervention).isCohortIntervention) {
       return this.formSectionBuilder.buildCohortReferralSections()
     }
     return this.formSectionBuilder.buildSingleReferralSections()


### PR DESCRIPTION
## What does this pull request do?

The piece of knowledge that a cohort intervention is one that has
multiple service categories should only exist in one place in the app.
It’s currently living in a presenter, but I need to use it in another
presenter.

If we had a "model" class called Intervention then we’d stick this as a
method in there, but we don’t - we just have a DTO interface that
contains the data returned by the interventions service API. I had
thought that perhaps we could create a model class that decorates the
DTO, allowing us to add further methods and properties. But there
doesn’t seem to be a simple way to do that in TypeScript.

So for now, I’ll just create a "decorator" class, which is really just a
utility class that takes a DTO and defines some properties derived from
it. "Decorator" is a bit of a misuse of the term; but the alternative
was another "Utils" type thing e.g. "InterventionUtils", which seemed a
bit vague. At least the naming I’ve gone for communicates what I was
_trying_ to do.

## What is the intent behind these changes?

To make a stab at creating a pattern that stops us from scattering this kind of thing in places it shouldn't be.