### PR TITLE
IC-1854: remove hardcoded and unavailable risk info from referral details page

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -153,9 +153,9 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('Autism spectrum condition')
     cy.contains('sciatica')
     cy.contains("Service user's risk information")
-    cy.contains('Risk to known adult')
-    cy.contains('Medium')
-    cy.contains('A danger to the elderly')
+    cy.contains(
+      'The Refer and Monitor an Intervention service cannot currently display this risk information. We will add it in the coming weeks.'
+    )
     cy.contains("Service user's needs")
     cy.contains('Alex is currently sleeping on her aunt’s sofa')
     cy.contains('She uses a wheelchair')

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -274,7 +274,12 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(sentReferral, intervention, deliusUser, null, null)
 
       expect(presenter.serviceUserRisks).toEqual([
-        { key: 'Additional risk information', lines: [sentReferral.referral.additionalRiskInformation] },
+        {
+          key: 'Additional risk information',
+          lines: [
+            'The Refer and Monitor an Intervention service cannot currently display this risk information. We will add it in the coming weeks.',
+          ],
+        },
       ])
     })
   })

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -274,10 +274,6 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(sentReferral, intervention, deliusUser, null, null)
 
       expect(presenter.serviceUserRisks).toEqual([
-        { key: 'Risk to known adult', lines: ['Medium'] },
-        { key: 'Risk to public', lines: ['Low'] },
-        { key: 'Risk to children', lines: ['Low'] },
-        { key: 'Risk to staff', lines: ['Low'] },
         { key: 'Additional risk information', lines: [sentReferral.referral.additionalRiskInformation] },
       ])
     })

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -155,10 +155,6 @@ export default class ShowReferralPresenter {
 
   get serviceUserRisks(): SummaryListItem[] {
     return [
-      { key: 'Risk to known adult', lines: ['Medium'] },
-      { key: 'Risk to public', lines: ['Low'] },
-      { key: 'Risk to children', lines: ['Low'] },
-      { key: 'Risk to staff', lines: ['Low'] },
       {
         key: 'Additional risk information',
         lines: [this.sentReferral.referral.additionalRiskInformation],

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.ts
@@ -157,7 +157,9 @@ export default class ShowReferralPresenter {
     return [
       {
         key: 'Additional risk information',
-        lines: [this.sentReferral.referral.additionalRiskInformation],
+        lines: [
+          'The Refer and Monitor an Intervention service cannot currently display this risk information. We will add it in the coming weeks.',
+        ],
       },
     ]
   }


### PR DESCRIPTION
## What does this pull request do?

Removes hardcoded risk info from the referral details page, and adds a message explaining that the risk info is not yet available.

## What is the intent behind these changes?

To make sure we don't show inaccurate risk information, and to explain when risk information will become available.

## Screenshot

![Screenshot 2021-06-04 at 11-43-10 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/120790215-8d02c780-c52a-11eb-8857-4882d321fae1.png)

