### PR TITLE
Set up CSP for GA via Tag Manager instructions

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -71,13 +71,16 @@ export default function createApp(
             'code.jquery.com',
             // Hash allows inline script pulled in from https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/template.njk
             "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
-            'www.googletagmanager.com',
-            'www.google-analytics.com',
+            'https://www.google-analytics.com',
+            'https://ssl.google-analytics.com',
+            'https://www.googletagmanager.com/',
             // Used to allow inline script to set Google Analytics uaId in `layout.njk`
             `'nonce-${nonce}'`,
           ],
           styleSrc: ["'self'", 'code.jquery.com'],
           fontSrc: ["'self'"],
+          imgSrc: ["'self'", 'https://www.google-analytics.com'],
+          connectSrc: ["'self'", 'https://www.google-analytics.com'],
         },
       },
     })


### PR DESCRIPTION
## What does this pull request do?

Attempts to fix the GA set up, which is currently still throwing errors in the console.

## What is the intent behind these changes?

Our previous attempts are still throwing errors in the web console. This
is following the instructions given in the Google Tag Manager docs [0].
Even though we're not using Tag Manager, it seems to be trying to load
itself via the scripts and complains without it, so I've left this line in.

[0]:
https://developers.google.com/tag-manager/web/csp#universal_analytics_google_analytics
