### PR TITLE
Remove hardcoded SU data from needs and requirements page

### DIFF
--- a/server/routes/referrals/needsAndRequirementsPresenter.test.ts
+++ b/server/routes/referrals/needsAndRequirementsPresenter.test.ts
@@ -1,20 +1,7 @@
 import NeedsAndRequirementsPresenter from './needsAndRequirementsPresenter'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
-import { ListStyle } from '../../utils/summaryList'
 
 describe('NeedsAndRequirementsPresenter', () => {
-  describe('summary', () => {
-    it('returns a summary of the service user’s details', () => {
-      const referral = draftReferralFactory.serviceCategorySelected().build()
-      const presenter = new NeedsAndRequirementsPresenter(referral)
-
-      expect(presenter.summary).toEqual([
-        { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], listStyle: ListStyle.noMarkers },
-        { key: 'Gender', lines: ['Male'] },
-      ])
-    })
-  })
-
   describe('errorSummary', () => {
     describe('when error is null', () => {
       it('returns null', () => {

--- a/server/routes/referrals/needsAndRequirementsPresenter.ts
+++ b/server/routes/referrals/needsAndRequirementsPresenter.ts
@@ -1,6 +1,5 @@
 import DraftReferral from '../../models/draftReferral'
 import { FormValidationError } from '../../utils/formValidationError'
-import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 import PresenterUtils from '../../utils/presenterUtils'
 
 export default class NeedsAndRequirementsPresenter {
@@ -9,12 +8,6 @@ export default class NeedsAndRequirementsPresenter {
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
-
-  readonly summary: SummaryListItem[] = [
-    { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], listStyle: ListStyle.noMarkers },
-    { key: 'Gender', lines: ['Male'] },
-    // TODO IC-746 populate with service user data once we have it
-  ]
 
   private errorMessageForField(field: string): string | null {
     return PresenterUtils.errorMessage(this.error, field)

--- a/server/routes/referrals/needsAndRequirementsView.ts
+++ b/server/routes/referrals/needsAndRequirementsView.ts
@@ -7,10 +7,6 @@ export default class NeedsAndRequirementsView {
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
-  private get summaryListArgs() {
-    return ViewUtils.summaryListArgs(this.presenter.summary)
-  }
-
   private get additionalNeedsInformationTextareaArgs(): TextareaArgs {
     return {
       name: 'additional-needs-information',
@@ -129,7 +125,6 @@ export default class NeedsAndRequirementsView {
       {
         presenter: this.presenter,
         errorSummaryArgs: this.errorSummaryArgs,
-        summaryListArgs: this.summaryListArgs,
         additionalNeedsInformationTextareaArgs: this.additionalNeedsInformationTextareaArgs,
         accessibilityNeedsTextareaArgs: this.accessibilityNeedsTextareaArgs,
         interpreterRadiosArgs: this.interpreterRadiosArgs.bind(this),

--- a/server/views/referrals/needsAndRequirements.njk
+++ b/server/views/referrals/needsAndRequirements.njk
@@ -23,13 +23,6 @@
 
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
 
-      {# TODO IC-746 remove this placeholder text #}
-      {{ govukInsetText({
-        text: "The following is hardcoded placeholder data, subject to change."
-      }) }}
-
-      {{ govukSummaryList(summaryListArgs) }}
-
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
 


### PR DESCRIPTION
## What does this pull request do?

Removes a summary list of hardcoded service user data from the needs and requirements make in the PP make a referral journey.

## What is the intent behind these changes?

We don’t want real probation practitioners to see this!