### PR TITLE
Fixes CWE-99 and CWE-117 flagged by veracode

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -9,10 +9,11 @@ initialiseAppInsights()
 buildAppInsightsClient()
 
 import app from './server/index'
+import config from './server/config'
 import log from './log'
 
-app.listen(app.get('port'), async () => {
-  log.info(`Server listening on port ${app.get('port')}`)
+app.listen(config.port, async () => {
+  log.info(`Server listening on port ${config.port}`)
 
   if (process.env.NODE_ENV === 'development') {
     const { default: setUpMocks } = await import('./mocks')

--- a/server/config.ts
+++ b/server/config.ts
@@ -37,7 +37,7 @@ export default {
   version: Date.now().toString(),
   production,
   testMode: process.env.NODE_ENV === 'test',
-  port: get('PORT', 3000),
+  port: Number(get('PORT', 3000)),
   https: production,
   staticResourceCacheDuration: 20,
   deploymentEnvironment: get('DEPLOYMENT_ENV', 'local', requiredInProduction),


### PR DESCRIPTION
## What does this pull request do?

CWE-99: Improper Control of Resource Identifiers is flagged on `app.listen(app.get('port')...`
CWE-117: Improper Output Neutralization for Logs is flagged on ```log.info(`Server listening on port ${app.get('port')}`)```

The code switches to use `config.port`, which is then sanitised by converting the env variable to a number, defaulting to a sane value

## What is the intent behind these changes?

Reduce medium CWEs open on the app.

To exploit these, someone would need to override the `PORT` variable on a production setting. Tbh if someone can do that, they can probably do much worse. 🤷 