### PR TITLE
IC-1892 styling pp dashboard

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -4,10 +4,11 @@ $path: "/assets/images/"
 @import 'govuk/all'
 @import 'moj/all'
 
+@import './components/find-filters'
 @import './components/header-bar'
 @import './components/inset-text'
 @import './components/notification-banner'
-@import './components/find-filters'
+@import './components/primary-navigation'
 @import './components/task-list'
 
 @import './local'

--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -11,4 +11,6 @@ $path: "/assets/images/"
 @import './components/primary-navigation'
 @import './components/task-list'
 
+@import './layout/grid'
+
 @import './local'

--- a/assets/sass/components/_header-bar.scss
+++ b/assets/sass/components/_header-bar.scss
@@ -87,4 +87,8 @@
 
 .refer-and-monitor-header {
   border-bottom: 0;
+
+  #user-block div:not(:last-child) {
+    border: 0;
+  }
 }

--- a/assets/sass/components/_header-bar.scss
+++ b/assets/sass/components/_header-bar.scss
@@ -84,3 +84,7 @@
     }
   }
 }
+
+.refer-and-monitor-header {
+  border-bottom: 0;
+}

--- a/assets/sass/components/_primary-navigation.scss
+++ b/assets/sass/components/_primary-navigation.scss
@@ -1,0 +1,5 @@
+.refer-and-monitor__primary-navigation {
+  .moj-primary-navigation__container {
+    @include govuk-width-container(1220px);  
+  }  
+}

--- a/assets/sass/layout/_grid.scss
+++ b/assets/sass/layout/_grid.scss
@@ -1,0 +1,3 @@
+.refer-and-monitor__main-grid-row {
+  margin: 0;
+}

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -78,7 +78,7 @@ describe('Probation practitioner referrals dashboard', () => {
         {
           Referral: 'ABCABCA1',
           'Service user': 'George Michael',
-          'Service Category': 'Accommodation',
+          'Service category': 'Accommodation',
           Provider: 'Harmony Living',
           Caseworker: 'Unassigned',
           Action: 'View',
@@ -86,7 +86,7 @@ describe('Probation practitioner referrals dashboard', () => {
         {
           Referral: 'ABCABCA2',
           'Service user': 'Jenny Jones',
-          'Service Category': "Womens' services",
+          'Service category': "Womens' services",
           Provider: 'Harmony Living',
           Caseworker: 'A. Caseworker',
           Action: 'View',

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
@@ -13,7 +13,7 @@ export default class MyCasesPresenter {
   readonly tableHeadings: SortableTableHeaders = [
     { text: 'Referral', sort: 'none' },
     { text: 'Service user', sort: 'ascending' },
-    { text: 'Service Category', sort: 'none' },
+    { text: 'Service category', sort: 'none' },
     { text: 'Provider', sort: 'none' },
     { text: 'Caseworker', sort: 'none' },
     { text: 'Action', sort: 'none' },

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -91,6 +91,7 @@ export default class ViewUtils {
   static primaryNav(items: PrimaryNavItem[]): Record<string, unknown> {
     return {
       label: 'Primary navigation',
+      containerClasses: 'refer-and-monitor__primary-navigation',
       items,
     }
   }

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -1,4 +1,4 @@
-<header class="govuk-header govuk-!-display-none-print" role="banner" data-module="govuk-header" >
+<header class="govuk-header govuk-!-display-none-print refer-and-monitor-header" role="banner" data-module="govuk-header" >
   <div id="header-contents" class="govuk-width-container">
     <a href="/" class="govuk-header__link govuk-header__link--homepage no-underline  govuk-!-padding-top-1 govuk-!-padding-bottom-1">
       <div id="site-header-block">

--- a/server/views/probationPractitionerReferrals/myCases.njk
+++ b/server/views/probationPractitionerReferrals/myCases.njk
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block pageContent %}
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row refer-and-monitor__main-grid-row">
     <div class="govuk-grid-column-full-width">
       <h1 class="govuk-heading-xl">My cases</h1>
 


### PR DESCRIPTION
## What does this pull request do?

Jira card link: https://dsdmoj.atlassian.net/browse/IC-1892

Fixed styling issues on PP dashboard. Changes included:
- Fixed the primary nav position
- Fixed the width of `main`
- Updated `Service Category` to `Service category`
- Reduced the space between black header and feedback banner
- Removed the vertical line between the user name and the sign out link
- Also added a sub-folder `layout` to gradually move to the ITSCC / 7-1 pattern SASS structure

## What is the intent behind these changes?

Fix the front-end according to the results of styling audit on this Miro:
https://miro.com/app/board/o9J_lCszXg8=/?moveToWidget=3074457359626817995&cot=14

### Before
![screencapture-localhost-3000-probation-practitioner-dashboard-2021-06-09-17_50_18](https://user-images.githubusercontent.com/6421298/121397031-e1071500-c94b-11eb-8fd3-e49ebe33ee39.png)


### After
![screencapture-localhost-3000-probation-practitioner-dashboard-2021-06-09-17_50_42](https://user-images.githubusercontent.com/6421298/121397050-e6645f80-c94b-11eb-8ecb-ebe369611aad.png)

