### PR TITLE
GA: Whitelist www.google-analytics.com scripts

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -72,6 +72,7 @@ export default function createApp(
             // Hash allows inline script pulled in from https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/template.njk
             "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
             'www.googletagmanager.com',
+            'www.google-analytics.com',
             // Used to allow inline script to set Google Analytics uaId in `layout.njk`
             `'nonce-${nonce}'`,
           ],


### PR DESCRIPTION
## What does this pull request do?

On dev, we're getting:

```
Content Security Policy: The page's settings blocked the loading of a
resource at https://www.google-analytics.com/... ['default-src']
```

The `default-src` directive serves as a fallback for the other CSP fetch
directives [0] (e.g. `script-src`) so I've opted to add it to that directive
rather than `default-src`. I'm hoping this will fix the client-side
error.

[0]:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src


## What is the intent behind these changes?

To set up GA properly.
