### PR TITLE
IC-1898 styling Find

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -7,6 +7,7 @@ $path: "/assets/images/"
 @import './components/find-filters'
 @import './components/header-bar'
 @import './components/inset-text'
+@import './components/intervention-summary-list'
 @import './components/notification-banner'
 @import './components/primary-navigation'
 @import './components/task-list'

--- a/assets/sass/components/_find-filters.scss
+++ b/assets/sass/components/_find-filters.scss
@@ -1,8 +1,15 @@
 .find-filters--scrollable {
-  max-height: 450px;
-  overflow-x: scroll;
+  margin-bottom: 0;
 
   input {
     height: 100%;
+  }
+}
+
+.refer-and-monitor__filters {
+  .govuk-form-group {
+    margin-bottom: 35px;
+    max-height: 450px;
+    overflow-y: auto;
   }
 }

--- a/assets/sass/components/_intervention-summary-list.scss
+++ b/assets/sass/components/_intervention-summary-list.scss
@@ -1,0 +1,8 @@
+.refer-and-monitor__intervention-summary-list {
+  .govuk-summary-list__key,
+  .govuk-summary-list__value,
+ 
+  .govuk-summary-list__actions {
+    padding-bottom: 0;
+  }
+}

--- a/server/routes/findInterventions/interventionDetailsView.ts
+++ b/server/routes/findInterventions/interventionDetailsView.ts
@@ -7,7 +7,10 @@ export default class InterventionDetailsView {
   constructor(private readonly presenter: InterventionDetailsPresenter) {}
 
   static summaryListArgs(items: SummaryListItem[]): SummaryListArgs {
-    return { ...ViewUtils.summaryListArgs(items), classes: 'govuk-summary-list--no-border' }
+    return {
+      ...ViewUtils.summaryListArgs(items),
+      classes: 'govuk-summary-list--no-border refer-and-monitor__intervention-summary-list',
+    }
   }
 
   private tabsArgs(summaryListMacro: (args: SummaryListArgs) => string): TabsArgs {

--- a/server/routes/findInterventions/searchResultsView.ts
+++ b/server/routes/findInterventions/searchResultsView.ts
@@ -50,7 +50,10 @@ export default class SearchResultsView {
   }
 
   static summaryListArgs(items: SummaryListItem[]): SummaryListArgs {
-    return { ...ViewUtils.summaryListArgs(items), classes: 'govuk-summary-list--no-border' }
+    return {
+      ...ViewUtils.summaryListArgs(items),
+      classes: 'govuk-summary-list--no-border refer-and-monitor__intervention-summary-list',
+    }
   }
 
   private searchSummarySummaryListArgs = ViewUtils.summaryListArgs(this.presenter.summary.summary)

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -25,7 +25,7 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-one-third refer-and-monitor__filters">
       <form method="get">
         {{ govukCheckboxes(pccRegionCheckboxArgs) }}
         {{ govukCheckboxes(genderCheckboxArgs) }}

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -3,7 +3,7 @@
     <a href="/" class="govuk-header__link govuk-header__link--homepage no-underline  govuk-!-padding-top-1 govuk-!-padding-bottom-1">
       <div id="site-header-block">
         <div id="logo">
-          <img src="/assets/images/crest.svg"/>
+          <img src="/assets/images/crest.svg" alt="HMPPS logo"/>
         </div>
         <span id="hmpps-title">
           HMPPS

--- a/server/views/probationPractitionerReferrals/findStart.njk
+++ b/server/views/probationPractitionerReferrals/findStart.njk
@@ -12,7 +12,7 @@
 
 {% block pageContent %}
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full-width">
+        <div class="govuk-grid-column-two-thirds">
 
             <h1 class="govuk-heading-xl">Refer and monitor an intervention</h1>
 


### PR DESCRIPTION
## What does this pull request do?

Jira card link: https://dsdmoj.atlassian.net/browse/IC-1898

Fixed styling issues on `Find`. Changes included:
- Changed the container width to two-thirds for the Find start page
- Added alt text for HMPPS logo
- Fixed unnecessary scrollbar from filters
- Reduced the space between each row in intervention summary tables

## What is the intent behind these changes?

Mainly about the cosmetic issues. Details on this Miro board:
https://miro.com/app/board/o9J_lCszXg8=/?moveToWidget=3074457359196783082&cot=14

### Start page - Before
![screencapture-localhost-3000-probation-practitioner-find-2021-06-10-11_54_10](https://user-images.githubusercontent.com/6421298/121556492-d57b2300-ca0b-11eb-936a-74f3526fac03.png)

### Start page - After
![screencapture-localhost-3000-probation-practitioner-find-2021-06-10-11_54_46](https://user-images.githubusercontent.com/6421298/121556517-dd3ac780-ca0b-11eb-8293-c0975816081b.png)

### Listing page - Before
![screencapture-localhost-3000-find-interventions-2021-06-10-16_50_58](https://user-images.githubusercontent.com/6421298/121557252-81bd0980-ca0c-11eb-9f31-78290b240f9b.png)

### Listing page - After
![screencapture-localhost-3000-find-interventions-2021-06-10-16_12_06](https://user-images.githubusercontent.com/6421298/121557287-88e41780-ca0c-11eb-9103-c46c709b552f.png)

### Details page - Before
![screencapture-localhost-3000-find-interventions-intervention-98a42c61-c30f-4beb-8062-04033c376e2d-2021-06-10-16_23_10](https://user-images.githubusercontent.com/6421298/121557335-94cfd980-ca0c-11eb-9eee-c7917d204578.png)

### Details page - After
![screencapture-localhost-3000-find-interventions-intervention-98a42c61-c30f-4beb-8062-04033c376e2d-2021-06-10-16_20_36](https://user-images.githubusercontent.com/6421298/121557402-a1ecc880-ca0c-11eb-944c-a2c2c0b3c001.png)



