### PR TITLE
IC-1859: Stop sending desired outcome id when updating action plan activities

### DIFF
--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.test.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.test.ts
@@ -7,14 +7,12 @@ describe(AddActionPlanActivitiesForm, () => {
       const form = await AddActionPlanActivitiesForm.createForm({
         body: {
           description: 'Attend a training course',
-          'desired-outcome-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
         },
       } as Request)
 
       expect(form.activityParamsForUpdate).toEqual({
         newActivity: {
           description: 'Attend a training course',
-          desiredOutcomeId: '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
         },
       })
     })
@@ -26,7 +24,6 @@ describe(AddActionPlanActivitiesForm, () => {
         const form = await AddActionPlanActivitiesForm.createForm({
           body: {
             description: 'Attend a training course',
-            'desired-outcome-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
           },
         } as Request)
 
@@ -39,7 +36,6 @@ describe(AddActionPlanActivitiesForm, () => {
         const form = await AddActionPlanActivitiesForm.createForm({
           body: {
             description: '',
-            'desired-outcome-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
           },
         } as Request)
 
@@ -54,7 +50,6 @@ describe(AddActionPlanActivitiesForm, () => {
         const form = await AddActionPlanActivitiesForm.createForm({
           body: {
             description: 'Attend a training course',
-            'desired-outcome-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
           },
         } as Request)
 
@@ -67,7 +62,6 @@ describe(AddActionPlanActivitiesForm, () => {
         const form = await AddActionPlanActivitiesForm.createForm({
           body: {
             description: '',
-            'desired-outcome-id': '29843fdf-8b88-4b08-a0f9-dfbd3208fd2e',
           },
         } as Request)
 

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesForm.ts
@@ -14,13 +14,8 @@ export default class AddActionPlanActivitiesForm {
     return {
       newActivity: {
         description: this.request.body.description,
-        desiredOutcomeId: this.desiredOutcomeId,
       },
     }
-  }
-
-  private get desiredOutcomeId(): string {
-    return this.request.body['desired-outcome-id']
   }
 
   get isValid(): boolean {

--- a/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/serviceProviderReferrals/addActionPlanActivitiesPresenter.ts
@@ -27,9 +27,6 @@ export default class AddActionPlanActivitiesPresenter {
 
   readonly errorSummary = PresenterUtils.errorSummary(this.errors)
 
-  // Temporary fix until we update the contracts to stop storing activities against a specific outcome - this will be removed in future
-  readonly firstDesiredOutcomeId = this.desiredOutcomesIds[0]
-
   readonly text = {
     title: `Add activity ${this.activityNumber} to action plan`,
     referredOutcomesHeader: `Referred outcomes for ${this.sentReferral.referral.serviceUser.firstName}`,

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -341,7 +341,6 @@ describe('POST /service-provider/action-plan/:id/add-activity', () => {
       .type('form')
       .send({
         description: 'Attend training course',
-        'desired-outcome-id': '8eb52caf-b462-4100-a0e9-7022d2551c92',
       })
       .expect(302)
       .expect('Location', `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
@@ -349,7 +348,6 @@ describe('POST /service-provider/action-plan/:id/add-activity', () => {
     expect(interventionsService.updateDraftActionPlan).toHaveBeenCalledWith('token', draftActionPlan.id, {
       newActivity: {
         description: 'Attend training course',
-        desiredOutcomeId: '8eb52caf-b462-4100-a0e9-7022d2551c92',
       },
     })
   })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1863,7 +1863,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           body: {
             newActivity: {
               description: 'Attend training course',
-              desiredOutcomeId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
             },
           },
         },
@@ -1890,7 +1889,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       const draftActionPlan = await interventionsService.updateDraftActionPlan(token, draftActionPlanId, {
         newActivity: {
           description: 'Attend training course',
-          desiredOutcomeId: '301ead30-30a4-4c7c-8296-2768abfb59b5',
         },
       })
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -30,7 +30,6 @@ export interface InterventionsFilterParams {
 
 interface UpdateActivityParams {
   description: string
-  desiredOutcomeId: string
 }
 
 export interface UpdateDraftActionPlanParams {

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -19,7 +19,6 @@
 
   <form method="post" action="{{ presenter.addActivityAction }}">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    <input type="hidden" name="desired-outcome-id" value="{{ presenter.firstDesiredOutcomeId }}">
 
     {{ govukTextarea(addActivityTextareaArgs) }}
 


### PR DESCRIPTION
## Do not merge before https://github.com/ministryofjustice/hmpps-interventions-service/pull/340 has been merged.

## What does this pull request do?

Reverts "keep sending the desired outcome id in the update action plan activity request so as not to break existing API contracts"

This reverts commit 6f74cb4560d29b43555ab575f1b61759a19aaf1e.

## What is the intent behind these changes?

So we don't need to store a desired outcome id against an activity, as this is no longer our intent (and we were just setting it to the first desired outcome id until the backend changed)
