### PR TITLE
add new risk id into sent referral model, and remove 'additionalRiskInformation' from sent referral DTO

### DIFF
--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -22,7 +22,6 @@ export interface ReferralFields {
   hasAdditionalResponsibilities: boolean
   whenUnavailable: string | null
   serviceUser: ServiceUser
-  additionalRiskInformation: string
   maximumEnforceableDays: number
 }
 
@@ -31,4 +30,6 @@ export default interface DraftReferral extends WithNullableValues<ReferralFields
   createdAt: string
   serviceUser: ServiceUser
   interventionId: string
+  // risk information is a special field which is only set on the draft referral
+  additionalRiskInformation: string | null
 }

--- a/server/models/sentReferral.ts
+++ b/server/models/sentReferral.ts
@@ -8,6 +8,7 @@ export default interface SentReferral {
   referenceNumber: string
   referral: ReferralFields
   sentBy: User
+  supplementaryRiskId: string
   assignedTo: User | null
   actionPlanId: string | null
   endRequestedAt: string | null

--- a/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/showReferralPresenter.test.ts
@@ -115,7 +115,6 @@ describe(ShowReferralPresenter, () => {
             religionOrBelief: 'Agnostic',
             disabilities: ['Autism spectrum condition', 'sciatica'],
           },
-          additionalRiskInformation: 'A danger to the elderly',
           maximumEnforceableDays: 10,
         },
       })
@@ -176,7 +175,6 @@ describe(ShowReferralPresenter, () => {
             religionOrBelief: 'Agnostic',
             disabilities: ['Autism spectrum condition', 'sciatica'],
           },
-          additionalRiskInformation: '',
           maximumEnforceableDays: 10,
         },
       })
@@ -322,7 +320,6 @@ describe(ShowReferralPresenter, () => {
               religionOrBelief: 'Agnostic',
               disabilities: ['Autism spectrum condition', 'sciatica'],
             },
-            additionalRiskInformation: 'A danger to the elderly',
             maximumEnforceableDays: 10,
           },
         })
@@ -405,7 +402,6 @@ describe(ShowReferralPresenter, () => {
               religionOrBelief: 'Agnostic',
               disabilities: ['Autism spectrum condition', 'sciatica'],
             },
-            additionalRiskInformation: '',
             maximumEnforceableDays: 10,
           },
         })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1241,6 +1241,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     concludedAt: null,
     endOfServiceReport: null,
     referenceNumber: 'HDJ2123F',
+    supplementaryRiskId: 'a1f5ce02-53a3-47c4-bc71-45f1bdbf504c',
     referral: {
       createdAt: '2021-01-11T10:32:12.382884Z',
       completionDeadline: '2021-04-01',
@@ -1270,7 +1271,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       hasAdditionalResponsibilities: true,
       whenUnavailable: 'She works Mondays 9am - midday',
       serviceUser,
-      additionalRiskInformation: 'A danger to the elderly',
       maximumEnforceableDays: 10,
     },
   }

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -47,7 +47,6 @@ const exampleReferralFields = () => {
       religionOrBelief: 'Agnostic',
       disabilities: ['Autism spectrum condition', 'sciatica'],
     },
-    additionalRiskInformation: 'A danger to the elderly',
     maximumEnforceableDays: 10,
   }
 }
@@ -103,6 +102,7 @@ export default SentReferralFactory.define(({ sequence }) => ({
     authSource: 'delius',
   },
   referenceNumber: sequence.toString().padStart(8, 'ABC'),
+  supplementaryRiskId: 'a1f5ce02-53a3-47c4-bc71-45f1bdbf504c',
   referral: exampleReferralFields(),
   assignedTo: null,
   actionPlanId: null,


### PR DESCRIPTION


## What does this pull request do?

add new risk id into sent referral model, and make draft referral 'additionalRiskInformation' nullable in sent referral

## What is the intent behind these changes?

allow the UI to accept the risk id, and ensure the field is included in the contract tests.
