### PR TITLE
IC-1832: Allow trailing and leading whitespace when entering CRN for …

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -126,7 +126,7 @@ describe('Referral form', () => {
 
       cy.visit(`/intervention/${randomInterventionId}/refer`)
 
-      cy.contains('Service user CRN').type('X123456')
+      cy.contains('Service user CRN').type(' X123456 ')
 
       cy.contains('Continue').click()
 

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -126,7 +126,7 @@ describe('Referral form', () => {
 
       cy.visit(`/intervention/${randomInterventionId}/refer`)
 
-      cy.contains('Service user CRN').type(' X123456 ')
+      cy.contains('Service user CRN').type(' x123456 ')
 
       cy.contains('Continue').click()
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -98,24 +98,46 @@ describe('POST /intervention/:id/refer', () => {
     })
   })
 
-  describe('when providing a CRN with blank space', () => {
-    it('trims any leading and trailing whitespace', async () => {
-      const interventionId = '98a42c61-c30f-4beb-8062-04033c376e2d'
-      const serviceUserCRN = ' X123456 '
-      const serviceUserCRNTrimmed = 'X123456'
+  describe('when a non standard CRN is entered', () => {
+    describe('having leading and trailing whitespace', () => {
+      it('trims any leading and trailing whitespace', async () => {
+        const interventionId = '98a42c61-c30f-4beb-8062-04033c376e2d'
+        const serviceUserCRN = ' X123456 '
+        const serviceUserCRNTrimmed = 'X123456'
 
-      await request(app)
-        .post(`/intervention/${interventionId}/refer`)
-        .send({ 'service-user-crn': serviceUserCRN })
-        .expect(303)
-        .expect('Location', '/referrals/1/form')
+        await request(app)
+          .post(`/intervention/${interventionId}/refer`)
+          .send({ 'service-user-crn': serviceUserCRN })
+          .expect(303)
+          .expect('Location', '/referrals/1/form')
 
-      expect(communityApiService.getServiceUserByCRN).toHaveBeenCalledWith(serviceUserCRNTrimmed)
-      expect(interventionsService.createDraftReferral).toHaveBeenCalledWith(
-        'token',
-        serviceUserCRNTrimmed,
-        interventionId
-      )
+        expect(communityApiService.getServiceUserByCRN).toHaveBeenCalledWith(serviceUserCRNTrimmed)
+        expect(interventionsService.createDraftReferral).toHaveBeenCalledWith(
+          'token',
+          serviceUserCRNTrimmed,
+          interventionId
+        )
+      })
+    })
+    describe('having lowercase characters', () => {
+      it('transforms lowercase characters to uppercase', async () => {
+        const interventionId = '98a42c61-c30f-4beb-8062-04033c376e2d'
+        const serviceUserCRN = 'x123456'
+        const serviceUserCRNTransformed = 'X123456'
+
+        await request(app)
+          .post(`/intervention/${interventionId}/refer`)
+          .send({ 'service-user-crn': serviceUserCRN })
+          .expect(303)
+          .expect('Location', '/referrals/1/form')
+
+        expect(communityApiService.getServiceUserByCRN).toHaveBeenCalledWith(serviceUserCRNTransformed)
+        expect(interventionsService.createDraftReferral).toHaveBeenCalledWith(
+          'token',
+          serviceUserCRNTransformed,
+          interventionId
+        )
+      })
     })
   })
   describe('when the interventions service returns an error', () => {

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -98,6 +98,26 @@ describe('POST /intervention/:id/refer', () => {
     })
   })
 
+  describe('when providing a CRN with blank space', () => {
+    it('trims any leading and trailing whitespace', async () => {
+      const interventionId = '98a42c61-c30f-4beb-8062-04033c376e2d'
+      const serviceUserCRN = ' X123456 '
+      const serviceUserCRNTrimmed = 'X123456'
+
+      await request(app)
+        .post(`/intervention/${interventionId}/refer`)
+        .send({ 'service-user-crn': serviceUserCRN })
+        .expect(303)
+        .expect('Location', '/referrals/1/form')
+
+      expect(communityApiService.getServiceUserByCRN).toHaveBeenCalledWith(serviceUserCRNTrimmed)
+      expect(interventionsService.createDraftReferral).toHaveBeenCalledWith(
+        'token',
+        serviceUserCRNTrimmed,
+        interventionId
+      )
+    })
+  })
   describe('when the interventions service returns an error', () => {
     beforeEach(() => {
       interventionsService.createDraftReferral.mockRejectedValue(new Error('Failed to create intervention'))

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -67,7 +67,7 @@ export default class ReferralsController {
 
     let serviceUser: DeliusServiceUser | null = null
 
-    const crn = req.body['service-user-crn']
+    const crn = req.body['service-user-crn']?.trim()
     const { interventionId } = req.params
 
     if (form.isValid) {

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -67,7 +67,8 @@ export default class ReferralsController {
 
     let serviceUser: DeliusServiceUser | null = null
 
-    const crn = req.body['service-user-crn']?.trim()
+    // We trim and change to uppercase to make user experience more pleasant. All CRNs are uppercase in delius.
+    const crn = req.body['service-user-crn']?.trim()?.toUpperCase()
     const { interventionId } = req.params
 
     if (form.isValid) {


### PR DESCRIPTION
…make a referral journey

## What does this pull request do?

Removes trailing and leading whitespace on CRN when being entered by user for make a referral journey.

![image](https://user-images.githubusercontent.com/83066216/120986123-2a9d0780-c774-11eb-9b3e-1ab2804fbd96.png)


## What is the intent behind these changes?

Make user experience more enjoyable when copy and pasting CRNs