### PR TITLE
IC-1773: Fix Google Analytics setup [take 3]

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -12,6 +12,7 @@ import flash from 'connect-flash'
 import redis from 'redis'
 import session from 'express-session'
 import connectRedis from 'connect-redis'
+import { randomBytes } from 'crypto'
 import indexRoutes from './routes'
 import healthcheck from './services/healthCheck'
 import nunjucksSetup from './utils/nunjucksSetup'
@@ -55,22 +56,36 @@ export default function createApp(
   // The Sentry request handler must be the first middleware on the app
   app.use(Sentry.Handlers.requestHandler())
 
+  const nonce = randomBytes(16).toString('base64')
   // Secure code best practice - see:
   // 1. https://expressjs.com/en/advanced/best-practice-security.html,
   // 2. https://www.npmjs.com/package/helmet
+
   app.use(
     helmet({
       contentSecurityPolicy: {
         directives: {
           defaultSrc: ["'self'"],
-          // Hash allows inline script pulled in from https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/template.njk
-          scriptSrc: ["'self'", 'code.jquery.com', "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"],
+          scriptSrc: [
+            "'self'",
+            'code.jquery.com',
+            // Hash allows inline script pulled in from https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/template.njk
+            "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
+            'www.googletagmanager.com',
+            // Used to allow inline script to set Google Analytics uaId in `layout.njk`
+            `'nonce-${nonce}'`,
+          ],
           styleSrc: ["'self'", 'code.jquery.com'],
           fontSrc: ["'self'"],
         },
       },
     })
   )
+
+  app.use((req, res, next) => {
+    res.locals.cspNonce = nonce
+    next()
+  })
 
   app.use(addRequestId())
 

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -13,7 +13,7 @@
   <script src="/assets/js/html5shiv-3.7.3.min.js"></script>
   <![endif]-->
 
-  <script type="application/javascript">
+  <script{% if cspNonce %} nonce="{{ cspNonce }}"{% endif %} type="application/javascript">
       window.gaConfig = {};
       window.gaConfig.uaId = "{{ googleAnalyticsTrackingId }}";
   </script>


### PR DESCRIPTION
## What does this pull request do?

Allows inline GA-variable-setting script to execute with our current CSP.

This allows us to set the GA `uaId` variable in views with a script, as we
attempted to do before in f10c703 - it was blocked due to our CSP
forbidding inline `<script>` execution. Supplying a whitelisted unique
nonce attribute to the script tag permits this execution.

See
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
for more information.

## What is the intent behind these changes?

To fix our GA setup 🤞 and track user behaviour.
