### PR TITLE
Fix ARN api config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=local,seed
       - POSTGRES_URI=postgres:5432
-      - COMMUNITY-API_BASEURL=http://community-api:8080
+      - COMMUNITYAPI_BASEURL=http://community-api:8080
       - ASSESSRISKSANDNEEDS_BASEURL=http://assess-risks-and-needs:8080
 
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       - SPRING_PROFILES_ACTIVE=local,seed
       - POSTGRES_URI=postgres:5432
       - COMMUNITY-API_BASEURL=http://community-api:8080
+      - ASSESSRISKSANDNEEDS_BASEURL=http://assess-risks-and-needs:8080
 
   postgres:
     image: postgres:10-alpine
@@ -84,6 +85,7 @@ services:
     networks:
       - hmpps
     container_name: assess-risks-and-needs
+    restart: always
     ports:
       - "8094:8080"
     healthcheck:


### PR DESCRIPTION
## What does this pull request do?

Sets the correct base url for the ARN api when running the interventions service locally with Docker.

Also sets the correct community api base url.

## What is the intent behind these changes?

The interventions service was unable to connect to the ARN api, meaning we would get a 500 error on sending a referral.
