### PR TITLE
Fix local Interventions API -> Community API comms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=local,seed
       - POSTGRES_URI=postgres:5432
+      - COMMUNITY-API_BASEURL=http://community-api:8080
 
   postgres:
     image: postgres:10-alpine


### PR DESCRIPTION
## What does this pull request do?

Fixes the local development environment, by fixing communications between the interventions service and Community API.

I’m not sure what’s changed recently, but the interventions service is
unable to connect to Community API on http://localhost:8091.

So, change the Community API base URL used by Interventions API to match
that used used in our configuration of HMPPS Auth. This solves the problem.

As I say, not sure why this problem has started happening. In
https://github.com/ministryofjustice/hmpps-interventions-service/commit/0ac9b60ed5de5eec662be854ecb60a331202c6b0
the interventions service switched the local Community API base URL from
http://localhost:8081 to http://localhost:8091, which I thought was the
culprit, but running `curl localhost:8081` from inside an interventions
service container also gives the same connection refused error, so perhaps it’s
not that.

## What is the intent behind these changes?

To unblock local testing.