### PR TITLE
Load instrumentation key on target environments

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
@@ -55,6 +55,12 @@ env:
         name: sentry
         key: ui_dsn
 
+  - name: APPLICATIONINSIGHTS_INSTRUMENTATION_KEY
+    valueFrom:
+      secretKeyRef:
+        name: application-insights
+        key: instrumentation_key
+
   {{ range $key, $value := .Values.env }}
   - name: {{ $key }}
     value: {{ $value | quote }}

--- a/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-ui/templates/_envs.tpl
@@ -55,11 +55,11 @@ env:
         name: sentry
         key: ui_dsn
 
-  - name: APPLICATIONINSIGHTS_INSTRUMENTATION_KEY
+  - name: APPLICATIONINSIGHTS_CONNECTION_STRING
     valueFrom:
       secretKeyRef:
         name: application-insights
-        key: instrumentation_key
+        key: connection_string
 
   {{ range $key, $value := .Values.env }}
   - name: {{ $key }}

--- a/helm_deploy/secrets-example.yaml
+++ b/helm_deploy/secrets-example.yaml
@@ -1,6 +1,6 @@
 ---
 secrets:
-  APPINSIGHTS_INSTRUMENTATIONKEY: somesecretvalue
+  APPLICATIONINSIGHTS_INSTRUMENTATION_KEY: somesecretvalue
   API_CLIENT_ID: clientid
   API_CLIENT_SECRET: clientsecret
   LOGIN_CLIENT_ID: clientid

--- a/helm_deploy/secrets-example.yaml
+++ b/helm_deploy/secrets-example.yaml
@@ -1,6 +1,6 @@
 ---
 secrets:
-  APPLICATIONINSIGHTS_INSTRUMENTATION_KEY: somesecretvalue
+  APPLICATIONINSIGHTS_CONNECTION_STRING: somesecretvalue
   API_CLIENT_ID: clientid
   API_CLIENT_SECRET: clientsecret
   LOGIN_CLIENT_ID: clientid

--- a/server/config.ts
+++ b/server/config.ts
@@ -48,7 +48,7 @@ export default {
     tls_enabled: get('REDIS_TLS_ENABLED', 'false'),
   },
   applicationInsights: {
-    instrumentationKey: get('APPLICATIONINSIGHTS_INSTRUMENTATION_KEY', 'dummy', requiredInProduction),
+    connectionString: get('APPLICATIONINSIGHTS_CONNECTION_STRING', 'dummy', requiredInProduction),
   },
   session: {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),

--- a/server/config.ts
+++ b/server/config.ts
@@ -47,6 +47,9 @@ export default {
     password: process.env.REDIS_AUTH_TOKEN,
     tls_enabled: get('REDIS_TLS_ENABLED', 'false'),
   },
+  applicationInsights: {
+    instrumentationKey: get('APPLICATIONINSIGHTS_INSTRUMENTATION_KEY', 'dummy', requiredInProduction),
+  },
   session: {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),
     expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', '120')),

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -15,16 +15,18 @@ function version(): string {
 }
 
 export function initialiseAppInsights(): void {
-  if (config.applicationInsights.instrumentationKey !== 'dummy') {
+  if (config.applicationInsights.connectionString !== 'dummy') {
     // eslint-disable-next-line no-console
     console.log('Enabling azure application insights')
 
-    setup().setDistributedTracingMode(DistributedTracingModes.AI_AND_W3C).start()
+    setup(config.applicationInsights.connectionString)
+      .setDistributedTracingMode(DistributedTracingModes.AI_AND_W3C)
+      .start()
   }
 }
 
 export function buildAppInsightsClient(name = defaultName()): TelemetryClient | null {
-  if (config.applicationInsights.instrumentationKey !== 'dummy') {
+  if (config.applicationInsights.connectionString !== 'dummy') {
     defaultClient.context.tags['ai.cloud.role'] = name
     defaultClient.context.tags['ai.application.ver'] = version()
     return defaultClient

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,6 +1,6 @@
-import { config } from 'dotenv'
 import { setup, defaultClient, TelemetryClient, DistributedTracingModes } from 'applicationinsights'
 import applicationVersion from '../applicationVersion'
+import config from '../config'
 
 function defaultName(): string {
   const {
@@ -15,9 +15,7 @@ function version(): string {
 }
 
 export function initialiseAppInsights(): void {
-  // Loads .env file contents into | process.env
-  config()
-  if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+  if (config.applicationInsights.instrumentationKey !== 'dummy') {
     // eslint-disable-next-line no-console
     console.log('Enabling azure application insights')
 
@@ -26,7 +24,7 @@ export function initialiseAppInsights(): void {
 }
 
 export function buildAppInsightsClient(name = defaultName()): TelemetryClient | null {
-  if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+  if (config.applicationInsights.instrumentationKey !== 'dummy') {
     defaultClient.context.tags['ai.cloud.role'] = name
     defaultClient.context.tags['ai.application.ver'] = version()
     return defaultClient


### PR DESCRIPTION
## What does this pull request do?

Load instrumentation key on target environments

`APPINSIGHTS_INSTRUMENTATIONKEY` was always unset on all environments -- this is now read from the same secret that the service uses

Switched to `APPLICATIONINSIGHTS_CONNECTION_STRING` as the service uses that same mechanism

## What is the intent behind these changes?

This will enable tracing across all interventions apps