### PR TITLE
Ic 1731: Remove old single referral fields

### DIFF
--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -10,13 +10,10 @@ export interface ReferralFields {
   completionDeadline: string
   serviceProvider: ServiceProvider
   interventionId: string
-  serviceCategoryId: string // deprecated
   serviceCategoryIds: string[]
-  complexityLevelId: string // deprecated in favour of complexityLevels
   complexityLevels: ReferralComplexityLevel[]
   furtherInformation: string
   relevantSentenceId: number
-  desiredOutcomesIds: string[] // deprecated in favour of desiredOutcomes
   desiredOutcomes: ReferralDesiredOutcomes[]
   additionalNeedsInformation: string
   accessibilityNeeds: string

--- a/server/routes/referrals/complexityLevelForm.ts
+++ b/server/routes/referrals/complexityLevelForm.ts
@@ -1,15 +1,15 @@
 import { Request } from 'express'
 import { ValidationChain, body, Result, ValidationError } from 'express-validator'
-import DraftReferral from '../../models/draftReferral'
 import errorMessages from '../../utils/errorMessages'
 import FormUtils from '../../utils/formUtils'
 import { FormValidationError } from '../../utils/formValidationError'
 import { FormData } from '../../utils/forms/formData'
+import ReferralComplexityLevel from '../../models/referralComplexityLevel'
 
 export default class ComplexityLevelForm {
   constructor(private readonly request: Request) {}
 
-  async data(): Promise<FormData<Partial<DraftReferral>>> {
+  async data(): Promise<FormData<Partial<ReferralComplexityLevel>>> {
     const validationResult = await FormUtils.runValidations({
       request: this.request,
       validations: ComplexityLevelForm.validations,

--- a/server/routes/referrals/desiredOutcomesForm.ts
+++ b/server/routes/referrals/desiredOutcomesForm.ts
@@ -1,16 +1,15 @@
 import { Request } from 'express'
 import { ValidationChain, body, Result, ValidationError } from 'express-validator'
-import DraftReferral from '../../models/draftReferral'
 import errorMessages from '../../utils/errorMessages'
 import { FormValidationError } from '../../utils/formValidationError'
 import { FormData } from '../../utils/forms/formData'
 import FormUtils from '../../utils/formUtils'
+import ReferralDesiredOutcomes from '../../models/referralDesiredOutcomes'
 
 export default class DesiredOutcomesForm {
   constructor(private readonly request: Request) {}
 
-  // TODO: return Partial<ReferralDesiredOutcomes> when we update the code for single-service referrals to use the new PATCH function.
-  async data(): Promise<FormData<Partial<DraftReferral>>> {
+  async data(): Promise<FormData<Partial<ReferralDesiredOutcomes>>> {
     const validationResult = await FormUtils.runValidations({
       request: this.request,
       validations: DesiredOutcomesForm.validations,

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -277,12 +277,12 @@ export default class ReferralsController {
   async viewCompletionDeadline(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
 
-    if (referral.serviceCategoryId === null) {
+    if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
       throw new Error('Attempting to view completion deadline without service category selected')
     }
 
     const [serviceCategory, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryId),
+      this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryIds[0]),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
     ])
 
@@ -321,12 +321,12 @@ export default class ReferralsController {
       )
 
       // fixme: no longer needed - change to check intervention service type
-      if (referral.serviceCategoryId === null) {
+      if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
         throw new Error('Attempting to view completion deadline without service category selected')
       }
 
       const [serviceCategory, serviceUser] = await Promise.all([
-        this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryId),
+        this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryIds[0]),
         this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
       ])
 
@@ -341,12 +341,12 @@ export default class ReferralsController {
   async viewFurtherInformation(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
 
-    if (referral.serviceCategoryId === null) {
+    if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
       throw new Error('Attempting to view further information without service category selected')
     }
 
     const [serviceCategory, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryId),
+      this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryIds[0]),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
     ])
 
@@ -382,12 +382,12 @@ export default class ReferralsController {
         req.params.id
       )
 
-      if (!referral.serviceCategoryId) {
+      if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
         throw new Error('Attempting to view complexity level without service category selected')
       }
 
       const [serviceCategory, serviceUser] = await Promise.all([
-        this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryId),
+        this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryIds[0]),
         this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
       ])
 
@@ -537,12 +537,12 @@ export default class ReferralsController {
   async viewRarDays(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
 
-    if (referral.serviceCategoryId === null) {
+    if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
       throw new Error('Attempting to view RAR days without service category selected')
     }
 
     const [serviceCategory, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryId),
+      this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryIds[0]),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
     ])
 
@@ -555,13 +555,13 @@ export default class ReferralsController {
   async updateRarDays(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
 
-    if (referral.serviceCategoryId === null) {
+    if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
       throw new Error('Attempting to update RAR days without service category selected')
     }
 
     const serviceCategory = await this.interventionsService.getServiceCategory(
       res.locals.user.token.accessToken,
-      referral.serviceCategoryId
+      referral.serviceCategoryIds[0]
     )
 
     const form = await RarDaysForm.createForm(req, serviceCategory)

--- a/server/routes/serviceProviderReferrals/endOfServiceReportFormPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFormPresenter.test.ts
@@ -4,7 +4,14 @@ import sentReferralFactory from '../../../testutils/factories/sentReferral'
 
 describe(EndOfServiceReportFormPresenter, () => {
   const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-  const referral = sentReferralFactory.build({ referral: { desiredOutcomesIds: ['1', '2', '3', '4', '5'] } })
+  const referral = sentReferralFactory.build({
+    referral: {
+      desiredOutcomes: [
+        { serviceCategoryId: '1', desiredOutcomesIds: ['1', '2'] },
+        { serviceCategoryId: '2', desiredOutcomesIds: ['3', '4', '5'] },
+      ],
+    },
+  })
 
   describe('title', () => {
     it('returns the title for all the form pages', () => {

--- a/server/routes/serviceProviderReferrals/endOfServiceReportFormPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportFormPresenter.ts
@@ -14,7 +14,7 @@ export default class EndOfServiceReportFormPresenter {
   constructor(private readonly serviceCategory: ServiceCategory, private readonly referral: SentReferral) {}
 
   private get numberOfDesiredOutcomes(): number {
-    return this.referral.referral.desiredOutcomesIds.length
+    return this.referral.referral.desiredOutcomes.flatMap(desiredOutcome => desiredOutcome.desiredOutcomesIds).length
   }
 
   private get title(): string {

--- a/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.test.ts
+++ b/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.test.ts
@@ -22,7 +22,7 @@ describe(FinaliseActionPlanActivitiesForm, () => {
     const serviceCategory = serviceCategoryFactory.build({ desiredOutcomes })
     const referral = sentReferralFactory.build({
       referral: {
-        serviceCategoryId: serviceCategory.id,
+        serviceCategoryIds: [serviceCategory.id],
         desiredOutcomes: [
           { serviceCategoryId: serviceCategory.id, desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id] },
         ],

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -87,10 +87,17 @@ describe(ShowReferralPresenter, () => {
           serviceProvider: {
             name: 'Harmony Living',
           },
-          serviceCategoryId: serviceCategory.id,
-          complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+          serviceCategoryIds: [serviceCategory.id],
+          complexityLevels: [
+            { serviceCategoryId: serviceCategory.id, complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2' },
+          ],
           furtherInformation: 'Some information about the service user',
-          desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', '9b30ffad-dfcb-44ce-bdca-0ea49239a21a'],
+          desiredOutcomes: [
+            {
+              serviceCategoryId: serviceCategory.id,
+              desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', '9b30ffad-dfcb-44ce-bdca-0ea49239a21a'],
+            },
+          ],
           additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
           accessibilityNeeds: 'She uses a wheelchair',
           needsInterpreter: true,
@@ -142,10 +149,17 @@ describe(ShowReferralPresenter, () => {
           serviceProvider: {
             name: 'Harmony Living',
           },
-          serviceCategoryId: serviceCategory.id,
-          complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+          serviceCategoryIds: [serviceCategory.id],
+          complexityLevels: [
+            { serviceCategoryId: serviceCategory.id, complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2' },
+          ],
           furtherInformation: '',
-          desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', '9b30ffad-dfcb-44ce-bdca-0ea49239a21a'],
+          desiredOutcomes: [
+            {
+              serviceCategoryId: serviceCategory.id,
+              desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', '9b30ffad-dfcb-44ce-bdca-0ea49239a21a'],
+            },
+          ],
           additionalNeedsInformation: '',
           accessibilityNeeds: '',
           needsInterpreter: false,
@@ -199,7 +213,6 @@ describe(ShowReferralPresenter, () => {
           name: 'Harmony Living',
         },
         serviceCategoryIds: cohortServiceCategories.map(it => it.id),
-        serviceCategoryId: cohortServiceCategories[0].id,
         complexityLevels: cohortServiceCategories.map(it => {
           return { serviceCategoryId: it.id, complexityLevelId: it.complexityLevels[0].id }
         }),
@@ -282,10 +295,17 @@ describe(ShowReferralPresenter, () => {
             serviceProvider: {
               name: 'Harmony Living',
             },
-            serviceCategoryId: serviceCategory.id,
-            complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+            serviceCategoryIds: [serviceCategory.id],
+            complexityLevels: [
+              { serviceCategoryId: serviceCategory.id, complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2' },
+            ],
             furtherInformation: 'Some information about the service user',
-            desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', '9b30ffad-dfcb-44ce-bdca-0ea49239a21a'],
+            desiredOutcomes: [
+              {
+                serviceCategoryId: serviceCategory.id,
+                desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', '9b30ffad-dfcb-44ce-bdca-0ea49239a21a'],
+              },
+            ],
             additionalNeedsInformation: "Alex is currently sleeping on her aunt's sofa",
             accessibilityNeeds: 'She uses a wheelchair',
             needsInterpreter: true,
@@ -359,10 +379,17 @@ describe(ShowReferralPresenter, () => {
             serviceProvider: {
               name: 'Harmony Living',
             },
-            serviceCategoryId: serviceCategory.id,
-            complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+            serviceCategoryIds: [serviceCategory.id],
+            complexityLevels: [
+              { serviceCategoryId: serviceCategory.id, complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2' },
+            ],
             furtherInformation: '',
-            desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', '9b30ffad-dfcb-44ce-bdca-0ea49239a21a'],
+            desiredOutcomes: [
+              {
+                serviceCategoryId: serviceCategory.id,
+                desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', '9b30ffad-dfcb-44ce-bdca-0ea49239a21a'],
+              },
+            ],
             additionalNeedsInformation: '',
             accessibilityNeeds: '',
             needsInterpreter: false,

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -64,8 +64,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             status: 200,
             body: Matchers.like({
               id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
-              serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
-              complexityLevelId: null,
+              serviceCategoryIds: ['428ee70f-3001-4399-95a6-ad25eaaede16'],
+              complexityLevels: null,
             }),
             headers: { 'Content-Type': 'application/json' },
           },
@@ -76,7 +76,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         const referral = await interventionsService.getDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962')
 
         expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
-        expect(referral.serviceCategoryId).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
+        expect(referral.serviceCategoryIds![0]).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
       })
     })
 
@@ -127,8 +127,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             status: 200,
             body: Matchers.like({
               id: '037cc90b-beaa-4a32-9ab7-7f79136e1d27',
-              serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
-              desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+              serviceCategoryIds: ['428ee70f-3001-4399-95a6-ad25eaaede16'],
+              desiredOutcomes: [
+                {
+                  serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+                  desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+                },
+              ],
             }),
             headers: { 'Content-Type': 'application/json' },
           },
@@ -139,7 +144,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         const referral = await interventionsService.getDraftReferral(token, '037cc90b-beaa-4a32-9ab7-7f79136e1d27')
 
         expect(referral.id).toBe('037cc90b-beaa-4a32-9ab7-7f79136e1d27')
-        expect(referral.desiredOutcomesIds).toEqual([
+        expect(referral.desiredOutcomes![0].desiredOutcomesIds).toEqual([
           '301ead30-30a4-4c7c-8296-2768abfb59b5',
           '65924ac6-9724-455b-ad30-906936291421',
         ])
@@ -206,7 +211,12 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             status: 200,
             body: Matchers.like({
               id: '037cc90b-beaa-4a32-9ab7-7f79136e1d27',
-              complexityLevelId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+              complexityLevels: [
+                {
+                  serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+                  complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+                },
+              ],
             }),
             headers: { 'Content-Type': 'application/json' },
           },
@@ -217,7 +227,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         const referral = await interventionsService.getDraftReferral(token, '037cc90b-beaa-4a32-9ab7-7f79136e1d27')
 
         expect(referral.id).toBe('037cc90b-beaa-4a32-9ab7-7f79136e1d27')
-        expect(referral.complexityLevelId).toEqual('301ead30-30a4-4c7c-8296-2768abfb59b5')
+        expect(referral.complexityLevels![0].complexityLevelId).toEqual('d0db50b0-4a50-4fc7-a006-9c97530e38b2')
       })
     })
 
@@ -492,19 +502,27 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         uponReceiving: 'a PATCH request to update the complexity level ID',
         withRequest: {
           method: 'PATCH',
-          path: '/draft-referral/d496e4a7-7cc1-44ea-ba67-c295084f1962',
+          path: '/draft-referral/d496e4a7-7cc1-44ea-ba67-c295084f1962/complexity-level',
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
           },
-          body: { complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2' },
+          body: {
+            serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+            complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+          },
         },
         willRespondWith: {
           status: 200,
           body: {
             id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
-            complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+            complexityLevels: [
+              {
+                serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+                complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+              },
+            ],
           },
           headers: {
             'Content-Type': 'application/json',
@@ -512,11 +530,16 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962', {
-        complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
-      })
+      const referral = await interventionsService.setComplexityLevelForServiceCategory(
+        token,
+        'd496e4a7-7cc1-44ea-ba67-c295084f1962',
+        {
+          serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+          complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
+        }
+      )
       expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
-      expect(referral.complexityLevelId).toBe('d0db50b0-4a50-4fc7-a006-9c97530e38b2')
+      expect(referral.complexityLevels![0].complexityLevelId).toBe('d0db50b0-4a50-4fc7-a006-9c97530e38b2')
     })
 
     it('returns the updated referral adding further information', async () => {
@@ -594,13 +617,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         uponReceiving: 'a PATCH request to update desired outcomes IDs',
         withRequest: {
           method: 'PATCH',
-          path: '/draft-referral/d496e4a7-7cc1-44ea-ba67-c295084f1962',
+          path: '/draft-referral/d496e4a7-7cc1-44ea-ba67-c295084f1962/desired-outcomes',
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
           },
           body: {
+            serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
             desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
           },
         },
@@ -608,7 +632,12 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           status: 200,
           body: {
             id: 'd496e4a7-7cc1-44ea-ba67-c295084f1962',
-            desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+            desiredOutcomes: [
+              {
+                serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+                desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+              },
+            ],
           },
           headers: {
             'Content-Type': 'application/json',
@@ -616,11 +645,16 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962', {
-        desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
-      })
+      const referral = await interventionsService.setDesiredOutcomesForServiceCategory(
+        token,
+        'd496e4a7-7cc1-44ea-ba67-c295084f1962',
+        {
+          serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
+          desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
+        }
+      )
       expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
-      expect(referral.desiredOutcomesIds).toEqual([
+      expect(referral.desiredOutcomes![0].desiredOutcomesIds).toEqual([
         '301ead30-30a4-4c7c-8296-2768abfb59b5',
         '65924ac6-9724-455b-ad30-906936291421',
       ])
@@ -1253,9 +1287,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         name: 'Harmony Living',
       },
       interventionId: '000b2538-914b-4641-a1cc-a293409536bf',
-      serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
       serviceCategoryIds: ['428ee70f-3001-4399-95a6-ad25eaaede16'],
-      complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
       complexityLevels: [
         {
           serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
@@ -1264,7 +1296,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       ],
       furtherInformation: 'Some information about the service user',
       relevantSentenceId: 2600295124,
-      desiredOutcomesIds: ['301ead30-30a4-4c7c-8296-2768abfb59b5', '65924ac6-9724-455b-ad30-906936291421'],
       desiredOutcomes: [
         {
           serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -14,6 +14,8 @@ import ServiceCategory from '../models/serviceCategory'
 import ActionPlan, { ActionPlanAppointment, AppointmentAttendance, AppointmentBehaviour } from '../models/actionPlan'
 import DraftReferral from '../models/draftReferral'
 import SentReferral from '../models/sentReferral'
+import ReferralDesiredOutcomes from '../models/referralDesiredOutcomes'
+import ReferralComplexityLevel from '../models/referralComplexityLevel'
 
 export type InterventionsServiceError = SanitisedError & { validationErrors?: InterventionsServiceValidationError[] }
 
@@ -156,8 +158,7 @@ export default class InterventionsService {
   async setDesiredOutcomesForServiceCategory(
     token: string,
     referralId: string,
-    // TODO: switch below to Partial<ReferralDesiredOutcomes> when we update the code for single-service referrals to use the new PATCH function.
-    desiredOutcomes: Partial<DraftReferral>
+    desiredOutcomes: Partial<ReferralDesiredOutcomes>
   ): Promise<DraftReferral> {
     const restClient = this.createRestClient(token)
 
@@ -175,8 +176,7 @@ export default class InterventionsService {
   async setComplexityLevelForServiceCategory(
     token: string,
     referralId: string,
-    // TODO: switch below to Partial<ReferralComplexityLevel> when we update the code for single-service referrals to use the new PATCH function.
-    complexityLevel: Partial<DraftReferral>
+    complexityLevel: Partial<ReferralComplexityLevel>
   ): Promise<DraftReferral> {
     const restClient = this.createRestClient(token)
 

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -16,7 +16,6 @@ class DraftReferralFactory extends Factory<DraftReferral> {
   serviceCategorySelected(serviceCategoryId?: string) {
     const resolvedServiceCategoryId = serviceCategoryId ?? serviceCategoryFactory.build().id
     return this.params({
-      serviceCategoryId: resolvedServiceCategoryId,
       serviceCategoryIds: [resolvedServiceCategoryId],
     })
   }
@@ -56,7 +55,6 @@ class DraftReferralFactory extends Factory<DraftReferral> {
   selectedServiceCategories(serviceCategories: ServiceCategory[]) {
     const resolvedServiceCategoryIds = serviceCategories.map(serviceCategory => serviceCategory.id)
     return this.serviceUserSelected().params({
-      serviceCategoryId: resolvedServiceCategoryIds[0],
       serviceCategoryIds: resolvedServiceCategoryIds,
     })
   }
@@ -86,9 +84,6 @@ class DraftReferralFactory extends Factory<DraftReferral> {
 
   addSelectedDesiredOutcomes(serviceCategories: ServiceCategory[]) {
     return this.params({
-      desiredOutcomesIds: serviceCategories
-        .map(serviceCategory => serviceCategory.desiredOutcomes.map(desiredOutcome => desiredOutcome.id))
-        .reduce((acc, list) => acc.concat(list), []),
       desiredOutcomes: serviceCategories.map(serviceCategory => {
         return {
           serviceCategoryId: serviceCategory.id,
@@ -100,7 +95,6 @@ class DraftReferralFactory extends Factory<DraftReferral> {
 
   addSelectedComplexityLevel(serviceCategories: ServiceCategory[] = [serviceCategoryFactory.build()]) {
     return this.params({
-      complexityLevelId: serviceCategories[0].complexityLevels[0].id,
       complexityLevels: serviceCategories.map(serviceCategory => {
         return {
           serviceCategoryId: serviceCategory.id,

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -14,9 +14,7 @@ const exampleReferralFields = () => {
       name: 'Harmony Living',
     },
     interventionId: interventionFactory.build().id,
-    serviceCategoryId,
     serviceCategoryIds: [serviceCategoryId],
-    complexityLevelId: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
     complexityLevels: [
       {
         serviceCategoryId,
@@ -25,7 +23,6 @@ const exampleReferralFields = () => {
     ],
     furtherInformation: 'Some information about the service user',
     relevantSentenceId: 2600295124,
-    desiredOutcomesIds: ['3415a6f2-38ef-4613-bb95-33355deff17e', '5352cfb6-c9ee-468c-b539-434a3e9b506e'],
     desiredOutcomes: [
       {
         serviceCategoryId,


### PR DESCRIPTION
## What does this pull request do?

Removes the `serviceCategoryId`, `desiredOutcomeIds` and `complexityLevelId` fields from contract tests and draft / sent referral objects

## What is the intent behind these changes?

Ensure that we're not relying on the old referral fields.


Note: This is branched off IC-1815 which is still waiting for review 