### PR TITLE
Remove links to case notes

### DIFF
--- a/server/routes/shared/referralOverviewPagePresenter.ts
+++ b/server/routes/shared/referralOverviewPagePresenter.ts
@@ -19,11 +19,6 @@ export default class ReferralOverviewPagePresenter {
         active: this.section === ReferralOverviewPageSection.Progress,
       },
       {
-        text: 'Case notes',
-        href: `/${this.subNavUrlPrefix}/referrals/${this.referralId}/case-notes`,
-        active: this.section === ReferralOverviewPageSection.CaseNotes,
-      },
-      {
         text: 'Referral details',
         href: `/${this.subNavUrlPrefix}/referrals/${this.referralId}/details`,
         active: this.section === ReferralOverviewPageSection.Details,


### PR DESCRIPTION
These aren't going to be done by the time we go live next week, so get
rid of the dead links.