### PR TITLE
Deploy to prod after successful preprod deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,17 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-interventions-ui-preprod
+      - hmpps/deploy_env:
+          name: deploy_prod
+          env: "prod"
+          retrieve_secrets: "none"
+          slack_notification: true
+          slack_channel_name: "interventions-alerts"
+          requires:
+            - deploy_preprod
+          context:
+            - hmpps-common-vars
+            - hmpps-interventions-ui-prod
 
   nightly:
     triggers:


### PR DESCRIPTION
## What does this pull request do?

Adds deployment (no manual approval needed) to prod after successful preprod deploy

## What is the intent behind these changes?

To make sure we can deploy