### PR TITLE
IC-1888: Provide front-end functionality to specify location details for an appointment

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -487,7 +487,7 @@ describe('Service provider referrals dashboard', () => {
         cy.get('#time-part-of-day').select('AM')
         cy.get('#duration-hours').type('1')
         cy.get('#duration-minutes').type('15')
-        cy.contains('In-person meeting - Other locations').click()
+        cy.contains('In-person meeting').click()
         cy.get('#method-other-location-address-line-1').type('Harmony Living Office, Room 4')
         cy.get('#method-other-location-address-line-2').type('44 Bouverie Road')
         cy.get('#method-other-location-address-town-or-city').type('Blackpool')
@@ -499,13 +499,13 @@ describe('Service provider referrals dashboard', () => {
           appointmentTime: '2021-03-24T09:02:02Z',
           durationInMinutes: 75,
           appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
-          appointmentDeliveryAddress: [
-            'Harmony Living Office, Room 4',
-            '44 Bouverie Road',
-            'Blackpool',
-            'Lancashire',
-            'SY4 0RE',
-          ],
+          appointmentDeliveryAddress: {
+            firstAddressLine: 'Harmony Living Office, Room 4',
+            secondAddressLine: '44 Bouverie Road',
+            townOrCity: 'Blackpool',
+            county: 'Lancashire',
+            postCode: 'SY4 0RE',
+          },
         })
         cy.stubGetActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
         cy.stubUpdateActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
@@ -549,6 +549,24 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('There is a problem').next().contains('Select a meeting method')
         })
       })
+
+      describe("when the user doesn't enter an address", () => {
+        it('should show an error', () => {
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.get('#date-day').type('24')
+          cy.get('#date-month').type('3')
+          cy.get('#date-year').type('2021')
+          cy.get('#time-hour').type('9')
+          cy.get('#time-minute').type('02')
+          cy.get('#time-part-of-day').select('AM')
+          cy.get('#duration-hours').type('1')
+          cy.get('#duration-minutes').type('15')
+          cy.contains('In-person meeting').click()
+          cy.contains('Save and continue').click()
+          cy.contains('There is a problem').next().contains('Enter a value for address line 1')
+          cy.contains('There is a problem').next().contains('Enter a postcode')
+        })
+      })
     })
   })
 
@@ -579,11 +597,13 @@ describe('Service provider referrals dashboard', () => {
           sessionNumber: 1,
           appointmentTime: '2021-03-24T09:02:02Z',
           durationInMinutes: 75,
+          appointmentDeliveryType: 'PHONE_CALL',
         }),
         actionPlanAppointmentFactory.build({
           sessionNumber: 2,
           appointmentTime: '2021-03-31T09:02:02Z',
           durationInMinutes: 75,
+          appointmentDeliveryType: 'PHONE_CALL',
         }),
       ]
 
@@ -729,11 +749,13 @@ describe('Service provider referrals dashboard', () => {
           sessionNumber: 1,
           appointmentTime: '2021-03-24T09:02:02Z',
           durationInMinutes: 75,
+          appointmentDeliveryType: 'PHONE_CALL',
         }),
         actionPlanAppointmentFactory.build({
           sessionNumber: 2,
           appointmentTime: '2021-03-31T09:02:02Z',
           durationInMinutes: 75,
+          appointmentDeliveryType: 'PHONE_CALL',
         }),
       ]
 

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -486,11 +486,25 @@ describe('Service provider referrals dashboard', () => {
     cy.get('#time-part-of-day').select('AM')
     cy.get('#duration-hours').type('1')
     cy.get('#duration-minutes').type('15')
+    cy.contains('In-person meeting - Other locations').click()
+    cy.get('#method-other-location-address-line-1').type('Harmony Living Office, Room 4')
+    cy.get('#method-other-location-address-line-2').type('44 Bouverie Road')
+    cy.get('#method-other-location-address-town-or-city').type('Blackpool')
+    cy.get('#method-other-location-address-county').type('Lancashire')
+    cy.get('#method-other-location-address-postcode').type('SY4 0RE')
 
     const scheduledAppointment = actionPlanAppointmentFactory.build({
       ...appointment,
       appointmentTime: '2021-03-24T09:02:02Z',
       durationInMinutes: 75,
+      appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+      appointmentDeliveryAddress: [
+        'Harmony Living Office, Room 4',
+        '44 Bouverie Road',
+        'Blackpool',
+        'Lancashire',
+        'SY4 0RE',
+      ],
     })
     cy.stubGetActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
     cy.stubUpdateActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
@@ -510,6 +524,11 @@ describe('Service provider referrals dashboard', () => {
     cy.get('#time-part-of-day').find('option:selected').should('have.text', 'AM')
     cy.get('#duration-hours').should('have.value', '1')
     cy.get('#duration-minutes').should('have.value', '15')
+    cy.get('#method-other-location-address-line-1').should('have.value', 'Harmony Living Office, Room 4')
+    cy.get('#method-other-location-address-line-2').should('have.value', '44 Bouverie Road')
+    cy.get('#method-other-location-address-town-or-city').should('have.value', 'Blackpool')
+    cy.get('#method-other-location-address-county').should('have.value', 'Lancashire')
+    cy.get('#method-other-location-address-postcode').should('have.value', 'SY4 0RE')
   })
 
   describe('Recording post session feedback', () => {

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -454,7 +454,7 @@ describe('Service provider referrals dashboard', () => {
     cy.get('.action-plan-submitted-date').contains(/\d{1,2} [A-Z][a-z]{2} \d{4}/)
   })
 
-  it('User schedules and views an action plan appointment', () => {
+  describe('User schedules and views an action plan appointment', () => {
     const serviceCategory = serviceCategoryFactory.build()
     const intervention = interventionFactory.build()
     const referral = sentReferralFactory.build({
@@ -466,69 +466,90 @@ describe('Service provider referrals dashboard', () => {
       .build({ referralId: referral.id, actionPlanId: actionPlan.id, sessionNumber: 1 })
     const deliusServiceUser = deliusServiceUserFactory.build()
 
-    cy.stubGetSentReferralsForUserToken([])
-    cy.stubGetIntervention(intervention.id, intervention)
-    cy.stubGetActionPlanAppointment(actionPlan.id, appointment.sessionNumber, appointment)
-    cy.stubGetActionPlan(actionPlan.id, actionPlan)
-    cy.stubGetSentReferral(referral.id, referral)
-    cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
-    cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
-
-    cy.login()
-
-    cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
-
-    cy.get('#date-day').type('24')
-    cy.get('#date-month').type('3')
-    cy.get('#date-year').type('2021')
-    cy.get('#time-hour').type('9')
-    cy.get('#time-minute').type('02')
-    cy.get('#time-part-of-day').select('AM')
-    cy.get('#duration-hours').type('1')
-    cy.get('#duration-minutes').type('15')
-    cy.contains('In-person meeting - Other locations').click()
-    cy.get('#method-other-location-address-line-1').type('Harmony Living Office, Room 4')
-    cy.get('#method-other-location-address-line-2').type('44 Bouverie Road')
-    cy.get('#method-other-location-address-town-or-city').type('Blackpool')
-    cy.get('#method-other-location-address-county').type('Lancashire')
-    cy.get('#method-other-location-address-postcode').type('SY4 0RE')
-
-    const scheduledAppointment = actionPlanAppointmentFactory.build({
-      ...appointment,
-      appointmentTime: '2021-03-24T09:02:02Z',
-      durationInMinutes: 75,
-      appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
-      appointmentDeliveryAddress: [
-        'Harmony Living Office, Room 4',
-        '44 Bouverie Road',
-        'Blackpool',
-        'Lancashire',
-        'SY4 0RE',
-      ],
+    beforeEach(() => {
+      cy.stubGetSentReferralsForUserToken([])
+      cy.stubGetIntervention(intervention.id, intervention)
+      cy.stubGetActionPlanAppointment(actionPlan.id, appointment.sessionNumber, appointment)
+      cy.stubGetActionPlan(actionPlan.id, actionPlan)
+      cy.stubGetSentReferral(referral.id, referral)
+      cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
+      cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+      cy.login()
     })
-    cy.stubGetActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
-    cy.stubUpdateActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
+    describe('with valid inputs', () => {
+      it('should present no errors and display scheduled appointment', () => {
+        cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+        cy.get('#date-day').type('24')
+        cy.get('#date-month').type('3')
+        cy.get('#date-year').type('2021')
+        cy.get('#time-hour').type('9')
+        cy.get('#time-minute').type('02')
+        cy.get('#time-part-of-day').select('AM')
+        cy.get('#duration-hours').type('1')
+        cy.get('#duration-minutes').type('15')
+        cy.contains('In-person meeting - Other locations').click()
+        cy.get('#method-other-location-address-line-1').type('Harmony Living Office, Room 4')
+        cy.get('#method-other-location-address-line-2').type('44 Bouverie Road')
+        cy.get('#method-other-location-address-town-or-city').type('Blackpool')
+        cy.get('#method-other-location-address-county').type('Lancashire')
+        cy.get('#method-other-location-address-postcode').type('SY4 0RE')
 
-    cy.contains('Save and continue').click()
+        const scheduledAppointment = actionPlanAppointmentFactory.build({
+          ...appointment,
+          appointmentTime: '2021-03-24T09:02:02Z',
+          durationInMinutes: 75,
+          appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+          appointmentDeliveryAddress: [
+            'Harmony Living Office, Room 4',
+            '44 Bouverie Road',
+            'Blackpool',
+            'Lancashire',
+            'SY4 0RE',
+          ],
+        })
+        cy.stubGetActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
+        cy.stubUpdateActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
 
-    cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
+        cy.contains('Save and continue').click()
 
-    cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+        cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
 
-    cy.get('#date-day').should('have.value', '24')
-    cy.get('#date-month').should('have.value', '3')
-    cy.get('#date-year').should('have.value', '2021')
-    cy.get('#time-hour').should('have.value', '9')
-    cy.get('#time-minute').should('have.value', '02')
-    // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
-    cy.get('#time-part-of-day').find('option:selected').should('have.text', 'AM')
-    cy.get('#duration-hours').should('have.value', '1')
-    cy.get('#duration-minutes').should('have.value', '15')
-    cy.get('#method-other-location-address-line-1').should('have.value', 'Harmony Living Office, Room 4')
-    cy.get('#method-other-location-address-line-2').should('have.value', '44 Bouverie Road')
-    cy.get('#method-other-location-address-town-or-city').should('have.value', 'Blackpool')
-    cy.get('#method-other-location-address-county').should('have.value', 'Lancashire')
-    cy.get('#method-other-location-address-postcode').should('have.value', 'SY4 0RE')
+        cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+
+        cy.get('#date-day').should('have.value', '24')
+        cy.get('#date-month').should('have.value', '3')
+        cy.get('#date-year').should('have.value', '2021')
+        cy.get('#time-hour').should('have.value', '9')
+        cy.get('#time-minute').should('have.value', '02')
+        // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
+        cy.get('#time-part-of-day').find('option:selected').should('have.text', 'AM')
+        cy.get('#duration-hours').should('have.value', '1')
+        cy.get('#duration-minutes').should('have.value', '15')
+        cy.get('#method-other-location-address-line-1').should('have.value', 'Harmony Living Office, Room 4')
+        cy.get('#method-other-location-address-line-2').should('have.value', '44 Bouverie Road')
+        cy.get('#method-other-location-address-town-or-city').should('have.value', 'Blackpool')
+        cy.get('#method-other-location-address-county').should('have.value', 'Lancashire')
+        cy.get('#method-other-location-address-postcode').should('have.value', 'SY4 0RE')
+      })
+    })
+
+    describe('with invalid inputs', () => {
+      describe("when the user doesn't select meeting method", () => {
+        it('should show an error', () => {
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.get('#date-day').type('24')
+          cy.get('#date-month').type('3')
+          cy.get('#date-year').type('2021')
+          cy.get('#time-hour').type('9')
+          cy.get('#time-minute').type('02')
+          cy.get('#time-part-of-day').select('AM')
+          cy.get('#duration-hours').type('1')
+          cy.get('#duration-minutes').type('15')
+          cy.contains('Save and continue').click()
+          cy.contains('There is a problem').next().contains('Select a meeting method')
+        })
+      })
+    })
   })
 
   describe('Recording post session feedback', () => {

--- a/server/models/actionPlan.ts
+++ b/server/models/actionPlan.ts
@@ -6,16 +6,31 @@ export interface Activity {
   createdAt: string
 }
 
+export interface Address {
+  firstAddressLine: string
+  secondAddressLine: string | null
+  townOrCity: string
+  county: string
+  postCode: string
+}
 export interface ActionPlanAppointment {
   sessionNumber: number
   appointmentTime: string | null
   durationInMinutes: number | null
+  appointmentDeliveryType: AppointmentDeliveryType | null
+  appointmentDeliveryAddress: Address | null
   sessionFeedback: {
     attendance: AppointmentAttendance
     behaviour: AppointmentBehaviour
     submitted: boolean
   }
 }
+
+export type AppointmentDeliveryType =
+  | 'PHONE_CALL'
+  | 'VIDEO_CALL'
+  | 'IN_PERSON_MEETING_PROBATION_OFFICE'
+  | 'IN_PERSON_MEETING_OTHER'
 
 export type Attended = 'yes' | 'no' | 'late' | null
 

--- a/server/routes/serviceProviderReferrals/editSessionForm.test.ts
+++ b/server/routes/serviceProviderReferrals/editSessionForm.test.ts
@@ -88,6 +88,7 @@ describe('EditSessionForm', () => {
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
               appointmentDeliveryAddress: {
                 firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '',
                 townOrCity: 'Blackpool',
                 county: 'Lancashire',
                 postCode: 'SY4 0RE',

--- a/server/routes/serviceProviderReferrals/editSessionForm.test.ts
+++ b/server/routes/serviceProviderReferrals/editSessionForm.test.ts
@@ -4,21 +4,97 @@ import TestUtils from '../../../testutils/testUtils'
 describe('EditSessionForm', () => {
   describe('data', () => {
     describe('with valid data', () => {
-      it('returns a paramsForUpdate with the completionDeadline key and an ISO-formatted date', async () => {
-        const request = TestUtils.createRequest({
-          'date-year': '2021',
-          'date-month': '09',
-          'date-day': '12',
-          'time-hour': '1',
-          'time-minute': '05',
-          'time-part-of-day': 'pm',
-          'duration-hours': '1',
-          'duration-minutes': '30',
+      describe('with a phone call appointment', () => {
+        it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
+          const request = TestUtils.createRequest({
+            'date-year': '2021',
+            'date-month': '09',
+            'date-day': '12',
+            'time-hour': '1',
+            'time-minute': '05',
+            'time-part-of-day': 'pm',
+            'duration-hours': '1',
+            'duration-minutes': '30',
+            'meeting-method': 'PHONE_CALL',
+          })
+
+          const data = await new EditSessionForm(request).data()
+
+          expect(data.paramsForUpdate).toEqual({
+            appointmentTime: '2021-09-12T12:05:00.000Z',
+            durationInMinutes: 90,
+            appointmentDeliveryType: 'PHONE_CALL',
+            appointmentDeliveryAddress: null,
+          })
+        })
+      })
+      describe('with an other locations appointment', () => {
+        it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
+          const request = TestUtils.createRequest({
+            'date-year': '2021',
+            'date-month': '09',
+            'date-day': '12',
+            'time-hour': '1',
+            'time-minute': '05',
+            'time-part-of-day': 'pm',
+            'duration-hours': '1',
+            'duration-minutes': '30',
+            'meeting-method': 'IN_PERSON_MEETING_OTHER',
+            'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+            'method-other-location-address-line-2': '44 Bouverie Road',
+            'method-other-location-address-town-or-city': 'Blackpool',
+            'method-other-location-address-county': 'Lancashire',
+            'method-other-location-address-postcode': 'SY4 0RE',
+          })
+
+          const data = await new EditSessionForm(request).data()
+
+          expect(data.paramsForUpdate).toEqual({
+            appointmentTime: '2021-09-12T12:05:00.000Z',
+            durationInMinutes: 90,
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+            appointmentDeliveryAddress: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY4 0RE',
+            },
+          })
         })
 
-        const data = await new EditSessionForm(request).data()
+        describe('with a missing second address line', () => {
+          it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
+            const request = TestUtils.createRequest({
+              'date-year': '2021',
+              'date-month': '09',
+              'date-day': '12',
+              'time-hour': '1',
+              'time-minute': '05',
+              'time-part-of-day': 'pm',
+              'duration-hours': '1',
+              'duration-minutes': '30',
+              'meeting-method': 'IN_PERSON_MEETING_OTHER',
+              'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+              'method-other-location-address-town-or-city': 'Blackpool',
+              'method-other-location-address-county': 'Lancashire',
+              'method-other-location-address-postcode': 'SY4 0RE',
+            })
 
-        expect(data.paramsForUpdate).toEqual({ appointmentTime: '2021-09-12T12:05:00.000Z', durationInMinutes: 90 })
+            const data = await new EditSessionForm(request).data()
+            expect(data.paramsForUpdate).toEqual({
+              appointmentTime: '2021-09-12T12:05:00.000Z',
+              durationInMinutes: 90,
+              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+              appointmentDeliveryAddress: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY4 0RE',
+              },
+            })
+          })
+        })
       })
     })
 
@@ -53,6 +129,11 @@ describe('EditSessionForm', () => {
               errorSummaryLinkedField: 'duration-hours',
               formFields: ['duration-hours', 'duration-minutes'],
               message: 'Enter a duration',
+            },
+            {
+              errorSummaryLinkedField: 'meeting-method',
+              formFields: ['meeting-method'],
+              message: 'Select a meeting method',
             },
           ],
         })

--- a/server/routes/serviceProviderReferrals/editSessionForm.ts
+++ b/server/routes/serviceProviderReferrals/editSessionForm.ts
@@ -16,14 +16,18 @@ export default class EditSessionForm {
     const [dateResult, durationResult, appointmentDeliveryType] = await Promise.all([
       new TwelveHourBritishDateTimeInput(this.request, 'date', 'time', errorMessages.editSession.time).validate(),
       new DurationInput(this.request, 'duration', errorMessages.editSession.duration).validate(),
-      new MeetingMethodInput(this.request, 'meeting-method').validate(),
+      new MeetingMethodInput(this.request, 'meeting-method', errorMessages.editSession.meetingMethod).validate(),
     ])
     let appointmentDeliveryAddress: FormValidationResult<Address | null> = { value: null, error: null }
     if (appointmentDeliveryType.value === 'IN_PERSON_MEETING_OTHER') {
-      appointmentDeliveryAddress = await new AddressInput(this.request, 'method-other-location').validate()
+      appointmentDeliveryAddress = await new AddressInput(
+        this.request,
+        'method-other-location',
+        errorMessages.editSession.address
+      ).validate()
     }
 
-    if (dateResult.error || durationResult.error || appointmentDeliveryType.error) {
+    if (dateResult.error || durationResult.error || appointmentDeliveryType.error || appointmentDeliveryAddress.error) {
       return {
         paramsForUpdate: null,
         error: {
@@ -31,6 +35,7 @@ export default class EditSessionForm {
             ...(dateResult.error?.errors ?? []),
             ...(durationResult.error?.errors ?? []),
             ...(appointmentDeliveryType.error?.errors ?? []),
+            ...(appointmentDeliveryAddress.error?.errors ?? []),
           ],
         },
       }

--- a/server/routes/serviceProviderReferrals/editSessionPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/editSessionPresenter.test.ts
@@ -108,12 +108,8 @@ describe(EditSessionPresenter, () => {
             hours: { value: '', hasError: false },
             minutes: { value: '', hasError: false },
           },
-          meetingMethod: null,
-          addressLine1: null,
-          addressLine2: null,
-          addressTownOrCity: null,
-          addressCounty: null,
-          addressPostCode: null,
+          meetingMethod: { value: null, errorMessage: null },
+          address: null,
         })
       })
     })
@@ -124,13 +120,13 @@ describe(EditSessionPresenter, () => {
           appointmentTime: '2021-03-24T10:30:00Z',
           durationInMinutes: 75,
           appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
-          appointmentDeliveryAddress: [
-            'Harmony Living Office, Room 4',
-            '44 Bouverie Road',
-            'Blackpool',
-            'Lancashire',
-            'SY4 0RE',
-          ],
+          appointmentDeliveryAddress: {
+            firstAddressLine: 'Harmony Living Office, Room 4',
+            secondAddressLine: '44 Bouverie Road',
+            townOrCity: 'Blackpool',
+            county: 'Lancashire',
+            postCode: 'SY4 0RE',
+          },
         })
         const presenter = new EditSessionPresenter(actionPlan)
 
@@ -155,12 +151,14 @@ describe(EditSessionPresenter, () => {
             hours: { value: '1', hasError: false },
             minutes: { value: '15', hasError: false },
           },
-          meetingMethod: 'IN_PERSON_MEETING_OTHER',
-          addressLine1: 'Harmony Living Office, Room 4',
-          addressLine2: '44 Bouverie Road',
-          addressTownOrCity: 'Blackpool',
-          addressCounty: 'Lancashire',
-          addressPostCode: 'SY4 0RE',
+          meetingMethod: { value: 'IN_PERSON_MEETING_OTHER', errorMessage: null },
+          address: {
+            firstAddressLine: 'Harmony Living Office, Room 4',
+            secondAddressLine: '44 Bouverie Road',
+            townOrCity: 'Blackpool',
+            county: 'Lancashire',
+            postCode: 'SY4 0RE',
+          },
         })
       })
     })

--- a/server/routes/serviceProviderReferrals/editSessionPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/editSessionPresenter.test.ts
@@ -108,6 +108,12 @@ describe(EditSessionPresenter, () => {
             hours: { value: '', hasError: false },
             minutes: { value: '', hasError: false },
           },
+          meetingMethod: null,
+          addressLine1: null,
+          addressLine2: null,
+          addressTownOrCity: null,
+          addressCounty: null,
+          addressPostCode: null,
         })
       })
     })
@@ -117,6 +123,14 @@ describe(EditSessionPresenter, () => {
         const actionPlan = actionPlanAppointmentFactory.build({
           appointmentTime: '2021-03-24T10:30:00Z',
           durationInMinutes: 75,
+          appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+          appointmentDeliveryAddress: [
+            'Harmony Living Office, Room 4',
+            '44 Bouverie Road',
+            'Blackpool',
+            'Lancashire',
+            'SY4 0RE',
+          ],
         })
         const presenter = new EditSessionPresenter(actionPlan)
 
@@ -141,6 +155,12 @@ describe(EditSessionPresenter, () => {
             hours: { value: '1', hasError: false },
             minutes: { value: '15', hasError: false },
           },
+          meetingMethod: 'IN_PERSON_MEETING_OTHER',
+          addressLine1: 'Harmony Living Office, Room 4',
+          addressLine2: '44 Bouverie Road',
+          addressTownOrCity: 'Blackpool',
+          addressCounty: 'Lancashire',
+          addressPostCode: 'SY4 0RE',
         })
       })
     })

--- a/server/routes/serviceProviderReferrals/editSessionPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/editSessionPresenter.test.ts
@@ -109,7 +109,13 @@ describe(EditSessionPresenter, () => {
             minutes: { value: '', hasError: false },
           },
           meetingMethod: { value: null, errorMessage: null },
-          address: null,
+          address: {
+            value: null,
+            errors: {
+              firstAddressLine: null,
+              postcode: null,
+            },
+          },
         })
       })
     })
@@ -153,11 +159,17 @@ describe(EditSessionPresenter, () => {
           },
           meetingMethod: { value: 'IN_PERSON_MEETING_OTHER', errorMessage: null },
           address: {
-            firstAddressLine: 'Harmony Living Office, Room 4',
-            secondAddressLine: '44 Bouverie Road',
-            townOrCity: 'Blackpool',
-            county: 'Lancashire',
-            postCode: 'SY4 0RE',
+            value: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY4 0RE',
+            },
+            errors: {
+              firstAddressLine: null,
+              postcode: null,
+            },
           },
         })
       })

--- a/server/routes/serviceProviderReferrals/editSessionPresenter.ts
+++ b/server/routes/serviceProviderReferrals/editSessionPresenter.ts
@@ -1,4 +1,4 @@
-import { ActionPlanAppointment } from '../../models/actionPlan'
+import { ActionPlanAppointment, AppointmentDeliveryType } from '../../models/actionPlan'
 import CalendarDay from '../../utils/calendarDay'
 import Duration from '../../utils/duration'
 import PresenterUtils from '../../utils/presenterUtils'
@@ -45,5 +45,26 @@ export default class EditSessionPresenter {
       'duration',
       this.validationError
     ),
+    meetingMethod: this.chosenAppointmentDeliveryType(this.appointment.appointmentDeliveryType),
+    address: this.appointment.appointmentDeliveryAddress,
+  }
+
+  private chosenAppointmentDeliveryType(
+    existingModelValue: AppointmentDeliveryType | null
+  ): AppointmentDeliveryType | null {
+    if (this.userInputData === null) {
+      return existingModelValue
+    }
+    const radioButtonValue = this.userInputData['meeting-method']
+    switch (radioButtonValue) {
+      case 'PHONE_CALL':
+        return 'PHONE_CALL'
+      case 'VIDEO_CALL':
+        return 'PHONE_CALL'
+      case 'IN_PERSON_MEETING_OTHER':
+        return 'IN_PERSON_MEETING_OTHER'
+      default:
+        return null
+    }
   }
 }

--- a/server/routes/serviceProviderReferrals/editSessionPresenter.ts
+++ b/server/routes/serviceProviderReferrals/editSessionPresenter.ts
@@ -1,4 +1,4 @@
-import { ActionPlanAppointment, AppointmentDeliveryType } from '../../models/actionPlan'
+import { ActionPlanAppointment } from '../../models/actionPlan'
 import CalendarDay from '../../utils/calendarDay'
 import Duration from '../../utils/duration'
 import PresenterUtils from '../../utils/presenterUtils'
@@ -45,26 +45,11 @@ export default class EditSessionPresenter {
       'duration',
       this.validationError
     ),
-    meetingMethod: this.chosenAppointmentDeliveryType(this.appointment.appointmentDeliveryType),
+    meetingMethod: this.utils.meetingMethodValue(
+      this.appointment.appointmentDeliveryType,
+      'meeting-method',
+      this.validationError
+    ),
     address: this.appointment.appointmentDeliveryAddress,
-  }
-
-  private chosenAppointmentDeliveryType(
-    existingModelValue: AppointmentDeliveryType | null
-  ): AppointmentDeliveryType | null {
-    if (this.userInputData === null) {
-      return existingModelValue
-    }
-    const radioButtonValue = this.userInputData['meeting-method']
-    switch (radioButtonValue) {
-      case 'PHONE_CALL':
-        return 'PHONE_CALL'
-      case 'VIDEO_CALL':
-        return 'PHONE_CALL'
-      case 'IN_PERSON_MEETING_OTHER':
-        return 'IN_PERSON_MEETING_OTHER'
-      default:
-        return null
-    }
   }
 }

--- a/server/routes/serviceProviderReferrals/editSessionPresenter.ts
+++ b/server/routes/serviceProviderReferrals/editSessionPresenter.ts
@@ -50,6 +50,10 @@ export default class EditSessionPresenter {
       'meeting-method',
       this.validationError
     ),
-    address: this.appointment.appointmentDeliveryAddress,
+    address: this.utils.addressValue(
+      this.appointment.appointmentDeliveryAddress,
+      'method-other-location',
+      this.validationError
+    ),
   }
 }

--- a/server/routes/serviceProviderReferrals/editSessionView.ts
+++ b/server/routes/serviceProviderReferrals/editSessionView.ts
@@ -1,9 +1,12 @@
-import { DateInputArgs, TimeInputArgs } from '../../utils/govukFrontendTypes'
+import { DateInputArgs, RadiosArgs, TimeInputArgs } from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
 import EditSessionPresenter from './editSessionPresenter'
+import AddressFormComponent from '../shared/addressFormComponent'
 
 export default class EditSessionView {
   constructor(private readonly presenter: EditSessionPresenter) {}
+
+  addressFormView = new AddressFormComponent(this.presenter.fields.address, 'method-other-location')
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [
@@ -15,6 +18,8 @@ export default class EditSessionView {
         durationDateInputArgs: this.durationDateInputArgs,
         errorSummaryArgs: this.errorSummaryArgs,
         serverError: this.serverError,
+        address: this.addressFormView.inputArgs,
+        meetingMethodRadioInputArgs: this.meetingMethodRadioInputArgs.bind(this),
       },
     ]
   }
@@ -130,6 +135,43 @@ export default class EditSessionView {
           }`,
           name: 'minutes',
           value: this.presenter.fields.duration.minutes.value,
+        },
+      ],
+    }
+  }
+
+  private meetingMethodRadioInputArgs(otherLocationHTML: string): RadiosArgs {
+    return {
+      idPrefix: 'meeting-method',
+      name: 'meeting-method',
+      fieldset: {
+        legend: {
+          text: 'Method',
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--l',
+        },
+      },
+      hint: {
+        text: 'Select one option.',
+      },
+      items: [
+        {
+          value: 'PHONE_CALL',
+          text: 'Phone call',
+          checked: this.presenter.fields.meetingMethod === 'PHONE_CALL',
+        },
+        {
+          value: 'VIDEO_CALL',
+          text: 'Video call',
+          checked: this.presenter.fields.meetingMethod === 'VIDEO_CALL',
+        },
+        {
+          value: 'IN_PERSON_MEETING_OTHER',
+          text: 'In-person meeting - Other locations',
+          checked: this.presenter.fields.meetingMethod === 'IN_PERSON_MEETING_OTHER',
+          conditional: {
+            html: otherLocationHTML,
+          },
         },
       ],
     }

--- a/server/routes/serviceProviderReferrals/editSessionView.ts
+++ b/server/routes/serviceProviderReferrals/editSessionView.ts
@@ -148,7 +148,7 @@ export default class EditSessionView {
         legend: {
           text: 'Method',
           isPageHeading: false,
-          classes: 'govuk-fieldset__legend--l',
+          classes: 'govuk-fieldset__legend--m',
         },
       },
       errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.meetingMethod.errorMessage),
@@ -168,7 +168,7 @@ export default class EditSessionView {
         },
         {
           value: 'IN_PERSON_MEETING_OTHER',
-          text: 'In-person meeting - Other locations',
+          text: 'In-person meeting',
           checked: this.presenter.fields.meetingMethod.value === 'IN_PERSON_MEETING_OTHER',
           conditional: {
             html: otherLocationHTML,

--- a/server/routes/serviceProviderReferrals/editSessionView.ts
+++ b/server/routes/serviceProviderReferrals/editSessionView.ts
@@ -151,6 +151,7 @@ export default class EditSessionView {
           classes: 'govuk-fieldset__legend--l',
         },
       },
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.meetingMethod.errorMessage),
       hint: {
         text: 'Select one option.',
       },
@@ -158,17 +159,17 @@ export default class EditSessionView {
         {
           value: 'PHONE_CALL',
           text: 'Phone call',
-          checked: this.presenter.fields.meetingMethod === 'PHONE_CALL',
+          checked: this.presenter.fields.meetingMethod.value === 'PHONE_CALL',
         },
         {
           value: 'VIDEO_CALL',
           text: 'Video call',
-          checked: this.presenter.fields.meetingMethod === 'VIDEO_CALL',
+          checked: this.presenter.fields.meetingMethod.value === 'VIDEO_CALL',
         },
         {
           value: 'IN_PERSON_MEETING_OTHER',
           text: 'In-person meeting - Other locations',
-          checked: this.presenter.fields.meetingMethod === 'IN_PERSON_MEETING_OTHER',
+          checked: this.presenter.fields.meetingMethod.value === 'IN_PERSON_MEETING_OTHER',
           conditional: {
             html: otherLocationHTML,
           },

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -661,6 +661,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
           'time-part-of-day': 'am',
           'duration-hours': '1',
           'duration-minutes': '15',
+          'meeting-method': 'PHONE_CALL',
         })
         .expect(302)
         .expect('Location', `/service-provider/referrals/${actionPlan.referralId}/progress`)
@@ -668,6 +669,8 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
       expect(interventionsService.updateActionPlanAppointment).toHaveBeenCalledWith('token', actionPlan.id, 1, {
         appointmentTime: '2021-03-24T09:02:00.000Z',
         durationInMinutes: 75,
+        appointmentDeliveryType: 'PHONE_CALL',
+        appointmentDeliveryAddress: null,
       })
     })
 
@@ -691,6 +694,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'meeting-method': 'PHONE_CALL',
           })
           .expect(400)
           .expect(res => {
@@ -717,6 +721,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'meeting-method': 'PHONE_CALL',
           })
           .expect(500)
           .expect(res => {
@@ -747,6 +752,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
           'time-part-of-day': 'am',
           'duration-hours': '1',
           'duration-minutes': '15',
+          'meeting-method': 'PHONE_CALL',
         })
         .expect(400)
         .expect(res => {

--- a/server/routes/shared/addressFormComponent.ts
+++ b/server/routes/shared/addressFormComponent.ts
@@ -1,10 +1,11 @@
 import { InputArgs } from '../../utils/govukFrontendTypes'
-import { Address } from '../../models/actionPlan'
+import { AddressInputPresenter } from '../../utils/presenterUtils'
+import ViewUtils from '../../utils/viewUtils'
 
 export default class AddressFormComponent {
-  constructor(private address: Address | null = null, private key: string) {}
+  constructor(private address: AddressInputPresenter, private key: string) {}
 
-  get inputArgs(): Record<string, unknown> {
+  get inputArgs(): Record<string, InputArgs> {
     return {
       firstAddressLineInputArgs: this.firstAddressLineInputArgs,
       secondAddressLineInputArgs: this.secondAddressLineInputArgs,
@@ -19,9 +20,10 @@ export default class AddressFormComponent {
       label: {
         html: 'Address line 1<span class="govuk-visually-hidden">line 1 of 2</span>',
       },
+      errorMessage: ViewUtils.govukErrorMessage(this.address.errors.firstAddressLine),
       id: `${this.key}-address-line-1`,
-      name: 'address-line-1',
-      value: this.address?.firstAddressLine,
+      name: `${this.key}-address-line-1`,
+      value: this.address.value?.firstAddressLine,
     }
   }
 
@@ -31,32 +33,32 @@ export default class AddressFormComponent {
         html: 'Address line 2 (optional) <span class="govuk-visually-hidden">line 2 of 2</span>',
       },
       id: `${this.key}-address-line-2`,
-      name: 'address-line-2',
-      value: this.address?.secondAddressLine,
+      name: `${this.key}-address-line-2`,
+      value: this.address.value?.secondAddressLine,
     }
   }
 
   private get townOrCityInputArgs(): InputArgs {
     return {
       label: {
-        text: 'Town or city',
+        text: 'Town or city (optional)',
       },
       classes: 'govuk-!-width-two-thirds',
       id: `${this.key}-address-town-or-city`,
-      name: 'address-town-or-city',
-      value: this.address?.townOrCity,
+      name: `${this.key}-address-town-or-city`,
+      value: this.address.value?.townOrCity,
     }
   }
 
   private get countyInputArgs(): InputArgs {
     return {
       label: {
-        text: 'County',
+        text: 'County (optional)',
       },
       classes: 'govuk-!-width-two-thirds',
       id: `${this.key}-address-county`,
-      name: 'address-county',
-      value: this.address?.county,
+      name: `${this.key}-address-county`,
+      value: this.address.value?.county,
     }
   }
 
@@ -65,10 +67,11 @@ export default class AddressFormComponent {
       label: {
         text: 'Postcode',
       },
+      errorMessage: ViewUtils.govukErrorMessage(this.address.errors.postcode),
       classes: 'govuk-input--width-10',
       id: `${this.key}-address-postcode`,
-      name: 'address-postcode',
-      value: this.address?.postCode,
+      name: `${this.key}-address-postcode`,
+      value: this.address.value?.postCode,
     }
   }
 }

--- a/server/routes/shared/addressFormComponent.ts
+++ b/server/routes/shared/addressFormComponent.ts
@@ -1,0 +1,74 @@
+import { InputArgs } from '../../utils/govukFrontendTypes'
+import { Address } from '../../models/actionPlan'
+
+export default class AddressFormComponent {
+  constructor(private address: Address | null = null, private key: string) {}
+
+  get inputArgs(): Record<string, unknown> {
+    return {
+      firstAddressLineInputArgs: this.firstAddressLineInputArgs,
+      secondAddressLineInputArgs: this.secondAddressLineInputArgs,
+      townOrCityInputArgs: this.townOrCityInputArgs,
+      countyInputArgs: this.countyInputArgs,
+      postCodeInputArgs: this.postCodeInputArgs,
+    }
+  }
+
+  private get firstAddressLineInputArgs(): InputArgs {
+    return {
+      label: {
+        html: 'Address line 1<span class="govuk-visually-hidden">line 1 of 2</span>',
+      },
+      id: `${this.key}-address-line-1`,
+      name: 'address-line-1',
+      value: this.address?.firstAddressLine,
+    }
+  }
+
+  private get secondAddressLineInputArgs(): InputArgs {
+    return {
+      label: {
+        html: 'Address line 2 (optional) <span class="govuk-visually-hidden">line 2 of 2</span>',
+      },
+      id: `${this.key}-address-line-2`,
+      name: 'address-line-2',
+      value: this.address?.secondAddressLine,
+    }
+  }
+
+  private get townOrCityInputArgs(): InputArgs {
+    return {
+      label: {
+        text: 'Town or city',
+      },
+      classes: 'govuk-!-width-two-thirds',
+      id: `${this.key}-address-town-or-city`,
+      name: 'address-town-or-city',
+      value: this.address?.townOrCity,
+    }
+  }
+
+  private get countyInputArgs(): InputArgs {
+    return {
+      label: {
+        text: 'County',
+      },
+      classes: 'govuk-!-width-two-thirds',
+      id: `${this.key}-address-county`,
+      name: 'address-county',
+      value: this.address?.county,
+    }
+  }
+
+  private get postCodeInputArgs(): InputArgs {
+    return {
+      label: {
+        text: 'Postcode',
+      },
+      classes: 'govuk-input--width-10',
+      id: `${this.key}-address-postcode`,
+      name: 'address-postcode',
+      value: this.address?.postCode,
+    }
+  }
+}

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2034,16 +2034,19 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         sessionNumber: 1,
         appointmentTime: '2021-05-13T12:30:00Z',
         durationInMinutes: 120,
+        appointmentDeliveryType: 'PHONE_CALL',
       }),
       actionPlanAppointmentFactory.build({
         sessionNumber: 2,
         appointmentTime: '2021-05-20T12:30:00Z',
         durationInMinutes: 120,
+        appointmentDeliveryType: 'PHONE_CALL',
       }),
       actionPlanAppointmentFactory.build({
         sessionNumber: 3,
         appointmentTime: '2021-05-27T12:30:00Z',
         durationInMinutes: 120,
+        appointmentDeliveryType: 'PHONE_CALL',
       }),
     ]
 
@@ -2078,6 +2081,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       sessionNumber: 1,
       appointmentTime: '2021-05-13T12:30:00Z',
       durationInMinutes: 120,
+      appointmentDeliveryType: 'PHONE_CALL',
     })
 
     beforeEach(async () => {
@@ -2110,6 +2114,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(appointment.sessionNumber).toEqual(1)
       expect(appointment.appointmentTime).toEqual('2021-05-13T12:30:00Z')
       expect(appointment.durationInMinutes).toEqual(120)
+      expect(appointment.appointmentDeliveryType).toEqual('PHONE_CALL')
     })
   })
 
@@ -2156,8 +2161,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           sessionNumber: 2,
           appointmentTime: '2021-05-13T12:30:00Z',
           durationInMinutes: 60,
-          appointmentDeliveryAddress: null,
-          appointmentDeliveryType: null,
+          appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+          appointmentDeliveryAddress: {
+            firstAddressLine: 'Harmony Living Office, Room 4',
+            secondAddressLine: '44 Bouverie Road',
+            townOrCity: 'Blackpool',
+            county: 'Lancashire',
+            postCode: 'SY40RE',
+          },
         })
 
         await provider.addInteraction({
@@ -2171,6 +2182,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             body: {
               appointmentTime: '2021-05-13T12:30:00Z',
               durationInMinutes: 60,
+              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+              appointmentDeliveryAddress: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '44 Bouverie Road',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY40RE',
+              },
             },
             headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
           },
@@ -2188,8 +2207,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           await interventionsService.updateActionPlanAppointment(token, '345059d4-1697-467b-8914-fedec9957279', 2, {
             appointmentTime: '2021-05-13T12:30:00Z',
             durationInMinutes: 60,
-            appointmentDeliveryType: 'PHONE_CALL',
-            appointmentDeliveryAddress: null,
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+            appointmentDeliveryAddress: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY40RE',
+            },
           })
         ).toMatchObject(actionPlanAppointment)
       })
@@ -2218,6 +2243,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             sessionNumber: 2,
             appointmentTime: '2021-05-13T12:30:00Z',
             durationInMinutes: 60,
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+            appointmentDeliveryAddress: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY40RE',
+            },
             sessionFeedback: {
               attendance: {
                 attended: 'late',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2156,6 +2156,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           sessionNumber: 2,
           appointmentTime: '2021-05-13T12:30:00Z',
           durationInMinutes: 60,
+          appointmentDeliveryAddress: null,
+          appointmentDeliveryType: null,
         })
 
         await provider.addInteraction({

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2186,6 +2186,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           await interventionsService.updateActionPlanAppointment(token, '345059d4-1697-467b-8914-fedec9957279', 2, {
             appointmentTime: '2021-05-13T12:30:00Z',
             durationInMinutes: 60,
+            appointmentDeliveryType: 'PHONE_CALL',
+            appointmentDeliveryAddress: null,
           })
         ).toMatchObject(actionPlanAppointment)
       })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -10,7 +10,13 @@ import Intervention from '../models/intervention'
 import PCCRegion from '../models/pccRegion'
 import CancellationReason from '../models/cancellationReason'
 import ServiceCategory from '../models/serviceCategory'
-import ActionPlan, { ActionPlanAppointment, AppointmentAttendance, AppointmentBehaviour } from '../models/actionPlan'
+import ActionPlan, {
+  ActionPlanAppointment,
+  Address,
+  AppointmentAttendance,
+  AppointmentBehaviour,
+  AppointmentDeliveryType,
+} from '../models/actionPlan'
 import DraftReferral from '../models/draftReferral'
 import SentReferral from '../models/sentReferral'
 import ReferralDesiredOutcomes from '../models/referralDesiredOutcomes'
@@ -40,6 +46,8 @@ export interface UpdateDraftActionPlanParams {
 export interface ActionPlanAppointmentUpdate {
   appointmentTime: string
   durationInMinutes: number
+  appointmentDeliveryType: AppointmentDeliveryType
+  appointmentDeliveryAddress: Address | null
 }
 
 export interface CreateEndOfServiceReportOutcome {

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -94,6 +94,16 @@ export default {
       empty: 'Enter a duration',
       invalidDuration: 'The session duration must be a real duration',
     },
+    meetingMethod: {
+      empty: 'Select a meeting method',
+    },
+    address: {
+      addressLine1Empty: 'Enter a value for address line 1',
+      townOrCityEmpty: 'Enter a town or city',
+      countyEmpty: 'Enter a county',
+      postCodeEmpty: 'Enter a postcode',
+      postCodeInvalid: 'Enter a valid postcode',
+    },
   },
   endOfServiceReportOutcome: {
     achievementLevel: {

--- a/server/utils/forms/inputs/addressInput.test.ts
+++ b/server/utils/forms/inputs/addressInput.test.ts
@@ -1,0 +1,41 @@
+import AddressInput from './addressInput'
+import TestUtils from '../../../../testutils/testUtils'
+
+describe(AddressInput, () => {
+  describe('validate', () => {
+    describe('with valid data', () => {
+      it('returns an address value when all fields are provided', async () => {
+        const request = TestUtils.createRequest({
+          'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+          'method-other-location-address-line-2': '44 Bouverie Road',
+          'method-other-location-address-town-or-city': 'Blackpool',
+          'method-other-location-address-county': 'Lancashire',
+          'method-other-location-address-postcode': 'SY4 0RE',
+        })
+        const result = await new AddressInput(request, 'method-other-location').validate()
+        expect(result.value).toEqual({
+          firstAddressLine: 'Harmony Living Office, Room 4',
+          secondAddressLine: '44 Bouverie Road',
+          townOrCity: 'Blackpool',
+          county: 'Lancashire',
+          postCode: 'SY4 0RE',
+        })
+      })
+      it('returns an address value when only address line 2 is missing', async () => {
+        const request = TestUtils.createRequest({
+          'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+          'method-other-location-address-town-or-city': 'Blackpool',
+          'method-other-location-address-county': 'Lancashire',
+          'method-other-location-address-postcode': 'SY4 0RE',
+        })
+        const result = await new AddressInput(request, 'method-other-location').validate()
+        expect(result.value).toEqual({
+          firstAddressLine: 'Harmony Living Office, Room 4',
+          townOrCity: 'Blackpool',
+          county: 'Lancashire',
+          postCode: 'SY4 0RE',
+        })
+      })
+    })
+  })
+})

--- a/server/utils/forms/inputs/addressInput.test.ts
+++ b/server/utils/forms/inputs/addressInput.test.ts
@@ -2,6 +2,13 @@ import AddressInput from './addressInput'
 import TestUtils from '../../../../testutils/testUtils'
 
 describe(AddressInput, () => {
+  const errorMessages = {
+    addressLine1Empty: 'Enter a value for address line 1',
+    townOrCityEmpty: 'Enter a town or city',
+    countyEmpty: 'Enter a county',
+    postCodeEmpty: 'Enter a postcode',
+    postCodeInvalid: 'Enter a valid postcode',
+  }
   describe('validate', () => {
     describe('with valid data', () => {
       it('returns an address value when all fields are provided', async () => {
@@ -10,30 +17,130 @@ describe(AddressInput, () => {
           'method-other-location-address-line-2': '44 Bouverie Road',
           'method-other-location-address-town-or-city': 'Blackpool',
           'method-other-location-address-county': 'Lancashire',
-          'method-other-location-address-postcode': 'SY4 0RE',
+          'method-other-location-address-postcode': 'EC1A 1BB',
         })
-        const result = await new AddressInput(request, 'method-other-location').validate()
+        const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
         expect(result.value).toEqual({
           firstAddressLine: 'Harmony Living Office, Room 4',
           secondAddressLine: '44 Bouverie Road',
           townOrCity: 'Blackpool',
           county: 'Lancashire',
+          postCode: 'EC1A 1BB',
+        })
+      })
+      it('returns an address value when only address line 1 and postcode is provided', async () => {
+        const request = TestUtils.createRequest({
+          'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+          'method-other-location-address-postcode': 'SY4 0RE',
+        })
+        const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
+        expect(result.value).toEqual({
+          firstAddressLine: 'Harmony Living Office, Room 4',
+          secondAddressLine: '',
+          townOrCity: '',
+          county: '',
           postCode: 'SY4 0RE',
         })
       })
-      it('returns an address value when only address line 2 is missing', async () => {
-        const request = TestUtils.createRequest({
-          'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
-          'method-other-location-address-town-or-city': 'Blackpool',
-          'method-other-location-address-county': 'Lancashire',
-          'method-other-location-address-postcode': 'SY4 0RE',
+      describe('postcode validation', () => {
+        function createRequest(postCode: string): Record<string, string> {
+          return {
+            'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+            'method-other-location-address-town-or-city': 'Blackpool',
+            'method-other-location-address-county': 'Lancashire',
+            'method-other-location-address-postcode': postCode,
+          }
+        }
+        async function validatePostCode(postCode: string): Promise<void> {
+          const request = TestUtils.createRequest(createRequest(postCode))
+          const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
+          expect(result.value?.postCode).toEqual(postCode)
+        }
+        it('returns an address value when all postcode is valid', async () => {
+          await validatePostCode('aa9a 9aa')
+          await validatePostCode('a9a 9aa')
+          await validatePostCode('a9 9aa')
+          await validatePostCode('a99 9aa')
+          await validatePostCode('aa9 9aa')
+          await validatePostCode('aa99 9aa')
+          await validatePostCode(' aa999aa ')
         })
-        const result = await new AddressInput(request, 'method-other-location').validate()
-        expect(result.value).toEqual({
-          firstAddressLine: 'Harmony Living Office, Room 4',
-          townOrCity: 'Blackpool',
-          county: 'Lancashire',
-          postCode: 'SY4 0RE',
+      })
+    })
+    describe('with invalid data', () => {
+      it('returns an error when address details are not entered', async () => {
+        const request = TestUtils.createRequest({})
+        const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
+        expect(result.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'method-other-location-address-line-1',
+              formFields: ['method-other-location-address-line-1'],
+              message: 'Enter a value for address line 1',
+            },
+            {
+              errorSummaryLinkedField: 'method-other-location-address-postcode',
+              formFields: ['method-other-location-address-postcode'],
+              message: 'Enter a postcode',
+            },
+            {
+              errorSummaryLinkedField: 'method-other-location-address-postcode',
+              formFields: ['method-other-location-address-postcode'],
+              message: 'Enter a valid postcode',
+            },
+          ],
+        })
+      })
+      it('returns an error when address details have blank values', async () => {
+        const request = TestUtils.createRequest({
+          'method-other-location-address-line-1': '',
+          'method-other-location-address-town-or-city': '',
+          'method-other-location-address-county': '',
+          'method-other-location-address-postcode': '',
+        })
+        const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
+        expect(result.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'method-other-location-address-line-1',
+              formFields: ['method-other-location-address-line-1'],
+              message: 'Enter a value for address line 1',
+            },
+            {
+              errorSummaryLinkedField: 'method-other-location-address-postcode',
+              formFields: ['method-other-location-address-postcode'],
+              message: 'Enter a postcode',
+            },
+            {
+              errorSummaryLinkedField: 'method-other-location-address-postcode',
+              formFields: ['method-other-location-address-postcode'],
+              message: 'Enter a valid postcode',
+            },
+          ],
+        })
+      })
+
+      describe('post code validation', () => {
+        it('returns an error when postcode is invalid', async () => {
+          const result = await new AddressInput(
+            TestUtils.createRequest({
+              'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+              'method-other-location-address-town-or-city': 'Blackpool',
+              'method-other-location-address-county': 'Lancashire',
+              'method-other-location-address-postcode': 'aaa1 1aa',
+            }),
+            'method-other-location',
+            errorMessages
+          ).validate()
+          expect(result.error).toEqual({
+            errors: [
+              {
+                errorSummaryLinkedField: 'method-other-location-address-postcode',
+                formFields: ['method-other-location-address-postcode'],
+                message: 'Enter a valid postcode',
+              },
+            ],
+          })
         })
       })
     })

--- a/server/utils/forms/inputs/addressInput.ts
+++ b/server/utils/forms/inputs/addressInput.ts
@@ -1,0 +1,34 @@
+import { Request } from 'express'
+import { FormValidationResult } from '../formValidationResult'
+import { Address } from '../../../models/actionPlan'
+
+export default class AddressInput {
+  constructor(private readonly request: Request, private readonly key: string) {}
+
+  private get keys() {
+    return {
+      addressLine1: `${this.key}-address-line-1`,
+      addressLine2: `${this.key}-address-line-2`,
+      townOrCity: `${this.key}-address-town-or-city`,
+      county: `${this.key}-address-county`,
+      postCode: `${this.key}-address-postcode`,
+    }
+  }
+
+  async validate(): Promise<FormValidationResult<Address>> {
+    return {
+      value: this.address!,
+      error: null,
+    }
+  }
+
+  get address(): Address | null {
+    return {
+      firstAddressLine: this.request.body[this.keys.addressLine1],
+      secondAddressLine: this.request.body[this.keys.addressLine2],
+      townOrCity: this.request.body[this.keys.townOrCity],
+      county: this.request.body[this.keys.county],
+      postCode: this.request.body[this.keys.postCode],
+    }
+  }
+}

--- a/server/utils/forms/inputs/addressInput.ts
+++ b/server/utils/forms/inputs/addressInput.ts
@@ -1,9 +1,27 @@
 import { Request } from 'express'
+import * as ExpressValidator from 'express-validator'
 import { FormValidationResult } from '../formValidationResult'
 import { Address } from '../../../models/actionPlan'
+import { FormValidationError } from '../../formValidationError'
+import FormUtils from '../../formUtils'
+import PresenterUtils from '../../presenterUtils'
+
+export interface AddressErrorMessages {
+  addressLine1Empty: string
+  townOrCityEmpty: string
+  countyEmpty: string
+  postCodeEmpty: string
+  postCodeInvalid: string
+}
 
 export default class AddressInput {
-  constructor(private readonly request: Request, private readonly key: string) {}
+  constructor(
+    private readonly request: Request,
+    private readonly key: string,
+    private readonly errorMessages: AddressErrorMessages
+  ) {}
+
+  private readonly utils = new PresenterUtils(this.request.body)
 
   private get keys() {
     return {
@@ -16,19 +34,43 @@ export default class AddressInput {
   }
 
   async validate(): Promise<FormValidationResult<Address>> {
+    const validationResult = await FormUtils.runValidations({ request: this.request, validations: this.validations })
+    const error = this.extractErrors(validationResult)
+    if (error) {
+      return { value: null, error }
+    }
+
     return {
       value: this.address!,
       error: null,
     }
   }
 
-  get address(): Address | null {
-    return {
-      firstAddressLine: this.request.body[this.keys.addressLine1],
-      secondAddressLine: this.request.body[this.keys.addressLine2],
-      townOrCity: this.request.body[this.keys.townOrCity],
-      county: this.request.body[this.keys.county],
-      postCode: this.request.body[this.keys.postCode],
+  private get validations(): ExpressValidator.ValidationChain[] {
+    return [
+      ExpressValidator.body(this.keys.addressLine1)
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(this.errorMessages.addressLine1Empty),
+
+      ExpressValidator.body(this.keys.postCode)
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(this.errorMessages.postCodeEmpty),
+
+      ExpressValidator.body(this.keys.postCode)
+        .matches(/^\s*[A-Za-z]{1,2}\d[A-Za-z\d]? ?\d[A-Za-z]{2}\s*$/)
+        .withMessage(this.errorMessages.postCodeInvalid),
+    ]
+  }
+
+  private extractErrors(result: ExpressValidator.Result): FormValidationError | null {
+    const formValidationError = FormUtils.validationErrorFromResult(result)
+    if (formValidationError !== null) {
+      return formValidationError
     }
+    return null
+  }
+
+  private get address(): Address | null {
+    return this.utils.addressValue(null, 'method-other-location', null).value ?? null
   }
 }

--- a/server/utils/forms/inputs/meetingMethodInput.test.ts
+++ b/server/utils/forms/inputs/meetingMethodInput.test.ts
@@ -1,0 +1,53 @@
+import AddressInput from './addressInput'
+import TestUtils from '../../../../testutils/testUtils'
+import MeetingMethodInput from './meetingMethodInput'
+
+describe(AddressInput, () => {
+  const errorMessages = {
+    empty: 'empty',
+  }
+  describe('validate', () => {
+    describe('with valid data', () => {
+      it('returns a meeting method', async () => {
+        const request = TestUtils.createRequest({
+          'meeting-method': 'PHONE_CALL',
+        })
+        const result = await new MeetingMethodInput(request, 'meeting-method', errorMessages).validate()
+        expect(result.value).toEqual('PHONE_CALL')
+      })
+    })
+    describe('with invalid data', () => {
+      describe('with empty selection', () => {
+        it('should present an error', async () => {
+          const request = TestUtils.createRequest({})
+          const result = await new MeetingMethodInput(request, 'meeting-method', errorMessages).validate()
+          expect(result.error).toEqual({
+            errors: [
+              {
+                errorSummaryLinkedField: 'meeting-method',
+                formFields: ['meeting-method'],
+                message: 'Select a meeting method',
+              },
+            ],
+          })
+        })
+      })
+
+      describe('with an invalid selection', () => {
+        it('should present an error', async () => {
+          const request = TestUtils.createRequest({ 'meeting-method': 'INVALID' })
+          const result = await new MeetingMethodInput(request, 'meeting-method', errorMessages).validate()
+          expect(result.error).toEqual({
+            errors: [
+              {
+                errorSummaryLinkedField: 'meeting-method',
+                formFields: ['meeting-method'],
+                message: 'Select a meeting method',
+              },
+            ],
+          })
+        })
+      })
+    })
+  })
+})

--- a/server/utils/forms/inputs/meetingMethodInput.test.ts
+++ b/server/utils/forms/inputs/meetingMethodInput.test.ts
@@ -4,7 +4,7 @@ import MeetingMethodInput from './meetingMethodInput'
 
 describe(AddressInput, () => {
   const errorMessages = {
-    empty: 'empty',
+    empty: 'Select a meeting method',
   }
   describe('validate', () => {
     describe('with valid data', () => {

--- a/server/utils/forms/inputs/meetingMethodInput.ts
+++ b/server/utils/forms/inputs/meetingMethodInput.ts
@@ -1,0 +1,56 @@
+import { Request } from 'express'
+import * as ExpressValidator from 'express-validator'
+import { FormValidationResult } from '../formValidationResult'
+import { FormValidationError } from '../../formValidationError'
+import FormUtils from '../../formUtils'
+import { AppointmentDeliveryType } from '../../../models/actionPlan'
+import PresenterUtils from '../../presenterUtils'
+
+export default class MeetingMethodInput {
+  constructor(private readonly request: Request, private readonly key: string) {}
+
+  private readonly utils = new PresenterUtils(this.request.body)
+
+  async validate(): Promise<FormValidationResult<AppointmentDeliveryType>> {
+    const validationResult = await FormUtils.runValidations({ request: this.request, validations: this.validations })
+    const error = this.extractErrors(validationResult)
+    if (error) {
+      return { value: null, error }
+    }
+    return {
+      value: this.meetingMethod!,
+      error: null,
+    }
+  }
+
+  private get meetingMethod(): AppointmentDeliveryType | null {
+    return this.utils.meetingMethodValue(null, this.key, null).value
+  }
+
+  private get validations(): ExpressValidator.ValidationChain[] {
+    return [
+      ExpressValidator.body(this.key).notEmpty({ ignore_whitespace: true }).withMessage('Select a meeting method'),
+    ]
+  }
+
+  private extractErrors(result: ExpressValidator.Result): FormValidationError | null {
+    const formValidationError = FormUtils.validationErrorFromResult(result)
+    if (formValidationError !== null) {
+      return formValidationError
+    }
+
+    if (this.meetingMethod === null) {
+      return {
+        errors: [
+          {
+            errorSummaryLinkedField: this.key,
+            formFields: [this.key],
+            message: 'Select a meeting method',
+          },
+        ],
+      }
+    }
+
+    return null
+  }
+}

--- a/server/utils/forms/inputs/meetingMethodInput.ts
+++ b/server/utils/forms/inputs/meetingMethodInput.ts
@@ -6,8 +6,16 @@ import FormUtils from '../../formUtils'
 import { AppointmentDeliveryType } from '../../../models/actionPlan'
 import PresenterUtils from '../../presenterUtils'
 
+export interface MeetingMethodErrorMessages {
+  empty: string
+}
+
 export default class MeetingMethodInput {
-  constructor(private readonly request: Request, private readonly key: string) {}
+  constructor(
+    private readonly request: Request,
+    private readonly key: string,
+    private readonly errorMessages: MeetingMethodErrorMessages
+  ) {}
 
   private readonly utils = new PresenterUtils(this.request.body)
 
@@ -28,9 +36,7 @@ export default class MeetingMethodInput {
   }
 
   private get validations(): ExpressValidator.ValidationChain[] {
-    return [
-      ExpressValidator.body(this.key).notEmpty({ ignore_whitespace: true }).withMessage('Select a meeting method'),
-    ]
+    return [ExpressValidator.body(this.key).notEmpty({ ignore_whitespace: true }).withMessage(this.errorMessages.empty)]
   }
 
   private extractErrors(result: ExpressValidator.Result): FormValidationError | null {

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -3,6 +3,7 @@ import draftReferralFactory from '../../testutils/factories/draftReferral'
 import CalendarDay from './calendarDay'
 import Duration from './duration'
 import ClockTime from './clockTime'
+import { FormValidationError } from './formValidationError'
 
 describe(PresenterUtils, () => {
   describe('stringValue', () => {
@@ -591,6 +592,98 @@ describe(PresenterUtils, () => {
           const utils = new PresenterUtils({ 'meeting-method': 'INVALID' })
           const value = utils.meetingMethodValue(null, 'meeting-method', null)
           expect(value).toMatchObject({ errorMessage: null, value: null })
+        })
+      })
+    })
+  })
+
+  describe('address', () => {
+    describe('when there are errors', () => {
+      it('they should be linked to the correct field', () => {
+        const utils = new PresenterUtils(null)
+        const errors: FormValidationError = {
+          errors: [
+            {
+              formFields: ['method-other-location-address-line-1'],
+              errorSummaryLinkedField: 'method-other-location-address-line-1',
+              message: 'address-line-1 error',
+            },
+            {
+              formFields: ['method-other-location-address-postcode'],
+              errorSummaryLinkedField: 'method-other-location-address-postcode',
+              message: 'address-postcode error',
+            },
+          ],
+        }
+        const value = utils.addressValue(null, 'method-other-location', errors)
+        expect(value).toMatchObject({
+          errors: {
+            firstAddressLine: 'address-line-1 error',
+            postcode: 'address-postcode error',
+          },
+        })
+      })
+    })
+
+    describe('when there is no user input data', () => {
+      describe('and the model has a null value', () => {
+        it('returns a null value', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.addressValue(null, 'method-other-location', null)
+          expect(value).toMatchObject({ value: null })
+        })
+      })
+      describe('and the model has a value', () => {
+        it('returns the model value', () => {
+          const utils = new PresenterUtils(null)
+          const address = {
+            firstAddressLine: 'Harmony Living Office, Room 4',
+            secondAddressLine: '44 Bouverie Road',
+            townOrCity: 'Blackpool',
+            county: 'Lancashire',
+            postCode: 'SY4 0RE',
+          }
+          const value = utils.addressValue(address, 'method-other-location', null)
+          expect(value).toMatchObject({ value: address })
+        })
+      })
+    })
+
+    describe('when there is user input data', () => {
+      describe('and the data is valid', () => {
+        it('returns an address', () => {
+          const utils = new PresenterUtils({
+            'method-other-location-address-line-1': 'a',
+            'method-other-location-address-line-2': 'b',
+            'method-other-location-address-town-or-city': 'c',
+            'method-other-location-address-county': 'd',
+            'method-other-location-address-postcode': 'e',
+          })
+          const value = utils.addressValue(null, 'method-other-location', null)
+          expect(value).toMatchObject({
+            value: {
+              firstAddressLine: 'a',
+              secondAddressLine: 'b',
+              townOrCity: 'c',
+              county: 'd',
+              postCode: 'e',
+            },
+          })
+        })
+      })
+      describe('and the data is invalid', () => {
+        it('returns a empty values', () => {
+          const utils = new PresenterUtils({ invalid: 'INVALID' })
+          const value = utils.addressValue(null, 'method-other-location', null)
+          expect(value).toMatchObject({
+            value: {
+              firstAddressLine: '',
+              secondAddressLine: '',
+              townOrCity: '',
+              county: '',
+              postCode: '',
+            },
+          })
         })
       })
     })

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -560,6 +560,42 @@ describe(PresenterUtils, () => {
     })
   })
 
+  describe('meetingMethod', () => {
+    describe('when there is no user input data', () => {
+      describe('and the model has a null value', () => {
+        it('returns a null value', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.meetingMethodValue(null, 'meeting-method', null)
+          expect(value).toMatchObject({ errorMessage: null, value: null })
+        })
+      })
+      describe('and the model has a value', () => {
+        it('returns the model value', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.meetingMethodValue('PHONE_CALL', 'meeting-method', null)
+          expect(value).toMatchObject({ errorMessage: null, value: 'PHONE_CALL' })
+        })
+      })
+    })
+
+    describe('when there is user input data', () => {
+      describe('and the data is valid', () => {
+        it('returns a meeting method', () => {
+          const utils = new PresenterUtils({ 'meeting-method': 'PHONE_CALL' })
+          const value = utils.meetingMethodValue(null, 'meeting-method', null)
+          expect(value).toMatchObject({ errorMessage: null, value: 'PHONE_CALL' })
+        })
+      })
+      describe('and the data is invalid', () => {
+        it('returns a null value', () => {
+          const utils = new PresenterUtils({ 'meeting-method': 'INVALID' })
+          const value = utils.meetingMethodValue(null, 'meeting-method', null)
+          expect(value).toMatchObject({ errorMessage: null, value: null })
+        })
+      })
+    })
+  })
+
   describe('.errorSummary', () => {
     describe('with null error', () => {
       it('returns null', () => {

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -7,7 +7,7 @@ import utils from './utils'
 import AuthUserDetails from '../models/hmppsAuth/authUserDetails'
 import ComplexityLevel from '../models/complexityLevel'
 import { TagArgs } from './govukFrontendTypes'
-import { AppointmentDeliveryType } from '../models/actionPlan'
+import { Address, AppointmentDeliveryType } from '../models/actionPlan'
 
 interface DateTimeComponentInputPresenter {
   value: string
@@ -42,6 +42,14 @@ interface TwelveHourTimeInputPresenter {
 interface MeetingMethodInputPresenter {
   errorMessage: string | null
   value: AppointmentDeliveryType | null
+}
+
+export interface AddressInputPresenter {
+  value: Address | null
+  errors: {
+    firstAddressLine: string | null
+    postcode: string | null
+  }
 }
 
 export default class PresenterUtils {
@@ -108,6 +116,41 @@ export default class PresenterUtils {
       year: {
         value: yearValue,
         hasError: PresenterUtils.hasError(error, yearKey),
+      },
+    }
+  }
+
+  addressValue(
+    modelValue: Address | null,
+    userInputKey: string,
+    error: FormValidationError | null
+  ): AddressInputPresenter {
+    let address: Address | null
+    if (this.userInputData === null) {
+      address = modelValue
+    } else {
+      const [firstAddressLine, secondAddressLine, townOrCity, county, postCode] = [
+        'address-line-1',
+        'address-line-2',
+        'address-town-or-city',
+        'address-county',
+        'address-postcode',
+      ]
+        .map(suffix => `${userInputKey}-${suffix}`)
+        .map(key => (this.userInputData![key] as string) ?? '')
+      address = {
+        firstAddressLine,
+        secondAddressLine,
+        townOrCity,
+        county,
+        postCode,
+      }
+    }
+    return {
+      value: address,
+      errors: {
+        firstAddressLine: PresenterUtils.errorMessage(error, `${userInputKey}-address-line-1`),
+        postcode: PresenterUtils.errorMessage(error, `${userInputKey}-address-postcode`),
       },
     }
   }

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -7,6 +7,7 @@ import utils from './utils'
 import AuthUserDetails from '../models/hmppsAuth/authUserDetails'
 import ComplexityLevel from '../models/complexityLevel'
 import { TagArgs } from './govukFrontendTypes'
+import { AppointmentDeliveryType } from '../models/actionPlan'
 
 interface DateTimeComponentInputPresenter {
   value: string
@@ -36,6 +37,11 @@ interface TwelveHourTimeInputPresenter {
   hour: DateTimeComponentInputPresenter
   minute: DateTimeComponentInputPresenter
   partOfDay: PartOfDayInputPresenter
+}
+
+interface MeetingMethodInputPresenter {
+  errorMessage: string | null
+  value: AppointmentDeliveryType | null
 }
 
 export default class PresenterUtils {
@@ -103,6 +109,27 @@ export default class PresenterUtils {
         value: yearValue,
         hasError: PresenterUtils.hasError(error, yearKey),
       },
+    }
+  }
+
+  meetingMethodValue(
+    modelValue: AppointmentDeliveryType | null,
+    userInputKey: string,
+    error: FormValidationError | null
+  ): MeetingMethodInputPresenter {
+    const errorMessage = PresenterUtils.errorMessage(error, userInputKey)
+    let appointmentDeliveryType: AppointmentDeliveryType | null = null
+    if (this.userInputData === null) {
+      appointmentDeliveryType = modelValue
+    } else {
+      const radioButtonValue = this.userInputData['meeting-method']
+      if (['PHONE_CALL', 'VIDEO_CALL', 'IN_PERSON_MEETING_OTHER'].includes(radioButtonValue as string)) {
+        appointmentDeliveryType = radioButtonValue as AppointmentDeliveryType
+      }
+    }
+    return {
+      errorMessage,
+      value: appointmentDeliveryType,
     }
   }
 

--- a/server/views/serviceProviderReferrals/editSession.njk
+++ b/server/views/serviceProviderReferrals/editSession.njk
@@ -2,6 +2,8 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "components/time-input/macro.njk" import appTimeInput %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -33,8 +35,15 @@
           {{ govukDateInput(dateInputArgs) }}
           {{ appTimeInput(timeInputArgs) }}
           {{ govukDateInput(durationDateInputArgs) }}
+          {% set otherLocationHtml %}
+              {{ govukInput(address.firstAddressLineInputArgs) }}
+              {{ govukInput(address.secondAddressLineInputArgs) }}
+              {{ govukInput(address.townOrCityInputArgs) }}
+              {{ govukInput(address.countyInputArgs) }}
+              {{ govukInput(address.postCodeInputArgs) }}
+          {% endset -%}
+          {{ govukRadios(meetingMethodRadioInputArgs(otherLocationHtml)) }}
         </div>
-
         {{ govukButton({ text: "Save and continue" }) }}
       </form>
     </div>

--- a/testutils/factories/actionPlanAppointment.ts
+++ b/testutils/factories/actionPlanAppointment.ts
@@ -34,6 +34,8 @@ export default ActionPlanAppointmentFactory.define(() => ({
   sessionNumber: 1,
   appointmentTime: null,
   durationInMinutes: null,
+  appointmentDeliveryType: null,
+  appointmentDeliveryAddress: null,
   sessionFeedback: {
     attendance: {
       attended: null,


### PR DESCRIPTION
## What does this pull request do?

Provides an input form for the user to specify how an appointment will be delivered (phone call, video call, address) - and if they've chosen an address - where an appointment will take place.

## What is the intent behind these changes?

Provide user with ability to edit and view address details of appointments.

The edit page looks like this:

![image](https://user-images.githubusercontent.com/83066216/122235951-0056f280-ceb6-11eb-9164-1114189acf85.png)
![image](https://user-images.githubusercontent.com/83066216/122534714-b50a2480-d01a-11eb-822e-d41d870c7cc3.png)
![image](https://user-images.githubusercontent.com/83066216/122534754-bfc4b980-d01a-11eb-8b3c-8e99e0c3e6f4.png)

If the user does not select a method:

![image](https://user-images.githubusercontent.com/83066216/122236456-6e9bb500-ceb6-11eb-9cf6-ac05a035b52d.png)
![image](https://user-images.githubusercontent.com/83066216/122534826-d3702000-d01a-11eb-9af5-21a0c5b70c8c.png)
If the user does not provide an address:

![image](https://user-images.githubusercontent.com/83066216/122534910-eb47a400-d01a-11eb-8a60-c4aa1616fe89.png)


![image](https://user-images.githubusercontent.com/83066216/122535001-061a1880-d01b-11eb-9a2e-289922a4729a.png)
![image](https://user-images.githubusercontent.com/83066216/122236331-562b9a80-ceb6-11eb-86b4-ca0f5b7da968.png)









