### PR TITLE
IC-1882: Changed initial find interventions page to use 'Service user' rather than 'Service User'

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -266,15 +266,15 @@ describe('Probation practitioner referrals dashboard', () => {
 
     cy.contains('Accommodation service')
     cy.contains('LOW COMPLEXITY')
-    cy.contains('Service User has some capacity and means to secure')
-    cy.contains('All barriers, as identified in the Service User Action Plan')
-    cy.contains('Service User makes progress in obtaining accommodation')
+    cy.contains('Service user has some capacity and means to secure')
+    cy.contains('All barriers, as identified in the Service user action plan')
+    cy.contains('Service user makes progress in obtaining accommodation')
 
     cy.contains('Social inclusion service')
     cy.contains('MEDIUM COMPLEXITY')
-    cy.contains('Service User is at risk of homelessness/is homeless')
-    cy.contains('Service User is helped to secure social or supported housing')
-    cy.contains('Service User is helped to secure a tenancy in the private rented sector (PRS)')
+    cy.contains('Service user is at risk of homelessness/is homeless')
+    cy.contains('Service user is helped to secure social or supported housing')
+    cy.contains('Service user is helped to secure a tenancy in the private rented sector (PRS)')
 
     cy.contains("Service user's personal details")
     cy.contains('English')

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -44,11 +44,11 @@ describe('Referral form', () => {
     desiredOutcomes: [
       {
         id: '1',
-        description: 'Service User makes progress in obtaining accommodation',
+        description: 'Service user makes progress in obtaining accommodation',
       },
       {
         id: '2',
-        description: 'Service User is prevented from becoming homeless',
+        description: 'Service user is prevented from becoming homeless',
       },
     ],
     complexityLevels: [
@@ -228,8 +228,8 @@ describe('Referral form', () => {
 
       cy.get('h1').contains('What are the desired outcomes for the Accommodation service?')
 
-      cy.contains('Service User makes progress in obtaining accommodation').click()
-      cy.contains('Service User is prevented from becoming homeless').click()
+      cy.contains('Service user makes progress in obtaining accommodation').click()
+      cy.contains('Service user is prevented from becoming homeless').click()
 
       cy.contains('Save and continue').click()
 
@@ -315,8 +315,8 @@ describe('Referral form', () => {
       cy.contains('Accommodation referral details')
       cy.contains('Low complexity')
       cy.contains('Info about low complexity')
-      cy.contains('Service User makes progress in obtaining accommodation')
-      cy.contains('Service User is prevented from becoming homeless')
+      cy.contains('Service user makes progress in obtaining accommodation')
+      cy.contains('Service user is prevented from becoming homeless')
 
       cy.contains('24 August 2021')
 
@@ -337,16 +337,16 @@ describe('Referral form', () => {
         desiredOutcomes: [
           {
             id: '3',
-            description: 'Service User develops and sustains social networks to reduce initial social isolation.',
+            description: 'Service user develops and sustains social networks to reduce initial social isolation.',
           },
           {
             id: '4',
-            description: 'Service User secures early post-release engagement with community based services.',
+            description: 'Service user secures early post-release engagement with community based services.',
           },
           {
             id: '5',
             description:
-              'Service User develops resilience and perseverance to cope with challenges and barriers on return to the community.',
+              'Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.',
           },
         ],
         complexityLevels: [
@@ -547,8 +547,8 @@ describe('Referral form', () => {
       )
       cy.get('h1').contains('What are the desired outcomes for the Accommodation service?')
 
-      cy.contains('Service User makes progress in obtaining accommodation').click()
-      cy.contains('Service User is prevented from becoming homeless').click()
+      cy.contains('Service user makes progress in obtaining accommodation').click()
+      cy.contains('Service user is prevented from becoming homeless').click()
 
       cy.contains('Save and continue').click()
 
@@ -567,10 +567,10 @@ describe('Referral form', () => {
         `/referrals/${draftReferral.id}/service-category/${completedSelectingServiceCategories.serviceCategoryIds[1]}/desired-outcomes`
       )
       cy.get('h1').contains('What are the desired outcomes for the Social inclusion service?')
-      cy.contains('Service User develops and sustains social networks to reduce initial social isolation.').click()
-      cy.contains('Service User secures early post-release engagement with community based services.').click()
+      cy.contains('Service user develops and sustains social networks to reduce initial social isolation.').click()
+      cy.contains('Service user secures early post-release engagement with community based services.').click()
       cy.contains(
-        'Service User develops resilience and perseverance to cope with challenges and barriers on return to the community.'
+        'Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.'
       ).click()
 
       cy.contains('Save and continue').click()

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -166,15 +166,15 @@ describe('Service provider referrals dashboard', () => {
 
     cy.contains('Accommodation service')
     cy.contains('LOW COMPLEXITY')
-    cy.contains('Service User has some capacity and means to secure')
-    cy.contains('All barriers, as identified in the Service User Action Plan')
-    cy.contains('Service User makes progress in obtaining accommodation')
+    cy.contains('Service user has some capacity and means to secure')
+    cy.contains('All barriers, as identified in the Service user action plan')
+    cy.contains('Service user makes progress in obtaining accommodation')
 
     cy.contains('Social inclusion service')
     cy.contains('MEDIUM COMPLEXITY')
-    cy.contains('Service User is at risk of homelessness/is homeless')
-    cy.contains('Service User is helped to secure social or supported housing')
-    cy.contains('Service User is helped to secure a tenancy in the private rented sector (PRS)')
+    cy.contains('Service user is at risk of homelessness/is homeless')
+    cy.contains('Service user is helped to secure social or supported housing')
+    cy.contains('Service user is helped to secure a tenancy in the private rented sector (PRS)')
 
     cy.contains("Service user's personal details")
     cy.contains('English')
@@ -259,19 +259,19 @@ describe('Service provider referrals dashboard', () => {
       {
         id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
         description:
-          'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+          'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
       },
       {
         id: '65924ac6-9724-455b-ad30-906936291421',
-        description: 'Service User makes progress in obtaining accommodation',
+        description: 'Service user makes progress in obtaining accommodation',
       },
       {
         id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-        description: 'Service User is helped to secure social or supported housing',
+        description: 'Service user is helped to secure social or supported housing',
       },
       {
         id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-        description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+        description: 'Service user is helped to secure a tenancy in the private rented sector (PRS)',
       },
     ]
 
@@ -463,7 +463,7 @@ describe('Service provider referrals dashboard', () => {
   })
 
   describe('Recording post session feedback', () => {
-    it('user records the Service User as having attended, and fills out behaviour screen', () => {
+    it('user records the Service user as having attended, and fills out behaviour screen', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const accommodationIntervention = interventionFactory.build({
         contractType: { code: 'SOC', name: 'Social inclusion' },
@@ -613,7 +613,7 @@ describe('Service provider referrals dashboard', () => {
         ])
     })
 
-    it('user records the Service User as having not attended, and skips behaviour screen', () => {
+    it('user records the Service user as having not attended, and skips behaviour screen', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const intervention = interventionFactory.build({
         contractType: { code: 'ACC', name: 'accommodation' },
@@ -848,19 +848,19 @@ describe('Service provider referrals dashboard', () => {
       {
         id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
         description:
-          'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+          'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
       },
       {
         id: '65924ac6-9724-455b-ad30-906936291421',
-        description: 'Service User makes progress in obtaining accommodation',
+        description: 'Service user makes progress in obtaining accommodation',
       },
       {
         id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-        description: 'Service User is helped to secure social or supported housing',
+        description: 'Service user is helped to secure social or supported housing',
       },
       {
         id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-        description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+        description: 'Service user is helped to secure a tenancy in the private rented sector (PRS)',
       },
     ]
 

--- a/server/routes/probationPractitionerReferrals/findStartView.ts
+++ b/server/routes/probationPractitionerReferrals/findStartView.ts
@@ -8,7 +8,7 @@ export default class FindStartView {
   private get tableArgs(): TableArgs {
     return {
       firstCellIsHeader: true,
-      head: [{ text: 'Service User' }, { text: 'Started on' }],
+      head: [{ text: 'Service user' }, { text: 'Started on' }],
       rows: this.presenter.orderedReferrals.map(referral => {
         return [
           { html: `<a href="${ViewUtils.escape(referral.url)}">${ViewUtils.escape(referral.serviceUserFullName)}</a>` },

--- a/server/routes/referrals/desiredOutcomesPresenter.test.ts
+++ b/server/routes/referrals/desiredOutcomesPresenter.test.ts
@@ -9,19 +9,19 @@ describe('DesiredOutcomesPresenter', () => {
       {
         id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
         description:
-          'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+          'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
       },
       {
         id: '65924ac6-9724-455b-ad30-906936291421',
-        description: 'Service User makes progress in obtaining accommodation',
+        description: 'Service user makes progress in obtaining accommodation',
       },
       {
         id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-        description: 'Service User is helped to secure social or supported housing',
+        description: 'Service user is helped to secure social or supported housing',
       },
       {
         id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-        description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+        description: 'Service user is helped to secure a tenancy in the private rented sector (PRS)',
       },
     ],
   })

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -1041,19 +1041,19 @@ describe('POST /referrals/:referralId/service-category/:service-category-id/desi
     {
       id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
       description:
-        'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+        'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
     },
     {
       id: '65924ac6-9724-455b-ad30-906936291421',
-      description: 'Service User makes progress in obtaining accommodation',
+      description: 'Service user makes progress in obtaining accommodation',
     },
     {
       id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-      description: 'Service User is helped to secure social or supported housing',
+      description: 'Service user is helped to secure social or supported housing',
     },
     {
       id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-      description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+      description: 'Service user is helped to secure a tenancy in the private rented sector (PRS)',
     },
   ]
 

--- a/server/routes/referrals/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.test.ts
@@ -43,7 +43,7 @@ describe(ServiceUserDetailsPresenter, () => {
   })
 
   describe('summary', () => {
-    it('returns an array of summary list items for each field on the Service User', () => {
+    it('returns an array of summary list items for each field on the Service user', () => {
       const presenter = new ServiceUserDetailsPresenter(serviceUser)
 
       expect(presenter.summary).toEqual([
@@ -60,7 +60,7 @@ describe(ServiceUserDetailsPresenter, () => {
       ])
     })
 
-    it('returns an empty values in lines for nullable fields on the Service User', () => {
+    it('returns an empty values in lines for nullable fields on the Service user', () => {
       const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser)
 
       expect(presenter.summary).toEqual([

--- a/server/routes/referrals/updateServiceCategoriesPresenter.test.ts
+++ b/server/routes/referrals/updateServiceCategoriesPresenter.test.ts
@@ -4,7 +4,7 @@ import UpdateServiceCategoriesPresenter from './updateServiceCategoriesPresenter
 
 describe(UpdateServiceCategoriesPresenter, () => {
   describe('text', () => {
-    it("contains a title including the Service User's name", () => {
+    it("contains a title including the Service user's name", () => {
       const referral = draftReferral.serviceUserSelected().build()
       const serviceCategoriesFromIntervention = serviceCategory.buildList(2)
 

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.test.ts
@@ -8,19 +8,19 @@ describe(AddActionPlanActivitiesPresenter, () => {
     {
       id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
       description:
-        'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+        'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
     },
     {
       id: '65924ac6-9724-455b-ad30-906936291421',
-      description: 'Service User makes progress in obtaining accommodation',
+      description: 'Service user makes progress in obtaining accommodation',
     },
     {
       id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-      description: 'Service User is helped to secure social or supported housing',
+      description: 'Service user is helped to secure social or supported housing',
     },
     {
       id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-      description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+      description: 'Service user is helped to secure a tenancy in the private rented sector (PRS)',
     },
   ]
   const serviceCategories = [serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })]
@@ -141,8 +141,8 @@ describe(AddActionPlanActivitiesPresenter, () => {
         {
           serviceCategory: 'Accommodation',
           desiredOutcomes: [
-            'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
-            'Service User makes progress in obtaining accommodation',
+            'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+            'Service user makes progress in obtaining accommodation',
           ],
         },
       ])

--- a/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/reviewActionPlanPresenter.test.ts
@@ -8,19 +8,19 @@ describe(ReviewActionPlanPresenter, () => {
     {
       id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
       description:
-        'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+        'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
     },
     {
       id: '65924ac6-9724-455b-ad30-906936291421',
-      description: 'Service User makes progress in obtaining accommodation',
+      description: 'Service user makes progress in obtaining accommodation',
     },
     {
       id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-      description: 'Service User is helped to secure social or supported housing',
+      description: 'Service user is helped to secure social or supported housing',
     },
     {
       id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-      description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+      description: 'Service user is helped to secure a tenancy in the private rented sector (PRS)',
     },
   ]
   const serviceCategories = [serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })]
@@ -74,8 +74,8 @@ describe(ReviewActionPlanPresenter, () => {
         {
           serviceCategory: 'Accommodation',
           desiredOutcomes: [
-            'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
-            'Service User makes progress in obtaining accommodation',
+            'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+            'Service user makes progress in obtaining accommodation',
           ],
         },
       ])

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -746,7 +746,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
 })
 
 describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', () => {
-  it('renders a page with which the Service Provider can record the Service User‘s attendance', async () => {
+  it('renders a page with which the Service Provider can record the Service user‘s attendance', async () => {
     const deliusServiceUser = deliusServiceUserFactory.build()
     const referral = sentReferralFactory.assigned().build()
     const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
@@ -774,8 +774,8 @@ describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNu
 })
 
 describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', () => {
-  describe('when the Service Provider marks the Service User as having attended the session', () => {
-    it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the behaviour page', async () => {
+  describe('when the Service Provider marks the Service user as having attended the session', () => {
+    it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the behaviour page', async () => {
       const updatedAppointment = actionPlanAppointmentFactory.build({
         sessionNumber: 1,
         sessionFeedback: {
@@ -807,8 +807,8 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
     })
   })
 
-  describe('when the Service Provider marks the Service User as not having attended the session', () => {
-    it('makes a request to the interventions service to record the Service User‘s attendance and redirects to the check-your-answers page', async () => {
+  describe('when the Service Provider marks the Service user as not having attended the session', () => {
+    it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the check-your-answers page', async () => {
       const updatedAppointment = actionPlanAppointmentFactory.build({
         sessionNumber: 1,
         sessionFeedback: {
@@ -842,7 +842,7 @@ describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionN
 })
 
 describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', () => {
-  it('renders a page with which the Service Provider can record the Service User‘s behaviour', async () => {
+  it('renders a page with which the Service Provider can record the Service user‘s behaviour', async () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
     const deliusServiceUser = deliusServiceUserFactory.build()
     const referral = sentReferralFactory.assigned().build()
@@ -869,7 +869,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNu
 })
 
 describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', () => {
-  it('makes a request to the interventions service to record the Service User‘s behaviour and redirects to the check your answers page', async () => {
+  it('makes a request to the interventions service to record the Service user‘s behaviour and redirects to the check your answers page', async () => {
     const updatedAppointment = actionPlanAppointmentFactory.build({
       sessionNumber: 1,
       sessionFeedback: {
@@ -1263,11 +1263,11 @@ describe('POST /service-provider/end-of-service-report/:id/outcomes/:number', ()
           desiredOutcomes: [
             {
               id: '27186755-7b67-497f-ad6f-6c0fde016f89',
-              description: 'Service User makes progress in obtaining accommodation',
+              description: 'Service user makes progress in obtaining accommodation',
             },
             {
               id: '73a836a4-0b5d-49a5-a4d7-1564876f3e69',
-              description: 'Service User is helped to secure social or supported housing',
+              description: 'Service user is helped to secure social or supported housing',
             },
           ],
         })

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -341,14 +341,14 @@ describe(ShowReferralPresenter, () => {
           key: 'Complexity level',
           lines: [
             'LOW COMPLEXITY',
-            'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
+            'Service user has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
           ],
         },
         {
           key: 'Desired outcomes',
           lines: [
-            'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
-            'Service User makes progress in obtaining accommodation',
+            'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+            'Service user makes progress in obtaining accommodation',
           ],
         },
       ])

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1051,46 +1051,46 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
         title: 'Low complexity',
         description:
-          'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
+          'Service user has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
       },
       {
         id: '110f2405-d944-4c15-836c-0c6684e2aa78',
         title: 'Medium complexity',
         description:
-          'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
+          'Service user is at risk of homelessness/is homeless, or will be on release from prison. Service user has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
       },
       {
         id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
         title: 'High complexity',
         description:
-          'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
+          'Service user is homeless or in temporary/unstable accommodation, or will be on release from prison. Service user has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
       },
     ]
     const desiredOutcomes = [
       {
         id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
         description:
-          'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+          'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
       },
       {
         id: '65924ac6-9724-455b-ad30-906936291421',
-        description: 'Service User makes progress in obtaining accommodation',
+        description: 'Service user makes progress in obtaining accommodation',
       },
       {
         id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-        description: 'Service User is helped to secure social or supported housing',
+        description: 'Service user is helped to secure social or supported housing',
       },
       {
         id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-        description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+        description: 'Service user is helped to secure a tenancy in the private rented sector (PRS)',
       },
       {
         id: '19d5ef58-5cfc-41fe-894c-acd705dc1325',
-        description: 'Service User is helped to sustain existing accommodation',
+        description: 'Service user is helped to sustain existing accommodation',
       },
       {
         id: 'f6f70273-16a2-4dc7-aafc-9bc74215e713',
-        description: 'Service User is prevented from becoming homeless',
+        description: 'Service user is prevented from becoming homeless',
       },
       {
         id: '449a93d7-e705-4340-9936-c859644abd52',
@@ -1099,7 +1099,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       },
       {
         id: '55a9cf76-428d-4409-8a57-aaa523f3b631',
-        description: 'Service User at risk of losing their tenancy are successfully helped to retain it',
+        description: 'Service user at risk of losing their tenancy are successfully helped to retain it',
       },
     ]
 

--- a/testutils/factories/serviceCategory.ts
+++ b/testutils/factories/serviceCategory.ts
@@ -9,38 +9,38 @@ export default Factory.define<ServiceCategory>(({ sequence }) => ({
       id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
       title: 'Low complexity',
       description:
-        'Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
+        'Service user has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.',
     },
     {
       id: '110f2405-d944-4c15-836c-0c6684e2aa78',
       title: 'Medium complexity',
       description:
-        'Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
+        'Service user is at risk of homelessness/is homeless, or will be on release from prison. Service user has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.',
     },
     {
       id: 'c86be5ec-31fa-4dfa-8c0c-8fe13451b9f6',
       title: 'High complexity',
       description:
-        'Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
+        'Service user is homeless or in temporary/unstable accommodation, or will be on release from prison. Service user has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.',
     },
   ],
   desiredOutcomes: [
     {
       id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
       description:
-        'All barriers, as identified in the Service User Action Plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+        'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
     },
     {
       id: '65924ac6-9724-455b-ad30-906936291421',
-      description: 'Service User makes progress in obtaining accommodation',
+      description: 'Service user makes progress in obtaining accommodation',
     },
     {
       id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
-      description: 'Service User is helped to secure social or supported housing',
+      description: 'Service user is helped to secure social or supported housing',
     },
     {
       id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
-      description: 'Service User is helped to secure a tenancy in the private rented sector (PRS)',
+      description: 'Service user is helped to secure a tenancy in the private rented sector (PRS)',
     },
   ],
 }))


### PR DESCRIPTION
## What does this pull request do?

Change occurrences of 'Service User' to 'Service user'

## What is the intent behind these changes?

Ensure that the user only sees 'Service user' as sentence case


Split into three parts:
3a23c1f: Changes to front end screen directly
be60a85: Change to factories
bd47688: Changes to unit tests
