### PR TITLE
IC-1866 add more fine grained control over ignored and unsuccessful requests in app insights

### DIFF
--- a/server/azureAppInsights.ts
+++ b/server/azureAppInsights.ts
@@ -31,26 +31,24 @@ function addUsernameProcessor(
     const userId = (contextObjects?.['http.ServerRequest'] as Request)?.user?.userId
     if (userId) {
       // eslint-disable-next-line no-param-reassign
-      envelope.tags['ai.user.authUserId'] = userId
+      envelope.tags[defaultClient.context.keys.userAuthUserId] = userId
     }
   }
   return true
 }
 
-function errorStatusCodeProcessor(
-  envelope: Contracts.EnvelopeTelemetry,
-  _contextObjects: { [name: string]: unknown } | undefined
-): boolean {
-  if (envelope.data.baseType === Contracts.TelemetryTypeString.Request) {
-    if (envelope.data.baseData !== undefined) {
-      // eslint-disable-next-line no-param-reassign
-      envelope.data.baseData.success = !(
-        envelope.data.baseData.responseCode in config.applicationInsights.errorStatusCodes
-      )
-    }
-  }
-  return true
-}
+// function errorStatusCodeProcessor(
+//   envelope: Contracts.EnvelopeTelemetry,
+//   _contextObjects: { [name: string]: unknown } | undefined
+// ): boolean {
+//   if (envelope.data.baseType === Contracts.TelemetryTypeString.Request && envelope.data.baseData !== undefined) {
+//     // eslint-disable-next-line no-param-reassign
+//     envelope.data.baseData.success = !(
+//       envelope.data.baseData.responseCode in config.applicationInsights.errorStatusCodes
+//     )
+//   }
+//   return true
+// }
 
 export default function initialiseAppInsights(): void {
   const { connectionString } = config.applicationInsights
@@ -60,12 +58,11 @@ export default function initialiseAppInsights(): void {
     setup(connectionString).setDistributedTracingMode(DistributedTracingModes.AI_AND_W3C).start()
 
     // application level properties
-    defaultClient.context.tags['ai.cloud.role'] = config.applicationInsights.cloudRoleName
-    defaultClient.context.tags['ai.application.ver'] = applicationVersion.buildNumber
+    defaultClient.context.tags[defaultClient.context.keys.cloudRole] = config.applicationInsights.cloudRoleName
+    defaultClient.context.tags[defaultClient.context.keys.applicationVersion] = applicationVersion.buildNumber
 
     // custom processors to fine tune behaviour
     defaultClient.addTelemetryProcessor(ignoreExcludedRequestsProcessor)
     defaultClient.addTelemetryProcessor(addUsernameProcessor)
-    defaultClient.addTelemetryProcessor(errorStatusCodeProcessor)
   }
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -52,7 +52,6 @@ export default {
     connectionString: get('APPLICATIONINSIGHTS_CONNECTION_STRING', null, requiredInProduction),
     cloudRoleName: 'interventions-ui',
     excludedRequests: [/^GET \/assets\/.*/, /^GET \/health.*/],
-    errorStatusCodes: [403, 500],
   },
   session: {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),

--- a/server/config.ts
+++ b/server/config.ts
@@ -50,6 +50,9 @@ export default {
   },
   applicationInsights: {
     connectionString: get('APPLICATIONINSIGHTS_CONNECTION_STRING', null, requiredInProduction),
+    cloudRoleName: 'interventions-ui',
+    excludedRequests: [/^GET \/assets\/.*/, /^GET \/health.*/],
+    errorStatusCodes: [403, 500],
   },
   session: {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),


### PR DESCRIPTION


## What does this pull request do?

add more fine grained control over ignored and unsuccessful requests in app insights
 - allows requests matching patterns to be ignored
 - allows customization of which status codes are treated as errors in the UI

## What is the intent behind these changes?

make app insights more useable