### PR TITLE
fix back link URL in referral detail screens

### DIFF
--- a/server/routes/shared/referralOverviewPagePresenter.test.ts
+++ b/server/routes/shared/referralOverviewPagePresenter.test.ts
@@ -47,7 +47,7 @@ describe(ReferralOverviewPagePresenter, () => {
       const sentReferral = sentReferralFactory.build()
       const presenter = new ReferralOverviewPagePresenter(ReferralOverviewPageSection.Details, sentReferral.id, prefix)
 
-      expect(presenter.dashboardURL).toEqual(`/${prefix}/referrals/dashboard`)
+      expect(presenter.dashboardURL).toEqual(`/${prefix}/dashboard`)
     })
   })
 })

--- a/server/routes/shared/referralOverviewPagePresenter.ts
+++ b/server/routes/shared/referralOverviewPagePresenter.ts
@@ -26,5 +26,5 @@ export default class ReferralOverviewPagePresenter {
     ],
   }
 
-  readonly dashboardURL = `/${this.subNavUrlPrefix}/referrals/dashboard`
+  readonly dashboardURL = `/${this.subNavUrlPrefix}/dashboard`
 }


### PR DESCRIPTION
## What does this pull request do?

fix back link URL in referral detail screens - the existing link didn't work

## What is the intent behind these changes?

make the back link functional
