### PR TITLE
IC-1825: Make pages compatible with cohort referrals

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -240,7 +240,7 @@ describe('Referral form', () => {
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/completion-deadline`)
-      cy.get('h1').contains('What date does the Accommodation service need to be completed by?')
+      cy.get('h1').contains('What date does the Accommodation referral need to be completed by?')
       cy.contains('Day').type('15')
       cy.contains('Month').type('8')
       cy.contains('Year').type('2021')
@@ -248,14 +248,16 @@ describe('Referral form', () => {
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/rar-days`)
-      cy.get('h1').contains('Are you using RAR days for the Accommodation service?')
+      cy.get('h1').contains('Are you using RAR days for the Accommodation referral?')
       cy.contains('Yes').click()
-      cy.contains('What is the maximum number of RAR days for the Accommodation service?').type('10')
+      cy.contains('What is the maximum number of RAR days for the Accommodation referral?').type('10')
 
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/further-information`)
-      cy.get('h1').contains('Do you have further information for the Accommodation service provider? (optional)')
+      cy.get('h1').contains(
+        'Do you have further information for the Accommodation referral service provider? (optional)'
+      )
       cy.get('textarea').type('Some information about Alex')
 
       // stub completed draft referral to mark section as completed
@@ -568,7 +570,7 @@ describe('Referral form', () => {
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/completion-deadline`)
-      cy.get('h1').contains('What date does the Accommodation service need to be completed by?')
+      cy.get('h1').contains("What date does the Women's services referral need to be completed by?")
       cy.contains('Day').type('15')
       cy.contains('Month').type('8')
       cy.contains('Year').type('2021')
@@ -576,14 +578,16 @@ describe('Referral form', () => {
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/rar-days`)
-      cy.get('h1').contains('Are you using RAR days for the Accommodation service?')
+      cy.get('h1').contains("Are you using RAR days for the Women's services referral?")
       cy.contains('Yes').click()
-      cy.contains('What is the maximum number of RAR days for the Accommodation service?').type('10')
+      cy.contains("What is the maximum number of RAR days for the Women's services referral?").type('10')
 
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/further-information`)
-      cy.get('h1').contains('Do you have further information for the Accommodation service provider? (optional)')
+      cy.get('h1').contains(
+        "Do you have further information for the Women's services referral service provider? (optional)"
+      )
       cy.get('textarea').type('Some information about Alex')
 
       // stub completed draft referral to mark section as completed

--- a/server/routes/referrals/completionDeadlinePresenter.test.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.test.ts
@@ -1,14 +1,14 @@
 import CompletionDeadlinePresenter from './completionDeadlinePresenter'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import interventionFactory from '../../../testutils/factories/intervention'
 
 describe('CompletionDeadlinePresenter', () => {
+  const intervention = interventionFactory.build({ contractType: { name: "Women's Service" } })
   describe('day, month, year', () => {
     describe('when the referral has no completion deadline and there is no user input data', () => {
       it('returns empty strings', () => {
-        const serviceCategory = serviceCategoryFactory.build()
-        const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
-        const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
+        const referral = draftReferralFactory.build()
+        const presenter = new CompletionDeadlinePresenter(referral, intervention)
 
         expect(presenter.fields.completionDeadline.day.value).toBe('')
         expect(presenter.fields.completionDeadline.month.value).toBe('')
@@ -18,11 +18,8 @@ describe('CompletionDeadlinePresenter', () => {
 
     describe('when the referral has a completion deadline and there is no user input data', () => {
       it('returns the corresponding values from the completion deadline', () => {
-        const serviceCategory = serviceCategoryFactory.build()
-        const referral = draftReferralFactory
-          .serviceCategorySelected(serviceCategory.id)
-          .build({ completionDeadline: '2021-09-12' })
-        const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
+        const referral = draftReferralFactory.build({ completionDeadline: '2021-09-12' })
+        const presenter = new CompletionDeadlinePresenter(referral, intervention)
 
         expect(presenter.fields.completionDeadline.day.value).toBe('12')
         expect(presenter.fields.completionDeadline.month.value).toBe('9')
@@ -32,12 +29,8 @@ describe('CompletionDeadlinePresenter', () => {
 
     describe('when there is user input data', () => {
       it('returns the user input data, or an empty string if a field is missing', () => {
-        const serviceCategory = serviceCategoryFactory.build()
-        const referral = draftReferralFactory
-          .serviceCategorySelected(serviceCategory.id)
-          .completionDeadlineSet()
-          .build()
-        const presenter = new CompletionDeadlinePresenter(referral, serviceCategory, null, {
+        const referral = draftReferralFactory.completionDeadlineSet().build()
+        const presenter = new CompletionDeadlinePresenter(referral, intervention, null, {
           'completion-deadline-day': 'egg',
           'completion-deadline-month': '7',
         })
@@ -52,9 +45,8 @@ describe('CompletionDeadlinePresenter', () => {
   describe('error information', () => {
     describe('when a null error is passed in', () => {
       it('returns no errors', () => {
-        const serviceCategory = serviceCategoryFactory.build()
-        const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
-        const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
+        const referral = draftReferralFactory.build()
+        const presenter = new CompletionDeadlinePresenter(referral, intervention)
 
         expect(presenter.fields.completionDeadline.errorMessage).toBeNull()
         expect(presenter.fields.completionDeadline.day.hasError).toEqual(false)
@@ -66,9 +58,8 @@ describe('CompletionDeadlinePresenter', () => {
 
     describe('when a non-null error is passed in', () => {
       it('returns error information', () => {
-        const serviceCategory = serviceCategoryFactory.build()
-        const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
-        const presenter = new CompletionDeadlinePresenter(referral, serviceCategory, {
+        const referral = draftReferralFactory.build()
+        const presenter = new CompletionDeadlinePresenter(referral, intervention, {
           errors: [
             {
               errorSummaryLinkedField: 'completion-deadline-month',
@@ -91,19 +82,17 @@ describe('CompletionDeadlinePresenter', () => {
 
   describe('title', () => {
     it('returns a title', () => {
-      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-      const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
-      const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
+      const referral = draftReferralFactory.build()
+      const presenter = new CompletionDeadlinePresenter(referral, intervention)
 
-      expect(presenter.title).toEqual('What date does the Social inclusion service need to be completed by?')
+      expect(presenter.title).toEqual("What date does the Women's service referral need to be completed by?")
     })
   })
 
   describe('hint', () => {
     it('returns a hint', () => {
-      const serviceCategory = serviceCategoryFactory.build()
-      const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
-      const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
+      const referral = draftReferralFactory.build()
+      const presenter = new CompletionDeadlinePresenter(referral, intervention)
 
       expect(presenter.hint).toEqual('For example, 27 10 2021')
     })

--- a/server/routes/referrals/completionDeadlinePresenter.ts
+++ b/server/routes/referrals/completionDeadlinePresenter.ts
@@ -1,22 +1,22 @@
 import DraftReferral from '../../models/draftReferral'
-import ServiceCategory from '../../models/serviceCategory'
 import CalendarDay from '../../utils/calendarDay'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import Intervention from '../../models/intervention'
 import utils from '../../utils/utils'
 
 export default class CompletionDeadlinePresenter {
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
   readonly title = `What date does the ${utils.convertToProperCase(
-    this.serviceCategory.name
-  )} service need to be completed by?`
+    this.intervention.contractType.name
+  )} referral need to be completed by?`
 
   readonly hint = 'For example, 27 10 2021'
 
   constructor(
     private readonly referral: DraftReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly intervention: Intervention,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}

--- a/server/routes/referrals/furtherInformationPresenter.test.ts
+++ b/server/routes/referrals/furtherInformationPresenter.test.ts
@@ -1,23 +1,23 @@
 import FurtherInformationPresenter from './furtherInformationPresenter'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import interventionFactory from '../../../testutils/factories/intervention'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
 
 describe('FurtherInformationPresenter', () => {
-  const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-  const draftReferral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+  const intervention = interventionFactory.build({ contractType: { name: "Women's Service" } })
+  const draftReferral = draftReferralFactory.build()
 
   describe('title', () => {
     it('returns a title', () => {
-      const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
+      const presenter = new FurtherInformationPresenter(draftReferral, intervention)
       expect(presenter.title).toEqual(
-        'Do you have further information for the Social inclusion service provider? (optional)'
+        "Do you have further information for the Women's service referral service provider? (optional)"
       )
     })
   })
 
   describe('hint', () => {
     it('returns a hint', () => {
-      const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
+      const presenter = new FurtherInformationPresenter(draftReferral, intervention)
       expect(presenter.hint).toEqual(
         'For example, relevant previous offences, previously completed programmes or further reasons for this referral'
       )
@@ -27,7 +27,7 @@ describe('FurtherInformationPresenter', () => {
   describe('errorMessage', () => {
     describe('when no error is passed in', () => {
       it('returns null', () => {
-        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
+        const presenter = new FurtherInformationPresenter(draftReferral, intervention)
 
         expect(presenter.errorMessage).toBeNull()
       })
@@ -35,7 +35,7 @@ describe('FurtherInformationPresenter', () => {
 
     describe('when an error is passed in', () => {
       it('returns an error message', () => {
-        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory, {
+        const presenter = new FurtherInformationPresenter(draftReferral, intervention, {
           errors: [
             {
               formFields: ['further-information'],
@@ -53,7 +53,7 @@ describe('FurtherInformationPresenter', () => {
   describe('errorSummary', () => {
     describe('when no error is passed in', () => {
       it('returns null', () => {
-        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
+        const presenter = new FurtherInformationPresenter(draftReferral, intervention)
 
         expect(presenter.errorSummary).toBeNull()
       })
@@ -61,7 +61,7 @@ describe('FurtherInformationPresenter', () => {
 
     describe('when an error is passed in', () => {
       it('returns error information', () => {
-        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory, {
+        const presenter = new FurtherInformationPresenter(draftReferral, intervention, {
           errors: [
             {
               formFields: ['further-information'],
@@ -85,7 +85,7 @@ describe('FurtherInformationPresenter', () => {
     describe('when the referral already has further information set', () => {
       it('uses that further information as the value attribute', () => {
         draftReferral.furtherInformation = 'Some information about the service user'
-        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory)
+        const presenter = new FurtherInformationPresenter(draftReferral, intervention)
 
         expect(presenter.value).toEqual('Some information about the service user')
       })
@@ -93,7 +93,7 @@ describe('FurtherInformationPresenter', () => {
 
     describe('when there is user input data', () => {
       it('uses that further information as the value attribute', () => {
-        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory, null, {
+        const presenter = new FurtherInformationPresenter(draftReferral, intervention, null, {
           'further-information': 'Some information about the service user',
         })
 
@@ -104,7 +104,7 @@ describe('FurtherInformationPresenter', () => {
     describe('when the referral already has further information and there is user input data', () => {
       it('sets the new input data as the further information value', () => {
         draftReferral.furtherInformation = 'Some old information about the service user'
-        const presenter = new FurtherInformationPresenter(draftReferral, serviceCategory, null, {
+        const presenter = new FurtherInformationPresenter(draftReferral, intervention, null, {
           'further-information': 'Some new information about the service user',
         })
 

--- a/server/routes/referrals/furtherInformationPresenter.ts
+++ b/server/routes/referrals/furtherInformationPresenter.ts
@@ -1,20 +1,20 @@
 import DraftReferral from '../../models/draftReferral'
-import ServiceCategory from '../../models/serviceCategory'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import Intervention from '../../models/intervention'
 import utils from '../../utils/utils'
 
 export default class FurtherInformationPresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly intervention: Intervention,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, string> | null = null
   ) {}
 
   readonly title = `Do you have further information for the ${utils.convertToProperCase(
-    this.serviceCategory.name
-  )} service provider? (optional)`
+    this.intervention.contractType.name
+  )} referral service provider? (optional)`
 
   readonly hint =
     'For example, relevant previous offences, previously completed programmes or further reasons for this referral'

--- a/server/routes/referrals/rarDaysForm.test.ts
+++ b/server/routes/referrals/rarDaysForm.test.ts
@@ -1,14 +1,14 @@
 import { Request } from 'express'
 import RarDaysForm from './rarDaysForm'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import interventionFactory from '../../../testutils/factories/intervention'
 
 describe(RarDaysForm, () => {
-  const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+  const intervention = interventionFactory.build({ contractType: { name: "Women's Service" } })
 
   describe('isValid', () => {
     describe('when there are no errors in the form', () => {
       it('returns true', async () => {
-        const form = await RarDaysForm.createForm({ body: { 'using-rar-days': 'no' } } as Request, serviceCategory)
+        const form = await RarDaysForm.createForm({ body: { 'using-rar-days': 'no' } } as Request, intervention)
 
         expect(form.isValid).toBe(true)
       })
@@ -16,7 +16,7 @@ describe(RarDaysForm, () => {
 
     describe('when there are errors in the form', () => {
       it('returns false', async () => {
-        const form = await RarDaysForm.createForm({ body: {} } as Request, serviceCategory)
+        const form = await RarDaysForm.createForm({ body: {} } as Request, intervention)
 
         expect(form.isValid).toBe(false)
       })
@@ -26,14 +26,14 @@ describe(RarDaysForm, () => {
   describe('errors', () => {
     describe('when no answer is selected for using-rar-days', () => {
       it('gives an error for using-rar-days', async () => {
-        const form = await RarDaysForm.createForm({ body: {} } as Request, serviceCategory)
+        const form = await RarDaysForm.createForm({ body: {} } as Request, intervention)
 
         expect(form.error).toEqual({
           errors: [
             {
               formFields: ['using-rar-days'],
               errorSummaryLinkedField: 'using-rar-days',
-              message: 'Select yes if you are using RAR days for the Accommodation service',
+              message: "Select yes if you are using RAR days for the Women's service referral",
             },
           ],
         })
@@ -42,7 +42,7 @@ describe(RarDaysForm, () => {
 
     describe('when choosing no for using-rar-days', () => {
       it('gives no error', async () => {
-        const form = await RarDaysForm.createForm({ body: { 'using-rar-days': 'no' } } as Request, serviceCategory)
+        const form = await RarDaysForm.createForm({ body: { 'using-rar-days': 'no' } } as Request, intervention)
 
         expect(form.error).toBeNull()
       })
@@ -53,7 +53,7 @@ describe(RarDaysForm, () => {
         it('gives no error', async () => {
           const form = await RarDaysForm.createForm(
             { body: { 'using-rar-days': 'yes', 'maximum-rar-days': '10' } } as Request,
-            serviceCategory
+            intervention
           )
 
           expect(form.error).toBeNull()
@@ -64,7 +64,7 @@ describe(RarDaysForm, () => {
         it('gives no error', async () => {
           const form = await RarDaysForm.createForm(
             { body: { 'using-rar-days': 'yes', 'maximum-rar-days': ' 10  ' } } as Request,
-            serviceCategory
+            intervention
           )
 
           expect(form.error).toBeNull()
@@ -75,7 +75,7 @@ describe(RarDaysForm, () => {
         it('gives an error for maximum-rar-days', async () => {
           const form = await RarDaysForm.createForm(
             { body: { 'using-rar-days': 'yes', 'maximum-rar-days': '' } } as Request,
-            serviceCategory
+            intervention
           )
 
           expect(form.error).toEqual({
@@ -83,7 +83,7 @@ describe(RarDaysForm, () => {
               {
                 formFields: ['maximum-rar-days'],
                 errorSummaryLinkedField: 'maximum-rar-days',
-                message: 'Enter the maximum number of RAR days for the Accommodation service',
+                message: "Enter the maximum number of RAR days for the Women's service referral",
               },
             ],
           })
@@ -94,7 +94,7 @@ describe(RarDaysForm, () => {
         it('gives an error for maximum-rar-days', async () => {
           const form = await RarDaysForm.createForm(
             { body: { 'using-rar-days': 'yes', 'maximum-rar-days': 'blah' } } as Request,
-            serviceCategory
+            intervention
           )
 
           expect(form.error).toEqual({
@@ -102,7 +102,7 @@ describe(RarDaysForm, () => {
               {
                 formFields: ['maximum-rar-days'],
                 errorSummaryLinkedField: 'maximum-rar-days',
-                message: 'The maximum number of RAR days for the Accommodation service must be a number, like 5',
+                message: "The maximum number of RAR days for the Women's service referral must be a number, like 5",
               },
             ],
           })
@@ -113,7 +113,7 @@ describe(RarDaysForm, () => {
         it('gives an error for maximum-rar-days', async () => {
           const form = await RarDaysForm.createForm(
             { body: { 'using-rar-days': 'yes', 'maximum-rar-days': '3.5' } } as Request,
-            serviceCategory
+            intervention
           )
 
           expect(form.error).toEqual({
@@ -121,7 +121,8 @@ describe(RarDaysForm, () => {
               {
                 formFields: ['maximum-rar-days'],
                 errorSummaryLinkedField: 'maximum-rar-days',
-                message: 'The maximum number of RAR days for the Accommodation service must be a whole number, like 5',
+                message:
+                  "The maximum number of RAR days for the Women's service referral must be a whole number, like 5",
               },
             ],
           })
@@ -135,7 +136,7 @@ describe(RarDaysForm, () => {
       it('returns true for usingRarDays, and a non-null maximumRarDays', async () => {
         const form = await RarDaysForm.createForm(
           { body: { 'using-rar-days': 'yes', 'maximum-rar-days': '3' } } as Request,
-          serviceCategory
+          intervention
         )
 
         expect(form.paramsForUpdate).toEqual({ usingRarDays: true, maximumRarDays: 3 })
@@ -146,7 +147,7 @@ describe(RarDaysForm, () => {
       it('returns false for usingRarDays, and a null maximumRarDays', async () => {
         const form = await RarDaysForm.createForm(
           { body: { 'using-rar-days': 'no', 'maximum-rar-days': '' } } as Request,
-          serviceCategory
+          intervention
         )
 
         expect(form.paramsForUpdate).toEqual({ usingRarDays: false, maximumRarDays: null })
@@ -157,7 +158,7 @@ describe(RarDaysForm, () => {
       it('correctly converts it to a number', async () => {
         const form = await RarDaysForm.createForm(
           { body: { 'using-rar-days': 'yes', 'maximum-rar-days': '  3  ' } } as Request,
-          serviceCategory
+          intervention
         )
 
         expect(form.paramsForUpdate).toEqual({ usingRarDays: true, maximumRarDays: 3 })

--- a/server/routes/referrals/rarDaysForm.ts
+++ b/server/routes/referrals/rarDaysForm.ts
@@ -1,39 +1,39 @@
 import { Request } from 'express'
 import { Result, ValidationChain, ValidationError } from 'express-validator'
 import DraftReferral from '../../models/draftReferral'
-import ServiceCategory from '../../models/serviceCategory'
 import errorMessages from '../../utils/errorMessages'
 import FormUtils from '../../utils/formUtils'
 import { FormValidationError } from '../../utils/formValidationError'
+import Intervention from '../../models/intervention'
 
 export default class RarDaysForm {
   private constructor(private readonly request: Request, private readonly result: Result<ValidationError>) {}
 
-  static async createForm(request: Request, serviceCategory: ServiceCategory): Promise<RarDaysForm> {
+  static async createForm(request: Request, intervention: Intervention): Promise<RarDaysForm> {
     return new RarDaysForm(
       request,
-      await FormUtils.runValidations({ request, validations: this.validations(serviceCategory) })
+      await FormUtils.runValidations({ request, validations: this.validations(intervention) })
     )
   }
 
-  static validations(serviceCategory: ServiceCategory): ValidationChain[] {
-    const firstName = serviceCategory.name
+  static validations(intervention: Intervention): ValidationChain[] {
+    const referralName = intervention.contractType.name
 
     return FormUtils.yesNoRadioWithConditionalInputValidationChain({
       radioName: 'using-rar-days',
       inputName: 'maximum-rar-days',
-      notSelectedErrorMessage: errorMessages.usingRarDays.empty(firstName),
+      notSelectedErrorMessage: errorMessages.usingRarDays.empty(referralName),
       inputValidator: chain =>
         chain
           .notEmpty({ ignore_whitespace: true })
-          .withMessage(errorMessages.maximumRarDays.empty(serviceCategory.name))
+          .withMessage(errorMessages.maximumRarDays.empty(referralName))
           .bail()
           .trim()
           .isNumeric()
-          .withMessage(errorMessages.maximumRarDays.notNumber(serviceCategory.name))
+          .withMessage(errorMessages.maximumRarDays.notNumber(referralName))
           .bail()
           .isInt()
-          .withMessage(errorMessages.maximumRarDays.notWholeNumber(serviceCategory.name)),
+          .withMessage(errorMessages.maximumRarDays.notWholeNumber(referralName)),
     })
   }
 

--- a/server/routes/referrals/rarDaysPresenter.test.ts
+++ b/server/routes/referrals/rarDaysPresenter.test.ts
@@ -1,22 +1,22 @@
 import RarDaysPresenter from './rarDaysPresenter'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import interventionFactory from '../../../testutils/factories/intervention'
 
 describe(RarDaysPresenter, () => {
+  const intervention = interventionFactory.build({ contractType: { name: "Women's Service" } })
   describe('text', () => {
     it('returns text to be displayed', () => {
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const referral = draftReferralFactory.build()
 
-      const presenter = new RarDaysPresenter(referral, serviceCategory)
+      const presenter = new RarDaysPresenter(referral, intervention)
 
       expect(presenter.text).toEqual({
-        title: 'Are you using RAR days for the Accommodation service?',
+        title: "Are you using RAR days for the Women's service referral?",
         usingRarDays: {
           errorMessage: null,
         },
         maximumRarDays: {
-          label: 'What is the maximum number of RAR days for the Accommodation service?',
+          label: "What is the maximum number of RAR days for the Women's service referral?",
           errorMessage: null,
         },
       })
@@ -24,10 +24,9 @@ describe(RarDaysPresenter, () => {
 
     describe('when some fields have errors', () => {
       it('includes error messages for those fields', () => {
-        const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.build()
 
-        const presenter = new RarDaysPresenter(referral, serviceCategory, {
+        const presenter = new RarDaysPresenter(referral, intervention, {
           errors: [
             { formFields: ['using-rar-days'], errorSummaryLinkedField: 'using-rar-days', message: 'usingRarDays msg' },
             {
@@ -53,10 +52,9 @@ describe(RarDaysPresenter, () => {
   describe('fields', () => {
     describe('when the answers are null on the referral and there is no user input data', () => {
       it('returns values corresponding to no selection', () => {
-        const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.build()
 
-        const presenter = new RarDaysPresenter(referral, serviceCategory)
+        const presenter = new RarDaysPresenter(referral, intervention)
 
         expect(presenter.fields).toEqual({
           usingRarDays: null,
@@ -67,10 +65,9 @@ describe(RarDaysPresenter, () => {
 
     describe('when the answers are present on the referral', () => {
       it('returns the values from the referral', () => {
-        const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.build({ usingRarDays: true, maximumRarDays: 10 })
 
-        const presenter = new RarDaysPresenter(referral, serviceCategory)
+        const presenter = new RarDaysPresenter(referral, intervention)
 
         expect(presenter.fields).toEqual({
           usingRarDays: true,
@@ -81,10 +78,9 @@ describe(RarDaysPresenter, () => {
 
     describe('when there is user input data', () => {
       it('returns the user input values', () => {
-        const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.build()
 
-        const presenter = new RarDaysPresenter(referral, serviceCategory, null, {
+        const presenter = new RarDaysPresenter(referral, intervention, null, {
           'using-rar-days': 'yes',
           'maximum-rar-days': 'blah',
         })
@@ -98,10 +94,9 @@ describe(RarDaysPresenter, () => {
 
     describe('when there is user input data and the answers are present on the referral', () => {
       it('returns the user input values', () => {
-        const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.build({ usingRarDays: false, maximumRarDays: null })
 
-        const presenter = new RarDaysPresenter(referral, serviceCategory, null, {
+        const presenter = new RarDaysPresenter(referral, intervention, null, {
           'using-rar-days': 'yes',
           'maximum-rar-days': 'blah',
         })
@@ -117,10 +112,9 @@ describe(RarDaysPresenter, () => {
   describe('errorSummary', () => {
     describe('when error is null', () => {
       it('returns null', () => {
-        const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.build()
 
-        const presenter = new RarDaysPresenter(referral, serviceCategory)
+        const presenter = new RarDaysPresenter(referral, intervention)
 
         expect(presenter.errorSummary).toBeNull()
       })
@@ -128,10 +122,9 @@ describe(RarDaysPresenter, () => {
 
     describe('when error is not null', () => {
       it('returns a summary of the errors sorted by the order the fields appear on the page', () => {
-        const serviceCategory = serviceCategoryFactory.build()
         const referral = draftReferralFactory.build()
 
-        const presenter = new RarDaysPresenter(referral, serviceCategory, {
+        const presenter = new RarDaysPresenter(referral, intervention, {
           errors: [
             {
               formFields: ['maximum-rar-days'],

--- a/server/routes/referrals/rarDaysPresenter.ts
+++ b/server/routes/referrals/rarDaysPresenter.ts
@@ -1,13 +1,13 @@
 import DraftReferral from '../../models/draftReferral'
-import ServiceCategory from '../../models/serviceCategory'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import Intervention from '../../models/intervention'
 import utils from '../../utils/utils'
 
 export default class RarDaysPresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly intervention: Intervention,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
@@ -17,14 +17,14 @@ export default class RarDaysPresenter {
   })
 
   readonly text = {
-    title: `Are you using RAR days for the ${utils.convertToProperCase(this.serviceCategory.name)} service?`,
+    title: `Are you using RAR days for the ${utils.convertToProperCase(this.intervention.contractType.name)} referral?`,
     usingRarDays: {
       errorMessage: PresenterUtils.errorMessage(this.error, 'using-rar-days'),
     },
     maximumRarDays: {
       label: `What is the maximum number of RAR days for the ${utils.convertToProperCase(
-        this.serviceCategory.name
-      )} service?`,
+        this.intervention.contractType.name
+      )} referral?`,
       errorMessage: PresenterUtils.errorMessage(this.error, 'maximum-rar-days'),
     },
   }

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -440,11 +440,11 @@ describe('POST /referrals/:id/needs-and-requirements', () => {
 
 describe('GET /referrals/:id/completion-deadline', () => {
   beforeEach(() => {
-    const serviceCategory = serviceCategoryFactory.build()
-    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+    const intervention = interventionFactory.build({ contractType: { name: "Women's Service" } })
+    const referral = draftReferralFactory.build()
 
     interventionsService.getDraftReferral.mockResolvedValue(referral)
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
   })
 
   it('renders a form page', async () => {
@@ -452,7 +452,7 @@ describe('GET /referrals/:id/completion-deadline', () => {
       .get('/referrals/1/completion-deadline')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('What date does the Accommodation service need to be completed by?')
+        expect(res.text).toContain('What date does the Women&#39;s service referral need to be completed by?')
       })
   })
   // TODO how do we (or indeed, do we) test what happens when the request has a completion deadline - i.e. that the
@@ -461,19 +461,16 @@ describe('GET /referrals/:id/completion-deadline', () => {
 
 describe('POST /referrals/:id/completion-deadline', () => {
   beforeEach(() => {
-    const serviceCategory = serviceCategoryFactory.build()
-    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+    const intervention = interventionFactory.build({ contractType: { name: "Women's Service" } })
+    const referral = draftReferralFactory.build()
 
     interventionsService.getDraftReferral.mockResolvedValue(referral)
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
   })
 
   describe('when the user inputs a valid date', () => {
     it('updates the referral on the backend and redirects to the next question if the API call succeeds', async () => {
-      const serviceCategory = serviceCategoryFactory.build()
-      const referral = draftReferralFactory
-        .serviceCategorySelected(serviceCategory.id)
-        .build({ completionDeadline: '2021-09-15' })
+      const referral = draftReferralFactory.build({ completionDeadline: '2021-09-15' })
 
       interventionsService.patchDraftReferral.mockResolvedValue(referral)
 
@@ -502,7 +499,7 @@ describe('POST /referrals/:id/completion-deadline', () => {
         .send({ 'completion-deadline-day': '15', 'completion-deadline-month': '9', 'completion-deadline-year': '2021' })
         .expect(400)
         .expect(res => {
-          expect(res.text).toContain('What date does the Accommodation service need to be completed by?')
+          expect(res.text).toContain('What date does the Women&#39;s service referral need to be completed by?')
           expect(res.text).toContain('The date by which the service needs to be completed must be in the future')
         })
 
@@ -713,11 +710,11 @@ describe('POST /referrals/:referralId/service-category/:service-category-id/comp
 
 describe('GET /referrals/:id/further-information', () => {
   beforeEach(() => {
-    const serviceCategory = serviceCategoryFactory.build()
-    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+    const intervention = interventionFactory.build({ contractType: { name: "Women's Service" } })
+    const referral = draftReferralFactory.build()
 
     interventionsService.getDraftReferral.mockResolvedValue(referral)
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
   })
 
   it('renders a form page', async () => {
@@ -725,18 +722,20 @@ describe('GET /referrals/:id/further-information', () => {
       .get('/referrals/1/further-information')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Do you have further information for the Accommodation service provider? (optional)')
+        expect(res.text).toContain(
+          'Do you have further information for the Women&#39;s service referral service provider? (optional)'
+        )
       })
   })
 })
 
 describe('POST /referrals/:id/further-information', () => {
   beforeEach(() => {
-    const serviceCategory = serviceCategoryFactory.build()
-    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+    const intervention = interventionFactory.build({ contractType: { name: "Women's Service" } })
+    const referral = draftReferralFactory.build()
 
     interventionsService.getDraftReferral.mockResolvedValue(referral)
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
   })
 
   it('updates the referral on the backend and redirects to the referral form', async () => {
@@ -1088,10 +1087,10 @@ describe('POST /referrals/:referralId/service-category/:service-category-id/desi
 
 describe('GET /referrals/:id/rar-days', () => {
   beforeEach(() => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+    const intervention = interventionFactory.build({ contractType: { name: "Women's Service" } })
+    const referral = draftReferralFactory.build()
 
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
@@ -1100,7 +1099,7 @@ describe('GET /referrals/:id/rar-days', () => {
       .get('/referrals/1/rar-days')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Are you using RAR days for the Accommodation service?')
+        expect(res.text).toContain('Are you using RAR days for the Women&#39;s service referral?')
       })
 
     expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['token', '1'])
@@ -1118,23 +1117,23 @@ describe('GET /referrals/:id/rar-days', () => {
   })
 
   it('renders an error when the service category call fails', async () => {
-    interventionsService.getDraftReferral.mockRejectedValue(new Error('Failed to get service category'))
+    interventionsService.getIntervention.mockRejectedValue(new Error('Failed to get intervention'))
 
     await request(app)
       .get('/referrals/1/rar-days')
       .expect(500)
       .expect(res => {
-        expect(res.text).toContain('Failed to get service category')
+        expect(res.text).toContain('Failed to get intervention')
       })
   })
 })
 
 describe('POST /referrals/:id/rar-days', () => {
   beforeEach(() => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-    const referral = draftReferralFactory.serviceCategorySelected(serviceCategory.id).build()
+    const intervention = interventionFactory.build({ contractType: { name: "Women's Service" } })
+    const referral = draftReferralFactory.build()
 
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
@@ -1177,7 +1176,7 @@ describe('POST /referrals/:id/rar-days', () => {
         })
         .expect(400)
         .expect(res => {
-          expect(res.text).toContain('Enter the maximum number of RAR days for the Accommodation service')
+          expect(res.text).toContain('What is the maximum number of RAR days for the Women&#39;s service referral')
         })
 
       expect(interventionsService.patchDraftReferral).not.toHaveBeenCalled()
@@ -1205,12 +1204,8 @@ describe('POST /referrals/:id/rar-days', () => {
 
 describe('GET /referrals/:id/check-answers', () => {
   beforeEach(() => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-    const referral = draftReferralFactory
-      .serviceCategorySelected(serviceCategory.id)
-      .build({ serviceUser: { firstName: 'Johnny', religionOrBelief: 'Agnostic' } })
+    const referral = draftReferralFactory.build({ serviceUser: { firstName: 'Johnny', religionOrBelief: 'Agnostic' } })
 
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -259,10 +259,6 @@ export default class ReferralsController {
       }
     }
 
-    if (!referral.serviceCategoryIds || !referral.serviceCategoryIds.includes(serviceCategoryId)) {
-      throw new Error('Attempting to view complexity level without service categories set on the referral')
-    }
-
     const [serviceCategory, serviceUser] = await Promise.all([
       this.interventionsService.getServiceCategory(accessToken, serviceCategoryId),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
@@ -277,16 +273,12 @@ export default class ReferralsController {
   async viewCompletionDeadline(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
 
-    if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
-      throw new Error('Attempting to view completion deadline without service category selected')
-    }
-
-    const [serviceCategory, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryIds[0]),
+    const [intervention, serviceUser] = await Promise.all([
+      this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
     ])
 
-    const presenter = new CompletionDeadlinePresenter(referral, serviceCategory)
+    const presenter = new CompletionDeadlinePresenter(referral, intervention)
 
     const view = new CompletionDeadlineView(presenter)
 
@@ -320,17 +312,12 @@ export default class ReferralsController {
         req.params.id
       )
 
-      // fixme: no longer needed - change to check intervention service type
-      if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
-        throw new Error('Attempting to view completion deadline without service category selected')
-      }
-
-      const [serviceCategory, serviceUser] = await Promise.all([
-        this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryIds[0]),
+      const [intervention, serviceUser] = await Promise.all([
+        this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
         this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
       ])
 
-      const presenter = new CompletionDeadlinePresenter(referral, serviceCategory, error, req.body)
+      const presenter = new CompletionDeadlinePresenter(referral, intervention, error, req.body)
       const view = new CompletionDeadlineView(presenter)
 
       res.status(400)
@@ -341,16 +328,12 @@ export default class ReferralsController {
   async viewFurtherInformation(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
 
-    if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
-      throw new Error('Attempting to view further information without service category selected')
-    }
-
-    const [serviceCategory, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryIds[0]),
+    const [intervention, serviceUser] = await Promise.all([
+      this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
     ])
 
-    const presenter = new FurtherInformationPresenter(referral, serviceCategory)
+    const presenter = new FurtherInformationPresenter(referral, intervention)
 
     const view = new FurtherInformationView(presenter)
 
@@ -382,16 +365,12 @@ export default class ReferralsController {
         req.params.id
       )
 
-      if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
-        throw new Error('Attempting to view complexity level without service category selected')
-      }
-
-      const [serviceCategory, serviceUser] = await Promise.all([
-        this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryIds[0]),
+      const [intervention, serviceUser] = await Promise.all([
+        this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
         this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
       ])
 
-      const presenter = new FurtherInformationPresenter(referral, serviceCategory, error, req.body)
+      const presenter = new FurtherInformationPresenter(referral, intervention, error, req.body)
       const view = new FurtherInformationView(presenter)
 
       res.status(400)
@@ -537,16 +516,12 @@ export default class ReferralsController {
   async viewRarDays(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
 
-    if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
-      throw new Error('Attempting to view RAR days without service category selected')
-    }
-
-    const [serviceCategory, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, referral.serviceCategoryIds[0]),
+    const [intervention, serviceUser] = await Promise.all([
+      this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
     ])
 
-    const presenter = new RarDaysPresenter(referral, serviceCategory)
+    const presenter = new RarDaysPresenter(referral, intervention)
     const view = new RarDaysView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)
@@ -555,16 +530,12 @@ export default class ReferralsController {
   async updateRarDays(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
 
-    if (referral.serviceCategoryIds === null || referral.serviceCategoryIds.length < 1) {
-      throw new Error('Attempting to update RAR days without service category selected')
-    }
-
-    const serviceCategory = await this.interventionsService.getServiceCategory(
+    const intervention = await this.interventionsService.getIntervention(
       res.locals.user.token.accessToken,
-      referral.serviceCategoryIds[0]
+      referral.interventionId
     )
 
-    const form = await RarDaysForm.createForm(req, serviceCategory)
+    const form = await RarDaysForm.createForm(req, intervention)
 
     let error: FormValidationError | null = null
 
@@ -586,7 +557,7 @@ export default class ReferralsController {
       res.redirect(`/referrals/${req.params.id}/further-information`)
     } else {
       const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn)
-      const presenter = new RarDaysPresenter(referral, serviceCategory, error, req.body)
+      const presenter = new RarDaysPresenter(referral, intervention, error, req.body)
       const view = new RarDaysView(presenter)
 
       res.status(400)

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -42,16 +42,20 @@ export default {
     empty: (name: string) => `Enter details of when ${name} will not be able to attend sessions`,
   },
   usingRarDays: {
-    empty: (name: string) => `Select yes if you are using RAR days for the ${utils.convertToProperCase(name)} service`,
+    empty: (referralName: string) =>
+      `Select yes if you are using RAR days for the ${utils.convertToProperCase(referralName)} referral`,
   },
   maximumRarDays: {
-    empty: (name: string) => `Enter the maximum number of RAR days for the ${utils.convertToProperCase(name)} service`,
-    notNumber: (name: string) =>
-      `The maximum number of RAR days for the ${utils.convertToProperCase(name)} service must be a number, like 5`,
-    notWholeNumber: (name: string) =>
+    empty: (referralName: string) =>
+      `Enter the maximum number of RAR days for the ${utils.convertToProperCase(referralName)} referral`,
+    notNumber: (referralName: string) =>
       `The maximum number of RAR days for the ${utils.convertToProperCase(
-        name
-      )} service must be a whole number, like 5`,
+        referralName
+      )} referral must be a number, like 5`,
+    notWholeNumber: (referralName: string) =>
+      `The maximum number of RAR days for the ${utils.convertToProperCase(
+        referralName
+      )} referral must be a whole number, like 5`,
   },
   assignReferral: {
     emailEmpty: 'An email address is required',


### PR DESCRIPTION
## What does this pull request do?

Changes some references of service category for single referral to intervention contract type

## What is the intent behind these changes?

Makes the front-end capable of displaying both single referral details and cohort referral details.

Note: I've left out actionPlan as George mentioned he's making major changes to it and prefer that I leave it for his PR. This will essentially be all the changes in SP journey.