### PR TITLE
Change the appointment update request DTO to ensure time and duration are always sent

### DIFF
--- a/server/routes/serviceProviderReferrals/editSessionForm.ts
+++ b/server/routes/serviceProviderReferrals/editSessionForm.ts
@@ -8,7 +8,7 @@ import errorMessages from '../../utils/errorMessages'
 export default class EditSessionForm {
   constructor(private readonly request: Request) {}
 
-  async data(): Promise<FormData<Partial<ActionPlanAppointmentUpdate>>> {
+  async data(): Promise<FormData<ActionPlanAppointmentUpdate>> {
     const [dateResult, durationResult] = await Promise.all([
       new TwelveHourBritishDateTimeInput(this.request, 'date', 'time', errorMessages.editSession.time).validate(),
       new DurationInput(this.request, 'duration', errorMessages.editSession.duration).validate(),
@@ -24,8 +24,8 @@ export default class EditSessionForm {
     return {
       error: null,
       paramsForUpdate: {
-        appointmentTime: dateResult.value.toISOString() ?? null,
-        durationInMinutes: durationResult.value.minutes ?? null,
+        appointmentTime: dateResult.value.toISOString(),
+        durationInMinutes: durationResult.value.minutes!,
       },
     }
   }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2125,6 +2125,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             method: 'PATCH',
             path: '/action-plan/345059d4-1697-467b-8914-fedec9957279/appointment/2',
             body: {
+              appointmentTime: '2021-05-13T12:30:00Z',
               durationInMinutes: 60,
             },
             headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
@@ -2141,6 +2142,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
         expect(
           await interventionsService.updateActionPlanAppointment(token, '345059d4-1697-467b-8914-fedec9957279', 2, {
+            appointmentTime: '2021-05-13T12:30:00Z',
             durationInMinutes: 60,
           })
         ).toMatchObject(actionPlanAppointment)

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -42,8 +42,8 @@ export interface UpdateDraftActionPlanParams {
 }
 
 export interface ActionPlanAppointmentUpdate {
-  appointmentTime: string | null
-  durationInMinutes: number | null
+  appointmentTime: string
+  durationInMinutes: number
 }
 
 export interface CreateEndOfServiceReportOutcome {
@@ -373,7 +373,7 @@ export default class InterventionsService {
     token: string,
     actionPlanId: string,
     sessionNumber: number,
-    appointmentUpdate: Partial<ActionPlanAppointmentUpdate>
+    appointmentUpdate: ActionPlanAppointmentUpdate
   ): Promise<ActionPlanAppointment> {
     const restClient = this.createRestClient(token)
     return (await restClient.patch({


### PR DESCRIPTION
## What does this pull request do?

Change the appointment update request DTO to ensure time and duration are always sent

## What is the intent behind these changes?

fit new appointment model changes in the API.
