### PR TITLE
IC-1826: Ensure we're using Sentence case for Contract type names and service categories in Refer journey

### DIFF
--- a/integration_tests/integration/make_a_referral/referralSectionVerifier.js
+++ b/integration_tests/integration/make_a_referral/referralSectionVerifier.js
@@ -23,7 +23,7 @@ class _ReferralSectionChecker {
 
   interventionReferralDetails(activeLinks) {
     cy.get('[data-cy=url]')
-      .contains('Confirm the relevant sentence for the accommodation referral')
+      .contains('Confirm the relevant sentence for the Accommodation referral')
       .should(hrefAttrChainer(activeLinks.relevantSentence), 'href')
     cy.get('[data-cy=url]')
       .contains('Select required complexity level')
@@ -32,7 +32,7 @@ class _ReferralSectionChecker {
       .contains('Select desired outcomes')
       .should(hrefAttrChainer(activeLinks.desiredOutcomes), 'href')
     cy.get('[data-cy=url]')
-      .contains('Enter when the accommodation service need to be completed')
+      .contains('Enter when the Accommodation service needs to be completed')
       .should(hrefAttrChainer(activeLinks.completedDate), 'href')
     cy.get('[data-cy=url]').contains('Enter enforceable days used').should(hrefAttrChainer(activeLinks.rarDays), 'href')
     cy.get('[data-cy=url]')
@@ -42,7 +42,7 @@ class _ReferralSectionChecker {
   }
 
   selectServiceCategories(activeLinks) {
-    cy.get(`[data-cy=url]:contains("Select service categories for the Women's Services referral")`).should(
+    cy.get(`[data-cy=url]:contains("Select service categories for the Women's services referral")`).should(
       hrefAttrChainer(activeLinks.selectServiceCategories),
       'href'
     )
@@ -50,7 +50,7 @@ class _ReferralSectionChecker {
   }
 
   cohortInterventionReferralDetails(activeLinks) {
-    cy.get(`[data-cy=url]:contains("Confirm the relevant sentence for the Women's Services referral")`).should(
+    cy.get(`[data-cy=url]:contains("Confirm the relevant sentence for the Women's services referral")`).should(
       hrefAttrChainer(activeLinks.relevantSentence),
       'href'
     )
@@ -67,7 +67,7 @@ class _ReferralSectionChecker {
       .eq(1)
       .should(hrefAttrChainer(activeLinks.desiredOutcomes1), 'href')
     cy.get('[data-cy=url]')
-      .contains("Enter when the Women's Services referral need to be completed")
+      .contains("Enter when the Women's services referral needs to be completed")
       .should(hrefAttrChainer(activeLinks.completedDate), 'href')
     cy.get('[data-cy=url]').contains('Enter enforceable days used').should(hrefAttrChainer(activeLinks.rarDays), 'href')
     cy.get('[data-cy=url]')

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -209,10 +209,10 @@ describe('Referral form', () => {
 
       cy.contains('Confirm service user’s personal details').should('have.attr', 'href')
 
-      cy.contains('Confirm the relevant sentence for the accommodation referral').click()
+      cy.contains('Confirm the relevant sentence for the Accommodation referral').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/relevant-sentence`)
-      cy.get('h1').contains('Select the relevant sentence for the accommodation referral')
+      cy.get('h1').contains('Select the relevant sentence for the Accommodation referral')
 
       cy.contains('Burglary').click()
 
@@ -223,7 +223,7 @@ describe('Referral form', () => {
         `/referrals/${draftReferral.id}/service-category/${draftReferral.serviceCategoryIds[0]}/desired-outcomes`
       )
 
-      cy.get('h1').contains('What are the desired outcomes for the accommodation service?')
+      cy.get('h1').contains('What are the desired outcomes for the Accommodation service?')
 
       cy.contains('Service User makes progress in obtaining accommodation').click()
       cy.contains('Service User is prevented from becoming homeless').click()
@@ -234,13 +234,13 @@ describe('Referral form', () => {
         'equal',
         `/referrals/${draftReferral.id}/service-category/${draftReferral.serviceCategoryIds[0]}/complexity-level`
       )
-      cy.get('h1').contains('What is the complexity level for the accommodation service?')
+      cy.get('h1').contains('What is the complexity level for the Accommodation service?')
       cy.contains('Low complexity').click()
 
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/completion-deadline`)
-      cy.get('h1').contains('What date does the accommodation service need to be completed by?')
+      cy.get('h1').contains('What date does the Accommodation service need to be completed by?')
       cy.contains('Day').type('15')
       cy.contains('Month').type('8')
       cy.contains('Year').type('2021')
@@ -248,14 +248,14 @@ describe('Referral form', () => {
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/rar-days`)
-      cy.get('h1').contains('Are you using RAR days for the accommodation service?')
+      cy.get('h1').contains('Are you using RAR days for the Accommodation service?')
       cy.contains('Yes').click()
-      cy.contains('What is the maximum number of RAR days for the accommodation service?').type('10')
+      cy.contains('What is the maximum number of RAR days for the Accommodation service?').type('10')
 
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/further-information`)
-      cy.get('h1').contains('Do you have further information for the accommodation service provider? (optional)')
+      cy.get('h1').contains('Do you have further information for the Accommodation service provider? (optional)')
       cy.get('textarea').type('Some information about Alex')
 
       // stub completed draft referral to mark section as completed
@@ -514,10 +514,10 @@ describe('Referral form', () => {
         })
         .checkYourAnswers({ checkAnswers: false })
 
-      cy.contains("Confirm the relevant sentence for the Women's Services referral").click()
+      cy.contains("Confirm the relevant sentence for the Women's services referral").click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/relevant-sentence`)
-      cy.get('h1').contains("Select the relevant sentence for the women's services referral")
+      cy.get('h1').contains("Select the relevant sentence for the Women's services referral")
 
       cy.contains('Burglary').click()
 
@@ -527,7 +527,7 @@ describe('Referral form', () => {
         'equal',
         `/referrals/${draftReferral.id}/service-category/${completedSelectingServiceCategories.serviceCategoryIds[0]}/desired-outcomes`
       )
-      cy.get('h1').contains('What are the desired outcomes for the accommodation service?')
+      cy.get('h1').contains('What are the desired outcomes for the Accommodation service?')
 
       cy.contains('Service User makes progress in obtaining accommodation').click()
       cy.contains('Service User is prevented from becoming homeless').click()
@@ -539,7 +539,7 @@ describe('Referral form', () => {
         `/referrals/${draftReferral.id}/service-category/${completedSelectingServiceCategories.serviceCategoryIds[0]}/complexity-level`
       )
 
-      cy.get('h1').contains('What is the complexity level for the accommodation service?')
+      cy.get('h1').contains('What is the complexity level for the Accommodation service?')
       cy.contains('Low complexity').click()
 
       cy.contains('Save and continue').click()
@@ -548,7 +548,7 @@ describe('Referral form', () => {
         'equal',
         `/referrals/${draftReferral.id}/service-category/${completedSelectingServiceCategories.serviceCategoryIds[1]}/desired-outcomes`
       )
-      cy.get('h1').contains('What are the desired outcomes for the social inclusion service?')
+      cy.get('h1').contains('What are the desired outcomes for the Social inclusion service?')
       cy.contains('Service User develops and sustains social networks to reduce initial social isolation.').click()
       cy.contains('Service User secures early post-release engagement with community based services.').click()
       cy.contains(
@@ -562,13 +562,13 @@ describe('Referral form', () => {
         `/referrals/${draftReferral.id}/service-category/${completedSelectingServiceCategories.serviceCategoryIds[1]}/complexity-level`
       )
 
-      cy.get('h1').contains('What is the complexity level for the social inclusion service?')
+      cy.get('h1').contains('What is the complexity level for the Social inclusion service?')
       cy.contains('Low complexity').click()
 
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/completion-deadline`)
-      cy.get('h1').contains('What date does the accommodation service need to be completed by?')
+      cy.get('h1').contains('What date does the Accommodation service need to be completed by?')
       cy.contains('Day').type('15')
       cy.contains('Month').type('8')
       cy.contains('Year').type('2021')
@@ -576,14 +576,14 @@ describe('Referral form', () => {
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/rar-days`)
-      cy.get('h1').contains('Are you using RAR days for the accommodation service?')
+      cy.get('h1').contains('Are you using RAR days for the Accommodation service?')
       cy.contains('Yes').click()
-      cy.contains('What is the maximum number of RAR days for the accommodation service?').type('10')
+      cy.contains('What is the maximum number of RAR days for the Accommodation service?').type('10')
 
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/further-information`)
-      cy.get('h1').contains('Do you have further information for the accommodation service provider? (optional)')
+      cy.get('h1').contains('Do you have further information for the Accommodation service provider? (optional)')
       cy.get('textarea').type('Some information about Alex')
 
       // stub completed draft referral to mark section as completed

--- a/server/routes/referrals/completionDeadlinePresenter.test.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.test.ts
@@ -95,7 +95,7 @@ describe('CompletionDeadlinePresenter', () => {
       const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
       const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
 
-      expect(presenter.title).toEqual('What date does the social inclusion service need to be completed by?')
+      expect(presenter.title).toEqual('What date does the Social inclusion service need to be completed by?')
     })
   })
 

--- a/server/routes/referrals/completionDeadlinePresenter.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.ts
@@ -3,11 +3,14 @@ import ServiceCategory from '../../models/serviceCategory'
 import CalendarDay from '../../utils/calendarDay'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import utils from '../../utils/utils'
 
 export default class CompletionDeadlinePresenter {
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
-  readonly title = `What date does the ${this.serviceCategory.name} service need to be completed by?`
+  readonly title = `What date does the ${utils.convertToProperCase(
+    this.serviceCategory.name
+  )} service need to be completed by?`
 
   readonly hint = 'For example, 27 10 2021'
 

--- a/server/routes/referrals/complexityLevelPresenter.test.ts
+++ b/server/routes/referrals/complexityLevelPresenter.test.ts
@@ -81,7 +81,7 @@ describe('ComplexityLevelPresenter', () => {
     it('returns a title', () => {
       const presenter = new ComplexityLevelPresenter(draftReferral, serviceCategory)
 
-      expect(presenter.title).toEqual('What is the complexity level for the social inclusion service?')
+      expect(presenter.title).toEqual('What is the complexity level for the Social inclusion service?')
     })
   })
 })

--- a/server/routes/referrals/complexityLevelPresenter.ts
+++ b/server/routes/referrals/complexityLevelPresenter.ts
@@ -2,6 +2,7 @@ import DraftReferral from '../../models/draftReferral'
 import ServiceCategory from '../../models/serviceCategory'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import utils from '../../utils/utils'
 
 export default class ComplexityLevelPresenter {
   constructor(
@@ -40,5 +41,7 @@ export default class ComplexityLevelPresenter {
     )
   }
 
-  readonly title = `What is the complexity level for the ${this.serviceCategory.name} service?`
+  readonly title = `What is the complexity level for the ${utils.convertToProperCase(
+    this.serviceCategory.name
+  )} service?`
 }

--- a/server/routes/referrals/desiredOutcomesPresenter.test.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.test.ts
@@ -192,7 +192,7 @@ describe('DesiredOutcomesPresenter', () => {
     it('returns a title', () => {
       const presenter = new DesiredOutcomesPresenter(draftReferral, serviceCategory)
 
-      expect(presenter.title).toEqual('What are the desired outcomes for the social inclusion service?')
+      expect(presenter.title).toEqual('What are the desired outcomes for the Social inclusion service?')
     })
   })
 })

--- a/server/routes/referrals/desiredOutcomesPresenter.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.ts
@@ -2,6 +2,7 @@ import DraftReferral from '../../models/draftReferral'
 import ServiceCategory from '../../models/serviceCategory'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import utils from '../../utils/utils'
 
 export default class DesiredOutcomesPresenter {
   constructor(
@@ -38,5 +39,7 @@ export default class DesiredOutcomesPresenter {
     )
   }
 
-  readonly title = `What are the desired outcomes for the ${this.serviceCategory.name} service?`
+  readonly title = `What are the desired outcomes for the ${utils.convertToProperCase(
+    this.serviceCategory.name
+  )} service?`
 }

--- a/server/routes/referrals/furtherInformationPresenter.test.ts
+++ b/server/routes/referrals/furtherInformationPresenter.test.ts
@@ -10,7 +10,7 @@ describe('FurtherInformationPresenter', () => {
     it('returns a title', () => {
       const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
       expect(presenter.title).toEqual(
-        'Do you have further information for the social inclusion service provider? (optional)'
+        'Do you have further information for the Social inclusion service provider? (optional)'
       )
     })
   })

--- a/server/routes/referrals/furtherInformationPresenter.ts
+++ b/server/routes/referrals/furtherInformationPresenter.ts
@@ -2,6 +2,7 @@ import DraftReferral from '../../models/draftReferral'
 import ServiceCategory from '../../models/serviceCategory'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import utils from '../../utils/utils'
 
 export default class FurtherInformationPresenter {
   constructor(
@@ -11,7 +12,9 @@ export default class FurtherInformationPresenter {
     private readonly userInputData: Record<string, string> | null = null
   ) {}
 
-  readonly title = `Do you have further information for the ${this.serviceCategory.name} service provider? (optional)`
+  readonly title = `Do you have further information for the ${utils.convertToProperCase(
+    this.serviceCategory.name
+  )} service provider? (optional)`
 
   readonly hint =
     'For example, relevant previous offences, previously completed programmes or further reasons for this referral'

--- a/server/routes/referrals/rarDaysForm.test.ts
+++ b/server/routes/referrals/rarDaysForm.test.ts
@@ -33,7 +33,7 @@ describe(RarDaysForm, () => {
             {
               formFields: ['using-rar-days'],
               errorSummaryLinkedField: 'using-rar-days',
-              message: 'Select yes if you are using RAR days for the accommodation service',
+              message: 'Select yes if you are using RAR days for the Accommodation service',
             },
           ],
         })
@@ -83,7 +83,7 @@ describe(RarDaysForm, () => {
               {
                 formFields: ['maximum-rar-days'],
                 errorSummaryLinkedField: 'maximum-rar-days',
-                message: 'Enter the maximum number of RAR days for the accommodation service',
+                message: 'Enter the maximum number of RAR days for the Accommodation service',
               },
             ],
           })
@@ -102,7 +102,7 @@ describe(RarDaysForm, () => {
               {
                 formFields: ['maximum-rar-days'],
                 errorSummaryLinkedField: 'maximum-rar-days',
-                message: 'The maximum number of RAR days for the accommodation service must be a number, like 5',
+                message: 'The maximum number of RAR days for the Accommodation service must be a number, like 5',
               },
             ],
           })
@@ -121,7 +121,7 @@ describe(RarDaysForm, () => {
               {
                 formFields: ['maximum-rar-days'],
                 errorSummaryLinkedField: 'maximum-rar-days',
-                message: 'The maximum number of RAR days for the accommodation service must be a whole number, like 5',
+                message: 'The maximum number of RAR days for the Accommodation service must be a whole number, like 5',
               },
             ],
           })

--- a/server/routes/referrals/rarDaysPresenter.test.ts
+++ b/server/routes/referrals/rarDaysPresenter.test.ts
@@ -11,12 +11,12 @@ describe(RarDaysPresenter, () => {
       const presenter = new RarDaysPresenter(referral, serviceCategory)
 
       expect(presenter.text).toEqual({
-        title: 'Are you using RAR days for the accommodation service?',
+        title: 'Are you using RAR days for the Accommodation service?',
         usingRarDays: {
           errorMessage: null,
         },
         maximumRarDays: {
-          label: 'What is the maximum number of RAR days for the accommodation service?',
+          label: 'What is the maximum number of RAR days for the Accommodation service?',
           errorMessage: null,
         },
       })

--- a/server/routes/referrals/rarDaysPresenter.ts
+++ b/server/routes/referrals/rarDaysPresenter.ts
@@ -2,6 +2,7 @@ import DraftReferral from '../../models/draftReferral'
 import ServiceCategory from '../../models/serviceCategory'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import utils from '../../utils/utils'
 
 export default class RarDaysPresenter {
   constructor(
@@ -16,12 +17,14 @@ export default class RarDaysPresenter {
   })
 
   readonly text = {
-    title: `Are you using RAR days for the ${this.serviceCategory.name} service?`,
+    title: `Are you using RAR days for the ${utils.convertToProperCase(this.serviceCategory.name)} service?`,
     usingRarDays: {
       errorMessage: PresenterUtils.errorMessage(this.error, 'using-rar-days'),
     },
     maximumRarDays: {
-      label: `What is the maximum number of RAR days for the ${this.serviceCategory.name} service?`,
+      label: `What is the maximum number of RAR days for the ${utils.convertToProperCase(
+        this.serviceCategory.name
+      )} service?`,
       errorMessage: PresenterUtils.errorMessage(this.error, 'maximum-rar-days'),
     },
   }

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -1,6 +1,7 @@
 /* eslint max-classes-per-file: 0 */
 import DraftReferral from '../../models/draftReferral'
 import Intervention from '../../models/intervention'
+import utils from '../../utils/utils'
 
 export default class ReferralFormPresenter {
   private readonly taskValues: TaskValues
@@ -91,7 +92,9 @@ class FormSectionBuilder {
       ),
       tasks: [
         {
-          title: `Select service categories for the ${this.intervention.contractType.name} referral`,
+          title: `Select service categories for the ${utils.convertToProperCase(
+            this.intervention.contractType.name
+          )} referral`,
           url: this.calculateTaskUrl('service-categories', this.taskValues.needsAndRequirements),
         },
       ],
@@ -103,7 +106,7 @@ class FormSectionBuilder {
   ): ReferralFormSingleListSectionPresenter {
     return {
       type: 'single',
-      title: `Add ${this.intervention.serviceCategories[0].name} referral details`,
+      title: `Add ${utils.convertToProperCase(this.intervention.serviceCategories[0].name)} referral details`,
       number: '2',
       status: this.calculateStatus(
         this.sectionValues.serviceCategoryReferralDetails,
@@ -111,7 +114,9 @@ class FormSectionBuilder {
       ),
       tasks: [
         {
-          title: `Confirm the relevant sentence for the ${this.intervention.serviceCategories[0].name} referral`,
+          title: `Confirm the relevant sentence for the ${utils.convertToProperCase(
+            this.intervention.serviceCategories[0].name
+          )} referral`,
           url: this.calculateTaskUrl('relevant-sentence', this.taskValues.needsAndRequirements),
         },
         {
@@ -133,7 +138,9 @@ class FormSectionBuilder {
           ),
         },
         {
-          title: `Enter when the ${this.intervention.serviceCategories[0].name} service need to be completed`,
+          title: `Enter when the ${utils.convertToProperCase(
+            this.intervention.serviceCategories[0].name
+          )} service needs to be completed`,
           url: this.calculateTaskUrl('completion-deadline', this.taskValues.allComplexityLevels),
         },
         {
@@ -153,7 +160,7 @@ class FormSectionBuilder {
   ): ReferralFormMultiListSectionPresenter {
     return {
       type: 'multi',
-      title: `Add ${this.intervention.contractType.name} referral details`,
+      title: `Add ${utils.convertToProperCase(this.intervention.contractType.name)} referral details`,
       number: '3',
       status: this.calculateStatus(
         this.sectionValues.serviceCategoryReferralDetails,
@@ -163,7 +170,9 @@ class FormSectionBuilder {
         {
           tasks: [
             {
-              title: `Confirm the relevant sentence for the ${this.intervention.contractType.name} referral`,
+              title: `Confirm the relevant sentence for the ${utils.convertToProperCase(
+                this.intervention.contractType.name
+              )} referral`,
               url: this.calculateTaskUrl('relevant-sentence', this.taskValues.cohortServiceCategories),
             },
           ],
@@ -179,7 +188,7 @@ class FormSectionBuilder {
             })
             .map((serviceCat, index) => {
               return {
-                title: serviceCat.name,
+                title: utils.convertToProperCase(serviceCat.name),
                 tasks: [
                   {
                     title: `Select desired outcomes`,
@@ -205,7 +214,9 @@ class FormSectionBuilder {
           {
             tasks: [
               {
-                title: `Enter when the ${this.intervention.contractType.name} referral need to be completed`,
+                title: `Enter when the ${utils.convertToProperCase(
+                  this.intervention.contractType.name
+                )} referral needs to be completed`,
                 url: this.calculateTaskUrl('completion-deadline', this.taskValues.allComplexityLevels),
               },
               {

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -172,7 +172,7 @@ describe('GET /referrals/:id/form', () => {
       .get('/referrals/1/form')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Add accommodation referral details')
+        expect(res.text).toContain('Add Accommodation referral details')
       })
 
     expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['token', '1'])
@@ -452,7 +452,7 @@ describe('GET /referrals/:id/completion-deadline', () => {
       .get('/referrals/1/completion-deadline')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('What date does the accommodation service need to be completed by?')
+        expect(res.text).toContain('What date does the Accommodation service need to be completed by?')
       })
   })
   // TODO how do we (or indeed, do we) test what happens when the request has a completion deadline - i.e. that the
@@ -502,7 +502,7 @@ describe('POST /referrals/:id/completion-deadline', () => {
         .send({ 'completion-deadline-day': '15', 'completion-deadline-month': '9', 'completion-deadline-year': '2021' })
         .expect(400)
         .expect(res => {
-          expect(res.text).toContain('What date does the accommodation service need to be completed by?')
+          expect(res.text).toContain('What date does the Accommodation service need to be completed by?')
           expect(res.text).toContain('The date by which the service needs to be completed must be in the future')
         })
 
@@ -579,7 +579,7 @@ describe('GET /referrals/:referralId/service-category/:service-category-id/compl
       .get('/referrals/1/service-category/b33c19d1-7414-4014-b543-e543e59c5b39/complexity-level')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('What is the complexity level for the social inclusion service?')
+        expect(res.text).toContain('What is the complexity level for the Social inclusion service?')
       })
 
     expect(interventionsService.getServiceCategory).toHaveBeenCalledWith(
@@ -725,7 +725,7 @@ describe('GET /referrals/:id/further-information', () => {
       .get('/referrals/1/further-information')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Do you have further information for the accommodation service provider? (optional)')
+        expect(res.text).toContain('Do you have further information for the Accommodation service provider? (optional)')
       })
   })
 })
@@ -795,7 +795,7 @@ describe('GET /referrals/:id/relevant-sentence', () => {
       .get('/referrals/1/relevant-sentence')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Select the relevant sentence for the accommodation referral')
+        expect(res.text).toContain('Select the relevant sentence for the Accommodation referral')
       })
 
     expect(communityApiService.getActiveConvictionsByCRN).toHaveBeenCalledWith(serviceUserCRN)
@@ -951,7 +951,7 @@ describe('GET /referrals/:referralId/service-category/:service-category-id/desir
       .get('/referrals/1/service-category/b33c19d1-7414-4014-b543-e543e59c5b39/desired-outcomes')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('What are the desired outcomes for the social inclusion service?')
+        expect(res.text).toContain('What are the desired outcomes for the Social inclusion service?')
       })
 
     expect(interventionsService.getServiceCategory.mock.calls[0]).toEqual([
@@ -1100,7 +1100,7 @@ describe('GET /referrals/:id/rar-days', () => {
       .get('/referrals/1/rar-days')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Are you using RAR days for the accommodation service?')
+        expect(res.text).toContain('Are you using RAR days for the Accommodation service?')
       })
 
     expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['token', '1'])
@@ -1177,7 +1177,7 @@ describe('POST /referrals/:id/rar-days', () => {
         })
         .expect(400)
         .expect(res => {
-          expect(res.text).toContain('Enter the maximum number of RAR days for the accommodation service')
+          expect(res.text).toContain('Enter the maximum number of RAR days for the Accommodation service')
         })
 
       expect(interventionsService.patchDraftReferral).not.toHaveBeenCalled()

--- a/server/routes/referrals/relevantSentencePresenter.test.ts
+++ b/server/routes/referrals/relevantSentencePresenter.test.ts
@@ -12,7 +12,7 @@ describe(RelevantSentencePresenter, () => {
       const convictions = [deliusConvictionFactory.build()]
       const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
-      expect(presenter.title).toEqual('Select the relevant sentence for the personal wellbeing referral')
+      expect(presenter.title).toEqual('Select the relevant sentence for the Personal wellbeing referral')
     })
   })
 

--- a/server/routes/referrals/relevantSentencePresenter.ts
+++ b/server/routes/referrals/relevantSentencePresenter.ts
@@ -3,6 +3,7 @@ import DraftReferral from '../../models/draftReferral'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 import Intervention from '../../models/intervention'
+import utils from '../../utils/utils'
 
 export default class RelevantSentencePresenter {
   constructor(
@@ -13,7 +14,9 @@ export default class RelevantSentencePresenter {
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
-  readonly title = `Select the relevant sentence for the ${this.intervention.contractType.name.toLocaleLowerCase()} referral`
+  readonly title = `Select the relevant sentence for the ${utils.convertToProperCase(
+    this.intervention.contractType.name
+  )} referral`
 
   readonly errorMessage = PresenterUtils.errorMessage(this.error, 'relevant-sentence-id')
 

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -2,6 +2,8 @@
 // Explicit return types would make this file very messy and not much more
 // informational — everything returned is a string, since they’re messages!
 
+import utils from './utils'
+
 export default {
   startReferral: {
     crnEmpty: 'A CRN is needed',
@@ -40,13 +42,16 @@ export default {
     empty: (name: string) => `Enter details of when ${name} will not be able to attend sessions`,
   },
   usingRarDays: {
-    empty: (name: string) => `Select yes if you are using RAR days for the ${name} service`,
+    empty: (name: string) => `Select yes if you are using RAR days for the ${utils.convertToProperCase(name)} service`,
   },
   maximumRarDays: {
-    empty: (name: string) => `Enter the maximum number of RAR days for the ${name} service`,
-    notNumber: (name: string) => `The maximum number of RAR days for the ${name} service must be a number, like 5`,
+    empty: (name: string) => `Enter the maximum number of RAR days for the ${utils.convertToProperCase(name)} service`,
+    notNumber: (name: string) =>
+      `The maximum number of RAR days for the ${utils.convertToProperCase(name)} service must be a number, like 5`,
     notWholeNumber: (name: string) =>
-      `The maximum number of RAR days for the ${name} service must be a whole number, like 5`,
+      `The maximum number of RAR days for the ${utils.convertToProperCase(
+        name
+      )} service must be a whole number, like 5`,
   },
   assignReferral: {
     emailEmpty: 'An email address is required',

--- a/testutils/factories/cohortReferralFormSection.ts
+++ b/testutils/factories/cohortReferralFormSection.ts
@@ -3,6 +3,7 @@ import {
   ReferralFormMultiListSectionPresenter,
   ReferralFormStatus,
 } from '../../server/routes/referrals/referralFormPresenter'
+import utils from '../../server/utils/utils'
 
 class CohortReferralFormSectionFactory extends Factory<ReferralFormMultiListSectionPresenter> {
   cohortInterventionDetails(
@@ -16,13 +17,16 @@ class CohortReferralFormSectionFactory extends Factory<ReferralFormMultiListSect
   ) {
     return this.params({
       type: 'multi',
-      title: `Add ${contractName} referral details`,
+      title: `Add ${utils.convertToProperCase(contractName)} referral details`,
       number: '3',
       status: referralFormStatus,
       taskListSections: [
         {
           tasks: [
-            { title: `Confirm the relevant sentence for the ${contractName} referral`, url: relevantSentenceUrl },
+            {
+              title: `Confirm the relevant sentence for the ${utils.convertToProperCase(contractName)} referral`,
+              url: relevantSentenceUrl,
+            },
           ],
         },
       ]
@@ -31,7 +35,7 @@ class CohortReferralFormSectionFactory extends Factory<ReferralFormMultiListSect
             ? []
             : cohortUrls.map(cohortUrl => {
                 return {
-                  title: cohortUrl.title,
+                  title: utils.convertToProperCase(cohortUrl.title),
                   tasks: [
                     { title: 'Select desired outcomes', url: cohortUrl.desiredOutcomesUrl },
                     { title: 'Select required complexity level', url: cohortUrl.complexityLevelUrl },
@@ -43,7 +47,7 @@ class CohortReferralFormSectionFactory extends Factory<ReferralFormMultiListSect
           {
             tasks: [
               {
-                title: `Enter when the ${contractName} referral need to be completed`,
+                title: `Enter when the ${utils.convertToProperCase(contractName)} referral needs to be completed`,
                 url: completionDateUrl,
               },
               { title: 'Enter enforceable days used', url: rarDaysUrl },

--- a/testutils/factories/referralFormSection.ts
+++ b/testutils/factories/referralFormSection.ts
@@ -3,6 +3,7 @@ import {
   ReferralFormSingleListSectionPresenter,
   ReferralFormStatus,
 } from '../../server/routes/referrals/referralFormPresenter'
+import utils from '../../server/utils/utils'
 
 class ReferralFormSectionFactory extends Factory<ReferralFormSingleListSectionPresenter> {
   reviewServiceUser(
@@ -33,7 +34,12 @@ class ReferralFormSectionFactory extends Factory<ReferralFormSingleListSectionPr
       title: 'Choose service categories',
       number: '2',
       status: referralFormStatus,
-      tasks: [{ title: `Select service categories for the ${contractName} referral`, url: serviceCategoriesUrl }],
+      tasks: [
+        {
+          title: `Select service categories for the ${utils.convertToProperCase(contractName)} referral`,
+          url: serviceCategoriesUrl,
+        },
+      ],
     })
   }
 
@@ -49,15 +55,18 @@ class ReferralFormSectionFactory extends Factory<ReferralFormSingleListSectionPr
   ) {
     return this.params({
       type: 'single',
-      title: `Add ${serviceCategoryName} referral details`,
+      title: `Add ${utils.convertToProperCase(serviceCategoryName)} referral details`,
       number: '2',
       status: referralFormStatus,
       tasks: [
-        { title: `Confirm the relevant sentence for the ${serviceCategoryName} referral`, url: relevantSentenceUrl },
+        {
+          title: `Confirm the relevant sentence for the ${utils.convertToProperCase(serviceCategoryName)} referral`,
+          url: relevantSentenceUrl,
+        },
         { title: 'Select desired outcomes', url: desiredOutcomesUrl },
         { title: 'Select required complexity level', url: complexityLevelUrl },
         {
-          title: `Enter when the ${serviceCategoryName} service need to be completed`,
+          title: `Enter when the ${utils.convertToProperCase(serviceCategoryName)} service needs to be completed`,
           url: completionDateUrl,
         },
         { title: 'Enter enforceable days used', url: rarDaysUrl },


### PR DESCRIPTION
## What does this pull request do?

Ensures we're consistently using Sentence case for Contract type names and service categories (after discussion with content team) in Refer journey by using `utils.convertToProperCase`. e.g. Social inclusion, Women's services, Accommodation.

Apologies for the large commit - it was difficult to do this in smaller chunks do the integration tests, but it's essentially just wrapping names in that function everywhere and updating tests to expect this.

## What is the intent behind these changes?

To ensure we're consistent with our casing throughout the Refer journey.
