### PR TITLE
allow 'not submitted' action plans to be continued

### DIFF
--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -315,14 +315,14 @@ describe(InterventionProgressPresenter, () => {
     })
   })
 
-  describe('allowActionPlanCreation', () => {
+  describe('actionPlanExists', () => {
     describe('when there is no action plan', () => {
       it('returns true', () => {
         const referral = sentReferralFactory.build()
         const intervention = interventionFactory.build()
         const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
-        expect(presenter.allowActionPlanCreation).toEqual(true)
+        expect(presenter.actionPlanExists).toEqual(false)
       })
     })
 
@@ -333,7 +333,7 @@ describe(InterventionProgressPresenter, () => {
         const actionPlan = actionPlanFactory.notSubmitted().build()
         const presenter = new InterventionProgressPresenter(referral, intervention, actionPlan, [])
 
-        expect(presenter.allowActionPlanCreation).toEqual(false)
+        expect(presenter.actionPlanExists).toEqual(true)
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -40,6 +40,8 @@ export default class InterventionProgressPresenter {
     return this.referral.assignedTo !== null
   }
 
+  readonly actionPlanFormUrl = `/service-provider/action-plan/${this.actionPlan?.id}/add-activities`
+
   readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
 
   readonly text = {
@@ -50,12 +52,12 @@ export default class InterventionProgressPresenter {
 
   readonly actionPlanStatusStyle: 'active' | 'inactive' = this.actionPlanSubmitted ? 'active' : 'inactive'
 
-  private get actionPlanSubmitted() {
-    return this.actionPlan !== null && this.actionPlan.submittedAt !== null
+  get actionPlanSubmitted(): boolean {
+    return this.actionPlan?.submittedAt != null
   }
 
-  get allowActionPlanCreation(): boolean {
-    return this.actionPlan === null
+  get actionPlanExists(): boolean {
+    return this.actionPlan !== null
   }
 
   get referralEnded(): boolean {

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -88,7 +88,7 @@ export default class InterventionProgressView {
       },
     ]
 
-    if (this.presenter.allowActionPlanCreation) {
+    if (!this.presenter.actionPlanExists) {
       rows.push({
         key: { text: 'Action' },
         value: {
@@ -99,6 +99,12 @@ export default class InterventionProgressView {
                    </button>
                  </form>`,
         },
+      })
+    } else if (!this.presenter.actionPlanSubmitted) {
+      // action plan exists, but has not been submitted
+      rows.push({
+        key: { text: 'Action' },
+        value: { html: `<a href="${this.presenter.actionPlanFormUrl}" class="govuk-link">Continue</a>` },
       })
     }
 


### PR DESCRIPTION
## What does this pull request do?

if an action plan exists, but it isn't submitted, show a link to pick it back up.

## What is the intent behind these changes?

fix a useabiliy bug where you can't complete an action plan 
