### PR TITLE
IC-1899: Display user friendly message when no convictions

### DIFF
--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -884,6 +884,7 @@ describe('GET /referrals/:id/relevant-sentence', () => {
       .expect(500)
       .expect(res => {
         expect(res.text).toContain(`No active convictions found for service user ${serviceUserCRN}`)
+        expect(res.text).toContain(`No convictions were found in nDelius for ${serviceUserCRN}`)
       })
   })
 })

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import createError from 'http-errors'
 import InterventionsService from '../../services/interventionsService'
 import { FormValidationError } from '../../utils/formValidationError'
 import createFormValidationErrorOrRethrow from '../../utils/interventionsFormError'
@@ -167,7 +168,9 @@ export default class ReferralsController {
     ])
 
     if (convictions.length < 1) {
-      throw new Error(`No active convictions found for service user ${referral.serviceUser.crn}`)
+      throw createError(500, `No active convictions found for service user ${referral.serviceUser.crn}`, {
+        userMessage: `No convictions were found in nDelius for ${referral.serviceUser.crn}.`,
+      })
     }
 
     const presenter = new RelevantSentencePresenter(referral, intervention, convictions)
@@ -214,7 +217,9 @@ export default class ReferralsController {
       ])
 
       if (convictions.length < 1) {
-        throw new Error(`No active convictions found for service user ${referral.serviceUser.crn}`)
+        throw createError(500, `No active convictions found for service user ${referral.serviceUser.crn}`, {
+          userMessage: `No convictions were found in nDelius for ${referral.serviceUser.crn}.`,
+        })
       }
 
       const presenter = new RelevantSentencePresenter(referral, intervention, convictions, error)


### PR DESCRIPTION
## What does this pull request do?

Displays 'No convictions found in nDelius for [CRN]' to a user when trying to select a relevant sentence for a service user without any active convictions.

## What is the intent behind these changes?

To surface a more useful error to inform the user that something's not right with the Service User record they're trying to refer, so they know to contact us.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/121885441-11fc9680-cd0c-11eb-934f-facce8c74681.png)

