### PR TITLE
IC-1858: Wording changes for presentation of find interventions page

### DIFF
--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -171,7 +171,7 @@ three lines.`,
 
     describe('Service type', () => {
       describe('for a single-service intervention', () => {
-        it('is the service category name', () => {
+        it('is the service type name', () => {
           expect(
             linesForKey('Service type', {
               serviceCategories: [serviceCategoryFactory.build({ name: 'accommodation' })],
@@ -181,7 +181,7 @@ three lines.`,
       })
 
       describe('for a cohort intervention', () => {
-        it('has a pluralised key, and is a list of service category names', () => {
+        it('has a pluralised key, and is a list of service types names', () => {
           const summary = summaryForParams({
             serviceCategories: [
               serviceCategoryFactory.build({ name: 'accommodation' }),

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -129,8 +129,8 @@ three lines.`,
     }
 
     describe('Type', () => {
-      it('is “Dynamic Framework”', () => {
-        expect(linesForKey('Type', {})).toEqual(['Dynamic Framework'])
+      it('is “Commissioned Rehabilitative Service”', () => {
+        expect(linesForKey('Type', {})).toEqual(['Commissioned Rehabilitative Service'])
       })
     })
 

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -171,9 +171,9 @@ three lines.`,
 
     describe('Service type', () => {
       describe('for a single-service intervention', () => {
-        it('is the service type name', () => {
+        it('is the service category name', () => {
           expect(
-            linesForKey('Service type', {
+            linesForKey('Service category', {
               serviceCategories: [serviceCategoryFactory.build({ name: 'accommodation' })],
             })
           ).toEqual(['Accommodation'])
@@ -181,14 +181,14 @@ three lines.`,
       })
 
       describe('for a cohort intervention', () => {
-        it('has a pluralised key, and is a list of service types names', () => {
+        it('has a pluralised key, and is a list of service category names', () => {
           const summary = summaryForParams({
             serviceCategories: [
               serviceCategoryFactory.build({ name: 'accommodation' }),
               serviceCategoryFactory.build({ name: 'emotional wellbeing' }),
             ],
           })
-          const item = summary.find(anItem => anItem.key === 'Service types')
+          const item = summary.find(anItem => anItem.key === 'Service categories')
           expect(item).toMatchObject({ lines: ['Accommodation', 'Emotional wellbeing'], listStyle: ListStyle.bulleted })
         })
       })

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -41,7 +41,7 @@ export default class InterventionDetailsPresenter {
     const summary = [
       {
         key: 'Type',
-        lines: ['Dynamic Framework'],
+        lines: ['Commissioned Rehabilitative Service'],
       },
       {
         key: 'Location',

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -48,7 +48,7 @@ export default class InterventionDetailsPresenter {
         lines: [this.intervention.pccRegions.map(region => region.name).join(', ')],
       },
       {
-        key: this.intervention.serviceCategories.length > 1 ? 'Service types' : 'Service type',
+        key: this.intervention.serviceCategories.length > 1 ? 'Service categories' : 'Service category',
         lines: this.intervention.serviceCategories.map(serviceCategory =>
           utils.convertToProperCase(serviceCategory.name)
         ),

--- a/server/routes/referrals/updateServiceCategoriesForm.test.ts
+++ b/server/routes/referrals/updateServiceCategoriesForm.test.ts
@@ -29,7 +29,7 @@ describe(UpdateServiceCategoriesForm, () => {
         expect(data.error?.errors).toContainEqual({
           errorSummaryLinkedField: 'service-category-ids',
           formFields: ['service-category-ids'],
-          message: 'At least one service type must be selected',
+          message: 'At least one service category must be selected',
         })
       })
     })

--- a/server/routes/serviceProviderReferrals/actionPlanConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/actionPlanConfirmationPresenter.test.ts
@@ -29,7 +29,7 @@ describe(ActionPlanConfirmationPresenter, () => {
           lines: ['CEF345'],
         },
         {
-          key: 'Service type',
+          key: 'Service category',
           lines: ['Social inclusion'],
         },
       ])

--- a/server/routes/serviceProviderReferrals/actionPlanConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/actionPlanConfirmationPresenter.ts
@@ -24,7 +24,7 @@ export default class ActionPlanConfirmationPresenter {
       lines: [this.sentReferral.referenceNumber],
     },
     {
-      key: 'Service type',
+      key: 'Service category',
       lines: [utils.convertToProperCase(this.serviceCategory.name)],
     },
   ]

--- a/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.test.ts
@@ -29,7 +29,7 @@ describe(EndOfServiceReportConfirmationPresenter, () => {
           lines: ['CEF345'],
         },
         {
-          key: 'Service type',
+          key: 'Service category',
           lines: ['Social inclusion'],
         },
       ])

--- a/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/endOfServiceReportConfirmationPresenter.ts
@@ -19,7 +19,7 @@ export default class EndOfServiceReportConfirmationPresenter {
       lines: [this.referral.referenceNumber],
     },
     {
-      key: 'Service type',
+      key: 'Service category',
       lines: [utils.convertToProperCase(this.serviceCategory.name)],
     },
   ]

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -20,7 +20,7 @@ export default {
     mustBeInFuture: 'The date by which the service needs to be completed must be in the future',
   },
   serviceCategories: {
-    empty: 'At least one service type must be selected',
+    empty: 'At least one service category must be selected',
   },
   complexityLevel: {
     empty: 'Select a complexity level',

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -19,7 +19,7 @@
       Welcome to this new repository, where you can find the most appropriate interventions for your service users, according to their region and age group. At the moment, you can use this to find:
       </p>
       <ul class="govuk-list govuk-list--bullet">
-        <li><strong>Dynamic Framework</strong> interventions – individual rehabilitation and resettlement services that help to stabilise a service user’s life</li>
+        <li><strong>Commissioned Rehabilitative Services</strong> – individual rehabilitation and resettlement services that help to stabilise a service user’s life</li>
       </ul>
     </div>
   </div>

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -16,11 +16,10 @@
       <h1 class="govuk-heading-xl">Find interventions</h1>
 
       <p class="govuk-body">
-      Welcome to this new repository, where you can find the most appropriate interventions for your service users, according to their region and criminogenic needs. At the moment, you can use this to find:
+      Welcome to this new repository, where you can find the most appropriate interventions for your service users, according to their region and age group. At the moment, you can use this to find:
       </p>
       <ul class="govuk-list govuk-list--bullet">
         <li><strong>Dynamic Framework</strong> interventions – individual rehabilitation and resettlement services that help to stabilise a service user’s life</li>
-        <li><strong>Structured Interventions</strong> – classroom-style group courses aimed at changing behaviours</li>
       </ul>
     </div>
   </div>

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -27,7 +27,7 @@
       {{ govukSummaryList(needsAndRequirementsSummaryListArgs) }}
 
       {% if serviceCategoriesSummaryListArgs %}
-        <h2 class="govuk-heading-l">Service types</h2>
+        <h2 class="govuk-heading-l">Service categories</h2>
 
         {{ govukSummaryList(serviceCategoriesSummaryListArgs) }}
       {% endif %}


### PR DESCRIPTION
## What does this pull request do?

Changes wording on find interventions page:
1. Dynamic Framework now called Commissioned Rehabilitative Service
2. Service type now called service categories
3. remove reference to ‘structured interventions’ as not available until day 1
4. reference to criminogenic needs and replaced with ‘age group’

Also change wording of all occurrences of Service Type to Service Category on all pages, but only for where it refers to service category. 

'Service Type' wording still remains for intervention contract type name - confirmed with Shieda that it should be named 'Intervention type' or 'Referral type' depending on if it's assigned or not. These changes will be in another PR since it's not the scope of this ticket. This is on the referral details page and referral assignment confirmation screen.

## What is the intent behind these changes?

Ensure that page is consistent with latest terminology 
