### PR TITLE
IC-1874: Allow users to go back to EOSR creation page after clicking the "back" button.

### DIFF
--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -368,6 +368,52 @@ describe(InterventionProgressPresenter, () => {
     })
   })
 
+  describe('canSubmitEndOfServiceReport', () => {
+    describe('when the referral has been assigned', () => {
+      describe('when there is no end of service report', () => {
+        it('returns true', () => {
+          const referral = sentReferralFactory.assigned().build({ endOfServiceReport: null })
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
+
+          expect(presenter.canSubmitEndOfServiceReport).toEqual(true)
+        })
+      })
+
+      describe('when there is an end of service report but it has not been submitted', () => {
+        it('returns true', () => {
+          const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
+          const referral = sentReferralFactory.assigned().build({ endOfServiceReport })
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
+
+          expect(presenter.canSubmitEndOfServiceReport).toEqual(true)
+        })
+      })
+
+      describe('when there is an end of service report and it has been submitted', () => {
+        it('returns false', () => {
+          const endOfServiceReport = endOfServiceReportFactory.submitted().build()
+          const referral = sentReferralFactory.assigned().build({ endOfServiceReport })
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
+
+          expect(presenter.canSubmitEndOfServiceReport).toEqual(false)
+        })
+      })
+    })
+
+    describe('when the referral has not been assigned', () => {
+      it('returns false', () => {
+        const referral = sentReferralFactory.build()
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
+
+        expect(presenter.canSubmitEndOfServiceReport).toEqual(false)
+      })
+    })
+  })
+
   describe('endOfServiceReportSubmitted', () => {
     describe('when there is no end of service report', () => {
       it('returns false', () => {

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -368,25 +368,70 @@ describe(InterventionProgressPresenter, () => {
     })
   })
 
-  describe('allowEndOfServiceReportCreation', () => {
+  describe('endOfServiceReportSubmitted', () => {
     describe('when there is no end of service report', () => {
-      it('returns true', () => {
+      it('returns false', () => {
         const referral = sentReferralFactory.build({ endOfServiceReport: null })
         const intervention = interventionFactory.build()
         const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
-        expect(presenter.allowEndOfServiceReportCreation).toEqual(true)
+        expect(presenter.endOfServiceReportSubmitted).toEqual(false)
       })
     })
 
-    describe('when there is an end of service report', () => {
+    describe('when there is an end of service report but it has not been submitted', () => {
       it('returns false', () => {
         const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
         const referral = sentReferralFactory.build({ endOfServiceReport })
         const intervention = interventionFactory.build()
         const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
 
-        expect(presenter.allowEndOfServiceReportCreation).toEqual(false)
+        expect(presenter.endOfServiceReportSubmitted).toEqual(false)
+      })
+    })
+
+    describe('when there is an end of service report and it has been submitted', () => {
+      it('returns false', () => {
+        const endOfServiceReport = endOfServiceReportFactory.submitted().build()
+        const referral = sentReferralFactory.build({ endOfServiceReport })
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
+
+        expect(presenter.endOfServiceReportSubmitted).toEqual(true)
+      })
+    })
+  })
+
+  describe('endOfServiceReportButtonActionText', () => {
+    describe('when there is no end of service report', () => {
+      it('returns Create', () => {
+        const referral = sentReferralFactory.build({ endOfServiceReport: null })
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
+
+        expect(presenter.endOfServiceReportButtonActionText).toEqual('Create')
+      })
+    })
+
+    describe('when there is an end of service report but it has not been submitted', () => {
+      it('returns Continue', () => {
+        const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
+        const referral = sentReferralFactory.build({ endOfServiceReport })
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
+
+        expect(presenter.endOfServiceReportButtonActionText).toEqual('Continue')
+      })
+    })
+
+    describe('when there is an end of service report and it has been submitted', () => {
+      it('returns null', () => {
+        const endOfServiceReport = endOfServiceReportFactory.submitted().build()
+        const referral = sentReferralFactory.build({ endOfServiceReport })
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(referral, intervention, null, [])
+
+        expect(presenter.endOfServiceReportButtonActionText).toEqual(null)
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -185,11 +185,19 @@ export default class InterventionProgressPresenter {
     ? 'active'
     : 'inactive'
 
-  private get endOfServiceReportSubmitted() {
-    return this.referral.endOfServiceReport !== null && this.referral.endOfServiceReport.submittedAt !== null
+  get endOfServiceReportSubmitted(): boolean {
+    return !!this.referral.endOfServiceReport?.submittedAt
   }
 
-  get allowEndOfServiceReportCreation(): boolean {
-    return this.referral.endOfServiceReport === null
+  private get endOfServiceReportStarted(): boolean {
+    return this.referral.endOfServiceReport !== null && !this.endOfServiceReportSubmitted
+  }
+
+  get endOfServiceReportButtonActionText(): string | null {
+    if (this.endOfServiceReportSubmitted) {
+      return null
+    }
+
+    return this.endOfServiceReportStarted ? 'Continue' : 'Create'
   }
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -189,6 +189,10 @@ export default class InterventionProgressPresenter {
     return !!this.referral.endOfServiceReport?.submittedAt
   }
 
+  get canSubmitEndOfServiceReport(): boolean {
+    return this.referralAssigned && !this.endOfServiceReportSubmitted
+  }
+
   private get endOfServiceReportStarted(): boolean {
     return this.referral.endOfServiceReport !== null && !this.endOfServiceReportSubmitted
   }

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -190,7 +190,7 @@ export default class InterventionProgressView {
       },
     ]
 
-    if (!this.presenter.endOfServiceReportSubmitted) {
+    if (this.presenter.canSubmitEndOfServiceReport) {
       rows.push({
         key: { text: 'Action' },
         value: {

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -190,14 +190,14 @@ export default class InterventionProgressView {
       },
     ]
 
-    if (this.presenter.allowEndOfServiceReportCreation) {
+    if (!this.presenter.endOfServiceReportSubmitted) {
       rows.push({
         key: { text: 'Action' },
         value: {
           html: `<form method="post" action="${ViewUtils.escape(this.presenter.createEndOfServiceReportFormAction)}">
                    <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken)}">
                    <button class="govuk-button govuk-button--secondary">
-                     Create end of service report
+                     ${this.presenter.endOfServiceReportButtonActionText} end of service report
                    </button>
                  </form>`,
         },

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1074,16 +1074,40 @@ describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNu
 })
 
 describe('POST /service-provider/referrals/:id/end-of-service-report', () => {
-  it('creates an end of service report for that referral on the interventions service, and redirects to the first page of the service provider end of service report journey', async () => {
-    const endOfServiceReport = endOfServiceReportFactory.build()
-    interventionsService.createDraftEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+  describe('when a draft end of service report does not yet exist', () => {
+    it('creates an end of service report for that referral on the interventions service, and redirects to the first page of the service provider end of service report journey', async () => {
+      const referral = sentReferralFactory.build({ id: '19', endOfServiceReport: null })
+      const endOfServiceReport = endOfServiceReportFactory.build()
 
-    await request(app)
-      .post(`/service-provider/referrals/19/end-of-service-report`)
-      .expect(303)
-      .expect('Location', `/service-provider/end-of-service-report/${endOfServiceReport.id}/outcomes/1`)
+      interventionsService.getSentReferral.mockResolvedValue(referral)
+      interventionsService.createDraftEndOfServiceReport.mockResolvedValue(endOfServiceReport)
 
-    expect(interventionsService.createDraftEndOfServiceReport).toHaveBeenCalledWith('token', '19')
+      await request(app)
+        .post(`/service-provider/referrals/19/end-of-service-report`)
+        .expect(303)
+        .expect('Location', `/service-provider/end-of-service-report/${endOfServiceReport.id}/outcomes/1`)
+
+      expect(interventionsService.createDraftEndOfServiceReport).toHaveBeenCalledWith('token', '19')
+    })
+  })
+
+  describe('when a draft end of service report has been created but not yet submitted', () => {
+    it('creates an end of service report for that referral on the interventions service, and redirects to the first page of the service provider end of service report journey', async () => {
+      const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
+      const referral = sentReferralFactory.build({
+        id: '19',
+        endOfServiceReport,
+      })
+
+      interventionsService.getSentReferral.mockResolvedValue(referral)
+
+      await request(app)
+        .post(`/service-provider/referrals/19/end-of-service-report`)
+        .expect(303)
+        .expect('Location', `/service-provider/end-of-service-report/${endOfServiceReport.id}/outcomes/1`)
+
+      expect(interventionsService.createDraftEndOfServiceReport).not.toHaveBeenCalledWith('token', '19')
+    })
   })
 })
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -678,12 +678,23 @@ export default class ServiceProviderReferralsController {
   }
 
   async createDraftEndOfServiceReport(req: Request, res: Response): Promise<void> {
-    const draftEndOfServiceReport = await this.interventionsService.createDraftEndOfServiceReport(
-      res.locals.user.token.accessToken,
-      req.params.id
-    )
+    const { accessToken } = res.locals.user.token
+    const referralId = req.params.id
 
-    res.redirect(303, `/service-provider/end-of-service-report/${draftEndOfServiceReport.id}/outcomes/1`)
+    const referral = await this.interventionsService.getSentReferral(accessToken, referralId)
+
+    let draftEndOfServiceReportId = referral.endOfServiceReport?.id
+
+    if (!draftEndOfServiceReportId) {
+      const draftEndOfServiceReport = await this.interventionsService.createDraftEndOfServiceReport(
+        accessToken,
+        referralId
+      )
+
+      draftEndOfServiceReportId = draftEndOfServiceReport.id
+    }
+
+    res.redirect(303, `/service-provider/end-of-service-report/${draftEndOfServiceReportId}/outcomes/1`)
   }
 
   async editEndOfServiceReportOutcome(req: Request, res: Response): Promise<void> {


### PR DESCRIPTION
## What does this pull request do?

Ensures "Create End of Service Report" link is displayed if a user clicks the "back" button from that page.

As part of this, we want to ensure that we don't try and create a new End of Service report here when clicking this button if one already exists - we could implement this logic on the backend POST endpoint to return the existing End of Service report, so that it won't try and create a duplicate EOSR, but this felt like an easy approach for now.

## What is the intent behind these changes?

To stop users being stuck and unable to create an end of service report.
