### PR TITLE
IC-1871: Fix bug where desired outcomes link was inactive for cohort referrals after previous step filled in.

### DIFF
--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -250,10 +250,13 @@ describe('ReferralFormPresenter', () => {
   })
   describe('for a cohort referral', () => {
     const serviceCategories: ServiceCategory[] = [
-      serviceCategoryFactory.build({ name: 'accommodation' }),
-      serviceCategoryFactory.build({ name: 'social inclusion' }),
+      serviceCategoryFactory.build({ name: 'accommodation', id: '2' }),
+      serviceCategoryFactory.build({ name: 'social inclusion', id: '3' }),
     ]
-    const cohortIntervention = interventionFactory.build({ serviceCategories })
+    const cohortIntervention = interventionFactory.build({
+      serviceCategories: [...serviceCategories, serviceCategoryFactory.build({ name: 'personal wellbeing', id: '1' })],
+    })
+
     describe('select service categories section', () => {
       describe('when "needs and requirements" has been set', () => {
         it('should contain a "Not Started" label', () => {

--- a/server/routes/referrals/referralFormPresenter.test.ts
+++ b/server/routes/referrals/referralFormPresenter.test.ts
@@ -339,6 +339,7 @@ describe('ReferralFormPresenter', () => {
           ]
           expect(presenter.sections).toEqual(expected)
         })
+
         it('should contain a "Not Started" label and "relevant-sentence" url is visible', () => {
           const referral = draftReferralFactory
             .filledFormUpToNeedsAndRequirements(serviceCategories)
@@ -371,7 +372,8 @@ describe('ReferralFormPresenter', () => {
           expect(presenter.sections).toEqual(expected)
         })
       })
-      describe('when "relevant" has been set', () => {
+
+      describe('when "relevant sentence" has been set', () => {
         it('should contain a "Not Started" label and only the first "complexity-level" url is visible', () => {
           const referral = draftReferralFactory.filledFormUpToRelevantSentence(serviceCategories).build()
           const presenter = new ReferralFormPresenter(referral, cohortIntervention)
@@ -401,7 +403,8 @@ describe('ReferralFormPresenter', () => {
           expect(presenter.sections).toEqual(expected)
         })
       })
-      describe('when "complexity level" has been set for the first service', () => {
+
+      describe('when "desired outcomes" has been set for the first service', () => {
         it('should contain a "Not Started" label and only the first "complexity-level" url is visible', () => {
           const referral = draftReferralFactory
             .filledFormUpToRelevantSentence(serviceCategories)
@@ -434,8 +437,9 @@ describe('ReferralFormPresenter', () => {
           expect(presenter.sections).toEqual(expected)
         })
       })
-      describe('when "desired outcomes" has been set for the first service', () => {
-        it('should contain a "Not Started" label and the second "complexity-level" url is visible', () => {
+
+      describe('when "complexity level" has been set for the first service', () => {
+        it('should contain a "Not Started" label and the second "desired outcomes" url is visible', () => {
           const referral = draftReferralFactory
             .filledFormUpToRelevantSentence(serviceCategories)
             .addSelectedDesiredOutcomes([serviceCategories[0]])
@@ -473,13 +477,14 @@ describe('ReferralFormPresenter', () => {
         })
       })
 
-      describe('when "complexity level" has been set for the second service', () => {
-        it('should contain a "Not Started" label and the second "desired-outcomes" url is visible', () => {
+      describe('when "desired outcomes" has been set for the second service', () => {
+        it('should contain a "Not Started" label and the second "complexity level" url is visible', () => {
           const referral = draftReferralFactory
             .filledFormUpToRelevantSentence(serviceCategories)
             .addSelectedDesiredOutcomes(serviceCategories)
             .addSelectedComplexityLevel([serviceCategories[0]])
             .build()
+
           const presenter = new ReferralFormPresenter(referral, cohortIntervention)
           const expected = [
             referralFormSectionFactory
@@ -511,7 +516,8 @@ describe('ReferralFormPresenter', () => {
           expect(presenter.sections).toEqual(expected)
         })
       })
-      describe('when "desired outcomes" has been set for second service', () => {
+
+      describe('when "complexity level" has been set for second service', () => {
         it('should contain a "Not Started" label and "completion-deadline" url visible', () => {
           const referral = draftReferralFactory
             .filledFormUpToRelevantSentence(serviceCategories)
@@ -555,6 +561,7 @@ describe('ReferralFormPresenter', () => {
           expect(presenter.sections).toEqual(expected)
         })
       })
+
       describe('when "date completed by" has been set', () => {
         it('should contain a "Not Started" label and "enforceable-days" url visible', () => {
           const referral = draftReferralFactory.filledFormUpToCompletionDate(serviceCategories).build()
@@ -596,6 +603,7 @@ describe('ReferralFormPresenter', () => {
           expect(presenter.sections).toEqual(expected)
         })
       })
+
       describe('when "enforceable days" has been set', () => {
         it('should contain a "Not Started" label and "further-information" url visible', () => {
           const referral = draftReferralFactory.filledFormUpToEnforceableDays(serviceCategories).build()
@@ -638,6 +646,7 @@ describe('ReferralFormPresenter', () => {
           expect(presenter.sections).toEqual(expected)
         })
       })
+
       describe('when all required values have been set', () => {
         it('should contain a "Completed" label and allow user to submit answers', () => {
           const referral = draftReferralFactory.filledFormUpToFurtherInformation(serviceCategories).build()

--- a/server/routes/referrals/referralFormPresenter.ts
+++ b/server/routes/referrals/referralFormPresenter.ts
@@ -208,7 +208,9 @@ class FormSectionBuilder {
                       `service-category/${serviceCat.id}/desired-outcomes`,
                       index === 0
                         ? this.taskValues.relevantSentence
-                        : this.taskValues.complexityLevel(this.intervention.serviceCategories[index - 1].id)
+                        : this.taskValues.complexityLevel(
+                            this.referral.serviceCategoryIds!.sort((a, b) => a.localeCompare(b))[index - 1]
+                          )
                     ),
                   },
                   {


### PR DESCRIPTION
## What does this pull request do?

Fixes a bug where the second desired outcomes selection link in the Refer journey wasn't accessible due to slightly incorrect logic. Before this change,  after filling out the referral details section, the "select desired outcomes" link was still inactive.

## What is the intent behind these changes?

To make sure PPs can tell they're at the correct step in the journey, particularly after having filled out most of the referral form.

## Screenshot of bug

<img width="1234" alt="image" src="https://user-images.githubusercontent.com/19826940/121053681-8470f200-c7b3-11eb-8704-64b4902b4703.png">

