### PR TITLE
IC-1828: Display supplementary risk information from ARN on Referral Details page

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,7 +19,6 @@ env:
   DEPLOYMENT_ENV: dev
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
-  OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/
   INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
   ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -21,6 +21,7 @@ env:
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/
   INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
+  ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true
   REDIS_TLS_ENABLED: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -19,7 +19,6 @@ env:
   DEPLOYMENT_ENV: preprod
   HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io
-  OFFENDER_ASSESSMENTS_API_URL: https://offender-prprod.aks-live-1.studio-hosting.service.justice.gov.uk
   INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
   ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,6 +21,7 @@ env:
   COMMUNITY_API_URL: https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: https://offender-prprod.aks-live-1.studio-hosting.service.justice.gov.uk
   INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
+  ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true
   REDIS_TLS_ENABLED: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -19,6 +19,7 @@ env:
   COMMUNITY_API_URL: https://community-api-secure.probation.service.justice.gov.uk
   OFFENDER_ASSESSMENTS_API_URL: https://offender-prod.aks-live-1.studio-hosting.service.justice.gov.uk
   INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
+  ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs.hmpps.service.justice.gov.uk
   TOKEN_VERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true
   REDIS_TLS_ENABLED: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,7 +17,6 @@ env:
   DEPLOYMENT_ENV: prod
   HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.probation.service.justice.gov.uk
-  OFFENDER_ASSESSMENTS_API_URL: https://offender-prod.aks-live-1.studio-hosting.service.justice.gov.uk
   INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
   ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs.hmpps.service.justice.gov.uk
   TOKEN_VERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -16,7 +16,6 @@ env:
   DEPLOYMENT_ENV: research
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
-  OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/
   INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
   ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -18,6 +18,7 @@ env:
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
   OFFENDER_ASSESSMENTS_API_URL: http://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk/
   INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
+  ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true
   REDIS_TLS_ENABLED: true

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -5,6 +5,7 @@ import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUse
 import interventionFactory from '../../testutils/factories/intervention'
 import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
+import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 
 describe('Probation practitioner referrals dashboard', () => {
   beforeEach(() => {
@@ -216,6 +217,10 @@ describe('Probation practitioner referrals dashboard', () => {
       },
     })
 
+    const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
+      riskSummaryComments: 'They are low risk.',
+    })
+
     const deliusUser = deliusUserFactory.build({
       firstName: 'Bernard',
       surname: 'Beaks',
@@ -242,6 +247,7 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
     cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+    cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
 
     cy.login()
 
@@ -275,9 +281,7 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.contains('Autism spectrum condition')
     cy.contains('sciatica')
     cy.contains("Service user's risk information")
-    cy.contains(
-      'The Refer and Monitor an Intervention service cannot currently display this risk information. It will be available before Service Providers start using the digital service.'
-    )
+    cy.contains('They are low risk.')
     cy.contains("Service user's needs")
     cy.contains('Alex is currently sleeping on her aunt’s sofa')
     cy.contains('She uses a wheelchair')

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -8,6 +8,7 @@ import actionPlanAppointmentFactory from '../../testutils/factories/actionPlanAp
 import endOfServiceReportFactory from '../../testutils/factories/endOfServiceReport'
 import interventionFactory from '../../testutils/factories/intervention'
 import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
+import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 
 describe('Service provider referrals dashboard', () => {
   beforeEach(() => {
@@ -111,6 +112,10 @@ describe('Service provider referrals dashboard', () => {
 
     const referralToSelect = sentReferrals[1]
 
+    const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
+      riskSummaryComments: 'They are low risk.',
+    })
+
     cy.stubGetIntervention(personalWellbeingIntervention.id, personalWellbeingIntervention)
     cy.stubGetIntervention(socialInclusionIntervention.id, socialInclusionIntervention)
     sentReferrals.forEach(referral => cy.stubGetSentReferral(referral.id, referral))
@@ -118,6 +123,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetServiceUserByCRN(referralToSelect.referral.serviceUser.crn, deliusServiceUser)
     cy.stubGetConvictionById(referralToSelect.referral.serviceUser.crn, conviction.convictionId, conviction)
+    cy.stubGetSupplementaryRiskInformation(referralToSelect.supplementaryRiskId, supplementaryRiskInformation)
 
     cy.login()
 
@@ -175,9 +181,7 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('Autism spectrum condition')
     cy.contains('sciatica')
     cy.contains("Service user's risk information")
-    cy.contains(
-      'The Refer and Monitor an Intervention service cannot currently display this risk information. It will be available before Service Providers start using the digital service.'
-    )
+    cy.contains('They are low risk.')
     cy.contains("Service user's needs")
     cy.contains('Alex is currently sleeping on her aunt’s sofa')
     cy.contains('She uses a wheelchair')
@@ -203,6 +207,7 @@ describe('Service provider referrals dashboard', () => {
     const deliusUser = deliusUserFactory.build()
     const deliusServiceUser = deliusServiceUserFactory.build()
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
+    const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
 
     cy.stubGetIntervention(intervention.id, intervention)
     cy.stubGetSentReferral(referral.id, referral)
@@ -213,6 +218,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
     cy.stubAssignSentReferral(referral.id, referral)
     cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
+    cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
 
     cy.login()
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -3,12 +3,14 @@ import AuthServiceMocks from '../../mockApis/auth'
 import TokenVerificationMocks from '../../mockApis/tokenVerification'
 import CommunityApiMocks from '../../mockApis/communityApi'
 import InterventionsServiceMocks from '../../mockApis/interventionsService'
+import AssessRisksAndNeedsServiceMocks from '../../mockApis/assessRisksAndNeedsService'
 
 const wiremock = new Wiremock('http://localhost:9091/__admin')
 const auth = new AuthServiceMocks(wiremock)
 const tokenVerification = new TokenVerificationMocks(wiremock)
 const communityApi = new CommunityApiMocks(wiremock)
 const interventionsService = new InterventionsServiceMocks(wiremock, '/interventions')
+const assessRisksAndNeedsService = new AssessRisksAndNeedsServiceMocks(wiremock)
 
 module.exports = on => {
   on('task', {
@@ -167,6 +169,10 @@ module.exports = on => {
 
     stubGetReferralCancellationReasons: arg => {
       return interventionsService.stubGetReferralCancellationReasons(arg.responseJson)
+    },
+
+    stubGetSupplementaryRiskInformation: arg => {
+      return assessRisksAndNeedsService.stubGetSupplementaryRiskInformation(arg.riskId, arg.responseJson)
     },
   })
 }

--- a/integration_tests/support/assessRisksAndNeedsServiceStubs.js
+++ b/integration_tests/support/assessRisksAndNeedsServiceStubs.js
@@ -1,0 +1,3 @@
+Cypress.Commands.add('stubGetSupplementaryRiskInformation', (riskId, responseJson) => {
+  cy.task('stubGetSupplementaryRiskInformation', { riskId, responseJson })
+})

--- a/integration_tests/support/index.js
+++ b/integration_tests/support/index.js
@@ -1,3 +1,4 @@
 import './commands'
 import './interventionsServiceStubs'
 import './communityApiStubs'
+import './assessRisksAndNeedsServiceStubs'

--- a/mockApis/assessRisksAndNeedsService.ts
+++ b/mockApis/assessRisksAndNeedsService.ts
@@ -1,0 +1,21 @@
+import Wiremock from './wiremock'
+
+export default class AssessRisksAndNeedsServiceMocks {
+  constructor(private readonly wiremock: Wiremock) {}
+
+  stubGetSupplementaryRiskInformation = async (riskId: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/assess-risks-and-needs/risks/supplementary/${riskId}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -25,13 +25,15 @@ import InterventionsService from './services/interventionsService'
 import HmppsAuthService from './services/hmppsAuthService'
 import passportSetup from './authentication/passport'
 import authErrorHandler from './authentication/authErrorHandler'
+import AssessRisksAndNeedsService from './services/assessRisksAndNeedsService'
 
 const RedisStore = connectRedis(session)
 
 export default function createApp(
   communityApiService: CommunityApiService,
   interventionsService: InterventionsService,
-  hmppsAuthService: HmppsAuthService
+  hmppsAuthService: HmppsAuthService,
+  assessRisksAndNeedsService: AssessRisksAndNeedsService
 ): express.Application {
   const app = express()
 
@@ -171,6 +173,7 @@ export default function createApp(
       communityApiService,
       interventionsService,
       hmppsAuthService,
+      assessRisksAndNeedsService,
     })
   )
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -64,6 +64,14 @@ export default {
       },
       agent: new AgentConfig(),
     },
+    assessRisksAndNeedsApi: {
+      url: get('ASSESS_RISKS_AND_NEEDS_API_URL', 'http://localhost:8094', requiredInProduction),
+      timeout: {
+        response: Number(get('ASSESS_RISKS_AND_NEEDS_API_TIMEOUT_RESPONSE', 20000)),
+        deadline: Number(get('ASSESS_RISKS_AND_NEEDS_API_TIMEOUT_DEADLINE', 20000)),
+      },
+      agent: new AgentConfig(),
+    },
     hmppsAuth: {
       url: get('HMPPS_AUTH_URL', 'http://hmpps-auth:8090/auth', requiredInProduction),
       timeout: {

--- a/server/data/testutils/mockRestClient.ts
+++ b/server/data/testutils/mockRestClient.ts
@@ -1,0 +1,8 @@
+import config from '../../config'
+import RestClient from '../restClient'
+
+export default class MockRestClient extends RestClient {
+  constructor() {
+    super('', config.apis.assessRisksAndNeedsApi, '')
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,11 +3,16 @@ import HmppsAuthService from './services/hmppsAuthService'
 import CommunityApiService from './services/communityApiService'
 import config from './config'
 import InterventionsService from './services/interventionsService'
+import RestClient from './data/restClient'
+import AssessRisksAndNeedsService from './services/assessRisksAndNeedsService'
+
+const assessRisksAndNeedsRestClient = new RestClient('assessRisksAndNeedsClient', config.apis.assessRisksAndNeedsApi)
 
 const hmppsAuthService = new HmppsAuthService()
 const communityApiService = new CommunityApiService(hmppsAuthService)
 const interventionsService = new InterventionsService(config.apis.interventionsService)
+const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthService, assessRisksAndNeedsRestClient)
 
-const app = createApp(communityApiService, interventionsService, hmppsAuthService)
+const app = createApp(communityApiService, interventionsService, hmppsAuthService, assessRisksAndNeedsService)
 
 export default app

--- a/server/models/assessRisksAndNeeds/supplementaryRiskInformation.ts
+++ b/server/models/assessRisksAndNeeds/supplementaryRiskInformation.ts
@@ -1,0 +1,3 @@
+export interface SupplementaryRiskInformation {
+  riskSummaryComments: string
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -10,11 +10,13 @@ import StaticContentController from './staticContent/staticContentController'
 import FindInterventionsController from './findInterventions/findInterventionsController'
 import ProbationPractitionerReferralsController from './probationPractitionerReferrals/probationPractitionerReferralsController'
 import CommonController from './common/commonController'
+import AssessRisksAndNeedsService from '../services/assessRisksAndNeedsService'
 
 export interface Services {
   communityApiService: CommunityApiService
   interventionsService: InterventionsService
   hmppsAuthService: HmppsAuthService
+  assessRisksAndNeedsService: AssessRisksAndNeedsService
 }
 
 export default function routes(router: Router, services: Services): Router {
@@ -24,14 +26,16 @@ export default function routes(router: Router, services: Services): Router {
   const probationPractitionerReferralsController = new ProbationPractitionerReferralsController(
     services.interventionsService,
     services.communityApiService,
-    services.hmppsAuthService
+    services.hmppsAuthService,
+    services.assessRisksAndNeedsService
   )
   const referralsController = new ReferralsController(services.interventionsService, services.communityApiService)
   const staticContentController = new StaticContentController()
   const serviceProviderReferralsController = new ServiceProviderReferralsController(
     services.interventionsService,
     services.communityApiService,
-    services.hmppsAuthService
+    services.hmppsAuthService,
+    services.assessRisksAndNeedsService
   )
   const findInterventionsController = new FindInterventionsController(services.interventionsService)
   const commonController = new CommonController()

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -24,12 +24,14 @@ import ControllerUtils from '../../utils/controllerUtils'
 import ShowReferralPresenter from '../shared/showReferralPresenter'
 import ShowReferralView from '../shared/showReferralView'
 import HmppsAuthService from '../../services/hmppsAuthService'
+import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 
 export default class ProbationPractitionerReferralsController {
   constructor(
     private readonly interventionsService: InterventionsService,
     private readonly communityApiService: CommunityApiService,
-    private readonly hmppsAuthService: HmppsAuthService
+    private readonly hmppsAuthService: HmppsAuthService,
+    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService
   ) {}
 
   async showMyCases(req: Request, res: Response): Promise<void> {
@@ -95,7 +97,7 @@ export default class ProbationPractitionerReferralsController {
       res.locals.user.token.accessToken,
       req.params.id
     )
-    const [intervention, sentBy, serviceUser, conviction] = await Promise.all([
+    const [intervention, sentBy, serviceUser, conviction, riskInformation] = await Promise.all([
       this.interventionsService.getIntervention(
         res.locals.user.token.accessToken,
         sentReferral.referral.interventionId
@@ -106,6 +108,7 @@ export default class ProbationPractitionerReferralsController {
         sentReferral.referral.serviceUser.crn,
         sentReferral.referral.relevantSentenceId
       ),
+      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId),
     ])
 
     const assignee =
@@ -120,6 +123,7 @@ export default class ProbationPractitionerReferralsController {
       sentReferral,
       intervention,
       conviction,
+      riskInformation,
       sentBy,
       assignee,
       null,

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -56,12 +56,14 @@ import EndOfServiceReportConfirmationView from './endOfServiceReportConfirmation
 import ControllerUtils from '../../utils/controllerUtils'
 import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
 import ServiceCategory from '../../models/serviceCategory'
+import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 
 export default class ServiceProviderReferralsController {
   constructor(
     private readonly interventionsService: InterventionsService,
     private readonly communityApiService: CommunityApiService,
-    private readonly hmppsAuthService: HmppsAuthService
+    private readonly hmppsAuthService: HmppsAuthService,
+    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService
   ) {}
 
   async showDashboard(req: Request, res: Response): Promise<void> {
@@ -84,7 +86,8 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       req.params.id
     )
-    const [intervention, sentBy, serviceUser, conviction] = await Promise.all([
+
+    const [intervention, sentBy, serviceUser, conviction, riskInformation] = await Promise.all([
       this.interventionsService.getIntervention(
         res.locals.user.token.accessToken,
         sentReferral.referral.interventionId
@@ -95,6 +98,7 @@ export default class ServiceProviderReferralsController {
         sentReferral.referral.serviceUser.crn,
         sentReferral.referral.relevantSentenceId
       ),
+      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId),
     ])
 
     const assignee =
@@ -125,6 +129,7 @@ export default class ServiceProviderReferralsController {
       sentReferral,
       intervention,
       conviction,
+      riskInformation,
       sentBy,
       assignee,
       formError,

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -7,6 +7,7 @@ import interventionFactory from '../../../testutils/factories/intervention'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import { TagArgs } from '../../utils/govukFrontendTypes'
 import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
+import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
 
 describe(ShowReferralPresenter, () => {
   const intervention = interventionFactory.build()
@@ -37,6 +38,8 @@ describe(ShowReferralPresenter, () => {
   })
   const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
 
+  const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+
   describe('assignmentFormAction', () => {
     it('returns the relative URL for the check assignment page', () => {
       const referral = sentReferralFactory.build(referralParams)
@@ -44,6 +47,7 @@ describe(ShowReferralPresenter, () => {
         referral,
         intervention,
         deliusConviction,
+        supplementaryRiskInformation,
         deliusUser,
         null,
         null,
@@ -64,6 +68,7 @@ describe(ShowReferralPresenter, () => {
             referral,
             intervention,
             deliusConviction,
+            supplementaryRiskInformation,
             deliusUser,
             null,
             null,
@@ -82,6 +87,7 @@ describe(ShowReferralPresenter, () => {
             referral,
             intervention,
             deliusConviction,
+            supplementaryRiskInformation,
             deliusUser,
             hmppsAuthUser,
             null,
@@ -102,6 +108,7 @@ describe(ShowReferralPresenter, () => {
         sentReferral,
         intervention,
         deliusConviction,
+        supplementaryRiskInformation,
         deliusUser,
         null,
         null,
@@ -178,6 +185,7 @@ describe(ShowReferralPresenter, () => {
           referralWithAllOptionalFields,
           intervention,
           burglaryConviction,
+          supplementaryRiskInformation,
           deliusUser,
           null,
           null,
@@ -264,6 +272,7 @@ describe(ShowReferralPresenter, () => {
           referralWithNoOptionalFields,
           intervention,
           burglaryConviction,
+          supplementaryRiskInformation,
           deliusUser,
           null,
           null,
@@ -316,6 +325,7 @@ describe(ShowReferralPresenter, () => {
         referral,
         cohortIntervention,
         deliusConviction,
+        supplementaryRiskInformation,
         deliusUser,
         null,
         null,
@@ -352,6 +362,7 @@ describe(ShowReferralPresenter, () => {
         sentReferral,
         intervention,
         deliusConviction,
+        supplementaryRiskInformation,
         deliusUser,
         null,
         null,
@@ -376,11 +387,15 @@ describe(ShowReferralPresenter, () => {
 
   describe('serviceUserRisks', () => {
     it("returns a summary list of the service user's risk information", () => {
+      const lowRiskInformation = supplementaryRiskInformationFactory.build({
+        riskSummaryComments: 'Alex is low risk.',
+      })
       const sentReferral = sentReferralFactory.build(referralParams)
       const presenter = new ShowReferralPresenter(
         sentReferral,
         intervention,
         deliusConviction,
+        lowRiskInformation,
         deliusUser,
         null,
         null,
@@ -391,9 +406,7 @@ describe(ShowReferralPresenter, () => {
       expect(presenter.serviceUserRisks).toEqual([
         {
           key: 'Additional risk information',
-          lines: [
-            'The Refer and Monitor an Intervention service cannot currently display this risk information. It will be available before Service Providers start using the digital service.',
-          ],
+          lines: ['Alex is low risk.'],
         },
       ])
     })
@@ -446,6 +459,7 @@ describe(ShowReferralPresenter, () => {
           referralWithAllConditionalFields,
           intervention,
           deliusConviction,
+          supplementaryRiskInformation,
           deliusUser,
           null,
           null,
@@ -531,6 +545,7 @@ describe(ShowReferralPresenter, () => {
           referralWithNoConditionalFields,
           intervention,
           deliusConviction,
+          supplementaryRiskInformation,
           deliusUser,
           null,
           null,

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -15,6 +15,7 @@ import DesiredOutcome from '../../models/desiredOutcome'
 import logger from '../../../log'
 import DeliusConviction from '../../models/delius/deliusConviction'
 import SentencePresenter from '../referrals/sentencePresenter'
+import { SupplementaryRiskInformation } from '../../models/assessRisksAndNeeds/supplementaryRiskInformation'
 
 export default class ShowReferralPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
@@ -23,6 +24,7 @@ export default class ShowReferralPresenter {
     private readonly sentReferral: SentReferral,
     private readonly intervention: Intervention,
     private readonly conviction: DeliusConviction,
+    private readonly riskInformation: SupplementaryRiskInformation,
     private readonly sentBy: DeliusUser,
     private readonly assignee: AuthUserDetails | null,
     private readonly assignEmailError: FormValidationError | null,
@@ -194,9 +196,7 @@ export default class ShowReferralPresenter {
     return [
       {
         key: 'Additional risk information',
-        lines: [
-          'The Refer and Monitor an Intervention service cannot currently display this risk information. It will be available before Service Providers start using the digital service.',
-        ],
+        lines: [this.riskInformation.riskSummaryComments],
       },
     ]
   }

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -12,6 +12,7 @@ import MockCommunityApiService from './mocks/mockCommunityApiService'
 import InterventionsService from '../../services/interventionsService'
 import MockedHmppsAuthService from '../../services/testutils/hmppsAuthServiceSetup'
 import LoggedInUserFactory from '../../../testutils/factories/loggedInUser'
+import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 
 export enum AppSetupUserType {
   probationPractitioner = 'delius',
@@ -66,6 +67,7 @@ export default function appWithAllRoutes({
       communityApiService: new MockCommunityApiService(),
       interventionsService: {} as InterventionsService,
       hmppsAuthService: new MockedHmppsAuthService(),
+      assessRisksAndNeedsService: {} as AssessRisksAndNeedsService,
       ...overrides,
     }),
     production,

--- a/server/routes/testutils/mocks/mockAssessRisksAndNeedsService.ts
+++ b/server/routes/testutils/mocks/mockAssessRisksAndNeedsService.ts
@@ -1,0 +1,9 @@
+import MockRestClient from '../../../data/testutils/mockRestClient'
+import AssessRisksAndNeedsService from '../../../services/assessRisksAndNeedsService'
+import MockedHmppsAuthService from '../../../services/testutils/hmppsAuthServiceSetup'
+
+export default class MockAssessRisksAndNeedsService extends AssessRisksAndNeedsService {
+  constructor() {
+    super(new MockedHmppsAuthService(), new MockRestClient())
+  }
+}

--- a/server/services/assessRisksAndNeedsService.test.ts
+++ b/server/services/assessRisksAndNeedsService.test.ts
@@ -1,0 +1,30 @@
+import AssessRisksAndNeedsService from './assessRisksAndNeedsService'
+
+import RestClient from '../data/restClient'
+import MockedHmppsAuthService from './testutils/hmppsAuthServiceSetup'
+import HmppsAuthService from './hmppsAuthService'
+import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
+import MockRestClient from '../data/testutils/mockRestClient'
+
+// wraps mocking API around the class exported by the module
+jest.mock('../data/restClient')
+
+describe(AssessRisksAndNeedsService, () => {
+  describe('getSupplementaryRiskInformation', () => {
+    const hmppsAuthServiceMock = new MockedHmppsAuthService() as jest.Mocked<HmppsAuthService>
+
+    const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
+
+    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock)
+
+    const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+
+    it('makes a request to the Assess Risks and Needs API', async () => {
+      hmppsAuthServiceMock.getApiClientToken.mockResolvedValue('testToken')
+      restClientMock.get.mockResolvedValue(supplementaryRiskInformation)
+      await assessRisksAndNeedsService.getSupplementaryRiskInformation('riskId')
+
+      expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/supplementary/riskId`, token: 'testToken' })
+    })
+  })
+})

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -1,0 +1,18 @@
+import RestClient from '../data/restClient'
+import HmppsAuthService from './hmppsAuthService'
+import logger from '../../log'
+import { SupplementaryRiskInformation } from '../models/assessRisksAndNeeds/supplementaryRiskInformation'
+
+export default class AssessRisksAndNeedsService {
+  constructor(private readonly hmppsAuthService: HmppsAuthService, private readonly restClient: RestClient) {}
+
+  async getSupplementaryRiskInformation(riskId: string): Promise<SupplementaryRiskInformation> {
+    const token = await this.hmppsAuthService.getApiClientToken()
+
+    logger.info({ riskId }, 'getting supplementary risk information')
+    return (await this.restClient.get({
+      path: `/risks/supplementary/${riskId}`,
+      token,
+    })) as SupplementaryRiskInformation
+  }
+}

--- a/test.env
+++ b/test.env
@@ -3,5 +3,6 @@ HMPPS_AUTH_URL=http://localhost:9091/auth
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 INTERVENTIONS_SERVICE_URL=http://localhost:9091/interventions
 COMMUNITY_API_URL=http://localhost:9091/community-api
+ASSESS_RISKS_AND_NEEDS_API_URL=http://localhost:9091/assess-risks-and-needs
 NODE_ENV=test
 REDIS_PORT=6380

--- a/testutils/factories/supplementaryRiskInformation.ts
+++ b/testutils/factories/supplementaryRiskInformation.ts
@@ -1,0 +1,6 @@
+import { Factory } from 'fishery'
+import { SupplementaryRiskInformation } from '../../server/models/assessRisksAndNeeds/supplementaryRiskInformation'
+
+export default Factory.define<SupplementaryRiskInformation>(() => ({
+  riskSummaryComments: 'Some risk information about the user',
+}))


### PR DESCRIPTION
## What does this pull request do?

Adds an Assess Risks and Needs Service to fetch supplementary risk information from the ARN API that was set in the Refer journey.

Refactors the `RestClient` to take an optional token, rather than requiring one on instantiation. This will make it possible to eventually refactor the other clients so we can write useful tests for them, e.g. we currently have no tests for the community API - see commit message in #b8ed580 for further information.

Displays risk information on the PP / SP referral details page.

## What is the intent behind these changes?

<img width="838" alt="image" src="https://user-images.githubusercontent.com/19826940/121512128-507b1400-c9e1-11eb-9fcf-84dd953fcca5.png">


To inform PP / SPs of Service User risks.

## Screenshot