### PR TITLE
Remove deprecated serviceCategory in favour of serviceCategories for intervention

### DIFF
--- a/server/models/intervention.ts
+++ b/server/models/intervention.ts
@@ -21,7 +21,6 @@ export default interface Intervention {
   description: string
   npsRegion: NPSRegion | null
   pccRegions: PCCRegion[]
-  serviceCategory: ServiceCategory // deprecated
   serviceCategories: ServiceCategory[]
   serviceProvider: ServiceProvider
   eligibility: Eligibility

--- a/server/routes/findInterventions/findInterventionsController.test.ts
+++ b/server/routes/findInterventions/findInterventionsController.test.ts
@@ -6,6 +6,7 @@ import InterventionsService from '../../services/interventionsService'
 import apiConfig from '../../config'
 import interventionFactory from '../../../testutils/factories/intervention'
 import pccRegionFactory from '../../../testutils/factories/pccRegion'
+import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 
 jest.mock('../../services/interventionsService')
 const interventionsService = new InterventionsService(apiConfig.apis.interventionsService) as jest.Mocked<
@@ -32,7 +33,10 @@ describe(FindInterventionsController, () => {
         { title: 'Better solutions (anger management)', categoryName: 'thinking and behaviour' },
         { title: 'HELP (domestic violence for males)', categoryName: 'relationships' },
       ].map(params => {
-        return interventionFactory.build({ title: params.title, serviceCategory: { name: params.categoryName } })
+        return interventionFactory.build({
+          title: params.title,
+          serviceCategories: [serviceCategoryFactory.build({ name: params.categoryName })],
+        })
       })
       interventionsService.getInterventions.mockResolvedValue(interventions)
 
@@ -75,7 +79,7 @@ describe(FindInterventionsController, () => {
     it('responds with a 200', async () => {
       const intervention = interventionFactory.build({
         title: 'Better solutions (anger management)',
-        serviceCategory: { name: 'thinking and behaviour' },
+        serviceCategories: [serviceCategoryFactory.build({ name: 'thinking and behaviour' })],
       })
 
       interventionsService.getIntervention.mockResolvedValue(intervention)

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -156,7 +156,6 @@ describe('GET /referrals/:id/form', () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const intervention = interventionFactory.build({
       serviceCategories: [serviceCategory],
-      serviceCategory,
     })
     const referral = draftReferralFactory
       .serviceCategorySelected(serviceCategory.id)

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -9,7 +9,7 @@ import { TagArgs } from '../../utils/govukFrontendTypes'
 
 describe(ShowReferralPresenter, () => {
   const intervention = interventionFactory.build()
-  const { serviceCategory } = intervention
+  const serviceCategory = intervention.serviceCategories[0]
 
   const cohortServiceCategories = [
     serviceCategoryFactory.build({ name: 'Lifestyle and associates' }),
@@ -18,7 +18,6 @@ describe(ShowReferralPresenter, () => {
   const cohortIntervention = interventionFactory.build({
     contractType: { code: 'PWB', name: 'Personal wellbeing' },
     serviceCategories: cohortServiceCategories,
-    serviceCategory: cohortServiceCategories[0],
   })
 
   const referralParams = {

--- a/testutils/factories/intervention.ts
+++ b/testutils/factories/intervention.ts
@@ -26,7 +26,6 @@ The service will use the following methods:
       { id: 'lancashire', name: 'Lancashire' },
       { id: 'merseyside', name: 'Merseyside' },
     ],
-    serviceCategory,
     serviceCategories: [serviceCategory],
     serviceProvider: serviceProviderFactory.build(),
     eligibility: eligibilityFactory.allAdults().build(),


### PR DESCRIPTION
## What does this pull request do?

Removes deprecated serviceCategory in favour of serviceCategories for intervention

## What is the intent behind these changes?

To help make pact tests green because on the back-end the InterventionDTO has `serviceCategory` removed
