### PR TITLE
 Ensure service categories always show in same order as selectedServiceCategories on make a referral screen

### DIFF
--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -304,6 +304,41 @@ describe('ReferralFormPresenter', () => {
     })
     describe('service category referral details section', () => {
       describe('when "selected service categories" has been set', () => {
+        it('should always be ordered in same order as selected service cateogries', () => {
+          const disorderedServiceCategories = [serviceCategories[0], serviceCategories[1]]
+          const disorderedCohortIntervention = interventionFactory.build({
+            serviceCategories: disorderedServiceCategories,
+          })
+          const referral = draftReferralFactory
+            .filledFormUpToNeedsAndRequirements(serviceCategories)
+            .selectedServiceCategories(serviceCategories)
+            .build()
+          const presenter = new ReferralFormPresenter(referral, disorderedCohortIntervention)
+          const expected = [
+            referralFormSectionFactory
+              .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+              .build(),
+            referralFormSectionFactory
+              .selectedServiceCategories(
+                cohortIntervention.contractType.name,
+                ReferralFormStatus.Completed,
+                'service-categories'
+              )
+              .build(),
+            cohortReferralFormSectionFactory
+              .cohortInterventionDetails('Accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence', [
+                {
+                  title: 'accommodation',
+                  desiredOutcomesUrl: null,
+                  complexityLevelUrl: null,
+                },
+                { title: 'social inclusion', complexityLevelUrl: null, desiredOutcomesUrl: null },
+              ])
+              .build(),
+            referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet, null, '4').build(),
+          ]
+          expect(presenter.sections).toEqual(expected)
+        })
         it('should contain a "Not Started" label and "relevant-sentence" url is visible', () => {
           const referral = draftReferralFactory
             .filledFormUpToNeedsAndRequirements(serviceCategories)

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -191,6 +191,7 @@ class FormSectionBuilder {
       ]
         .concat(
           this.intervention.serviceCategories
+            .sort((a, b) => a.id.localeCompare(b.id))
             .filter(serviceCat => {
               if (this.referral.serviceCategoryIds !== null) {
                 return this.referral.serviceCategoryIds.some(id => id === serviceCat.id)


### PR DESCRIPTION
## What does this pull request do?

 Ensures service categories always show in same order as selectedServiceCategories on make a referral screen

## What is the intent behind these changes?

 Ensures service categories always show in same order as selectedServiceCategories on make a referral screen
