### PR TITLE
IC-1773: Pass in GA_ID from configuration

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -41,7 +41,7 @@ export default {
   https: production,
   staticResourceCacheDuration: 20,
   deploymentEnvironment: get('DEPLOYMENT_ENV', 'local', requiredInProduction),
-  uaId: get('GA_ID', '', requiredInProduction),
+  googleAnalyticsTrackingId: get('GA_ID', '', requiredInProduction),
   redis: {
     host: process.env.REDIS_HOST,
     port: Number(process.env.REDIS_PORT) || 6379,

--- a/server/routes/shared/layoutView.ts
+++ b/server/routes/shared/layoutView.ts
@@ -1,5 +1,6 @@
 import ServiceUserBannerView from './serviceUserBannerView'
 import LayoutPresenter from './layoutPresenter'
+import config from '../../config'
 
 export interface PageContentView {
   renderArgs: [string, Record<string, unknown>]
@@ -18,6 +19,7 @@ export default class LayoutView {
       {
         ...(this.serviceUserBannerView?.locals ?? {}),
         headerPresenter: this.presenter.headerPresenter,
+        googleAnalyticsTrackingId: config.googleAnalyticsTrackingId,
         ...this.content.renderArgs[1],
       },
     ]

--- a/server/utils/controllerUtils.test.ts
+++ b/server/utils/controllerUtils.test.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express'
 import ControllerUtils from './controllerUtils'
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
+import config from '../config'
 
 describe(ControllerUtils, () => {
   describe('.renderWithLayout', () => {
@@ -9,6 +10,7 @@ describe(ControllerUtils, () => {
         const res = { render: jest.fn(), locals: { user: null } } as unknown as Response
         const renderArgs: [string, Record<string, unknown>] = ['myTemplate', { foo: '1', bar: '2' }]
         const contentView = { renderArgs }
+        config.googleAnalyticsTrackingId = 'UA-TEST-ID'
 
         ControllerUtils.renderWithLayout(res, contentView, null)
 
@@ -16,6 +18,7 @@ describe(ControllerUtils, () => {
           foo: '1',
           bar: '2',
           headerPresenter: expect.anything(),
+          googleAnalyticsTrackingId: 'UA-TEST-ID',
         })
       })
     })
@@ -26,6 +29,7 @@ describe(ControllerUtils, () => {
         const renderArgs: [string, Record<string, unknown>] = ['myTemplate', { foo: '1', bar: '2' }]
         const contentView = { renderArgs }
         const serviceUser = deliusServiceUserFactory.build()
+        config.googleAnalyticsTrackingId = 'UA-TEST-ID'
 
         ControllerUtils.renderWithLayout(res, contentView, serviceUser)
 
@@ -33,6 +37,7 @@ describe(ControllerUtils, () => {
           foo: '1',
           bar: '2',
           headerPresenter: expect.anything(),
+          googleAnalyticsTrackingId: 'UA-TEST-ID',
           serviceUserBannerPresenter: expect.anything(),
         })
       })

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -15,10 +15,10 @@
 
   <script type="application/javascript">
       window.gaConfig = {};
-      window.gaConfig.uaId = "{{ uaId }}";
+      window.gaConfig.uaId = "{{ googleAnalyticsTrackingId }}";
   </script>
   <script src="/assets/googleAnalytics.js"></script>
-  <script src="/assets/js/jquery.min.js"></script> 
+  <script src="/assets/js/jquery.min.js"></script>
   <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
           integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
           crossorigin="anonymous"></script>


### PR DESCRIPTION
## What does this pull request do?

Fills in the missing link between configuration and layout locals to make sure GA tracking ID works.

I renamed `uaId` to `googleAnalyticsTrackingId` as it was weird passing it around out of context

## What is the intent behind these changes?

Bugfix:

**Actual behaviour**: Currently, the tracking ID is empty on all environments.

**Expected behaviour**: Tracking ID is not empty
