### PR TITLE
IC-1857: Hide intervention details until service categories are selected

### DIFF
--- a/integration_tests/integration/make_a_referral/referralSectionVerifier.js
+++ b/integration_tests/integration/make_a_referral/referralSectionVerifier.js
@@ -51,6 +51,14 @@ class _ReferralSectionChecker {
     return this
   }
 
+  disabledCohortInterventionReferralDetails() {
+    cy.get(`[data-cy=url]:contains("Details of this part will depend on the services you choose")`).should(
+      'not.have.attr',
+      'href'
+    )
+    return this
+  }
+
   cohortInterventionReferralDetails(activeLinks) {
     cy.get(`[data-cy=url]:contains("Confirm the relevant sentence for the Women's services referral")`).should(
       hrefAttrChainer(activeLinks.relevantSentence),

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -447,6 +447,7 @@ describe('Referral form', () => {
           needsAndRequirements: false,
         })
         .selectServiceCategories({ selectServiceCategories: false })
+        .disabledCohortInterventionReferralDetails()
         .checkYourAnswers({ checkAnswers: false })
 
       cy.contains('Confirm service user’s personal details').click()

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -272,9 +272,7 @@ describe('ReferralFormPresenter', () => {
                 'service-categories'
               )
               .build(),
-            cohortReferralFormSectionFactory
-              .cohortInterventionDetails('Accommodation', ReferralFormStatus.CannotStartYet, null, null)
-              .build(),
+            referralFormSectionFactory.disabledCohortInterventionDetails('Accommodation').build(),
             referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
           ]
           expect(presenter.sections).toEqual(expected)

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -278,6 +278,29 @@ describe('ReferralFormPresenter', () => {
           expect(presenter.sections).toEqual(expected)
         })
       })
+      describe('when service categories is empty', () => {
+        it('should contain a "Not Started" label', () => {
+          const referral = draftReferralFactory
+            .filledFormUpToNeedsAndRequirements(serviceCategories)
+            .build({ serviceCategoryIds: [] })
+          const presenter = new ReferralFormPresenter(referral, cohortIntervention)
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+              .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.NotStarted,
+                'service-categories'
+              )
+              .build(),
+            referralFormSectionFactory.disabledCohortInterventionDetails('Accommodation').build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
+      })
     })
     describe('service category referral details section', () => {
       describe('when "selected service categories" has been set', () => {

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -338,15 +338,15 @@ class TaskValues {
     ]
   }
 
-  get relevantSentence(): DraftReferralValues {
-    return [this.referral.relevantSentenceId]
-  }
-
   get cohortServiceCategories(): DraftReferralValues {
-    if (this.referral.serviceCategoryIds === null) {
+    if (this.referral.serviceCategoryIds === null || this.referral.serviceCategoryIds.length === 0) {
       return [null]
     }
     return this.referral.serviceCategoryIds
+  }
+
+  get relevantSentence(): DraftReferralValues {
+    return [this.referral.relevantSentenceId]
   }
 
   get allComplexityLevels(): DraftReferralValues {

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -154,7 +154,21 @@ class FormSectionBuilder {
 
   private buildCohortReferralDetailsSection(
     selectServiceCategoriesSection: ReferralFormSingleListSectionPresenter
-  ): ReferralFormMultiListSectionPresenter {
+  ): ReferralFormSectionPresenter {
+    if (selectServiceCategoriesSection.status !== ReferralFormStatus.Completed) {
+      return {
+        type: 'single',
+        title: `Add ${utils.convertToProperCase(this.intervention.contractType.name)} referral details`,
+        number: '3',
+        status: ReferralFormStatus.CannotStartYet,
+        tasks: [
+          {
+            title: 'Details of this part will depend on the services you choose',
+            url: null,
+          },
+        ],
+      }
+    }
     return {
       type: 'multi',
       title: `Add ${utils.convertToProperCase(this.intervention.contractType.name)} referral details`,

--- a/testutils/factories/referralFormSection.ts
+++ b/testutils/factories/referralFormSection.ts
@@ -75,6 +75,21 @@ class ReferralFormSectionFactory extends Factory<ReferralFormSingleListSectionPr
     })
   }
 
+  disabledCohortInterventionDetails(contractName: string) {
+    return this.params({
+      type: 'single',
+      title: `Add ${utils.convertToProperCase(contractName)} referral details`,
+      number: '3',
+      status: ReferralFormStatus.CannotStartYet,
+      tasks: [
+        {
+          title: `Details of this part will depend on the services you choose`,
+          url: null,
+        },
+      ],
+    })
+  }
+
   checkAnswers(
     referralFormStatus: ReferralFormStatus = ReferralFormStatus.CannotStartYet,
     checkAnswersUrl: string | null = null,


### PR DESCRIPTION
## What does this pull request do?

Hides service category related details section for cohort referrals until user has selected them


![image](https://user-images.githubusercontent.com/83066216/120815929-3310fa80-c548-11eb-9dcf-918f9a7dc702.png)

## What is the intent behind these changes?

Ensure that the page doesn't show incomplete sections
