### PR TITLE
Remove duplicated "Date of birth:" label from SU banner

### DIFF
--- a/server/routes/shared/serviceUserBannerPresenter.test.ts
+++ b/server/routes/shared/serviceUserBannerPresenter.test.ts
@@ -36,11 +36,11 @@ describe(ServiceUserBannerPresenter, () => {
       serviceUser.dateOfBirth = '1989-02-10'
 
       const presenterWithDOB = new ServiceUserBannerPresenter(serviceUser)
-      expect(presenterWithDOB.dateOfBirth).toEqual('Date of birth: 10 February 1989')
+      expect(presenterWithDOB.dateOfBirth).toEqual('10 February 1989')
 
       serviceUser.dateOfBirth = null
       const presenterWithoutDOB = new ServiceUserBannerPresenter(serviceUser)
-      expect(presenterWithoutDOB.dateOfBirth).toEqual('Date of birth: Not found')
+      expect(presenterWithoutDOB.dateOfBirth).toEqual('Not found')
     })
   })
 

--- a/server/routes/shared/serviceUserBannerPresenter.ts
+++ b/server/routes/shared/serviceUserBannerPresenter.ts
@@ -10,7 +10,7 @@ export default class ServiceUserBannerPresenter {
   }
 
   get dateOfBirth(): string {
-    return `Date of birth: ${PresenterUtils.govukFormattedDateFromStringOrNull(this.serviceUser.dateOfBirth)}`
+    return PresenterUtils.govukFormattedDateFromStringOrNull(this.serviceUser.dateOfBirth)
   }
 
   get serviceUserEmail(): string {


### PR DESCRIPTION
## What does this pull request do?

Fixes the SU banner saying "Date of birth: Date of birth:"

(It was being added in both the presenter and the view.)

## What is the intent behind these changes?

To fix a bug.