### PR TITLE
WIP: Show friendly error to users when no convictions are found in Delius for the user being referred

### DIFF
--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -869,14 +869,16 @@ describe('GET /referrals/:id/relevant-sentence', () => {
       })
   })
 
-  it('renders an error when no convictions are found for that service user', async () => {
+  it('renders the page with an error message when no convictions are found for that service user', async () => {
     communityApiService.getActiveConvictionsByCRN.mockResolvedValue([])
 
     await request(app)
       .get('/referrals/1/relevant-sentence')
-      .expect(500)
+      .expect(404)
       .expect(res => {
-        expect(res.text).toContain(`No active convictions found for service user ${serviceUserCRN}`)
+        expect(res.text).toContain(
+          `No convictions were found in Delius for CRN ${serviceUserCRN}. The error has been logged.`
+        )
       })
   })
 })

--- a/server/routes/referrals/relevantSentencePresenter.test.ts
+++ b/server/routes/referrals/relevantSentencePresenter.test.ts
@@ -169,4 +169,25 @@ describe(RelevantSentencePresenter, () => {
       })
     })
   })
+
+  describe('noConvictionsErrorMessage', () => {
+    describe('when no convictions are passed in', () => {
+      it('returns a user-friendly error message', () => {
+        const presenter = new RelevantSentencePresenter(draftReferral, intervention, [])
+
+        expect(presenter.noConvictionsErrorMessage).toEqual(
+          `No convictions were found in Delius for CRN ${draftReferral.serviceUser.crn}. The error has been logged.`
+        )
+      })
+    })
+
+    describe('when at least one conviction is passed in', () => {
+      it('returns null', () => {
+        const convictions = deliusConvictionFactory.buildList(2)
+        const presenter = new RelevantSentencePresenter(draftReferral, intervention, convictions)
+
+        expect(presenter.noConvictionsErrorMessage).toBeNull()
+      })
+    })
+  })
 })

--- a/server/routes/referrals/relevantSentencePresenter.ts
+++ b/server/routes/referrals/relevantSentencePresenter.ts
@@ -5,6 +5,7 @@ import PresenterUtils from '../../utils/presenterUtils'
 import Intervention from '../../models/intervention'
 import utils from '../../utils/utils'
 import SentencePresenter from './sentencePresenter'
+import errorMessages from '../../utils/errorMessages'
 
 export default class RelevantSentencePresenter {
   constructor(
@@ -19,9 +20,15 @@ export default class RelevantSentencePresenter {
     this.intervention.contractType.name
   )} referral`
 
+  private readonly hasNoConvictions = this.convictions.length < 1
+
   readonly errorMessage = PresenterUtils.errorMessage(this.error, 'relevant-sentence-id')
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
+
+  readonly noConvictionsErrorMessage = this.hasNoConvictions
+    ? errorMessages.relevantSentence.noConvictionsFound(this.referral.serviceUser.crn)
+    : null
 
   get relevantSentenceFields(): {
     presenter: SentencePresenter

--- a/server/routes/referrals/relevantSentenceView.ts
+++ b/server/routes/referrals/relevantSentenceView.ts
@@ -1,4 +1,4 @@
-import { RadiosArgs } from '../../utils/govukFrontendTypes'
+import { NotificationBannerArgs, RadiosArgs } from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
 import RelevantSentencePresenter from './relevantSentencePresenter'
 
@@ -30,6 +30,13 @@ export default class RelevantSentenceView {
     }
   }
 
+  get noConvictionsNotificationBannerArgs(): NotificationBannerArgs {
+    return {
+      titleText: 'There is a problem',
+      text: this.presenter.noConvictionsErrorMessage,
+    }
+  }
+
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   get renderArgs(): [string, Record<string, unknown>] {
@@ -39,6 +46,7 @@ export default class RelevantSentenceView {
         presenter: this.presenter,
         radioButtonArgs: this.radioButtonArgs,
         errorSummaryArgs: this.errorSummaryArgs,
+        noConvictionsNotificationBannerArgs: this.noConvictionsNotificationBannerArgs,
       },
     ]
   }

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -27,6 +27,8 @@ export default {
   },
   relevantSentence: {
     empty: 'Select the relevant sentence',
+    noConvictionsFound: (crn: string) =>
+      `No convictions were found in Delius for CRN ${crn}. The error has been logged.`,
   },
   desiredOutcomes: {
     empty: 'Select desired outcomes',

--- a/server/views/referrals/relevantSentence.njk
+++ b/server/views/referrals/relevantSentence.njk
@@ -11,13 +11,21 @@
         {{ govukErrorSummary(errorSummaryArgs) }}
       {% endif %}
 
-      <form method="post">
-        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      {% if presenter.noConvictionsErrorMessage %}
+        <h1 class="govuk-fieldset__legend--xl govuk-!-margin-bottom-8">{{ presenter.title }}</h1>
+        {{ govukNotificationBanner(noConvictionsNotificationBannerArgs) }}
+        <form action="/">
+          {{ govukButton({ text: "Back to dashboard" }) }}
+        </form>
+      {% else %}
+        <form method="post">
+          <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
-        {{ govukRadios(radioButtonArgs) }}
+          {{ govukRadios(radioButtonArgs) }}
 
-        {{ govukButton({ text: "Save and continue" }) }}
-      </form>
+          {{ govukButton({ text: "Save and continue" }) }}
+        </form>
+      {% endif %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Renders an error on the "Select the relevant sentence" screen when no convictions are found for a user in Delius, rather than using the generic server error page we usually display when something goes wrong.

## What is the intent behind these changes?

To stop the user journey from effectively breaking, and to signpost them back to where they can keep using the service.

## Note

This is waiting on feedback from the content / design team, but I've opened this as a PR to get feedback on the approach.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/121677978-7e7a5a00-caae-11eb-9f72-b27e8b63d7e5.png)
