### PR TITLE
IC-1861: Display real relevant sentence info on referral

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -4,6 +4,7 @@ import endOfServiceReportFactory from '../../testutils/factories/endOfServiceRep
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
 import interventionFactory from '../../testutils/factories/intervention'
 import deliusUserFactory from '../../testutils/factories/deliusUser'
+import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 
 describe('Probation practitioner referrals dashboard', () => {
   beforeEach(() => {
@@ -169,12 +170,28 @@ describe('Probation practitioner referrals dashboard', () => {
       serviceCategories: [accommodationServiceCategory, socialInclusionServiceCategory],
     })
 
+    const conviction = deliusConvictionFactory.build({
+      offences: [
+        {
+          mainOffence: true,
+          detail: {
+            mainCategoryDescription: 'Burglary',
+            subCategoryDescription: 'Theft act, 1968',
+          },
+        },
+      ],
+      sentence: {
+        expectedSentenceEndDate: '2025-11-15',
+      },
+    })
+
     const referral = sentReferralFactory.build({
       sentAt: '2020-09-13T13:00:00.000000Z',
       referenceNumber: 'ABCABCA2',
       referral: {
         interventionId: personalWellbeingIntervention.id,
         serviceUser: { firstName: 'Jenny', lastName: 'Jones', crn: 'X123456' },
+        relevantSentenceId: conviction.convictionId,
         serviceCategoryIds: [accommodationServiceCategory.id, socialInclusionServiceCategory.id],
         complexityLevels: [
           {
@@ -223,6 +240,7 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.stubGetSentReferral(referral.id, referral)
     cy.stubGetIntervention(personalWellbeingIntervention.id, personalWellbeingIntervention)
     cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
 
     cy.login()
@@ -235,6 +253,9 @@ describe('Probation practitioner referrals dashboard', () => {
 
     cy.contains('Intervention details')
     cy.contains('Personal wellbeing')
+    cy.contains('Burglary')
+    cy.contains('Theft act, 1968')
+    cy.contains('15 November 2025')
 
     cy.contains('Accommodation service')
     cy.contains('LOW COMPLEXITY')

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -19,6 +19,7 @@ import deliusUserFactory from '../../../testutils/factories/deliusUser'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 import MockedHmppsAuthService from '../../services/testutils/hmppsAuthServiceSetup'
 import HmppsAuthService from '../../services/hmppsAuthService'
+import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -317,11 +318,13 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
         ],
       },
     })
+    const conviction = deliusConvictionFactory.build()
 
     interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+    communityApiService.getConvictionById.mockResolvedValue(conviction)
 
     await request(app)
       .get(`/probation-practitioner/referrals/${sentReferral.id}/details`)
@@ -343,12 +346,14 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
       const deliusUser = deliusUserFactory.build()
       const deliusServiceUser = deliusServiceUserFactory.build()
       const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
+      const conviction = deliusConvictionFactory.build()
 
       interventionsService.getIntervention.mockResolvedValue(intervention)
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
       communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
       communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
       hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+      communityApiService.getConvictionById.mockResolvedValue(conviction)
 
       await request(app)
         .get(`/probation-practitioner/referrals/${sentReferral.id}/details`)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -95,13 +95,17 @@ export default class ProbationPractitionerReferralsController {
       res.locals.user.token.accessToken,
       req.params.id
     )
-    const [intervention, sentBy, serviceUser] = await Promise.all([
+    const [intervention, sentBy, serviceUser, conviction] = await Promise.all([
       this.interventionsService.getIntervention(
         res.locals.user.token.accessToken,
         sentReferral.referral.interventionId
       ),
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
+      this.communityApiService.getConvictionById(
+        sentReferral.referral.serviceUser.crn,
+        sentReferral.referral.relevantSentenceId
+      ),
     ])
 
     const assignee =
@@ -115,6 +119,7 @@ export default class ProbationPractitionerReferralsController {
     const presenter = new ShowReferralPresenter(
       sentReferral,
       intervention,
+      conviction,
       sentBy,
       assignee,
       null,

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -16,6 +16,7 @@ import actionPlanFactory from '../../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
 import interventionFactory from '../../../testutils/factories/intervention'
+import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -104,11 +105,13 @@ describe('GET /service-provider/referrals/:id/details', () => {
         ],
       },
     })
+    const conviction = deliusConvictionFactory.build()
 
     interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+    communityApiService.getConvictionById.mockResolvedValue(conviction)
 
     await request(app)
       .get(`/service-provider/referrals/${sentReferral.id}/details`)
@@ -130,12 +133,14 @@ describe('GET /service-provider/referrals/:id/details', () => {
       const deliusUser = deliusUserFactory.build()
       const deliusServiceUser = deliusServiceUserFactory.build()
       const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
+      const conviction = deliusConvictionFactory.build()
 
       interventionsService.getIntervention.mockResolvedValue(intervention)
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
       communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
       communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
       hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+      communityApiService.getConvictionById.mockResolvedValue(conviction)
 
       await request(app)
         .get(`/service-provider/referrals/${sentReferral.id}/details`)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -84,13 +84,17 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       req.params.id
     )
-    const [intervention, sentBy, serviceUser] = await Promise.all([
+    const [intervention, sentBy, serviceUser, conviction] = await Promise.all([
       this.interventionsService.getIntervention(
         res.locals.user.token.accessToken,
         sentReferral.referral.interventionId
       ),
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
+      this.communityApiService.getConvictionById(
+        sentReferral.referral.serviceUser.crn,
+        sentReferral.referral.relevantSentenceId
+      ),
     ])
 
     const assignee =
@@ -120,6 +124,7 @@ export default class ServiceProviderReferralsController {
     const presenter = new ShowReferralPresenter(
       sentReferral,
       intervention,
+      conviction,
       sentBy,
       assignee,
       formError,

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -6,6 +6,7 @@ import { ListStyle } from '../../utils/summaryList'
 import interventionFactory from '../../../testutils/factories/intervention'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import { TagArgs } from '../../utils/govukFrontendTypes'
+import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
 
 describe(ShowReferralPresenter, () => {
   const intervention = interventionFactory.build()
@@ -19,6 +20,8 @@ describe(ShowReferralPresenter, () => {
     contractType: { code: 'PWB', name: 'Personal wellbeing' },
     serviceCategories: cohortServiceCategories,
   })
+
+  const deliusConviction = deliusConvictionFactory.build()
 
   const referralParams = {
     referral: {
@@ -40,6 +43,7 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(
         referral,
         intervention,
+        deliusConviction,
         deliusUser,
         null,
         null,
@@ -59,6 +63,7 @@ describe(ShowReferralPresenter, () => {
           const presenter = new ShowReferralPresenter(
             referral,
             intervention,
+            deliusConviction,
             deliusUser,
             null,
             null,
@@ -76,6 +81,7 @@ describe(ShowReferralPresenter, () => {
           const presenter = new ShowReferralPresenter(
             referral,
             intervention,
+            deliusConviction,
             deliusUser,
             hmppsAuthUser,
             null,
@@ -95,6 +101,7 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(
         sentReferral,
         intervention,
+        deliusConviction,
         deliusUser,
         null,
         null,
@@ -151,10 +158,26 @@ describe(ShowReferralPresenter, () => {
         },
       })
 
+      const burglaryConviction = deliusConvictionFactory.build({
+        offences: [
+          {
+            mainOffence: true,
+            detail: {
+              mainCategoryDescription: 'Burglary',
+              subCategoryDescription: 'Theft act, 1968',
+            },
+          },
+        ],
+        sentence: {
+          expectedSentenceEndDate: '2025-11-15',
+        },
+      })
+
       it('returns a summary list of intervention details', () => {
         const presenter = new ShowReferralPresenter(
           referralWithAllOptionalFields,
           intervention,
+          burglaryConviction,
           deliusUser,
           null,
           null,
@@ -164,7 +187,9 @@ describe(ShowReferralPresenter, () => {
 
         expect(presenter.interventionDetails).toEqual([
           { key: 'Service type', lines: ['Accommodation'] },
-          { key: 'Sentence information', lines: ['Not currently set'] },
+          { key: 'Sentence', lines: ['Burglary'] },
+          { key: 'Subcategory', lines: ['Theft act, 1968'] },
+          { key: 'End of sentence date', lines: ['15 November 2025'] },
           { key: 'Date to be completed by', lines: ['1 April 2021'] },
           {
             key: 'Maximum number of enforceable days',
@@ -219,10 +244,26 @@ describe(ShowReferralPresenter, () => {
         },
       })
 
-      it("returns a summary list of intervention details with a message for fields that haven't been set", () => {
+      const burglaryConviction = deliusConvictionFactory.build({
+        offences: [
+          {
+            mainOffence: true,
+            detail: {
+              mainCategoryDescription: 'Burglary',
+              subCategoryDescription: 'Theft act, 1968',
+            },
+          },
+        ],
+        sentence: {
+          expectedSentenceEndDate: '2025-11-15',
+        },
+      })
+
+      it('returns a summary list of intervention details', () => {
         const presenter = new ShowReferralPresenter(
           referralWithNoOptionalFields,
           intervention,
+          burglaryConviction,
           deliusUser,
           null,
           null,
@@ -232,7 +273,9 @@ describe(ShowReferralPresenter, () => {
 
         expect(presenter.interventionDetails).toEqual([
           { key: 'Service type', lines: ['Accommodation'] },
-          { key: 'Sentence information', lines: ['Not currently set'] },
+          { key: 'Sentence', lines: ['Burglary'] },
+          { key: 'Subcategory', lines: ['Theft act, 1968'] },
+          { key: 'End of sentence date', lines: ['15 November 2025'] },
           { key: 'Date to be completed by', lines: ['1 April 2021'] },
           {
             key: 'Maximum number of enforceable days',
@@ -272,6 +315,7 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(
         referral,
         cohortIntervention,
+        deliusConviction,
         deliusUser,
         null,
         null,
@@ -307,6 +351,7 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(
         sentReferral,
         intervention,
+        deliusConviction,
         deliusUser,
         null,
         null,
@@ -335,6 +380,7 @@ describe(ShowReferralPresenter, () => {
       const presenter = new ShowReferralPresenter(
         sentReferral,
         intervention,
+        deliusConviction,
         deliusUser,
         null,
         null,
@@ -399,6 +445,7 @@ describe(ShowReferralPresenter, () => {
         const presenter = new ShowReferralPresenter(
           referralWithAllConditionalFields,
           intervention,
+          deliusConviction,
           deliusUser,
           null,
           null,
@@ -483,6 +530,7 @@ describe(ShowReferralPresenter, () => {
         const presenter = new ShowReferralPresenter(
           referralWithNoConditionalFields,
           intervention,
+          deliusConviction,
           deliusUser,
           null,
           null,

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -13,6 +13,8 @@ import ComplexityLevel from '../../models/complexityLevel'
 import { TagArgs } from '../../utils/govukFrontendTypes'
 import DesiredOutcome from '../../models/desiredOutcome'
 import logger from '../../../log'
+import DeliusConviction from '../../models/delius/deliusConviction'
+import SentencePresenter from '../referrals/sentencePresenter'
 
 export default class ShowReferralPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
@@ -20,6 +22,7 @@ export default class ShowReferralPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly intervention: Intervention,
+    private readonly conviction: DeliusConviction,
     private readonly sentBy: DeliusUser,
     private readonly assignee: AuthUserDetails | null,
     private readonly assignEmailError: FormValidationError | null,
@@ -133,9 +136,22 @@ export default class ShowReferralPresenter {
   }
 
   get interventionDetails(): SummaryListItem[] {
+    const sentencePresenter = new SentencePresenter(this.conviction)
+
     return [
       { key: 'Service type', lines: [utils.convertToProperCase(this.intervention.contractType.name)] },
-      { key: 'Sentence information', lines: ['Not currently set'] },
+      {
+        key: 'Sentence',
+        lines: [sentencePresenter.category],
+      },
+      {
+        key: 'Subcategory',
+        lines: [sentencePresenter.subcategory],
+      },
+      {
+        key: 'End of sentence date',
+        lines: [sentencePresenter.endOfSentenceDate],
+      },
       {
         key: 'Date to be completed by',
         lines: [PresenterUtils.govukFormattedDateFromStringOrNull(this.sentReferral.referral.completionDeadline)],
@@ -147,6 +163,25 @@ export default class ShowReferralPresenter {
       {
         key: 'Further information for the provider',
         lines: [this.sentReferral.referral.furtherInformation || 'N/A'],
+      },
+    ]
+  }
+
+  get sentenceInformationSummary(): SummaryListItem[] {
+    const presenter = new SentencePresenter(this.conviction)
+
+    return [
+      {
+        key: 'Sentence',
+        lines: [presenter.category],
+      },
+      {
+        key: 'Subcategory',
+        lines: [presenter.subcategory],
+      },
+      {
+        key: 'End of sentence date',
+        lines: [presenter.endOfSentenceDate],
       },
     ]
   }


### PR DESCRIPTION
## What does this pull request do?

Displays real relevant sentence information on referral details for PP/SP.

This was previously "Not currently set", due to the fact that we hadn't
managed to fetch the relevant sentence from the Community API at that
point in development.

It looks like we forgot to update this once we did fetch that data.

## What is the intent behind these changes?

To show the SP/PP the SU's sentence at any stage in the process.

## Screenshot

<img width="750" alt="image" src="https://user-images.githubusercontent.com/19826940/121025226-d9edd480-c79c-11eb-92e2-6aad146231fd.png">


