### PR TITLE
IC-1904 Styling the service user banner

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -10,6 +10,7 @@ $path: "/assets/images/"
 @import './components/intervention-summary-list'
 @import './components/notification-banner'
 @import './components/primary-navigation'
+@import './components/service-user-banner'
 @import './components/task-list'
 
 @import './layout/grid'

--- a/assets/sass/components/_service-user-banner.scss
+++ b/assets/sass/components/_service-user-banner.scss
@@ -1,0 +1,35 @@
+.key-details-bar {
+  background-color: govuk-colour('blue');
+
+  .govuk-body,
+  .govuk-body-l {
+    color: govuk-colour('white');
+  }
+
+  span {
+    white-space: nowrap;
+  }
+}
+
+.key-details-bar .key-details-bar__key-details {
+  padding: 20px 0;
+  position: relative;
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__name {
+  line-height: 1.04167;
+  line-height: 1.11111;
+  margin-inline-start: 0;
+  margin-right: 10px;
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__bottom-block {
+  margin-top: 6px;
+  padding-top: 10px;
+}
+@media (min-width: 40.0625em) {
+  .key-details-bar .key-details-bar__key-details .key-details-bar__name {
+    font-size: 1.675rem;
+    line-height: 1.11111;
+  }
+}

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -249,7 +249,8 @@ describe('Probation practitioner referrals dashboard', () => {
 
     cy.contains('This intervention is not yet assigned to a caseworker')
 
-    cy.contains('07123456789 | jenny.jones@example.com')
+    cy.contains('07123456789')
+    cy.contains('jenny.jones@example.com')
 
     cy.contains('Intervention details')
     cy.contains('Personal wellbeing')

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -149,7 +149,8 @@ describe('Service provider referrals dashboard', () => {
     })
     cy.location('pathname').should('equal', `/service-provider/referrals/${referralToSelect.id}/details`)
     cy.get('h2').contains('Who do you want to assign this referral to?')
-    cy.contains('07123456789 | jenny.jones@example.com')
+    cy.contains('jenny.jones@example.com')
+    cy.contains('07123456789')
     cy.contains('Intervention details')
     cy.contains('Personal wellbeing')
 

--- a/server/routes/shared/serviceUserBannerPresenter.test.ts
+++ b/server/routes/shared/serviceUserBannerPresenter.test.ts
@@ -12,7 +12,7 @@ describe(ServiceUserBannerPresenter, () => {
 
       serviceUser.contactDetails.emailAddresses = null
       const presenterWithoutEmail = new ServiceUserBannerPresenter(serviceUser)
-      expect(presenterWithoutEmail.serviceUserEmail).toEqual('Email address not found')
+      expect(presenterWithoutEmail.serviceUserEmail).toEqual('Not found')
     })
   })
 
@@ -26,7 +26,7 @@ describe(ServiceUserBannerPresenter, () => {
 
       serviceUser.contactDetails.phoneNumbers = null
       const presenterWithoutMobile = new ServiceUserBannerPresenter(serviceUser)
-      expect(presenterWithoutMobile.serviceUserMobile).toEqual('Mobile number not found')
+      expect(presenterWithoutMobile.serviceUserMobile).toEqual('Not found')
     })
   })
 
@@ -52,6 +52,15 @@ describe(ServiceUserBannerPresenter, () => {
 
       const presenter = new ServiceUserBannerPresenter(serviceUser)
       expect(presenter.name).toEqual('Tom Jones')
+    })
+  })
+
+  describe('crn', () => {
+    it('returns the service user crn', () => {
+      const serviceUser = serviceUserFactory.build({ otherIds: { crn: 'X123456' } })
+      const presenter = new ServiceUserBannerPresenter(serviceUser)
+
+      expect(presenter.crn).toEqual('X123456')
     })
   })
 })

--- a/server/routes/shared/serviceUserBannerPresenter.ts
+++ b/server/routes/shared/serviceUserBannerPresenter.ts
@@ -20,12 +20,12 @@ export default class ServiceUserBannerPresenter {
       return emailAddresses[0]
     }
 
-    return 'Email address not found'
+    return 'Not found'
   }
 
   get serviceUserMobile(): string {
     const { phoneNumbers } = this.serviceUser.contactDetails
-    const notFoundMessage = 'Mobile number not found'
+    const notFoundMessage = 'Not found'
 
     if (phoneNumbers) {
       const mobileNumber = phoneNumbers.find(phoneNumber => phoneNumber.type === 'MOBILE')
@@ -34,5 +34,9 @@ export default class ServiceUserBannerPresenter {
     }
 
     return notFoundMessage
+  }
+
+  get crn(): string {
+    return this.serviceUser.otherIds.crn
   }
 }

--- a/server/routes/shared/serviceUserBannerView.ts
+++ b/server/routes/shared/serviceUserBannerView.ts
@@ -1,21 +1,9 @@
-import { NotificationBannerArgs } from '../../utils/govukFrontendTypes'
-import ViewUtils from '../../utils/viewUtils'
 import ServiceUserBannerPresenter from './serviceUserBannerPresenter'
 
 export default class ServiceUserBannerView {
   constructor(private readonly presenter: ServiceUserBannerPresenter) {}
 
-  private readonly serviceUserNotificationBannerArgs: NotificationBannerArgs = {
-    titleText: 'Service user details',
-    html:
-      `<p class="govuk-notification-banner__heading">${ViewUtils.escape(this.presenter.name)}<p>` +
-      `<p>Date of birth: ${ViewUtils.escape(this.presenter.dateOfBirth)}</p>` +
-      `<p class="govuk-body">${ViewUtils.escape(this.presenter.serviceUserMobile)} | ${ViewUtils.escape(
-        this.presenter.serviceUserEmail
-      )}</p>`,
-  }
-
   readonly locals = {
-    serviceUserNotificationBannerArgs: this.serviceUserNotificationBannerArgs,
+    serviceUserBannerPresenter: this.presenter,
   }
 }

--- a/server/utils/controllerUtils.test.ts
+++ b/server/utils/controllerUtils.test.ts
@@ -33,7 +33,7 @@ describe(ControllerUtils, () => {
           foo: '1',
           bar: '2',
           headerPresenter: expect.anything(),
-          serviceUserNotificationBannerArgs: expect.anything(),
+          serviceUserBannerPresenter: expect.anything(),
         })
       })
     })

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -29,10 +29,6 @@
 {% block pageTitle %}HMPPS Interventions{% endblock %}
 
 {% block content %} 
-  {% if serviceUserNotificationBannerArgs %}
-    {{ govukNotificationBanner(serviceUserNotificationBannerArgs) }}
-  {% endif %}
-
   {% block pageContent %}
   {% endblock %}
 {% endblock %}
@@ -49,6 +45,9 @@
   }) }}
 
   {% block primaryNav %}{% endblock %}
+  {% if serviceUserBannerPresenter %}
+    {% include "./serviceUserBanner.njk" %}
+  {% endif %}
 {% endblock %}
 
 {% block bodyStart %}

--- a/server/views/partials/serviceUserBanner.njk
+++ b/server/views/partials/serviceUserBanner.njk
@@ -1,0 +1,18 @@
+<section class="key-details-bar" aria-label="Key details">
+  <div class="key-details-bar__key-details govuk-width-container govuk-body">
+    <div class="prisoner-info">
+      <div class="key-details-bar__top-block">
+        <span class="govuk-visually-hidden">Name:</span>
+        <span class="key-details-bar__name govuk-body-l govuk-!-margin-right-6"><strong>
+        {{ serviceUserBannerPresenter.name | escape  }}</strong></span>
+        <span
+        class="govuk-body"><strong>CRN: </strong>{{ serviceUserBannerPresenter.crn | escape }}</span>
+      </div>
+      <div class="key-details-bar__bottom-block">
+        <span class="govuk-body"><strong>Date of birth: </strong>{{ serviceUserBannerPresenter.dateOfBirth | escape }}</span> |
+        <span class="govuk-body"><strong>Contact number: </strong>{{ serviceUserBannerPresenter.serviceUserMobile | escape }}</span> |
+        <span class="govuk-body"><strong>Email address: </strong>{{ serviceUserBannerPresenter.serviceUserEmail | escape }}</span>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## What does this pull request do?

Jira ticket: https://dsdmoj.atlassian.net/browse/IC-1904

A few things done:
- Added SU banner outside the main container
- Added a partial and CSS for the SU banner
- Added a method to get CRN
- Removed the original notification style SU banner

## What is the intent behind these changes?

To fix styling issues on the current service user banner

### Before
<img width="1278" alt="Screenshot 2021-06-11 at 14 32 39" src="https://user-images.githubusercontent.com/6421298/121697294-d2903900-cac4-11eb-953d-c38e091fd77d.png">


### After
<img width="1279" alt="Screenshot 2021-06-11 at 14 32 22" src="https://user-images.githubusercontent.com/6421298/121697313-d8861a00-cac4-11eb-9ddb-4f71800e1ee1.png">

