### PR TITLE
Don't absorb appointment update errors

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -661,7 +661,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
             'duration-hours': '1',
             'duration-minutes': '15',
           })
-          .expect(200)
+          .expect(400)
           .expect(res => {
             expect(res.text).toContain('The proposed date and time you selected clashes with another appointment.')
           })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -639,6 +639,34 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
         durationInMinutes: 75,
       })
     })
+
+    describe('when the interventions service responds with a 409 status code', () => {
+      it('renders a specific error message', async () => {
+        interventionsService.getActionPlanAppointment.mockResolvedValue(actionPlanAppointmentFactory.build())
+        interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+        interventionsService.getActionPlan.mockResolvedValue(actionPlanFactory.build())
+
+        const error = { status: 409 }
+        interventionsService.updateActionPlanAppointment.mockRejectedValue(error)
+
+        await request(app)
+          .post(`/service-provider/action-plan/1/sessions/1/edit`)
+          .send({
+            'date-day': '24',
+            'date-month': '3',
+            'date-year': '2021',
+            'time-hour': '9',
+            'time-minute': '02',
+            'time-part-of-day': 'am',
+            'duration-hours': '1',
+            'duration-minutes': '15',
+          })
+          .expect(200)
+          .expect(res => {
+            expect(res.text).toContain('The proposed date and time you selected clashes with another appointment.')
+          })
+      })
+    })
   })
 
   describe('with invalid data', () => {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -667,6 +667,32 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
           })
       })
     })
+
+    describe('when the interventions service responds with an error that isn’t a 409 status code', () => {
+      it('renders an error message', async () => {
+        interventionsService.getActionPlan.mockResolvedValue(actionPlanFactory.build())
+
+        const error = new Error('Failed to update appointment')
+        interventionsService.updateActionPlanAppointment.mockRejectedValue(error)
+
+        await request(app)
+          .post(`/service-provider/action-plan/1/sessions/1/edit`)
+          .send({
+            'date-day': '24',
+            'date-month': '3',
+            'date-year': '2021',
+            'time-hour': '9',
+            'time-minute': '02',
+            'time-part-of-day': 'am',
+            'duration-hours': '1',
+            'duration-minutes': '15',
+          })
+          .expect(500)
+          .expect(res => {
+            expect(res.text).toContain('Failed to update appointment')
+          })
+      })
+    })
   })
 
   describe('with invalid data', () => {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -462,6 +462,8 @@ export default class ServiceProviderReferralsController {
                 },
               ],
             }
+          } else {
+            throw e
           }
         }
       }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -451,6 +451,7 @@ export default class ServiceProviderReferralsController {
           return res.redirect(`/service-provider/referrals/${actionPlan.referralId}/progress`)
         } catch (e) {
           if (e.status === 409) {
+            res.status(400)
             serverError = {
               errors: [
                 {


### PR DESCRIPTION
## What does this pull request do?

Fixes a bug where non-409 appointment update response errors were being absorbed, causing the form to be re-rendered without any indication that something had gone wrong.

## What is the intent behind these changes?

To make sure that users see an error message when something goes wrong.