### PR TITLE
Make risk information mandatory, remove hardcoded risk data, and update design of risk page

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -168,6 +168,7 @@ describe('Referral form', () => {
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/risk-information`)
+      cy.contains('Information for the service provider about Alex’s risks').type('A danger to the elderly')
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/needs-and-requirements`)
@@ -463,6 +464,7 @@ describe('Referral form', () => {
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/risk-information`)
+      cy.contains('Information for the service provider about Alex’s risks').type('A danger to the elderly')
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/needs-and-requirements`)

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -301,6 +301,8 @@ describe('Referral form', () => {
       cy.contains('Agnostic')
       cy.contains('Autism')
 
+      cy.contains('A danger to the elderly')
+
       cy.contains('Alex is currently sleeping on her aunt’s sofa')
       cy.contains('She uses a wheelchair')
       cy.contains('Yes. Spanish')

--- a/server/routes/referrals/checkAnswersPresenter.test.ts
+++ b/server/routes/referrals/checkAnswersPresenter.test.ts
@@ -53,6 +53,23 @@ describe(CheckAnswersPresenter, () => {
     })
   })
 
+  describe('riskSection', () => {
+    const referral = parameterisedDraftReferralFactory.build({ additionalRiskInformation: 'Past assault of strangers' })
+    const presenter = new CheckAnswersPresenter(referral, interventionFactory.build({ serviceCategories }), conviction)
+
+    describe('title', () => {
+      it('returns the section title', () => {
+        expect(presenter.riskSection.title).toEqual('Alex’s risk information')
+      })
+    })
+
+    describe('text', () => {
+      it('returns the additional risk information', () => {
+        expect(presenter.riskSection.text).toEqual('Past assault of strangers')
+      })
+    })
+  })
+
   describe('needsAndRequirementsSection', () => {
     describe('title', () => {
       const referral = parameterisedDraftReferralFactory.build()

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -26,6 +26,13 @@ export default class CheckAnswersPresenter {
     }
   }
 
+  get riskSection(): { title: string; text: string } {
+    return {
+      title: `${this.serviceUserName}’s risk information`,
+      text: this.referral.additionalRiskInformation ?? '',
+    }
+  }
+
   get needsAndRequirementsSection(): { title: string; summary: SummaryListItem[] } {
     const needsAndRequirementsPresenter = new NeedsAndRequirementsPresenter(this.referral)
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -301,6 +301,23 @@ describe('POST /referrals/:id/risk-information', () => {
     ])
   })
 
+  describe('when the user enters invalid data', () => {
+    it('does not update the referral on the backend and returns a 400 with an error message', async () => {
+      await request(app)
+        .post('/referrals/1/risk-information')
+        .type('form')
+        .send({
+          'additional-risk-information': 'a'.repeat(4001),
+        })
+        .expect(400)
+        .expect(res => {
+          expect(res.text).toContain('Risk information must be 4000 characters or fewer')
+        })
+
+      expect(interventionsService.patchDraftReferral).not.toHaveBeenCalled()
+    })
+  })
+
   it('updates the referral on the backend and returns a 500 if the API call fails with a non-validation error', async () => {
     interventionsService.patchDraftReferral.mockRejectedValue({
       message: 'Some backend error message',

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -43,6 +43,7 @@ import UpdateServiceCategoriesForm from './updateServiceCategoriesForm'
 import EnforceableDaysForm from './enforceableDaysForm'
 import EnforceableDaysPresenter from './enforceableDaysPresenter'
 import EnforceableDaysView from './enforceableDaysView'
+import RiskInformationForm from './riskInformationForm'
 
 export default class ReferralsController {
   constructor(
@@ -482,18 +483,19 @@ export default class ReferralsController {
   async updateRiskInformation(req: Request, res: Response): Promise<void> {
     let error: FormValidationError | null = null
 
-    const paramsForUpdate = {
-      additionalRiskInformation: req.body['additional-risk-information'],
-    }
+    const data = await new RiskInformationForm(req).data()
+    error = data.error
 
-    try {
-      await this.interventionsService.patchDraftReferral(
-        res.locals.user.token.accessToken,
-        req.params.id,
-        paramsForUpdate
-      )
-    } catch (e) {
-      error = createFormValidationErrorOrRethrow(e)
+    if (data.error === null) {
+      try {
+        await this.interventionsService.patchDraftReferral(
+          res.locals.user.token.accessToken,
+          req.params.id,
+          data.paramsForUpdate
+        )
+      } catch (e) {
+        error = createFormValidationErrorOrRethrow(e)
+      }
     }
 
     if (error === null) {

--- a/server/routes/referrals/riskInformationForm.test.ts
+++ b/server/routes/referrals/riskInformationForm.test.ts
@@ -1,0 +1,52 @@
+import RiskInformationForm from './riskInformationForm'
+import TestUtils from '../../../testutils/testUtils'
+
+describe(RiskInformationForm, () => {
+  describe('data', () => {
+    describe('with valid input', () => {
+      it('returns a paramsForUpdate with the additionalRiskInformation key', async () => {
+        const request = TestUtils.createRequest({ 'additional-risk-information': 'Past assault of strangers' })
+
+        const data = await new RiskInformationForm(request).data()
+
+        expect(data.paramsForUpdate).toEqual({ additionalRiskInformation: 'Past assault of strangers' })
+      })
+    })
+
+    describe('with blank additional-risk-information', () => {
+      it('returns an error', async () => {
+        const request = TestUtils.createRequest({ 'additional-risk-information': '   ' })
+
+        const data = await new RiskInformationForm(request).data()
+
+        expect(data.error).toEqual({
+          errors: [
+            {
+              formFields: ['additional-risk-information'],
+              errorSummaryLinkedField: 'additional-risk-information',
+              message: 'Enter risk information',
+            },
+          ],
+        })
+      })
+    })
+
+    describe('with additional-risk-information over 4000 characters long', () => {
+      it('returns an error', async () => {
+        const request = TestUtils.createRequest({ 'additional-risk-information': 'a'.repeat(4001) })
+
+        const data = await new RiskInformationForm(request).data()
+
+        expect(data.error).toEqual({
+          errors: [
+            {
+              formFields: ['additional-risk-information'],
+              errorSummaryLinkedField: 'additional-risk-information',
+              message: 'Risk information must be 4000 characters or fewer',
+            },
+          ],
+        })
+      })
+    })
+  })
+})

--- a/server/routes/referrals/riskInformationForm.ts
+++ b/server/routes/referrals/riskInformationForm.ts
@@ -1,0 +1,37 @@
+import { Request } from 'express'
+import * as ExpressValidator from 'express-validator'
+import DraftReferral from '../../models/draftReferral'
+import { FormData } from '../../utils/forms/formData'
+import FormUtils from '../../utils/formUtils'
+import errorMessages from '../../utils/errorMessages'
+
+export default class RiskInformationForm {
+  constructor(private readonly request: Request) {}
+
+  async data(): Promise<FormData<Partial<DraftReferral>>> {
+    const result = await FormUtils.runValidations({
+      request: this.request,
+      validations: RiskInformationForm.validations,
+    })
+
+    const error = FormUtils.validationErrorFromResult(result)
+    if (error !== null) {
+      return { error, paramsForUpdate: null }
+    }
+
+    return {
+      paramsForUpdate: { additionalRiskInformation: this.request.body['additional-risk-information'] },
+      error: null,
+    }
+  }
+
+  private static get validations(): ExpressValidator.ValidationChain[] {
+    return [
+      ExpressValidator.body('additional-risk-information')
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(errorMessages.riskInformation.empty)
+        .isLength({ max: 4000 })
+        .withMessage(errorMessages.riskInformation.tooLong),
+    ]
+  }
+}

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -112,18 +112,4 @@ describe('RiskInformationPresenter', () => {
       })
     })
   })
-
-  describe('summary', () => {
-    it('returns a summary of the service user’s risk scores', () => {
-      const referral = draftReferralFactory.serviceUserSelected().build()
-      const presenter = new RiskInformationPresenter(referral)
-
-      expect(presenter.summary).toEqual([
-        { key: 'OGRS score', text: '50' },
-        { key: 'ROSHA score', text: 'Medium' },
-        { key: 'RM2000 score', text: 'Medium' },
-        { key: 'SARA score', text: 'Low' },
-      ])
-    })
-  })
 })

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -14,7 +14,7 @@ describe('RiskInformationPresenter', () => {
         title: 'Geoffrey’s risk information',
         additionalRiskInformation: {
           errorMessage: null,
-          label: 'Additional information for the provider about Geoffrey’s risks (optional)',
+          label: 'Information for the service provider about Geoffrey’s risks',
         },
       })
     })

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -86,7 +86,7 @@ describe('RiskInformationPresenter', () => {
   })
 
   describe('errorSummary', () => {
-    describe('when errors is null', () => {
+    describe('when error is null', () => {
       it('returns null', () => {
         const referral = draftReferralFactory.serviceUserSelected().build()
         const presenter = new RiskInformationPresenter(referral, null)
@@ -95,7 +95,7 @@ describe('RiskInformationPresenter', () => {
       })
     })
 
-    describe('when errors is not null', () => {
+    describe('when error is not null', () => {
       it('returns the errors', () => {
         const referral = draftReferralFactory.serviceUserSelected().build()
         const presenter = new RiskInformationPresenter(referral, {

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -12,7 +12,7 @@ export default class RiskInformationPresenter {
   readonly text = {
     title: `${this.referral.serviceUser?.firstName}’s risk information`,
     additionalRiskInformation: {
-      label: `Additional information for the provider about ${this.referral.serviceUser?.firstName}’s risks (optional)`,
+      label: `Information for the service provider about ${this.referral.serviceUser?.firstName}’s risks`,
       errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
     },
   }

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -9,14 +9,6 @@ export default class RiskInformationPresenter {
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
-  readonly summary = [
-    { key: 'OGRS score', text: '50' },
-    { key: 'ROSHA score', text: 'Medium' },
-    { key: 'RM2000 score', text: 'Medium' },
-    { key: 'SARA score', text: 'Low' },
-    // TODO IC-806 populate with service user data once we have it
-  ]
-
   readonly text = {
     title: `${this.referral.serviceUser?.firstName}’s risk information`,
     additionalRiskInformation: {

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -1,22 +1,11 @@
 import RiskInformationPresenter from './riskInformationPresenter'
 import ViewUtils from '../../utils/viewUtils'
-import { SummaryListArgs, TextareaArgs } from '../../utils/govukFrontendTypes'
+import { TextareaArgs } from '../../utils/govukFrontendTypes'
 
 export default class RiskInformationView {
   constructor(private readonly presenter: RiskInformationPresenter) {}
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
-
-  private get summaryListArgs(): SummaryListArgs {
-    return {
-      rows: this.presenter.summary.map(item => {
-        return {
-          key: { text: item.key },
-          value: { text: item.text },
-        }
-      }),
-    }
-  }
 
   private get additionalRiskInformationTextareaArgs(): TextareaArgs {
     return {
@@ -37,7 +26,6 @@ export default class RiskInformationView {
       {
         presenter: this.presenter,
         errorSummaryArgs: this.errorSummaryArgs,
-        summaryListArgs: this.summaryListArgs,
         additionalRiskInformationTextareaArgs: this.additionalRiskInformationTextareaArgs,
       },
     ]

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -16,6 +16,9 @@ export default class RiskInformationView {
         classes: 'govuk-label--s',
       },
       value: this.presenter.fields.additionalRiskInformation,
+      hint: {
+        text: 'Provide relevant risk information to share with the service provider.',
+      },
       errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.additionalRiskInformation.errorMessage),
     }
   }

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -8,6 +8,10 @@ export default {
     crnNotFound: 'CRN not found in nDelius',
     unknownError: 'Could not start referral due to service interruption; please try again later',
   },
+  riskInformation: {
+    empty: 'Enter risk information',
+    tooLong: 'Risk information must be 4000 characters or fewer',
+  },
   completionDeadline: {
     dayEmpty: 'The date by which the service needs to be completed must include a day',
     monthEmpty: 'The date by which the service needs to be completed must include a month',

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -18,6 +18,10 @@
 
       {{ govukSummaryList(serviceUserDetailsSummaryListArgs) }}
 
+      <h2 class="govuk-heading-l">{{ presenter.riskSection.title }}</h2>
+
+      <p class="govuk-body">{{ presenter.riskSection.text | escape | nl2br }}</p>
+
       <h2 class="govuk-heading-l">{{ presenter.needsAndRequirementsSection.title }}</h2>
 
       {{ govukSummaryList(needsAndRequirementsSummaryListArgs) }}

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -2,7 +2,6 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -20,13 +19,6 @@
       {% endif %}
 
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
-
-      {# TODO IC-806 remove this placeholder text #}
-      {{ govukInsetText({
-        text: "The following is hardcoded placeholder data, subject to change."
-      }) }}
-
-      {{ govukSummaryList(summaryListArgs) }}
 
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">


### PR DESCRIPTION
## What does this pull request do?

Changes the probation practitioner make a referral journey to get us ready for putting the service into production next week, when the only way in which PPs will be able to submit risk information is via the "risk information" text input.

So, we:

- stop pretending that we're pulling data from OASys and get rid of the hardcoded risk scores
- make the risk information mandatory and enforce a length limit
- update to match the latest designs (there is a bit of TBC about the text still, but nothing to block a review)

## What is the intent behind these changes?

To make sure that a probation practitioner provides risk information when making a referral.

# Screenshots

![Screenshot 2021-06-03 at 15-46-13 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/120665049-59209700-c483-11eb-80b1-9ecfcbf8b2e2.png)
![Screenshot 2021-06-03 at 15-45-42 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/120665076-5de54b00-c483-11eb-839c-d9d8a22b253c.png)
![Screenshot 2021-06-03 at 15-46-00 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/120665062-5b82f100-c483-11eb-91cd-0c9ada375163.png)