### PR TITLE
IC-1821: Update action plan to latest designs

### DIFF
--- a/assets/sass/application-ie8.sass
+++ b/assets/sass/application-ie8.sass
@@ -4,6 +4,7 @@ $path: "/assets/images/"
 @import 'govuk/all-ie8'
 
 @import './components/header-bar'
+@import './components/inset-text'
 @import './components/form-fields'
 @import './components/review-session-form'
 @import './components/badges-tags'

--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -5,6 +5,7 @@ $path: "/assets/images/"
 @import 'moj/all'
 
 @import './components/header-bar'
+@import './components/inset-text'
 @import './components/notification-banner'
 @import './components/find-filters'
 @import './components/task-list'

--- a/assets/sass/components/_inset-text.scss
+++ b/assets/sass/components/_inset-text.scss
@@ -1,0 +1,4 @@
+.app-inset-text--grey {
+  background: govuk-colour('light-grey');
+  border-left: 10px solid govuk-colour('blue');
+}

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -358,8 +358,12 @@ describe('Service provider referrals dashboard', () => {
     cy.stubSubmitActionPlan(draftActionPlan.id, submittedActionPlan)
     cy.stubGetActionPlan(draftActionPlan.id, submittedActionPlan)
 
-    cy.contains('Review Alex’s action plan')
+    cy.contains('Confirm action plan')
     cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/review`)
+    cy.contains('Activity 1')
+    cy.contains('Attend training course')
+    cy.contains('Activity 2')
+    cy.contains('Create appointment with local authority')
     cy.contains('Submit for approval').click()
 
     cy.contains('Action plan submitted for approval')

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -288,8 +288,8 @@ describe('Service provider referrals dashboard', () => {
 
     cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
 
-    cy.contains('Accommodation - create action plan')
-    cy.contains('Add suggested activities to Alex’s action plan')
+    cy.contains('Add activity 1 to action plan')
+    cy.contains('Referred outcomes for Alex')
     cy.contains(desiredOutcomes[0].description)
     cy.contains(desiredOutcomes[1].description)
 
@@ -310,11 +310,10 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetActionPlan(draftActionPlan.id, draftActionPlanWithActivity)
     cy.stubUpdateDraftActionPlan(draftActionPlan.id, draftActionPlanWithActivity)
 
-    cy.get('#description-1').type('Attend training course')
-    cy.get('#add-activity-1').click()
+    cy.get('#description').type('Attend training course')
+    cy.contains('Save and add activity 1').click()
 
     cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
-    cy.contains('Attend training course')
 
     const draftActionPlanWithAllActivities = {
       ...draftActionPlanWithActivity,
@@ -334,14 +333,12 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetActionPlan(draftActionPlan.id, draftActionPlanWithAllActivities)
     cy.stubUpdateDraftActionPlan(draftActionPlan.id, draftActionPlanWithAllActivities)
 
-    cy.get('#description-2').type('Create appointment with local authority')
-    cy.get('#add-activity-2').click()
+    cy.get('#description').type('Create appointment with local authority')
+    cy.contains('Save and add activity 2').click()
 
     cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
-    cy.contains('Attend training course')
-    cy.contains('Create appointment with local authority')
 
-    cy.contains('Save and continue').click()
+    cy.contains('Continue without adding other activities').click()
 
     const draftActionPlanWithNumberOfSessions = { ...draftActionPlanWithAllActivities, numberOfSessions: 4 }
 

--- a/server/routes/serviceProviderReferrals/actionPlanNumberOfSessionsPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/actionPlanNumberOfSessionsPresenter.test.ts
@@ -13,7 +13,6 @@ describe(ActionPlanNumberOfSessionsPresenter, () => {
       )
 
       expect(presenter.text).toMatchObject({
-        pageNumber: 2,
         serviceCategoryName: 'Accommodation',
         serviceUserFirstName: 'Alex',
         title: 'Accommodation - create action plan',

--- a/server/routes/serviceProviderReferrals/actionPlanNumberOfSessionsPresenter.ts
+++ b/server/routes/serviceProviderReferrals/actionPlanNumberOfSessionsPresenter.ts
@@ -21,7 +21,6 @@ export default class ActionPlanNumberOfSessionsPresenter {
     numberOfSessions: {
       errorMessage: PresenterUtils.errorMessage(this.error, 'number-of-sessions'),
     },
-    pageNumber: 2,
     serviceUserFirstName: this.serviceUser.firstName,
     serviceCategoryName: utils.convertToProperCase(this.serviceCategory.name),
   }

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.test.ts
@@ -48,7 +48,7 @@ describe(AddActionPlanActivitiesForm, () => {
     })
   })
 
-  describe('errors', () => {
+  describe('error', () => {
     describe('when there is a non-empty text string for "description"', () => {
       it('returns an empty array', async () => {
         const form = await AddActionPlanActivitiesForm.createForm({
@@ -58,12 +58,12 @@ describe(AddActionPlanActivitiesForm, () => {
           },
         } as Request)
 
-        expect(form.errors).toEqual([])
+        expect(form.error).toEqual(null)
       })
     })
 
     describe('when there is an empty string for "description"', () => {
-      it('returns an array with an error for the relevant desired outcome ID', async () => {
+      it('returns an error', async () => {
         const form = await AddActionPlanActivitiesForm.createForm({
           body: {
             description: '',
@@ -71,20 +71,15 @@ describe(AddActionPlanActivitiesForm, () => {
           },
         } as Request)
 
-        expect(form.errors).toEqual([
-          {
-            desiredOutcomeId: '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
-            error: {
-              errors: [
-                {
-                  errorSummaryLinkedField: 'description',
-                  formFields: ['description'],
-                  message: 'Enter an activity',
-                },
-              ],
+        expect(form.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'description',
+              formFields: ['description'],
+              message: 'Enter an activity',
             },
-          },
-        ])
+          ],
+        })
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.ts
@@ -27,24 +27,19 @@ export default class AddActionPlanActivitiesForm {
     return this.request.body.description !== ''
   }
 
-  get errors(): { desiredOutcomeId: string; error: FormValidationError }[] {
+  get error(): FormValidationError | null {
     if (this.isValid) {
-      return []
+      return null
     }
 
-    return [
-      {
-        desiredOutcomeId: this.desiredOutcomeId,
-        error: {
-          errors: [
-            {
-              errorSummaryLinkedField: 'description',
-              formFields: ['description'],
-              message: errorMessages.actionPlanActivity.empty,
-            },
-          ],
+    return {
+      errors: [
+        {
+          errorSummaryLinkedField: 'description',
+          formFields: ['description'],
+          message: errorMessages.actionPlanActivity.empty,
         },
-      },
-    ]
+      ],
+    }
   }
 }

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
@@ -46,7 +46,34 @@ describe(AddActionPlanActivitiesPresenter, () => {
 
   describe('text', () => {
     describe('title', () => {
-      it('includes the name of the service category', () => {
+      it('specifies the number of the activity to be added', () => {
+        const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const actionPlan = actionPlanFactory.oneActivityAdded().build()
+
+        const presenter = new AddActionPlanActivitiesPresenter(
+          sentReferral,
+          [socialInclusionServiceCategory],
+          actionPlan
+        )
+
+        expect(presenter.text.title).toEqual('Add activity 2 to action plan')
+      })
+    })
+
+    describe('referredOutcomesHeader', () => {
+      it('includes the name of the service user', () => {
+        const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
+
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
+
+        expect(presenter.text.referredOutcomesHeader).toEqual('Referred outcomes for Jenny')
+      })
+    })
+  })
+
+  describe('activityNumber', () => {
+    describe('when no activities have been added', () => {
+      it('specifies the number of the activity to be added', () => {
         const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
         const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
         const presenter = new AddActionPlanActivitiesPresenter(
@@ -55,167 +82,98 @@ describe(AddActionPlanActivitiesPresenter, () => {
           actionPlan
         )
 
-        expect(presenter.text.title).toEqual('Social inclusion - create action plan')
+        expect(presenter.activityNumber).toEqual(1)
       })
     })
 
-    describe('subTitle', () => {
-      it('includes the name of the service user', () => {
-        const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
+    describe('when 1 activity has been added', () => {
+      it('specifies the number of the activity to be added', () => {
+        const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+        const actionPlan = actionPlanFactory.oneActivityAdded().build()
+        const presenter = new AddActionPlanActivitiesPresenter(
+          sentReferral,
+          [socialInclusionServiceCategory],
+          actionPlan
+        )
 
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
-
-        expect(presenter.text.subTitle).toEqual('Add suggested activities to Jenny’s action plan')
+        expect(presenter.activityNumber).toEqual(2)
       })
     })
   })
 
   describe('errorSummary', () => {
-    describe('when an empty array of errors is passed in', () => {
+    describe('when an no error is passed in', () => {
       it('returns null', () => {
         const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, [])
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
 
         expect(presenter.errorSummary).toBeNull()
       })
     })
 
-    describe('when a non-empty array of errors is passed in', () => {
-      it('returns a summary of the errors, with the correct index appended to the field ID', () => {
+    describe('when an error is passed in', () => {
+      it('returns a summary of the error', () => {
         const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
-        const errors = [
-          {
-            desiredOutcomeId: desiredOutcomes[0].id,
-            error: {
-              errors: [
-                {
-                  formFields: ['description'],
-                  errorSummaryLinkedField: 'description',
-                  message: 'Enter an activity',
-                },
-              ],
+        const errors = {
+          errors: [
+            {
+              formFields: ['description'],
+              errorSummaryLinkedField: 'description',
+              message: 'Enter an activity',
             },
-          },
-        ]
+          ],
+        }
 
         const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, errors)
 
-        expect(presenter.errorSummary).toEqual([{ field: 'description-1', message: 'Enter an activity' }])
+        expect(presenter.errorSummary).toEqual([{ field: 'description', message: 'Enter an activity' }])
       })
     })
   })
 
-  describe('desiredOutcomes', () => {
+  describe('desiredOutcomesByServiceCategory', () => {
     it('returns the desired outcomes on the Service Category that match those populated on the SentReferral', () => {
       const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build({ activities: [] })
 
       const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
 
-      expect(presenter.desiredOutcomes).toEqual([
+      expect(presenter.desiredOutcomesByServiceCategory).toEqual([
         {
-          description:
+          serviceCategory: 'Accommodation',
+          desiredOutcomes: [
             'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
-          addActivityAction: `/service-provider/action-plan/${actionPlan.id}/add-activity`,
-          id: selectedDesiredOutcomesIds[0],
-          activities: [],
-          errorMessage: null,
-        },
-        {
-          description: 'Service User makes progress in obtaining accommodation',
-          addActivityAction: `/service-provider/action-plan/${actionPlan.id}/add-activity`,
-          id: selectedDesiredOutcomesIds[1],
-          activities: [],
-          errorMessage: null,
+            'Service User makes progress in obtaining accommodation',
+          ],
         },
       ])
     })
+  })
 
-    describe('activities', () => {
-      it('adds the activities to the correct desired outcome', () => {
-        const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build({
-          activities: [
-            {
-              id: '1',
-              description: 'description 1',
-              desiredOutcome: desiredOutcomes[0],
-              createdAt: '2021-03-15T10:00:00Z',
-            },
-            {
-              id: '2',
-              description: 'description 2',
-              desiredOutcome: desiredOutcomes[0],
-              createdAt: '2021-03-15T10:00:00Z',
-            },
-            {
-              id: '3',
-              description: 'description 3',
-              desiredOutcome: desiredOutcomes[1],
-              createdAt: '2021-03-15T10:00:00Z',
-            },
-          ],
-        })
+  describe('errorMessage', () => {
+    const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
+    const errors = {
+      errors: [
+        {
+          formFields: ['description'],
+          errorSummaryLinkedField: 'description',
+          message: 'Enter an activity',
+        },
+      ],
+    }
 
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
-        expect(presenter.desiredOutcomes).toMatchObject([
-          { activities: [{ text: 'description 1' }, { text: 'description 2' }] },
-          { activities: [{ text: 'description 3' }] },
-        ])
-      })
+    describe('when an error is passed in', () => {
+      it('returns an error message', () => {
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, errors)
 
-      it('sorts an outcome’s referrals into oldest-to-newest order', () => {
-        const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build({
-          activities: [
-            {
-              id: '1',
-              description: 'description 1',
-              desiredOutcome: desiredOutcomes[0],
-              createdAt: '2021-03-15T10:05:00Z',
-            },
-            {
-              id: '2',
-              description: 'description 2',
-              desiredOutcome: desiredOutcomes[0],
-              createdAt: '2021-03-15T10:00:00Z',
-            },
-          ],
-        })
-
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
-        expect(presenter.desiredOutcomes[0]).toMatchObject({
-          activities: [{ text: 'description 2' }, { text: 'description 1' }],
-        })
+        expect(presenter.errorMessage).toEqual('Enter an activity')
       })
     })
 
-    describe('errorMessage', () => {
-      const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
-      const errors = [
-        {
-          desiredOutcomeId: desiredOutcomes[0].id,
-          error: {
-            errors: [
-              {
-                formFields: ['description'],
-                errorSummaryLinkedField: 'description',
-                message: 'Enter an activity',
-              },
-            ],
-          },
-        },
-      ]
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
 
-      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, errors)
-
-      describe('when there is an error on the description field for that desired outcome', () => {
-        it('returns that error’s message', () => {
-          expect(presenter.desiredOutcomes[0]?.errorMessage).toEqual('Enter an activity')
-        })
-      })
-
-      describe('when there is no error for that desired outcome', () => {
-        it('returns null', () => {
-          expect(presenter.desiredOutcomes[1]?.errorMessage).toBeNull()
-        })
+        expect(presenter.errorMessage).toBeNull()
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
@@ -23,20 +23,20 @@ describe(AddActionPlanActivitiesPresenter, () => {
       description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
     },
   ]
-  const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })
+  const serviceCategories = [serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })]
   const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
   const sentReferral = sentReferralFactory.assigned().build({
     referral: {
-      serviceCategoryIds: [serviceCategory.id],
+      serviceCategoryIds: [serviceCategories[0].id],
       serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
-      desiredOutcomes: [{ serviceCategoryId: serviceCategory.id, desiredOutcomesIds: selectedDesiredOutcomesIds }],
+      desiredOutcomes: [{ serviceCategoryId: serviceCategories[0].id, desiredOutcomesIds: selectedDesiredOutcomesIds }],
     },
   })
 
   describe('saveAndContinueFormAction', () => {
     it('returns a relative URL of the action plan’s add-activities page', () => {
       const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
-      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
+      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
 
       expect(presenter.saveAndContinueFormAction).toEqual(
         `/service-provider/action-plan/${actionPlan.id}/add-activities`
@@ -49,7 +49,11 @@ describe(AddActionPlanActivitiesPresenter, () => {
       it('includes the name of the service category', () => {
         const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
         const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, socialInclusionServiceCategory, actionPlan)
+        const presenter = new AddActionPlanActivitiesPresenter(
+          sentReferral,
+          [socialInclusionServiceCategory],
+          actionPlan
+        )
 
         expect(presenter.text.title).toEqual('Social inclusion - create action plan')
       })
@@ -59,7 +63,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
       it('includes the name of the service user', () => {
         const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
 
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
 
         expect(presenter.text.subTitle).toEqual('Add suggested activities to Jenny’s action plan')
       })
@@ -70,7 +74,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
     describe('when an empty array of errors is passed in', () => {
       it('returns null', () => {
         const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan, [])
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, [])
 
         expect(presenter.errorSummary).toBeNull()
       })
@@ -94,7 +98,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
           },
         ]
 
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan, errors)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, errors)
 
         expect(presenter.errorSummary).toEqual([{ field: 'description-1', message: 'Enter an activity' }])
       })
@@ -105,7 +109,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
     it('returns the desired outcomes on the Service Category that match those populated on the SentReferral', () => {
       const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build({ activities: [] })
 
-      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
+      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
 
       expect(presenter.desiredOutcomes).toEqual([
         {
@@ -151,7 +155,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
           ],
         })
 
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
         expect(presenter.desiredOutcomes).toMatchObject([
           { activities: [{ text: 'description 1' }, { text: 'description 2' }] },
           { activities: [{ text: 'description 3' }] },
@@ -176,7 +180,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
           ],
         })
 
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
         expect(presenter.desiredOutcomes[0]).toMatchObject({
           activities: [{ text: 'description 2' }, { text: 'description 1' }],
         })
@@ -200,7 +204,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
         },
       ]
 
-      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan, errors)
+      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, errors)
 
       describe('when there is an error on the description field for that desired outcome', () => {
         it('returns that error’s message', () => {

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -32,7 +32,6 @@ export default class AddActionPlanActivitiesPresenter {
 
   readonly text = {
     title: `Add activity ${this.activityNumber} to action plan`,
-    pageNumber: 1,
     referredOutcomesHeader: `Referred outcomes for ${this.sentReferral.referral.serviceUser.firstName}`,
   }
 

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -9,7 +9,7 @@ import PresenterUtils from '../../utils/presenterUtils'
 export default class AddActionPlanActivitiesPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
-    private readonly serviceCategory: ServiceCategory,
+    private readonly serviceCategories: ServiceCategory[],
     private readonly actionPlan: ActionPlan,
     private readonly errors: { desiredOutcomeId: string; error: FormValidationError }[] = []
   ) {}
@@ -41,13 +41,13 @@ export default class AddActionPlanActivitiesPresenter {
   })()
 
   readonly text = {
-    title: `${utils.convertToProperCase(this.serviceCategory.name)} - create action plan`,
+    title: `${utils.convertToProperCase(this.serviceCategories[0].name)} - create action plan`,
     pageNumber: 1,
     subTitle: `Add suggested activities to ${this.sentReferral.referral.serviceUser.firstName}’s action plan`,
   }
 
   readonly desiredOutcomes = this.desiredOutcomesIds.map(id => {
-    const desiredOutcome = this.serviceCategory.desiredOutcomes.find(outcome => id === outcome.id)
+    const desiredOutcome = this.serviceCategories[0].desiredOutcomes.find(outcome => id === outcome.id)
 
     if (!desiredOutcome) {
       return null

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -1,75 +1,49 @@
-import ActionPlan, { Activity } from '../../models/actionPlan'
-import DesiredOutcome from '../../models/desiredOutcome'
+import ActionPlan from '../../models/actionPlan'
 import SentReferral from '../../models/sentReferral'
 import ServiceCategory from '../../models/serviceCategory'
 import { FormValidationError } from '../../utils/formValidationError'
-import utils from '../../utils/utils'
 import PresenterUtils from '../../utils/presenterUtils'
+import utils from '../../utils/utils'
 
 export default class AddActionPlanActivitiesPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly serviceCategories: ServiceCategory[],
     private readonly actionPlan: ActionPlan,
-    private readonly errors: { desiredOutcomeId: string; error: FormValidationError }[] = []
+    private readonly errors: FormValidationError | null = null
   ) {}
 
   readonly saveAndContinueFormAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activities`
+
+  readonly addActivityAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activity`
+
+  readonly activityNumber = this.actionPlan.activities.length + 1
 
   private readonly desiredOutcomesIds = this.sentReferral.referral.desiredOutcomes.flatMap(
     desiredOutcome => desiredOutcome.desiredOutcomesIds
   )
 
-  readonly errorSummary = (() => {
-    const errorSummary = this.errors.reduce((accumIndexedSummary, error) => {
-      const unindexedSummary = PresenterUtils.errorSummary(error.error)
-      if (unindexedSummary === null) {
-        return accumIndexedSummary
-      }
+  readonly errorMessage = PresenterUtils.errorMessage(this.errors, 'description')
 
-      const index = this.desiredOutcomesIds.indexOf(error.desiredOutcomeId)
-      const indexedSummary = unindexedSummary.map(item => ({ ...item, field: `${item.field}-${index + 1}` }))
+  readonly errorSummary = PresenterUtils.errorSummary(this.errors)
 
-      return [...accumIndexedSummary, ...indexedSummary]
-    }, new Array<{ field: string; message: string }>())
-
-    if (errorSummary.length === 0) {
-      return null
-    }
-
-    return errorSummary
-  })()
+  // Temporary fix until we update the contracts to stop storing activities against a specific outcome - this will be removed in future
+  readonly firstDesiredOutcomeId = this.desiredOutcomesIds[0]
 
   readonly text = {
-    title: `${utils.convertToProperCase(this.serviceCategories[0].name)} - create action plan`,
+    title: `Add activity ${this.activityNumber} to action plan`,
     pageNumber: 1,
-    subTitle: `Add suggested activities to ${this.sentReferral.referral.serviceUser.firstName}’s action plan`,
+    referredOutcomesHeader: `Referred outcomes for ${this.sentReferral.referral.serviceUser.firstName}`,
   }
 
-  readonly desiredOutcomes = this.desiredOutcomesIds.map(id => {
-    const desiredOutcome = this.serviceCategories[0].desiredOutcomes.find(outcome => id === outcome.id)
-
-    if (!desiredOutcome) {
-      return null
-    }
+  readonly desiredOutcomesByServiceCategory = this.serviceCategories.map(serviceCategory => {
+    const desiredOutcomesForServiceCategory = serviceCategory.desiredOutcomes.filter(desiredOutcome =>
+      this.desiredOutcomesIds.includes(desiredOutcome.id)
+    )
 
     return {
-      description: desiredOutcome.description,
-      id: desiredOutcome.id,
-      addActivityAction: `/service-provider/action-plan/${this.actionPlan.id}/add-activity`,
-      activities: this.orderedActivitiesForOutcome(desiredOutcome).map(activity => ({ text: activity.description })),
-      errorMessage: this.errorMessageForOutcome(desiredOutcome),
+      serviceCategory: utils.convertToProperCase(serviceCategory.name),
+      desiredOutcomes: desiredOutcomesForServiceCategory.map(desiredOutcome => desiredOutcome.description),
     }
   })
-
-  private errorMessageForOutcome(desiredOutcome: DesiredOutcome): string | null {
-    const error = this.errors.find(anError => anError.desiredOutcomeId === desiredOutcome.id)?.error ?? null
-    return PresenterUtils.errorMessage(error, 'description')
-  }
-
-  private orderedActivitiesForOutcome(outcome: DesiredOutcome): Activity[] {
-    return this.actionPlan.activities
-      .filter(activity => activity.desiredOutcome.id === outcome.id)
-      .sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1))
-  }
 }

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesView.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesView.ts
@@ -1,4 +1,3 @@
-import { TextareaArgs } from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
 import AddActionPlanActivitiesPresenter from './addActionPlanActivitiesPresenter'
 
@@ -18,21 +17,15 @@ export default class AddActionPlanActivitiesView {
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
-  private addActivityTextareaArgs: (index: number) => TextareaArgs = (index: number) => {
-    const desiredOutcome = this.presenter.desiredOutcomes[index]!
-
-    return {
-      name: 'description',
-      id: `description-${index + 1}`,
-      label: {
-        html: `<h4 class="govuk-heading-s">${ViewUtils.escape(
-          `Activity ${desiredOutcome.activities.length + 1}`
-        )}</h4>`,
-      },
-      hint: {
-        text: 'What activity will you deliver to achieve this outcome?',
-      },
-      errorMessage: ViewUtils.govukErrorMessage(desiredOutcome.errorMessage),
-    }
+  private readonly addActivityTextareaArgs = {
+    name: 'description',
+    id: 'description',
+    label: {
+      html: `<h2 class="govuk-heading-m">${ViewUtils.escape(`Activity ${this.presenter.activityNumber}`)}</h2>`,
+    },
+    hint: {
+      text: 'Please write the details of the activity here.',
+    },
+    errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
   }
 }

--- a/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.test.ts
+++ b/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.test.ts
@@ -1,79 +1,47 @@
 import FinaliseActionPlanActivitiesForm from './finaliseActionPlanActivitiesForm'
-import sentReferralFactory from '../../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
 
 describe(FinaliseActionPlanActivitiesForm, () => {
-  describe('errors', () => {
-    const desiredOutcomes = [
-      {
-        id: '1',
-        description: 'Description 1',
-      },
-      {
-        id: '2',
-        description: 'Description 2',
-      },
-      {
-        id: '3',
-        description: 'Description 3',
-      },
-    ]
-    const serviceCategory = serviceCategoryFactory.build({ desiredOutcomes })
-    const referral = sentReferralFactory.build({
-      referral: {
-        serviceCategoryIds: [serviceCategory.id],
-        desiredOutcomes: [
-          { serviceCategoryId: serviceCategory.id, desiredOutcomesIds: [desiredOutcomes[0].id, desiredOutcomes[1].id] },
-        ],
-      },
+  describe('isValid', () => {
+    it('returns true when there is at least one activity in the action plan', () => {
+      const actionPlan = actionPlanFactory.oneActivityAdded().build()
+      const form = new FinaliseActionPlanActivitiesForm(actionPlan)
+
+      expect(form.isValid).toEqual(true)
     })
 
-    describe('when there is an activity in the action plan for every desired outcome of the referral', () => {
-      it('returns an empty array', () => {
-        const actionPlan = actionPlanFactory.build({
-          activities: [
-            { id: '1', desiredOutcome: desiredOutcomes[0], createdAt: new Date().toISOString(), description: '' },
-            { id: '2', desiredOutcome: desiredOutcomes[1], createdAt: new Date().toISOString(), description: '' },
-          ],
-        })
-        const form = new FinaliseActionPlanActivitiesForm(referral, actionPlan, serviceCategory)
+    it('returns false when there are no activities in the action plan', () => {
+      const actionPlan = actionPlanFactory.build()
+      const form = new FinaliseActionPlanActivitiesForm(actionPlan)
 
-        expect(form.errors).toEqual([])
+      expect(form.isValid).toEqual(false)
+    })
+  })
+
+  describe('error', () => {
+    describe('when there is at least one activity in the action plan', () => {
+      it('returns an empty array', () => {
+        const actionPlan = actionPlanFactory.oneActivityAdded().build()
+        const form = new FinaliseActionPlanActivitiesForm(actionPlan)
+
+        expect(form.error).toEqual(null)
       })
     })
 
-    describe('when there is a desired outcome in the referral for which there is no activity in the action plan', () => {
-      it('returns an error for each outcome without an activity', () => {
+    describe('when there is no activity in the action plan', () => {
+      it('returns an error', () => {
         const actionPlan = actionPlanFactory.build({ activities: [] })
-        const form = new FinaliseActionPlanActivitiesForm(referral, actionPlan, serviceCategory)
+        const form = new FinaliseActionPlanActivitiesForm(actionPlan)
 
-        expect(form.errors).toEqual([
-          {
-            desiredOutcomeId: '1',
-            error: {
-              errors: [
-                {
-                  errorSummaryLinkedField: 'description',
-                  formFields: ['description'],
-                  message: 'You must add at least one activity for the desired outcome “Description 1”',
-                },
-              ],
+        expect(form.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'description',
+              formFields: ['description'],
+              message: 'You must add at least one activity',
             },
-          },
-          {
-            desiredOutcomeId: '2',
-            error: {
-              errors: [
-                {
-                  errorSummaryLinkedField: 'description',
-                  formFields: ['description'],
-                  message: 'You must add at least one activity for the desired outcome “Description 2”',
-                },
-              ],
-            },
-          },
-        ])
+          ],
+        })
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.ts
+++ b/server/routes/serviceProviderReferrals/finaliseActionPlanActivitiesForm.ts
@@ -1,43 +1,27 @@
 import ActionPlan from '../../models/actionPlan'
-import SentReferral from '../../models/sentReferral'
-import ServiceCategory from '../../models/serviceCategory'
 import { FormValidationError } from '../../utils/formValidationError'
 import errorMessages from '../../utils/errorMessages'
 
 export default class FinaliseActionPlanActivitiesForm {
-  constructor(
-    private readonly referral: SentReferral,
-    private readonly actionPlan: ActionPlan,
-    private readonly serviceCategory: ServiceCategory
-  ) {}
+  constructor(private readonly actionPlan: ActionPlan) {}
 
   get isValid(): boolean {
-    return this.errors.length === 0
+    return this.actionPlan.activities.length > 0
   }
 
-  get errors(): { desiredOutcomeId: string; error: FormValidationError }[] {
-    const desiredOutcomeIdsWithoutActivities = this.referral.referral.desiredOutcomes
-      .flatMap(desiredOutcome => desiredOutcome.desiredOutcomesIds)
-      .filter(
-        desiredOutcomeId =>
-          !this.actionPlan.activities.some(activity => activity.desiredOutcome.id === desiredOutcomeId)
-      )
+  get error(): FormValidationError | null {
+    if (this.isValid) {
+      return null
+    }
 
-    return desiredOutcomeIdsWithoutActivities.map(desiredOutcomeId => {
-      const desiredOutcome = this.serviceCategory.desiredOutcomes.find(outcome => desiredOutcomeId === outcome.id)
-
-      return {
-        desiredOutcomeId,
-        error: {
-          errors: [
-            {
-              formFields: ['description'],
-              message: errorMessages.actionPlanActivity.noneAdded(desiredOutcome?.description ?? ''),
-              errorSummaryLinkedField: 'description',
-            },
-          ],
+    return {
+      errors: [
+        {
+          formFields: ['description'],
+          message: errorMessages.actionPlanActivity.noneAdded,
+          errorSummaryLinkedField: 'description',
         },
-      }
-    })
+      ],
+    }
   }
 }

--- a/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.ts
+++ b/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.ts
@@ -19,7 +19,6 @@ export default class ReviewActionPlanPresenter {
   readonly text = {
     title: 'Confirm action plan',
     numberOfSessions: this.actionPlan.numberOfSessions?.toString() ?? '',
-    pageNumber: 3,
   }
 
   readonly desiredOutcomesByServiceCategory = this.serviceCategories.map(serviceCategory => {

--- a/server/routes/serviceProviderReferrals/reviewActionPlanView.ts
+++ b/server/routes/serviceProviderReferrals/reviewActionPlanView.ts
@@ -1,3 +1,4 @@
+import { InsetTextArgs } from '../../utils/govukFrontendTypes'
 import ReviewActionPlanPresenter from './reviewActionPlanPresenter'
 
 export default class ReviewActionPlanView {
@@ -8,7 +9,15 @@ export default class ReviewActionPlanView {
       'serviceProviderReferrals/reviewActionPlan',
       {
         presenter: this.presenter,
+        insetTextArgs: this.insetTextArgs,
       },
     ]
+  }
+
+  insetTextArgs(index: number, description: string): InsetTextArgs {
+    return {
+      html: `<h3 class="govuk-heading-m govuk-!-font-weight-bold">Activity ${index}</h3><p class="govuk-body">${description}</p>`,
+      classes: 'app-inset-text--grey',
+    }
   }
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -294,10 +294,10 @@ describe('GET /service-provider/action-plan/:actionPlanId/add-activities', () =>
       .get(`/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Accommodation - create action plan')
-        expect(res.text).toContain('Add suggested activities to Alex’s action plan')
+        expect(res.text).toContain('Add activity 2 to action plan')
+        expect(res.text).toContain('Referred outcomes for Alex')
+        expect(res.text).toContain('Accommodation')
         expect(res.text).toContain('Achieve a thing')
-        expect(res.text).toContain('Do a thing')
       })
   })
 })
@@ -404,7 +404,7 @@ describe('POST /service-provider/action-plan/:id/add-activities', () => {
     },
   })
 
-  describe('when there is an activity in the action plan for every desired outcome of the referral', () => {
+  describe('when there is at least one activity in the action plan', () => {
     it('redirects to the next page of the action plan journey', async () => {
       const actionPlan = actionPlanFactory.build({
         activities: [
@@ -424,7 +424,7 @@ describe('POST /service-provider/action-plan/:id/add-activities', () => {
     })
   })
 
-  describe('when there is a desired outcome in the referral for which there is no activity in the action plan', () => {
+  describe('when there is no activity in the action plan', () => {
     it('responds with a 400 and renders an error', async () => {
       const actionPlan = actionPlanFactory.build({ activities: [] })
 
@@ -436,8 +436,7 @@ describe('POST /service-provider/action-plan/:id/add-activities', () => {
         .post(`/service-provider/action-plan/${actionPlan.id}/add-activities`)
         .expect(400)
         .expect(res => {
-          expect(res.text).toContain('You must add at least one activity for the desired outcome “Description 1”')
-          expect(res.text).toContain('You must add at least one activity for the desired outcome “Description 2”')
+          expect(res.text).toContain('You must add at least one activity')
         })
     })
   })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -538,8 +538,10 @@ describe('GET /service-provider/action-plan/:actionPlanId/review', () => {
       .get(`/service-provider/action-plan/${draftActionPlan.id}/review`)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Review Alex’s action plan')
+        expect(res.text).toContain('Confirm action plan')
+        expect(res.text).toContain('Accommodation')
         expect(res.text).toContain('Achieve a thing')
+        expect(res.text).toContain('Activity 1')
         expect(res.text).toContain('Do a thing')
         expect(res.text).toContain('Suggested number of sessions: 10')
       })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -267,14 +267,16 @@ describe('GET /service-provider/referrals/:id/assignment/confirmation', () => {
 describe('GET /service-provider/action-plan/:actionPlanId/add-activities', () => {
   it('displays a page to add activities to an action plan', async () => {
     const desiredOutcome = { id: '1', description: 'Achieve a thing' }
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes: [desiredOutcome] })
+    const serviceCategories = [
+      serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes: [desiredOutcome] }),
+    ]
     const referral = sentReferralFactory.assigned().build({
       referral: {
-        serviceCategoryIds: [serviceCategory.id],
+        serviceCategoryIds: [serviceCategories[0].id],
         serviceUser: { firstName: 'Alex', lastName: 'River' },
         desiredOutcomes: [
           {
-            serviceCategoryId: serviceCategory.id,
+            serviceCategoryId: serviceCategories[0].id,
             desiredOutcomesIds: [desiredOutcome.id],
           },
         ],
@@ -286,7 +288,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/add-activities', () =>
 
     interventionsService.getActionPlan.mockResolvedValue(draftActionPlan)
     interventionsService.getSentReferral.mockResolvedValue(referral)
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategories[0])
 
     await request(app)
       .get(`/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
@@ -302,10 +304,10 @@ describe('GET /service-provider/action-plan/:actionPlanId/add-activities', () =>
 
 describe('POST /service-provider/action-plan/:id/add-activity', () => {
   it('updates the action plan with the specified activity and renders the add activity form again', async () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const serviceCategories = [serviceCategoryFactory.build({ name: 'accommodation' })]
     const referral = sentReferralFactory.assigned().build({
       referral: {
-        serviceCategoryIds: [serviceCategory.id],
+        serviceCategoryIds: [serviceCategories[0].id],
         serviceUser: { firstName: 'Alex', lastName: 'River' },
       },
     })
@@ -313,7 +315,7 @@ describe('POST /service-provider/action-plan/:id/add-activity', () => {
 
     interventionsService.getActionPlan.mockResolvedValue(draftActionPlan)
     interventionsService.getSentReferral.mockResolvedValue(referral)
-    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategories[0])
 
     await request(app)
       .post(`/service-provider/action-plan/${draftActionPlan.id}/add-activity`)
@@ -336,14 +338,16 @@ describe('POST /service-provider/action-plan/:id/add-activity', () => {
   describe('when the user enters no description', () => {
     it('does not update the action plan on the backend and returns a 400 with an error message', async () => {
       const desiredOutcome = { id: '8eb52caf-b462-4100-a0e9-7022d2551c92', description: 'Achieve a thing' }
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes: [desiredOutcome] })
+      const serviceCategories = [
+        serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes: [desiredOutcome] }),
+      ]
       const referral = sentReferralFactory.assigned().build({
         referral: {
-          serviceCategoryIds: [serviceCategory.id],
+          serviceCategoryIds: [serviceCategories[0].id],
           serviceUser: { firstName: 'Alex', lastName: 'River' },
           desiredOutcomes: [
             {
-              serviceCategoryId: serviceCategory.id,
+              serviceCategoryId: serviceCategories[0].id,
               desiredOutcomesIds: [desiredOutcome.id],
             },
           ],
@@ -353,7 +357,7 @@ describe('POST /service-provider/action-plan/:id/add-activity', () => {
 
       interventionsService.getActionPlan.mockResolvedValue(draftActionPlan)
       interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+      interventionsService.getServiceCategory.mockResolvedValue(serviceCategories[0])
 
       await request(app)
         .post(`/service-provider/action-plan/${draftActionPlan.id}/add-activity`)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -291,7 +291,7 @@ export default class ServiceProviderReferralsController {
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
 
-    const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, form.errors)
+    const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, form.error)
     const view = new AddActionPlanActivitiesView(presenter)
 
     res.status(400)
@@ -311,12 +311,12 @@ export default class ServiceProviderReferralsController {
       )
     )
 
-    const form = new FinaliseActionPlanActivitiesForm(sentReferral, actionPlan, serviceCategories[0])
+    const form = new FinaliseActionPlanActivitiesForm(actionPlan)
 
     if (form.isValid) {
       res.redirect(`/service-provider/action-plan/${actionPlan.id}/number-of-sessions`)
     } else {
-      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, form.errors)
+      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, form.error)
       const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
       const view = new AddActionPlanActivitiesView(presenter)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -332,15 +332,16 @@ export default class ServiceProviderReferralsController {
       actionPlan.referralId
     )
 
-    const [serviceCategory, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(
-        res.locals.user.token.accessToken,
-        sentReferral.referral.serviceCategoryIds[0]
+    const [serviceCategories, serviceUser] = await Promise.all([
+      Promise.all(
+        sentReferral.referral.serviceCategoryIds.map(id =>
+          this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
+        )
       ),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
 
-    const presenter = new ReviewActionPlanPresenter(sentReferral, serviceCategory, actionPlan)
+    const presenter = new ReviewActionPlanPresenter(sentReferral, serviceCategories, actionPlan)
     const view = new ReviewActionPlanView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -247,15 +247,16 @@ export default class ServiceProviderReferralsController {
       actionPlan.referralId
     )
 
-    const [serviceCategory, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(
-        res.locals.user.token.accessToken,
-        sentReferral.referral.serviceCategoryIds[0]
+    const [serviceCategories, serviceUser] = await Promise.all([
+      Promise.all(
+        sentReferral.referral.serviceCategoryIds.map(id =>
+          this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
+        )
       ),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
 
-    const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan)
+    const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
     const view = new AddActionPlanActivitiesView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)
@@ -281,15 +282,16 @@ export default class ServiceProviderReferralsController {
       actionPlan.referralId
     )
 
-    const [serviceCategory, serviceUser] = await Promise.all([
-      this.interventionsService.getServiceCategory(
-        res.locals.user.token.accessToken,
-        sentReferral.referral.serviceCategoryIds[0]
+    const [serviceCategories, serviceUser] = await Promise.all([
+      Promise.all(
+        sentReferral.referral.serviceCategoryIds.map(id =>
+          this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
+        )
       ),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
 
-    const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan, form.errors)
+    const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, form.errors)
     const view = new AddActionPlanActivitiesView(presenter)
 
     res.status(400)
@@ -303,17 +305,18 @@ export default class ServiceProviderReferralsController {
       actionPlan.referralId
     )
 
-    const serviceCategory = await this.interventionsService.getServiceCategory(
-      res.locals.user.token.accessToken,
-      sentReferral.referral.serviceCategoryIds[0]
+    const serviceCategories = await Promise.all(
+      sentReferral.referral.serviceCategoryIds.map(id =>
+        this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
+      )
     )
 
-    const form = new FinaliseActionPlanActivitiesForm(sentReferral, actionPlan, serviceCategory)
+    const form = new FinaliseActionPlanActivitiesForm(sentReferral, actionPlan, serviceCategories[0])
 
     if (form.isValid) {
       res.redirect(`/service-provider/action-plan/${actionPlan.id}/number-of-sessions`)
     } else {
-      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategory, actionPlan, form.errors)
+      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, form.errors)
       const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
       const view = new AddActionPlanActivitiesView(presenter)
 

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -64,8 +64,7 @@ export default {
   },
   actionPlanActivity: {
     empty: 'Enter an activity',
-    noneAdded: (desiredOutcomeDescription: string) =>
-      `You must add at least one activity for the desired outcome “${desiredOutcomeDescription}”`,
+    noneAdded: 'You must add at least one activity',
   },
   actionPlanNumberOfSessions: {
     empty: 'Enter the number of sessions',

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
@@ -17,10 +17,6 @@
         <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
       {% endif %}
 
-      {% if presenter.text.pageNumber %}
-        <p class="govuk-hint">Page {{ presenter.text.pageNumber }} of 3</p>
-      {% endif %}
-
       {% block formSection %}{% endblock %}
     </div>
   </div>

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -6,34 +6,28 @@
 {% block formSection %}
   <p class="govuk-body-m">This will be shared with the service user's probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
 
-  {% for desiredOutcome in presenter.desiredOutcomes %}
-    <form method="post" action="{{ desiredOutcome.addActivityAction }}">
-      <input type="hidden" name="_csrf" value="{{csrfToken}}">
-      <input type="hidden" name="desired-outcome-id" value="{{ desiredOutcome.id }}">
+  <h2 class="govuk-heading-m">{{ presenter.text.referredOutcomesHeader }}</h2>
 
-      <h3 class="govuk-heading-m">
-        Desired outcome {{ loop.index }}
-      </h3>
-
-      <p class="govuk-body">
-      {{ desiredOutcome.description }}
-      </p>
-
-      {% for activity in desiredOutcome.activities %}
-        <h4 class="govuk-heading-s">
-          Activity {{ loop.index }}
-        </h4>
-        <p class="govuk-body">{{ activity.text }}</p>
+  {% for serviceCategoryWithDesiredOutcomes in presenter.desiredOutcomesByServiceCategory %}
+    <h3 class="govuk-heading-s">{{ serviceCategoryWithDesiredOutcomes.serviceCategory }}</h3>
+    <ul class="govuk-list govuk-list--bullet">
+      {% for desiredOutcome in serviceCategoryWithDesiredOutcomes.desiredOutcomes %}
+        <li>{{ desiredOutcome }}</li>
       {% endfor %}
-
-      {{ govukTextarea(addActivityTextareaArgs(loop.index0)) }}
-
-      {{ govukButton({ text: "Add activity", classes: "govuk-button--secondary", attributes: { id: 'add-activity-' + loop.index } }) }}
-    </form>
+    </ul>
   {% endfor %}
+
+  <form method="post" action="{{ presenter.addActivityAction }}">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+    <input type="hidden" name="desired-outcome-id" value="{{ presenter.firstDesiredOutcomeId }}">
+
+    {{ govukTextarea(addActivityTextareaArgs) }}
+
+    {{ govukButton({ text: ('Save and add activity ' + presenter.activityNumber), classes: "govuk-button--secondary", attributes: { id: 'add-activity' } }) }}
+  </form>
 
   <form method="post" action="{{ presenter.saveAndContinueFormAction }}">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    {{ govukButton({ text: "Save and continue" }) }}
+    {{ govukButton({ text: "Continue without adding other activities" }) }}
   </form>
 {% endblock %}

--- a/server/views/serviceProviderReferrals/reviewActionPlan.njk
+++ b/server/views/serviceProviderReferrals/reviewActionPlan.njk
@@ -1,39 +1,38 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% extends "./actionPlan/actionPlanFormTemplate.njk" %}
 
 {% block formSection %}
-  <p class="govuk-body-m">Review the action plan before submitting it to the service user’s probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
+  <h2 class="govuk-heading-l">
+    Desired outcomes and activities
+  </h2>
 
-  <h3 class="govuk-heading-m">
-    Outcomes and activities
-  </h3>
-
-  {% for desiredOutcome in presenter.desiredOutcomes %}
-      <h4 class="govuk-heading-s">
-        Desired outcome {{ loop.index }}
-      </h4>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ desiredOutcome.description }}</li>
-      </ul>
-
-      {% for activity in desiredOutcome.activities %}
-        <h5 class="govuk-body govuk-!-font-weight-bold">
-          Activity {{ loop.index }}
-        </h5>
-        <p class="govuk-body">{{ activity.text }}</p>
+  {% for serviceCategoryWithDesiredOutcomes in presenter.desiredOutcomesByServiceCategory %}
+    <h3 class="govuk-heading-m">{{ serviceCategoryWithDesiredOutcomes.serviceCategory }}</h3>
+    <ul class="govuk-list govuk-list--bullet">
+      {% for desiredOutcome in serviceCategoryWithDesiredOutcomes.desiredOutcomes %}
+        <li>{{ desiredOutcome }}</li>
       {% endfor %}
+    </ul>
   {% endfor %}
 
-  <h3 class="govuk-heading-m">
+  {% for description in presenter.orderedActivities %}
+    {{ govukInsetText(insetTextArgs(loop.index, description)) }}
+  {% endfor %}
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+  <h2 class="govuk-heading-l">
     Suggested number of sessions for the action plan
-  </h3>
+  </h2>
 
   <p class="govuk-body">
-  Suggested number of sessions: {{ presenter.text.numberOfSessions }}
+    Suggested number of sessions: {{ presenter.text.numberOfSessions }}
   </p>
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
   <form method="post" action="{{ presenter.submitFormAction }}">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">

--- a/testutils/factories/actionPlan.ts
+++ b/testutils/factories/actionPlan.ts
@@ -1,5 +1,6 @@
 import { Factory } from 'fishery'
 import ActionPlan from '../../server/models/actionPlan'
+import actionPlanActivityFactory from './actionPlanActivity'
 
 class ActionPlanFactory extends Factory<ActionPlan> {
   notSubmitted() {
@@ -18,27 +19,7 @@ class ActionPlanFactory extends Factory<ActionPlan> {
     return this.params({
       referralId,
       numberOfSessions: 4,
-      activities: [
-        {
-          id: '91e7ceab-74fd-45d8-97c8-ec58844618dd',
-          description: 'Attend training course',
-          desiredOutcome: {
-            id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
-            description:
-              'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
-          },
-          createdAt: '2020-12-07T20:45:21.986389Z',
-        },
-        {
-          id: 'e5755c27-2c85-448b-9f6d-e3959ec9c2d0',
-          description: 'Attend session',
-          desiredOutcome: {
-            id: '65924ac6-9724-455b-ad30-906936291421',
-            description: 'Service User makes progress in obtaining accommodation.',
-          },
-          createdAt: '2020-12-07T20:47:21.986389Z',
-        },
-      ],
+      activities: actionPlanActivityFactory.buildList(2),
     })
   }
 }

--- a/testutils/factories/actionPlan.ts
+++ b/testutils/factories/actionPlan.ts
@@ -15,6 +15,12 @@ class ActionPlanFactory extends Factory<ActionPlan> {
     return this.params({ referralId })
   }
 
+  oneActivityAdded() {
+    return this.params({
+      activities: [actionPlanActivityFactory.build()],
+    })
+  }
+
   readyToSubmit(referralId: string) {
     return this.params({
       referralId,

--- a/testutils/factories/actionPlanActivity.ts
+++ b/testutils/factories/actionPlanActivity.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'fishery'
+import { Activity } from '../../server/models/actionPlan'
+
+export default Factory.define<Activity>(({ sequence }) => ({
+  id: sequence.toString(),
+  description: 'Attend training course',
+  desiredOutcome: {
+    id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+    description:
+      'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+  },
+  createdAt: '2020-12-07T20:45:21.986389Z',
+}))


### PR DESCRIPTION
## What does this pull request do?

Updates Action Plan "Add activity" and "Review" pages to match the latest designs. Activities are no longer linked to a specific desired outcome, so we'll want to update the API to reflect these changes (to come in a future PR).

The journey should also work with cohort referrals, but we should test this on dev with realistic data.

This also removes page numbers from the action plan journey, as they're not in the designs.

As mentioned above, this doesn't touch the contract tests, but we'll want to update the `updateDraftActionPlan` function to not link an Activity to desired outcomes once this is merged.

## What is the intent behind these changes?

To make the action plan journey work for both cohort and non-cohort referrals.

## Screenshots

### Add activity page

<img width="759" alt="image" src="https://user-images.githubusercontent.com/19826940/120515907-b60a4780-c3c6-11eb-95aa-f5a9a266cb55.png">

### Review action plan page

<img width="756" alt="image" src="https://user-images.githubusercontent.com/19826940/120515981-cae6db00-c3c6-11eb-9a76-38ec85c4f7db.png">

