### PR TITLE
IC-1696, IC-1784, IC-1822: Finish the make a referral check your answers page

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -102,7 +102,7 @@ describe('Referral form', () => {
 
       const sentReferral = sentReferralFactory.fromFields(completedDraftReferral).build()
 
-      const intervention = interventionFactory.build()
+      const intervention = interventionFactory.build({ serviceCategories: [accommodationServiceCategory] })
 
       cy.stubGetServiceUserByCRN('X123456', deliusServiceUser)
       cy.stubCreateDraftReferral(draftReferral)
@@ -622,6 +622,9 @@ describe('Referral form', () => {
 
       cy.get('a').contains('Check your answers').click()
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/check-answers`)
+
+      cy.contains('Accommodation')
+      cy.contains('Social inclusion')
 
       cy.contains('Submit referral').click()
       cy.location('pathname').should('equal', `/referrals/${sentReferral.id}/confirmation`)

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -98,6 +98,7 @@ describe('Referral form', () => {
           serviceProvider: {
             name: 'Harmony Living',
           },
+          furtherInformation: 'Some information about Alex',
         })
 
       const sentReferral = sentReferralFactory.fromFields(completedDraftReferral).build()

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -315,6 +315,8 @@ describe('Referral form', () => {
       cy.contains('Service User makes progress in obtaining accommodation')
       cy.contains('Service User is prevented from becoming homeless')
 
+      cy.contains('24 August 2021')
+
       cy.contains('Submit referral').click()
       cy.location('pathname').should('equal', `/referrals/${sentReferral.id}/confirmation`)
 

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -317,6 +317,9 @@ describe('Referral form', () => {
 
       cy.contains('24 August 2021')
 
+      cy.contains('Yes')
+      cy.contains('10')
+
       cy.contains('Submit referral').click()
       cy.location('pathname').should('equal', `/referrals/${sentReferral.id}/confirmation`)
 

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -114,6 +114,7 @@ describe('Referral form', () => {
       cy.stubSendDraftReferral(draftReferral.id, sentReferral)
       cy.stubGetSentReferral(sentReferral.id, sentReferral)
       cy.stubGetActiveConvictionsByCRN('X123456', convictions)
+      cy.stubGetConvictionById('X123456', 123456789, convictions[0])
       cy.stubGetIntervention(draftReferral.interventionId, intervention)
       cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
       cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
@@ -304,6 +305,10 @@ describe('Referral form', () => {
       cy.contains('Yes. Spanish')
       cy.contains('Yes. She works Mondays 9am - midday')
 
+      cy.contains('Burglary')
+      cy.contains('Theft act, 1968')
+      cy.contains('15 November 2025')
+
       cy.contains('Accommodation referral details')
       cy.contains('Low complexity')
       cy.contains('Info about low complexity')
@@ -407,6 +412,7 @@ describe('Referral form', () => {
       cy.stubSendDraftReferral(draftReferral.id, sentReferral)
       cy.stubGetSentReferral(sentReferral.id, sentReferral)
       cy.stubGetActiveConvictionsByCRN('X123456', convictions)
+      cy.stubGetConvictionById('X123456', 123456789, convictions[0])
       cy.stubGetIntervention(draftReferral.interventionId, intervention)
       cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
       cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -45,6 +45,10 @@ module.exports = on => {
       return communityApi.stubGetActiveConvictionsByCRN(arg.crn, arg.responseJson)
     },
 
+    stubGetConvictionById: arg => {
+      return communityApi.stubGetConvictionById(arg.crn, arg.id, arg.responseJson)
+    },
+
     stubGetDraftReferral: arg => {
       return interventionsService.stubGetDraftReferral(arg.id, arg.responseJson)
     },

--- a/integration_tests/support/communityApiStubs.js
+++ b/integration_tests/support/communityApiStubs.js
@@ -9,3 +9,7 @@ Cypress.Commands.add('stubGetUserByUsername', (username, responseJson) => {
 Cypress.Commands.add('stubGetActiveConvictionsByCRN', (crn, responseJson) => {
   cy.task('stubGetActiveConvictionsByCRN', { crn, responseJson })
 })
+
+Cypress.Commands.add('stubGetConvictionById', (crn, id, responseJson) => {
+  cy.task('stubGetConvictionById', { crn, id, responseJson })
+})

--- a/mockApis/communityApi.ts
+++ b/mockApis/communityApi.ts
@@ -50,4 +50,20 @@ export default class CommunityApiMocks {
       },
     })
   }
+
+  stubGetConvictionById = async (crn: string, id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/community-api/secure/offenders/crn/${crn}/convictions/${id}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/decorators/draftReferralDecorator.test.ts
+++ b/server/decorators/draftReferralDecorator.test.ts
@@ -1,0 +1,35 @@
+import DraftReferralDecorator from './draftReferralDecorator'
+import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
+import draftReferralFactory from '../../testutils/factories/draftReferral'
+
+describe(DraftReferralDecorator, () => {
+  describe('referralServiceCategories', () => {
+    const allServiceCategories = serviceCategoryFactory.buildList(3)
+
+    it('returns the referral’s service categories', () => {
+      const referral = draftReferralFactory.build({
+        serviceCategoryIds: allServiceCategories.slice(0, 2).map(val => val.id),
+      })
+
+      expect(new DraftReferralDecorator(referral).referralServiceCategories(allServiceCategories)).toEqual(
+        allServiceCategories.slice(0, 2)
+      )
+    })
+
+    describe('when the referral hasn’t had service categories set', () => {
+      it('throws an error', () => {
+        const referral = draftReferralFactory.build({ serviceCategoryIds: null })
+
+        expect(() => new DraftReferralDecorator(referral).referralServiceCategories(allServiceCategories)).toThrow()
+      })
+    })
+
+    describe('when a service category referenced by the referral isn’t in the list of service categories', () => {
+      it('throws an error', () => {
+        const referral = draftReferralFactory.build({ serviceCategoryIds: [serviceCategoryFactory.build().id] })
+
+        expect(() => new DraftReferralDecorator(referral).referralServiceCategories(allServiceCategories)).toThrow()
+      })
+    })
+  })
+})

--- a/server/decorators/draftReferralDecorator.test.ts
+++ b/server/decorators/draftReferralDecorator.test.ts
@@ -32,4 +32,30 @@ describe(DraftReferralDecorator, () => {
       })
     })
   })
+
+  describe('completionDeadline', () => {
+    describe('when referral has a null completionDeadline', () => {
+      it('returns null', () => {
+        const referral = draftReferralFactory.build({ completionDeadline: null })
+
+        expect(new DraftReferralDecorator(referral).completionDeadline).toBeNull()
+      })
+    })
+
+    describe('when referral has a parseable completionDeadline', () => {
+      it('returns the referral’s completion deadline as a calendar day', () => {
+        const referral = draftReferralFactory.build({ completionDeadline: '2021-03-10' })
+
+        expect(new DraftReferralDecorator(referral).completionDeadline).toEqual({ day: 10, month: 3, year: 2021 })
+      })
+    })
+
+    describe('when referral has a malformed completionDeadline', () => {
+      it('throws an error', () => {
+        const referral = draftReferralFactory.build({ completionDeadline: 'abc' })
+
+        expect(() => new DraftReferralDecorator(referral).completionDeadline).toThrow()
+      })
+    })
+  })
 })

--- a/server/decorators/draftReferralDecorator.ts
+++ b/server/decorators/draftReferralDecorator.ts
@@ -1,5 +1,6 @@
 import DraftReferral from '../models/draftReferral'
 import ServiceCategory from '../models/serviceCategory'
+import CalendarDay from '../utils/calendarDay'
 
 export default class DraftReferralDecorator {
   constructor(private readonly referral: DraftReferral) {}
@@ -16,5 +17,19 @@ export default class DraftReferralDecorator {
       }
       return serviceCategory
     })
+  }
+
+  get completionDeadline(): CalendarDay | null {
+    if (this.referral.completionDeadline === null) {
+      return null
+    }
+
+    const day = CalendarDay.parseIso8601Date(this.referral.completionDeadline)
+
+    if (day === null) {
+      throw new Error('Failed to parse completion deadline')
+    }
+
+    return day
   }
 }

--- a/server/decorators/draftReferralDecorator.ts
+++ b/server/decorators/draftReferralDecorator.ts
@@ -1,0 +1,20 @@
+import DraftReferral from '../models/draftReferral'
+import ServiceCategory from '../models/serviceCategory'
+
+export default class DraftReferralDecorator {
+  constructor(private readonly referral: DraftReferral) {}
+
+  referralServiceCategories(allServiceCategories: ServiceCategory[]): ServiceCategory[] {
+    if (this.referral.serviceCategoryIds === null) {
+      throw new Error(`Service categories not selected`)
+    }
+
+    return this.referral.serviceCategoryIds.map(id => {
+      const serviceCategory = allServiceCategories.find(val => val.id === id)
+      if (serviceCategory === undefined) {
+        throw new Error(`Service category not found for ID ${id}`)
+      }
+      return serviceCategory
+    })
+  }
+}

--- a/server/models/delius/deliusConviction.ts
+++ b/server/models/delius/deliusConviction.ts
@@ -6,7 +6,7 @@ export default interface DeliusConviction {
   offences: Offence[]
 }
 
-interface Sentence {
+export interface Sentence {
   description: string
   sentenceId: number
   expectedSentenceEndDate: string
@@ -16,7 +16,7 @@ interface Sentence {
   }
 }
 
-interface Offence {
+export interface Offence {
   detail: {
     mainCategoryDescription: string
     subCategoryDescription: string

--- a/server/routes/referrals/checkAnswersPresenter.test.ts
+++ b/server/routes/referrals/checkAnswersPresenter.test.ts
@@ -428,4 +428,44 @@ describe(CheckAnswersPresenter, () => {
       })
     })
   })
+
+  describe('furtherInformationSummary', () => {
+    describe('when the referral’s further information is not empty', () => {
+      const referral = parameterisedDraftReferralFactory.build({ furtherInformation: 'Some further information' })
+
+      it('contains the referral’s further information', () => {
+        const presenter = new CheckAnswersPresenter(
+          referral,
+          interventionFactory.build({ serviceCategories }),
+          conviction
+        )
+
+        expect(presenter.furtherInformationSummary).toEqual([
+          {
+            key: 'Further information for the provider',
+            lines: ['Some further information'],
+          },
+        ])
+      })
+    })
+
+    describe('when the referral’s further information is empty', () => {
+      const referral = parameterisedDraftReferralFactory.build({ furtherInformation: '' })
+
+      it('states that there is no further information', () => {
+        const presenter = new CheckAnswersPresenter(
+          referral,
+          interventionFactory.build({ serviceCategories }),
+          conviction
+        )
+
+        expect(presenter.furtherInformationSummary).toEqual([
+          {
+            key: 'Further information for the provider',
+            lines: ['None'],
+          },
+        ])
+      })
+    })
+  })
 })

--- a/server/routes/referrals/checkAnswersPresenter.test.ts
+++ b/server/routes/referrals/checkAnswersPresenter.test.ts
@@ -384,4 +384,48 @@ describe(CheckAnswersPresenter, () => {
       })
     })
   })
+
+  describe('enforceableDaysSummary', () => {
+    describe('when the referral is not using enforceable days', () => {
+      const referral = parameterisedDraftReferralFactory.build({ usingRarDays: false })
+
+      it('states that enforceable days aren’t being used', () => {
+        const presenter = new CheckAnswersPresenter(
+          referral,
+          interventionFactory.build({ serviceCategories }),
+          conviction
+        )
+
+        expect(presenter.enforceableDaysSummary).toEqual([
+          {
+            key: 'Are you using enforceable days?',
+            lines: ['No'],
+          },
+        ])
+      })
+    })
+
+    describe('when the referral is using enforceable days', () => {
+      const referral = parameterisedDraftReferralFactory.build({ usingRarDays: true, maximumRarDays: 15 })
+
+      it('states that enforceable days are being used and the maximum number to use', () => {
+        const presenter = new CheckAnswersPresenter(
+          referral,
+          interventionFactory.build({ serviceCategories }),
+          conviction
+        )
+
+        expect(presenter.enforceableDaysSummary).toEqual([
+          {
+            key: 'Are you using enforceable days?',
+            lines: ['Yes'],
+          },
+          {
+            key: 'Maximum number of enforceable days',
+            lines: ['15'],
+          },
+        ])
+      })
+    })
+  })
 })

--- a/server/routes/referrals/checkAnswersPresenter.test.ts
+++ b/server/routes/referrals/checkAnswersPresenter.test.ts
@@ -361,4 +361,27 @@ describe(CheckAnswersPresenter, () => {
       ])
     })
   })
+
+  describe('completionDeadlineSection', () => {
+    const intervention = interventionFactory.build({ contractType: { name: 'Women’s services' } })
+    const referral = parameterisedDraftReferralFactory.build({ completionDeadline: '2021-10-24' })
+    const presenter = new CheckAnswersPresenter(referral, intervention, conviction)
+
+    describe('title', () => {
+      it('includes the contract type name', () => {
+        expect(presenter.completionDeadlineSection.title).toEqual('Women’s services completion date')
+      })
+    })
+
+    describe('summary', () => {
+      it('returns information about the completion deadline', () => {
+        expect(presenter.completionDeadlineSection.summary).toEqual([
+          {
+            key: 'Date',
+            lines: ['24 October 2021'],
+          },
+        ])
+      })
+    })
+  })
 })

--- a/server/routes/referrals/checkAnswersPresenter.test.ts
+++ b/server/routes/referrals/checkAnswersPresenter.test.ts
@@ -2,6 +2,9 @@ import CheckAnswersPresenter from './checkAnswersPresenter'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import interventionFactory from '../../../testutils/factories/intervention'
+import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
+import deliusOffenceFactory from '../../../testutils/factories/deliusOffence'
+import deliusSentenceFactory from '../../../testutils/factories/deliusSentence'
 import { ListStyle } from '../../utils/summaryList'
 
 describe(CheckAnswersPresenter, () => {
@@ -20,10 +23,11 @@ describe(CheckAnswersPresenter, () => {
     },
   })
   const serviceCategories = serviceCategoryFactory.buildList(3)
+  const conviction = deliusConvictionFactory.build()
 
   describe('serviceUserDetailsSection', () => {
     const referral = parameterisedDraftReferralFactory.build()
-    const presenter = new CheckAnswersPresenter(referral, interventionFactory.build({ serviceCategories }))
+    const presenter = new CheckAnswersPresenter(referral, interventionFactory.build({ serviceCategories }), conviction)
 
     describe('title', () => {
       it('returns the section title', () => {
@@ -52,7 +56,11 @@ describe(CheckAnswersPresenter, () => {
   describe('needsAndRequirementsSection', () => {
     describe('title', () => {
       const referral = parameterisedDraftReferralFactory.build()
-      const presenter = new CheckAnswersPresenter(referral, interventionFactory.build({ serviceCategories }))
+      const presenter = new CheckAnswersPresenter(
+        referral,
+        interventionFactory.build({ serviceCategories }),
+        conviction
+      )
 
       it('returns the section title', () => {
         expect(presenter.needsAndRequirementsSection.title).toEqual('Alex’s needs and requirements')
@@ -64,7 +72,11 @@ describe(CheckAnswersPresenter, () => {
         const referral = parameterisedDraftReferralFactory.build({
           additionalNeedsInformation: 'Some additional needs information',
         })
-        const presenter = new CheckAnswersPresenter(referral, interventionFactory.build({ serviceCategories }))
+        const presenter = new CheckAnswersPresenter(
+          referral,
+          interventionFactory.build({ serviceCategories }),
+          conviction
+        )
 
         it('returns the value from the referral', () => {
           expect(presenter.needsAndRequirementsSection.summary[0]).toEqual({
@@ -78,7 +90,11 @@ describe(CheckAnswersPresenter, () => {
         const referral = parameterisedDraftReferralFactory.build({
           accessibilityNeeds: 'Some accessibility needs information',
         })
-        const presenter = new CheckAnswersPresenter(referral, interventionFactory.build({ serviceCategories }))
+        const presenter = new CheckAnswersPresenter(
+          referral,
+          interventionFactory.build({ serviceCategories }),
+          conviction
+        )
 
         it('returns the value from the referral', () => {
           expect(presenter.needsAndRequirementsSection.summary[1]).toEqual({
@@ -93,7 +109,11 @@ describe(CheckAnswersPresenter, () => {
           const referral = parameterisedDraftReferralFactory.build({
             needsInterpreter: false,
           })
-          const presenter = new CheckAnswersPresenter(referral, interventionFactory.build({ serviceCategories }))
+          const presenter = new CheckAnswersPresenter(
+            referral,
+            interventionFactory.build({ serviceCategories }),
+            conviction
+          )
 
           expect(presenter.needsAndRequirementsSection.summary[2]).toEqual({
             key: 'Does Alex need an interpreter?',
@@ -106,7 +126,11 @@ describe(CheckAnswersPresenter, () => {
             needsInterpreter: true,
             interpreterLanguage: 'Spanish',
           })
-          const presenter = new CheckAnswersPresenter(referral, interventionFactory.build({ serviceCategories }))
+          const presenter = new CheckAnswersPresenter(
+            referral,
+            interventionFactory.build({ serviceCategories }),
+            conviction
+          )
 
           it('also includes the language', () => {
             expect(presenter.needsAndRequirementsSection.summary[2]).toEqual({
@@ -122,7 +146,11 @@ describe(CheckAnswersPresenter, () => {
           const referral = parameterisedDraftReferralFactory.build({
             hasAdditionalResponsibilities: false,
           })
-          const presenter = new CheckAnswersPresenter(referral, interventionFactory.build({ serviceCategories }))
+          const presenter = new CheckAnswersPresenter(
+            referral,
+            interventionFactory.build({ serviceCategories }),
+            conviction
+          )
 
           expect(presenter.needsAndRequirementsSection.summary[3]).toEqual({
             key: 'Does Alex have caring or employment responsibilities?',
@@ -135,7 +163,11 @@ describe(CheckAnswersPresenter, () => {
             hasAdditionalResponsibilities: true,
             whenUnavailable: 'Alex can’t attend on Fridays',
           })
-          const presenter = new CheckAnswersPresenter(referral, interventionFactory.build({ serviceCategories }))
+          const presenter = new CheckAnswersPresenter(
+            referral,
+            interventionFactory.build({ serviceCategories }),
+            conviction
+          )
 
           it('includes information about when they’re unavailable', () => {
             expect(presenter.needsAndRequirementsSection.summary[3]).toEqual({
@@ -191,7 +223,7 @@ describe(CheckAnswersPresenter, () => {
     const intervention = interventionFactory.build({
       serviceCategories: [accommodationServiceCategory, eteServiceCategory, serviceCategoryFactory.build()],
     })
-    const presenter = new CheckAnswersPresenter(referral, intervention)
+    const presenter = new CheckAnswersPresenter(referral, intervention, conviction)
 
     it('contains a section for each service category in the referral', () => {
       expect(presenter.referralDetailsSections).toMatchObject([
@@ -246,7 +278,7 @@ describe(CheckAnswersPresenter, () => {
           serviceCategoryIds: [accommodationServiceCategory.id],
         })
 
-        const presenter = new CheckAnswersPresenter(referral, intervention)
+        const presenter = new CheckAnswersPresenter(referral, intervention, conviction)
 
         expect(presenter.serviceCategoriesSummary).toBeNull()
       })
@@ -263,7 +295,7 @@ describe(CheckAnswersPresenter, () => {
         })
 
         it('lists the service categories chosen in the referral', () => {
-          const presenter = new CheckAnswersPresenter(referral, intervention)
+          const presenter = new CheckAnswersPresenter(referral, intervention, conviction)
           expect(presenter.serviceCategoriesSummary).toEqual([
             {
               key: 'Selected service categories',
@@ -280,7 +312,7 @@ describe(CheckAnswersPresenter, () => {
         })
 
         it('lists the service categories chosen in the referral', () => {
-          const presenter = new CheckAnswersPresenter(referral, intervention)
+          const presenter = new CheckAnswersPresenter(referral, intervention, conviction)
           expect(presenter.serviceCategoriesSummary).toEqual([
             {
               key: 'Selected service categories',
@@ -290,6 +322,43 @@ describe(CheckAnswersPresenter, () => {
           ])
         })
       })
+    })
+  })
+
+  describe('sentenceInformationSummary', () => {
+    const referral = parameterisedDraftReferralFactory.build()
+    const intervention = interventionFactory.build()
+    const assaultConviction = deliusConvictionFactory.build({
+      offences: [
+        deliusOffenceFactory.build({
+          mainOffence: true,
+          detail: {
+            mainCategoryDescription: 'Common and other types of assault',
+          },
+        }),
+      ],
+      sentence: deliusSentenceFactory.build({
+        expectedSentenceEndDate: '2025-09-15',
+      }),
+    })
+
+    it('returns information about the conviction', () => {
+      const presenter = new CheckAnswersPresenter(referral, intervention, assaultConviction)
+
+      expect(presenter.sentenceInformationSummary).toEqual([
+        {
+          key: 'Sentence',
+          lines: ['Common and other types of assault'],
+        },
+        {
+          key: 'Subcategory',
+          lines: ['Common assault and battery'],
+        },
+        {
+          key: 'End of sentence date',
+          lines: ['15 September 2025'],
+        },
+      ])
     })
   })
 })

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -8,9 +8,15 @@ import utils from '../../utils/utils'
 import DraftReferralDecorator from '../../decorators/draftReferralDecorator'
 import Intervention from '../../models/intervention'
 import InterventionDecorator from '../../decorators/interventionDecorator'
+import DeliusConviction from '../../models/delius/deliusConviction'
+import SentencePresenter from './sentencePresenter'
 
 export default class CheckAnswersPresenter {
-  constructor(private readonly referral: DraftReferral, private readonly intervention: Intervention) {}
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly intervention: Intervention,
+    private readonly conviction: DeliusConviction
+  ) {}
 
   get serviceUserDetailsSection(): { title: string; summary: SummaryListItem[] } {
     return {
@@ -111,6 +117,25 @@ export default class CheckAnswersPresenter {
         key: 'Selected service categories',
         lines: serviceCategories.map(serviceCategory => utils.convertToProperCase(serviceCategory.name)),
         listStyle: ListStyle.noMarkers,
+      },
+    ]
+  }
+
+  get sentenceInformationSummary(): SummaryListItem[] {
+    const presenter = new SentencePresenter(this.conviction)
+
+    return [
+      {
+        key: 'Sentence',
+        lines: [presenter.category],
+      },
+      {
+        key: 'Subcategory',
+        lines: [presenter.subcategory],
+      },
+      {
+        key: 'End of sentence date',
+        lines: [presenter.endOfSentenceDate],
       },
     ]
   }

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -10,6 +10,7 @@ import Intervention from '../../models/intervention'
 import InterventionDecorator from '../../decorators/interventionDecorator'
 import DeliusConviction from '../../models/delius/deliusConviction'
 import SentencePresenter from './sentencePresenter'
+import PresenterUtils from '../../utils/presenterUtils'
 
 export default class CheckAnswersPresenter {
   constructor(
@@ -138,6 +139,19 @@ export default class CheckAnswersPresenter {
         lines: [presenter.endOfSentenceDate],
       },
     ]
+  }
+
+  get completionDeadlineSection(): { title: string; summary: SummaryListItem[] } {
+    const { completionDeadline } = new DraftReferralDecorator(this.referral)
+
+    if (completionDeadline === null) {
+      throw new Error('Trying to check answers with completion deadline not set')
+    }
+
+    return {
+      title: `${this.intervention.contractType.name} completion date`,
+      summary: [{ key: 'Date', lines: [PresenterUtils.govukFormattedDate(completionDeadline)] }],
+    }
   }
 
   private readonly serviceUserName = this.referral.serviceUser?.firstName ?? ''

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -154,5 +154,23 @@ export default class CheckAnswersPresenter {
     }
   }
 
+  get enforceableDaysSummary(): SummaryListItem[] {
+    const result = [
+      {
+        key: 'Are you using enforceable days?',
+        lines: [this.referral.usingRarDays ? 'Yes' : 'No'],
+      },
+    ]
+
+    if (this.referral.usingRarDays) {
+      if (this.referral.maximumRarDays === null) {
+        throw new Error('Trying to check answers for referral that uses RAR days, but without maximum RAR days set')
+      }
+      result.push({ key: 'Maximum number of enforceable days', lines: [this.referral.maximumRarDays.toString()] })
+    }
+
+    return result
+  }
+
   private readonly serviceUserName = this.referral.serviceUser?.firstName ?? ''
 }

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -172,5 +172,14 @@ export default class CheckAnswersPresenter {
     return result
   }
 
+  get furtherInformationSummary(): SummaryListItem[] {
+    return [
+      {
+        key: 'Further information for the provider',
+        lines: [this.referral.furtherInformation?.length ? this.referral.furtherInformation! : 'None'],
+      },
+    ]
+  }
+
   private readonly serviceUserName = this.referral.serviceUser?.firstName ?? ''
 }

--- a/server/routes/referrals/checkAnswersView.ts
+++ b/server/routes/referrals/checkAnswersView.ts
@@ -29,6 +29,8 @@ export default class CheckAnswersView {
     this.presenter.completionDeadlineSection.summary
   )
 
+  private readonly enforceableDaysSummaryListArgs = ViewUtils.summaryListArgs(this.presenter.enforceableDaysSummary)
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/checkAnswers',
@@ -40,6 +42,7 @@ export default class CheckAnswersView {
         serviceCategoriesSummaryListArgs: this.serviceCategoriesSummaryListArgs,
         sentenceInformationSummaryListArgs: this.sentenceInformationSummaryListArgs,
         completionDeadlineSummaryListArgs: this.completionDeadlineSummaryListArgs,
+        enforceableDaysSummaryListArgs: this.enforceableDaysSummaryListArgs,
       },
     ]
   }

--- a/server/routes/referrals/checkAnswersView.ts
+++ b/server/routes/referrals/checkAnswersView.ts
@@ -31,6 +31,10 @@ export default class CheckAnswersView {
 
   private readonly enforceableDaysSummaryListArgs = ViewUtils.summaryListArgs(this.presenter.enforceableDaysSummary)
 
+  private readonly furtherInformationSummaryListArgs = ViewUtils.summaryListArgs(
+    this.presenter.furtherInformationSummary
+  )
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/checkAnswers',
@@ -43,6 +47,7 @@ export default class CheckAnswersView {
         sentenceInformationSummaryListArgs: this.sentenceInformationSummaryListArgs,
         completionDeadlineSummaryListArgs: this.completionDeadlineSummaryListArgs,
         enforceableDaysSummaryListArgs: this.enforceableDaysSummaryListArgs,
+        furtherInformationSummaryListArgs: this.furtherInformationSummaryListArgs,
       },
     ]
   }

--- a/server/routes/referrals/checkAnswersView.ts
+++ b/server/routes/referrals/checkAnswersView.ts
@@ -25,6 +25,10 @@ export default class CheckAnswersView {
     this.presenter.sentenceInformationSummary
   )
 
+  private readonly completionDeadlineSummaryListArgs = ViewUtils.summaryListArgs(
+    this.presenter.completionDeadlineSection.summary
+  )
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/checkAnswers',
@@ -35,6 +39,7 @@ export default class CheckAnswersView {
         referralDetailsSections: this.referralDetailsSections,
         serviceCategoriesSummaryListArgs: this.serviceCategoriesSummaryListArgs,
         sentenceInformationSummaryListArgs: this.sentenceInformationSummaryListArgs,
+        completionDeadlineSummaryListArgs: this.completionDeadlineSummaryListArgs,
       },
     ]
   }

--- a/server/routes/referrals/checkAnswersView.ts
+++ b/server/routes/referrals/checkAnswersView.ts
@@ -21,6 +21,10 @@ export default class CheckAnswersView {
     ? ViewUtils.summaryListArgs(this.presenter.serviceCategoriesSummary)
     : null
 
+  private readonly sentenceInformationSummaryListArgs = ViewUtils.summaryListArgs(
+    this.presenter.sentenceInformationSummary
+  )
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/checkAnswers',
@@ -30,6 +34,7 @@ export default class CheckAnswersView {
         needsAndRequirementsSummaryListArgs: this.needsAndRequirementsSummaryListArgs,
         referralDetailsSections: this.referralDetailsSections,
         serviceCategoriesSummaryListArgs: this.serviceCategoriesSummaryListArgs,
+        sentenceInformationSummaryListArgs: this.sentenceInformationSummaryListArgs,
       },
     ]
   }

--- a/server/routes/referrals/checkAnswersView.ts
+++ b/server/routes/referrals/checkAnswersView.ts
@@ -17,6 +17,10 @@ export default class CheckAnswersView {
     summaryListArgs: ViewUtils.summaryListArgs(section.summary),
   }))
 
+  private readonly serviceCategoriesSummaryListArgs = this.presenter.serviceCategoriesSummary
+    ? ViewUtils.summaryListArgs(this.presenter.serviceCategoriesSummary)
+    : null
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/checkAnswers',
@@ -25,6 +29,7 @@ export default class CheckAnswersView {
         serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs,
         needsAndRequirementsSummaryListArgs: this.needsAndRequirementsSummaryListArgs,
         referralDetailsSections: this.referralDetailsSections,
+        serviceCategoriesSummaryListArgs: this.serviceCategoriesSummaryListArgs,
       },
     ]
   }

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -1204,8 +1204,13 @@ describe('POST /referrals/:id/rar-days', () => {
 
 describe('GET /referrals/:id/check-answers', () => {
   beforeEach(() => {
-    const referral = draftReferralFactory.build({ serviceUser: { firstName: 'Johnny', religionOrBelief: 'Agnostic' } })
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
+    const referral = draftReferralFactory
+      .serviceCategorySelected(serviceCategory.id)
+      .build({ serviceUser: { firstName: 'Johnny', religionOrBelief: 'Agnostic' } })
 
+    interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -1208,10 +1208,12 @@ describe('GET /referrals/:id/check-answers', () => {
     const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
     const referral = draftReferralFactory
       .serviceCategorySelected(serviceCategory.id)
-      .build({ serviceUser: { firstName: 'Johnny', religionOrBelief: 'Agnostic' } })
+      .build({ serviceUser: { firstName: 'Johnny', religionOrBelief: 'Agnostic' }, relevantSentenceId: 123 })
+    const conviction = deliusConvictionFactory.build()
 
     interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
+    communityApiService.getConvictionById.mockResolvedValue(conviction)
   })
 
   it('displays placeholder text in place of a summary of the referral', async () => {

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -1208,6 +1208,7 @@ describe('GET /referrals/:id/check-answers', () => {
     const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
     const referral = draftReferralFactory
       .serviceCategorySelected(serviceCategory.id)
+      .completionDeadlineSet()
       .build({ serviceUser: { firstName: 'Johnny', religionOrBelief: 'Agnostic' }, relevantSentenceId: 123 })
     const conviction = deliusConvictionFactory.build()
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -1217,13 +1217,12 @@ describe('GET /referrals/:id/check-answers', () => {
     communityApiService.getConvictionById.mockResolvedValue(conviction)
   })
 
-  it('displays placeholder text in place of a summary of the referral', async () => {
+  it('displays a summary of the draft referral', async () => {
     await request(app)
       .get('/referrals/1/check-answers')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Submit your referral')
-        expect(res.text).toContain('Make sure you have checked your answers before submitting your referral')
+        expect(res.text).toContain('Check your answers')
         expect(res.text).toContain('Johnny’s personal details')
         expect(res.text).toContain('Agnostic')
       })

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -570,12 +570,17 @@ export default class ReferralsController {
     if (referral.serviceCategoryIds === null) {
       throw new Error('Attempting to check answers without service categories selected')
     }
-    const [intervention, serviceUser] = await Promise.all([
+    if (referral.relevantSentenceId === null) {
+      throw new Error('Attempting to check answers without relevant sentence selected')
+    }
+
+    const [intervention, serviceUser, conviction] = await Promise.all([
       this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
+      this.communityApiService.getConvictionById(referral.serviceUser.crn, referral.relevantSentenceId),
     ])
 
-    const presenter = new CheckAnswersPresenter(referral, intervention)
+    const presenter = new CheckAnswersPresenter(referral, intervention, conviction)
     const view = new CheckAnswersView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -570,16 +570,12 @@ export default class ReferralsController {
     if (referral.serviceCategoryIds === null) {
       throw new Error('Attempting to check answers without service categories selected')
     }
-    const [serviceCategories, serviceUser] = await Promise.all([
-      Promise.all(
-        referral.serviceCategoryIds.map(id =>
-          this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
-        )
-      ),
+    const [intervention, serviceUser] = await Promise.all([
+      this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
     ])
 
-    const presenter = new CheckAnswersPresenter(referral, serviceCategories)
+    const presenter = new CheckAnswersPresenter(referral, intervention)
     const view = new CheckAnswersView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/referrals/relevantSentencePresenter.test.ts
+++ b/server/routes/referrals/relevantSentencePresenter.test.ts
@@ -1,5 +1,7 @@
 import RelevantSentencePresenter from './relevantSentencePresenter'
 import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
+import deliusOffenceFactory from '../../../testutils/factories/deliusOffence'
+import deliusSentenceFactory from '../../../testutils/factories/deliusSentence'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import interventionFactory from '../../../testutils/factories/intervention'
 
@@ -20,46 +22,18 @@ describe(RelevantSentencePresenter, () => {
     describe('category', () => {
       it('returns the main offence‘s category', () => {
         const offences = [
-          {
-            offenceId: 'M2500297061',
+          deliusOffenceFactory.build({
             mainOffence: false,
             detail: {
-              code: '10400',
-              description: 'Assault on Police Officer - 10400',
-              mainCategoryCode: '104',
               mainCategoryDescription: 'Assault on Police Officer',
-              mainCategoryAbbreviation: 'Assault on Police Officer',
-              ogrsOffenceCategory: 'Violence',
-              subCategoryCode: '00',
-              subCategoryDescription: 'Assault on Police Officer',
-              form20Code: '88',
             },
-            offenceDate: '2019-09-09T00:00:00',
-            offenceCount: 1,
-            offenderId: 2500343964,
-            createdDatetime: '2019-09-17T00:00:00',
-            lastUpdatedDatetime: '2019-09-17T00:00:00',
-          },
-          {
-            offenceId: 'M2600297062',
+          }),
+          deliusOffenceFactory.build({
             mainOffence: true,
             detail: {
-              code: '10501',
-              description: 'Common assault and battery - 10501',
-              mainCategoryCode: '105',
               mainCategoryDescription: 'Common and other types of assault',
-              mainCategoryAbbreviation: 'Common and other types of assault',
-              ogrsOffenceCategory: 'Violence',
-              subCategoryCode: '01',
-              subCategoryDescription: 'Common assault and battery',
-              form20Code: '88',
             },
-            offenceDate: '2019-09-09T00:00:00',
-            offenceCount: 1,
-            offenderId: 2600343964,
-            createdDatetime: '2019-09-17T00:00:00',
-            lastUpdatedDatetime: '2019-09-17T00:00:00',
-          },
+          }),
         ]
 
         const convictions = [deliusConvictionFactory.build({ offences })]
@@ -73,46 +47,18 @@ describe(RelevantSentencePresenter, () => {
     describe('subcategory', () => {
       it('returns the main offence‘s subcategory', () => {
         const offences = [
-          {
-            offenceId: 'M2500297061',
+          deliusOffenceFactory.build({
             mainOffence: false,
             detail: {
-              code: '10400',
-              description: 'Assault on Police Officer - 10400',
-              mainCategoryCode: '104',
-              mainCategoryDescription: 'Assault on Police Officer',
-              mainCategoryAbbreviation: 'Assault on Police Officer',
-              ogrsOffenceCategory: 'Violence',
-              subCategoryCode: '00',
               subCategoryDescription: 'Assault on Police Officer',
-              form20Code: '88',
             },
-            offenceDate: '2019-09-09T00:00:00',
-            offenceCount: 1,
-            offenderId: 2500343964,
-            createdDatetime: '2019-09-17T00:00:00',
-            lastUpdatedDatetime: '2019-09-17T00:00:00',
-          },
-          {
-            offenceId: 'M2600297062',
+          }),
+          deliusOffenceFactory.build({
             mainOffence: true,
             detail: {
-              code: '10501',
-              description: 'Common assault and battery - 10501',
-              mainCategoryCode: '105',
-              mainCategoryDescription: 'Common and other types of assault',
-              mainCategoryAbbreviation: 'Common and other types of assault',
-              ogrsOffenceCategory: 'Violence',
-              subCategoryCode: '01',
               subCategoryDescription: 'Common assault and battery',
-              form20Code: '88',
             },
-            offenceDate: '2019-09-09T00:00:00',
-            offenceCount: 1,
-            offenderId: 2600343964,
-            createdDatetime: '2019-09-17T00:00:00',
-            lastUpdatedDatetime: '2019-09-17T00:00:00',
-          },
+          }),
         ]
 
         const convictions = [deliusConvictionFactory.build({ offences })]
@@ -127,15 +73,9 @@ describe(RelevantSentencePresenter, () => {
       it('uses the GOV UK date format', () => {
         const convictions = [
           deliusConvictionFactory.build({
-            sentence: {
-              sentenceId: 2500284169,
-              description: 'Absolute/Conditional Discharge',
+            sentence: deliusSentenceFactory.build({
               expectedSentenceEndDate: '2025-09-15',
-              sentenceType: {
-                code: 'SC',
-                description: 'CJA - Indeterminate Public Prot.',
-              },
-            },
+            }),
           }),
         ]
 

--- a/server/routes/referrals/relevantSentencePresenter.test.ts
+++ b/server/routes/referrals/relevantSentencePresenter.test.ts
@@ -1,7 +1,6 @@
 import RelevantSentencePresenter from './relevantSentencePresenter'
 import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
 import deliusOffenceFactory from '../../../testutils/factories/deliusOffence'
-import deliusSentenceFactory from '../../../testutils/factories/deliusSentence'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import interventionFactory from '../../../testutils/factories/intervention'
 
@@ -19,69 +18,24 @@ describe(RelevantSentencePresenter, () => {
   })
 
   describe('relevantSentenceFields', () => {
-    describe('category', () => {
-      it('returns the main offence‘s category', () => {
-        const offences = [
-          deliusOffenceFactory.build({
-            mainOffence: false,
-            detail: {
-              mainCategoryDescription: 'Assault on Police Officer',
-            },
-          }),
-          deliusOffenceFactory.build({
-            mainOffence: true,
-            detail: {
-              mainCategoryDescription: 'Common and other types of assault',
-            },
-          }),
-        ]
-
-        const convictions = [deliusConvictionFactory.build({ offences })]
-
-        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
-
-        expect(presenter.relevantSentenceFields[0].category).toEqual('Common and other types of assault')
-      })
-    })
-
-    describe('subcategory', () => {
-      it('returns the main offence‘s subcategory', () => {
-        const offences = [
-          deliusOffenceFactory.build({
-            mainOffence: false,
-            detail: {
-              subCategoryDescription: 'Assault on Police Officer',
-            },
-          }),
-          deliusOffenceFactory.build({
-            mainOffence: true,
-            detail: {
-              subCategoryDescription: 'Common assault and battery',
-            },
-          }),
-        ]
-
-        const convictions = [deliusConvictionFactory.build({ offences })]
-
-        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
-
-        expect(presenter.relevantSentenceFields[0].subcategory).toEqual('Common assault and battery')
-      })
-    })
-
-    describe('endOfSentenceDate', () => {
-      it('uses the GOV UK date format', () => {
+    describe('presenter', () => {
+      it('returns a presenter with information about the conviction', () => {
         const convictions = [
           deliusConvictionFactory.build({
-            sentence: deliusSentenceFactory.build({
-              expectedSentenceEndDate: '2025-09-15',
-            }),
+            offences: [
+              deliusOffenceFactory.build({
+                mainOffence: true,
+                detail: {
+                  mainCategoryDescription: 'Common and other types of assault',
+                },
+              }),
+            ],
           }),
         ]
-
         const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
 
-        expect(presenter.relevantSentenceFields[0].endOfSentenceDate).toEqual('15 September 2025')
+        expect(presenter.relevantSentenceFields[0].presenter).toBeDefined()
+        expect(presenter.relevantSentenceFields[0].presenter.category).toEqual('Common and other types of assault')
       })
     })
 

--- a/server/routes/referrals/relevantSentencePresenter.ts
+++ b/server/routes/referrals/relevantSentencePresenter.ts
@@ -4,6 +4,7 @@ import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 import Intervention from '../../models/intervention'
 import utils from '../../utils/utils'
+import SentencePresenter from './sentencePresenter'
 
 export default class RelevantSentencePresenter {
   constructor(
@@ -23,28 +24,13 @@ export default class RelevantSentencePresenter {
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
   get relevantSentenceFields(): {
-    category: string
-    subcategory: string
-    endOfSentenceDate: string
+    presenter: SentencePresenter
     value: number
     checked: boolean
   }[] {
     return this.convictions.map(conviction => {
-      if (!conviction.offences) {
-        throw new Error(`No offences found for conviction id: ${conviction.convictionId}`)
-      }
-
-      const mainOffence = conviction.offences.find(offence => offence.mainOffence)
-
-      if (!mainOffence) {
-        throw new Error('No main offence found')
-      }
-
       return {
-        category: mainOffence.detail.mainCategoryDescription,
-        subcategory: mainOffence.detail.subCategoryDescription,
-        endOfSentenceDate:
-          PresenterUtils.govukFormattedDateFromStringOrNull(conviction.sentence.expectedSentenceEndDate) ?? 'Not found',
+        presenter: new SentencePresenter(conviction),
         value: conviction.convictionId,
         checked: this.selectedRelevantSentenceId === conviction.convictionId,
       }

--- a/server/routes/referrals/relevantSentenceView.ts
+++ b/server/routes/referrals/relevantSentenceView.ts
@@ -20,9 +20,9 @@ export default class RelevantSentenceView {
       items: this.presenter.relevantSentenceFields.map(relevantSentence => {
         return {
           value: relevantSentence.value.toString(),
-          html: `${ViewUtils.escape(relevantSentence.category)}<br>Subcategory: ${ViewUtils.escape(
-            relevantSentence.subcategory
-          )}<br>End of sentence date: ${ViewUtils.escape(relevantSentence.endOfSentenceDate)}`,
+          html: `${ViewUtils.escape(relevantSentence.presenter.category)}<br>Subcategory: ${ViewUtils.escape(
+            relevantSentence.presenter.subcategory
+          )}<br>End of sentence date: ${ViewUtils.escape(relevantSentence.presenter.endOfSentenceDate)}`,
           checked: relevantSentence.checked,
         }
       }),

--- a/server/routes/referrals/sentencePresenter.test.ts
+++ b/server/routes/referrals/sentencePresenter.test.ts
@@ -1,0 +1,70 @@
+import SentencePresenter from './sentencePresenter'
+import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
+import deliusOffenceFactory from '../../../testutils/factories/deliusOffence'
+import deliusSentenceFactory from '../../../testutils/factories/deliusSentence'
+
+describe(SentencePresenter, () => {
+  describe('category', () => {
+    it('returns the main offence‘s category', () => {
+      const offences = [
+        deliusOffenceFactory.build({
+          mainOffence: false,
+          detail: {
+            mainCategoryDescription: 'Assault on Police Officer',
+          },
+        }),
+        deliusOffenceFactory.build({
+          mainOffence: true,
+          detail: {
+            mainCategoryDescription: 'Common and other types of assault',
+          },
+        }),
+      ]
+
+      const conviction = deliusConvictionFactory.build({ offences })
+
+      const presenter = new SentencePresenter(conviction)
+
+      expect(presenter.category).toEqual('Common and other types of assault')
+    })
+  })
+
+  describe('subcategory', () => {
+    it('returns the main offence‘s subcategory', () => {
+      const offences = [
+        deliusOffenceFactory.build({
+          mainOffence: false,
+          detail: {
+            subCategoryDescription: 'Assault on Police Officer',
+          },
+        }),
+        deliusOffenceFactory.build({
+          mainOffence: true,
+          detail: {
+            subCategoryDescription: 'Common assault and battery',
+          },
+        }),
+      ]
+
+      const conviction = deliusConvictionFactory.build({ offences })
+
+      const presenter = new SentencePresenter(conviction)
+
+      expect(presenter.subcategory).toEqual('Common assault and battery')
+    })
+  })
+
+  describe('endOfSentenceDate', () => {
+    it('uses the GOV UK date format', () => {
+      const conviction = deliusConvictionFactory.build({
+        sentence: deliusSentenceFactory.build({
+          expectedSentenceEndDate: '2025-09-15',
+        }),
+      })
+
+      const presenter = new SentencePresenter(conviction)
+
+      expect(presenter.endOfSentenceDate).toEqual('15 September 2025')
+    })
+  })
+})

--- a/server/routes/referrals/sentencePresenter.ts
+++ b/server/routes/referrals/sentencePresenter.ts
@@ -1,0 +1,28 @@
+import DeliusConviction from '../../models/delius/deliusConviction'
+import PresenterUtils from '../../utils/presenterUtils'
+
+export default class SentencePresenter {
+  readonly category: string
+
+  readonly subcategory: string
+
+  readonly endOfSentenceDate: string
+
+  constructor(private readonly conviction: DeliusConviction) {
+    if (!conviction.offences) {
+      throw new Error(`No offences found for conviction id: ${conviction.convictionId}`)
+    }
+
+    const mainOffence = conviction.offences.find(offence => offence.mainOffence)
+
+    if (!mainOffence) {
+      throw new Error('No main offence found')
+    }
+
+    this.category = mainOffence.detail.mainCategoryDescription
+    this.subcategory = mainOffence.detail.subCategoryDescription
+
+    this.endOfSentenceDate =
+      PresenterUtils.govukFormattedDateFromStringOrNull(this.conviction.sentence.expectedSentenceEndDate) ?? 'Not found'
+  }
+}

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -28,11 +28,19 @@ export default class CommunityApiService {
 
   async getActiveConvictionsByCRN(crn: string): Promise<DeliusConviction[]> {
     const token = await this.hmppsAuthService.getApiClientToken()
-    logger.info({ crn }, 'getting conviction for service user')
+    logger.info({ crn }, 'getting convictions for service user')
     const convictions = (await this.restClient(token).get({
       path: `/secure/offenders/crn/${crn}/convictions`,
     })) as DeliusConviction[]
 
     return convictions.filter(conviction => conviction.active && conviction.sentence)
+  }
+
+  async getConvictionById(crn: string, id: number): Promise<DeliusConviction> {
+    const token = await this.hmppsAuthService.getApiClientToken()
+    logger.info({ crn, id }, 'getting conviction for service user')
+    return (await this.restClient(token).get({
+      path: `/secure/offenders/crn/${crn}/convictions/${id}`,
+    })) as DeliusConviction
   }
 }

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -12,9 +12,7 @@
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Submit your referral</h1>
-
-      <p class="govuk-body-m">Make sure you have checked your answers before submitting your referral.</p>
+      <h1 class="govuk-heading-xl">Check your answers</h1>
 
       <h2 class="govuk-heading-l">{{ presenter.serviceUserDetailsSection.title }}</h2>
 

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -48,6 +48,10 @@
 
       {{ govukSummaryList(enforceableDaysSummaryListArgs) }}
 
+      <h2 class="govuk-heading-l">Further information</h2>
+
+      {{ govukSummaryList(furtherInformationSummaryListArgs) }}
+
       <form method="post" action="send">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukButton({ text: "Submit referral" }) }}

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -44,6 +44,10 @@
 
       {{ govukSummaryList(completionDeadlineSummaryListArgs) }}
 
+      <h2 class="govuk-heading-l">Enforceable days</h2>
+
+      {{ govukSummaryList(enforceableDaysSummaryListArgs) }}
+
       <form method="post" action="send">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukButton({ text: "Submit referral" }) }}

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -24,6 +24,12 @@
 
       {{ govukSummaryList(needsAndRequirementsSummaryListArgs) }}
 
+      {% if serviceCategoriesSummaryListArgs %}
+        <h2 class="govuk-heading-l">Service types</h2>
+
+        {{ govukSummaryList(serviceCategoriesSummaryListArgs) }}
+      {% endif %}
+
       {% for section in referralDetailsSections %}
         <h2 class="govuk-heading-l">{{ section.title }}</h2>
 

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -30,6 +30,10 @@
         {{ govukSummaryList(serviceCategoriesSummaryListArgs) }}
       {% endif %}
 
+      <h2 class="govuk-heading-l">Sentence information</h2>
+
+      {{ govukSummaryList(sentenceInformationSummaryListArgs) }}
+
       {% for section in referralDetailsSections %}
         <h2 class="govuk-heading-l">{{ section.title }}</h2>
 

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -40,6 +40,10 @@
         {{ govukSummaryList(section.summaryListArgs) }}
       {% endfor %}
 
+      <h2 class="govuk-heading-l">{{ presenter.completionDeadlineSection.title }}</h2>
+
+      {{ govukSummaryList(completionDeadlineSummaryListArgs) }}
+
       <form method="post" action="send">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukButton({ text: "Submit referral" }) }}

--- a/testutils/factories/deliusOffence.ts
+++ b/testutils/factories/deliusOffence.ts
@@ -1,0 +1,23 @@
+import { Factory } from 'fishery'
+import { Offence } from '../../server/models/delius/deliusConviction'
+
+export default Factory.define<Offence>(({ sequence }) => ({
+  offenceId: sequence.toString(),
+  mainOffence: true,
+  detail: {
+    code: '10501',
+    description: 'Common assault and battery - 10501',
+    mainCategoryCode: '105',
+    mainCategoryDescription: 'Common and other types of assault',
+    mainCategoryAbbreviation: 'Common and other types of assault',
+    ogrsOffenceCategory: 'Violence',
+    subCategoryCode: '01',
+    subCategoryDescription: 'Common assault and battery',
+    form20Code: '88',
+  },
+  offenceDate: '2019-09-09T00:00:00',
+  offenceCount: 1,
+  offenderId: 2600343964,
+  createdDatetime: '2019-09-17T00:00:00',
+  lastUpdatedDatetime: '2019-09-17T00:00:00',
+}))

--- a/testutils/factories/deliusSentence.ts
+++ b/testutils/factories/deliusSentence.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery'
+import { Sentence } from '../../server/models/delius/deliusConviction'
+
+export default Factory.define<Sentence>(({ sequence }) => ({
+  sentenceId: sequence,
+  description: 'Absolute/Conditional Discharge',
+  expectedSentenceEndDate: '2025-09-15',
+  sentenceType: {
+    code: 'SC',
+    description: 'CJA - Indeterminate Public Prot.',
+  },
+}))


### PR DESCRIPTION
## What does this pull request do?

This finishes the first version of the "check your answers" page for the probation practitioner make a referral journey.

There's quite a few commits, but ultimately it's just displaying a bunch of summary lists.

## What is the intent behind these changes?

To allow a probation practitioner to check the information that they've provided before they submit it to the service provider.

## Screenshot

![Referral form -- for single referrals -- User starts a referral, fills in the form, and submits it (1)](https://user-images.githubusercontent.com/53756884/120631640-01bcff80-c460-11eb-9179-3319364583c9.png)
