### PR TITLE
add simple page for SP to view an under approval action plan

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -12,6 +12,7 @@ $path: "/assets/images/"
 @import './components/primary-navigation'
 @import './components/service-user-banner'
 @import './components/task-list'
+@import './components/shaded-list'
 
 @import './layout/grid'
 

--- a/assets/sass/components/_shaded-list.scss
+++ b/assets/sass/components/_shaded-list.scss
@@ -1,0 +1,10 @@
+.refer-and-monitor__shaded-list-item {
+  background-color: govuk-colour('light-grey');
+  border-left: 5px solid govuk-colour('blue');
+  margin-bottom: 30px;
+  padding: 15px;
+
+  .govuk-body:last-child {
+    margin-bottom: 5px;
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -240,5 +240,9 @@ export default function routes(router: Router, services: Services): Router {
     findInterventionsController.viewInterventionDetails(req, res)
   )
 
+  get('/service-provider/referrals/:id/action-plan', (req, res) =>
+    serviceProviderReferralsController.viewActionPlan(req, res)
+  )
+
   return router
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -128,7 +128,6 @@ export default class InterventionProgressView {
           classes: 'action-plan-submitted-date',
         },
       })
-      // FIXME: the 'view action plan' page doesn't exist yet!
       rows.push({
         key: { text: 'To do' },
         value: {

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -9,13 +9,13 @@ import {
 import ViewUtils from '../../utils/viewUtils'
 import InterventionProgressPresenter from './interventionProgressPresenter'
 import DateUtils from '../../utils/dateUtils'
-import ActionPlanDetailsView from '../shared/actionPlanDetailsView'
+import ActionPlanSummaryView from '../shared/actionPlanSummaryView'
 
 export default class InterventionProgressView {
-  actionPlanDetailsView: ActionPlanDetailsView
+  actionPlanSummaryView: ActionPlanSummaryView
 
   constructor(private readonly presenter: InterventionProgressPresenter) {
-    this.actionPlanDetailsView = new ActionPlanDetailsView(presenter.actionPlanDetailsPresenter)
+    this.actionPlanSummaryView = new ActionPlanSummaryView(presenter.actionPlanDetailsPresenter)
   }
 
   get cancelledReferralNotificationBannerArgs(): NotificationBannerArgs {
@@ -86,7 +86,7 @@ export default class InterventionProgressView {
         value: {
           text: tagMacro({
             text: this.presenter.actionPlanDetailsPresenter.text.actionPlanStatus,
-            classes: this.actionPlanDetailsView.actionPlanTagClass,
+            classes: this.actionPlanSummaryView.actionPlanTagClass,
             attributes: { id: 'action-plan-status' },
           }),
         },

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -15,7 +15,7 @@ export default class InterventionProgressView {
   actionPlanSummaryView: ActionPlanSummaryView
 
   constructor(private readonly presenter: InterventionProgressPresenter) {
-    this.actionPlanSummaryView = new ActionPlanSummaryView(presenter.actionPlanDetailsPresenter)
+    this.actionPlanSummaryView = new ActionPlanSummaryView(presenter.actionPlanDetailsPresenter, true)
   }
 
   get cancelledReferralNotificationBannerArgs(): NotificationBannerArgs {
@@ -77,85 +77,6 @@ export default class InterventionProgressView {
         },
       ],
     }
-  }
-
-  private actionPlanSummaryListArgs(tagMacro: (args: TagArgs) => string, csrfToken: string): SummaryListArgs {
-    const rows: SummaryListArgsRow[] = [
-      {
-        key: { text: 'Action plan status' },
-        value: {
-          text: tagMacro({
-            text: this.presenter.actionPlanDetailsPresenter.text.actionPlanStatus,
-            classes: this.actionPlanSummaryView.actionPlanTagClass,
-            attributes: { id: 'action-plan-status' },
-          }),
-        },
-      },
-    ]
-
-    if (!this.presenter.actionPlanDetailsPresenter.actionPlanCreated) {
-      // action plan doesn't exist; show link to create one
-      rows.push({
-        key: { text: 'To do' },
-        value: {
-          html: `<form method="post" action="${ViewUtils.escape(
-            this.presenter.actionPlanDetailsPresenter.createActionPlanFormAction
-          )}">
-                   <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken)}">
-                   <button class="govuk-button govuk-button--secondary">
-                     Create action plan
-                   </button>
-                 </form>`,
-        },
-      })
-    } else if (
-      this.presenter.actionPlanDetailsPresenter.actionPlanCreated &&
-      !this.presenter.actionPlanDetailsPresenter.actionPlanUnderReview
-    ) {
-      // action plan exists, but has not been submitted
-      rows.push({
-        key: { text: 'To do' },
-        value: {
-          html: `<a href="${this.presenter.actionPlanDetailsPresenter.actionPlanFormUrl}" class="govuk-link">Submit action plan</a>`,
-        },
-      })
-    } else if (this.presenter.actionPlanDetailsPresenter.actionPlanUnderReview) {
-      // action plan has been submitted; show link to view it
-      rows.push({
-        key: { text: 'Submitted date' },
-        value: {
-          text: this.presenter.actionPlanDetailsPresenter.text.actionPlanSubmittedDate,
-          classes: 'action-plan-submitted-date',
-        },
-      })
-      rows.push({
-        key: { text: 'To do' },
-        value: {
-          html: `<a href="${this.presenter.actionPlanDetailsPresenter.viewActionPlanUrl}" class="govuk-link">View action plan</a>`,
-        },
-      })
-    } else if (this.presenter.actionPlanDetailsPresenter.actionPlanApproved) {
-      // action plan has been approved; show link to view it
-      rows.push({
-        key: { text: 'Submitted date' },
-        value: {
-          text: this.presenter.actionPlanDetailsPresenter.text.actionPlanSubmittedDate,
-          classes: 'action-plan-submitted-date',
-        },
-      })
-      rows.push({
-        key: { text: 'Approval date' },
-        value: { text: this.presenter.actionPlanDetailsPresenter.text.actionPlanApprovalDate },
-      })
-      rows.push({
-        key: { text: 'To do' },
-        value: {
-          html: `<a href="${this.presenter.actionPlanDetailsPresenter.viewActionPlanUrl}" class="govuk-link">View action plan</a>`,
-        },
-      })
-    }
-
-    return { rows }
   }
 
   private sessionTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
@@ -226,7 +147,9 @@ export default class InterventionProgressView {
         presenter: this.presenter,
         subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         initialAssessmentSummaryListArgs: this.initialAssessmentSummaryListArgs.bind(this),
-        actionPlanSummaryListArgs: this.actionPlanSummaryListArgs.bind(this),
+        actionPlanSummaryListArgs: this.actionPlanSummaryView.actionPlanSummaryListArgs.bind(
+          this.actionPlanSummaryView
+        ),
         sessionTableArgs: this.sessionTableArgs.bind(this),
         backLinkArgs: this.backLinkArgs,
         endOfServiceReportSummaryListArgs: this.endOfServiceReportSummaryListArgs.bind(this),

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -859,8 +859,8 @@ export default class ServiceProviderReferralsController {
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
 
-    const presenter = new ActionPlanDetailsPresenter(actionPlan, sentReferral, 'service-provider')
-    const view = new ActionPlanSummaryView(presenter)
+    const presenter = new ActionPlanDetailsPresenter(sentReferral, actionPlan, 'service-provider')
+    const view = new ActionPlanSummaryView(presenter, false)
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -58,7 +58,7 @@ import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
 import ServiceCategory from '../../models/serviceCategory'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 import ActionPlanDetailsPresenter from '../shared/actionPlanDetailsPresenter'
-import ActionPlanDetailsView from '../shared/actionPlanDetailsView'
+import ActionPlanSummaryView from '../shared/actionPlanSummaryView'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -860,7 +860,7 @@ export default class ServiceProviderReferralsController {
     ])
 
     const presenter = new ActionPlanDetailsPresenter(actionPlan, sentReferral, 'service-provider')
-    const view = new ActionPlanDetailsView(presenter)
+    const view = new ActionPlanSummaryView(presenter)
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -57,6 +57,8 @@ import ControllerUtils from '../../utils/controllerUtils'
 import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
 import ServiceCategory from '../../models/serviceCategory'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
+import ActionPlanDetailsPresenter from '../shared/actionPlanDetailsPresenter'
+import ActionPlanDetailsView from '../shared/actionPlanDetailsView'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -839,6 +841,26 @@ export default class ServiceProviderReferralsController {
     const presenter = new EndOfServiceReportConfirmationPresenter(referral, serviceCategories[0])
     const view = new EndOfServiceReportConfirmationView(presenter)
 
+    ControllerUtils.renderWithLayout(res, view, serviceUser)
+  }
+
+  async viewActionPlan(req: Request, res: Response): Promise<void> {
+    const { accessToken } = res.locals.user.token
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
+
+    if (sentReferral.actionPlanId === null) {
+      throw createError(500, `could not view action plan for referral with id '${req.params.id}'`, {
+        userMessage: 'No action plan exists for this referral',
+      })
+    }
+
+    const [actionPlan, serviceUser] = await Promise.all([
+      this.interventionsService.getActionPlan(accessToken, sentReferral.actionPlanId),
+      this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
+    ])
+
+    const presenter = new ActionPlanDetailsPresenter(actionPlan, sentReferral, 'service-provider')
+    const view = new ActionPlanDetailsView(presenter)
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 

--- a/server/routes/shared/actionPlanDetailsPresenter.ts
+++ b/server/routes/shared/actionPlanDetailsPresenter.ts
@@ -21,6 +21,15 @@ export default class ActionPlanDetailsPresenter {
     actionPlanStatus: this.actionPlanStatus,
     actionPlanSubmittedDate: DateUtils.getDateStringFromDateTimeString(this.actionPlan?.submittedAt || null),
     actionPlanApprovalDate: DateUtils.getDateStringFromDateTimeString(this.actionPlan?.approvedAt || null),
+    actionPlanNumberOfSessions: this.actionPlan?.numberOfSessions,
+  }
+
+  get activities(): string[] {
+    return (
+      this.actionPlan?.activities?.map(it => {
+        return it.description
+      }) || []
+    )
   }
 
   private get actionPlanStatus(): string {

--- a/server/routes/shared/actionPlanDetailsView.ts
+++ b/server/routes/shared/actionPlanDetailsView.ts
@@ -1,0 +1,26 @@
+import ActionPlanDetailsPresenter from './actionPlanDetailsPresenter'
+import ActionPlanSummaryView from './actionPlanSummaryView'
+
+export default class ActionPlanDetailsView {
+  actionPlanSummaryView: ActionPlanSummaryView
+
+  constructor(private readonly presenter: ActionPlanDetailsPresenter, private readonly includeTodo: boolean) {
+    this.actionPlanSummaryView = new ActionPlanSummaryView(presenter, false)
+  }
+
+  private readonly backLinkArgs = {
+    text: 'Back',
+    href: this.presenter.interventionProgressURL,
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'shared/actionPlan',
+      {
+        presenter: this.presenter,
+        backLinkArgs: this.backLinkArgs,
+        actionPlanSummaryListArgs: this.actionPlanSummaryView.actionPlanSummaryListArgs.bind(this),
+      },
+    ]
+  }
+}

--- a/server/routes/shared/actionPlanDetailsView.ts
+++ b/server/routes/shared/actionPlanDetailsView.ts
@@ -1,4 +1,5 @@
 import ActionPlanDetailsPresenter from './actionPlanDetailsPresenter'
+import { SummaryListArgs, SummaryListArgsRow, TagArgs } from '../../utils/govukFrontendTypes'
 
 export default class ActionPlanDetailsView {
   constructor(private readonly presenter: ActionPlanDetailsPresenter) {}
@@ -19,12 +20,37 @@ export default class ActionPlanDetailsView {
     }
   }
 
+  private actionPlanSummaryListArgs(tagMacro: (args: TagArgs) => string): SummaryListArgs {
+    const rows: SummaryListArgsRow[] = [
+      {
+        key: { text: 'Action plan status' },
+        value: {
+          text: tagMacro({
+            text: this.presenter.text.actionPlanStatus,
+            classes: this.actionPlanTagClass,
+            attributes: { id: 'action-plan-status' },
+          }),
+        },
+      },
+      {
+        key: { text: 'Submitted date' },
+        value: {
+          text: this.presenter.text.actionPlanSubmittedDate,
+          classes: 'action-plan-submitted-date',
+        },
+      },
+    ]
+
+    return { rows }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'shared/actionPlan',
       {
         presenter: this.presenter,
         backLinkArgs: this.backLinkArgs,
+        actionPlanSummaryListArgs: this.actionPlanSummaryListArgs.bind(this),
       },
     ]
   }

--- a/server/routes/shared/actionPlanSummaryView.ts
+++ b/server/routes/shared/actionPlanSummaryView.ts
@@ -1,7 +1,7 @@
 import ActionPlanDetailsPresenter from './actionPlanDetailsPresenter'
 import { SummaryListArgs, SummaryListArgsRow, TagArgs } from '../../utils/govukFrontendTypes'
 
-export default class ActionPlanDetailsView {
+export default class ActionPlanSummaryView {
   constructor(private readonly presenter: ActionPlanDetailsPresenter) {}
 
   private readonly backLinkArgs = {
@@ -14,7 +14,7 @@ export default class ActionPlanDetailsView {
       case 'Approved':
         return 'govuk-tag--green'
       case 'Under review':
-        return 'govuk-tag- govuk-tag--red'
+        return 'govuk-tag--red'
       default:
         return 'govuk-tag--grey'
     }

--- a/server/routes/shared/actionPlanSummaryView.ts
+++ b/server/routes/shared/actionPlanSummaryView.ts
@@ -2,14 +2,9 @@ import ActionPlanDetailsPresenter from './actionPlanDetailsPresenter'
 import { SummaryListArgs, SummaryListArgsRow, TagArgs } from '../../utils/govukFrontendTypes'
 
 export default class ActionPlanSummaryView {
-  constructor(private readonly presenter: ActionPlanDetailsPresenter) {}
+  constructor(private readonly presenter: ActionPlanDetailsPresenter, private readonly includeTodo: boolean) {}
 
-  private readonly backLinkArgs = {
-    text: 'Back',
-    href: this.presenter.interventionProgressURL,
-  }
-
-  get actionPlanTagClass(): string {
+  private get actionPlanTagClass(): string {
     switch (this.presenter.text.actionPlanStatus) {
       case 'Approved':
         return 'govuk-tag--green'
@@ -19,8 +14,87 @@ export default class ActionPlanSummaryView {
         return 'govuk-tag--grey'
     }
   }
+  //
+  // private NEWactionPlanSummaryListArgs(tagMacro: (args: TagArgs) => string, csrfToken: string): SummaryListArgs {
+  //   const rows: SummaryListArgsRow[] = [
+  //     {
+  //       key: { text: 'Action plan status' },
+  //       value: {
+  //         text: tagMacro({
+  //           text: this.presenter.text.actionPlanStatus,
+  //           classes: this.actionPlanTagClass,
+  //           attributes: { id: 'action-plan-status' },
+  //         }),
+  //       },
+  //     },
+  //   ]
+  //
+  //   if (!this.presenter.actionPlanDetailsPresenter.actionPlanCreated) {
+  //     // action plan doesn't exist; show link to create one
+  //     rows.push({
+  //       key: { text: 'To do' },
+  //       value: {
+  //         html: `<form method="post" action="${ViewUtils.escape(
+  //           this.presenter.actionPlanDetailsPresenter.createActionPlanFormAction
+  //         )}">
+  //                  <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken)}">
+  //                  <button class="govuk-button govuk-button--secondary">
+  //                    Create action plan
+  //                  </button>
+  //                </form>`,
+  //       },
+  //     })
+  //   } else if (
+  //     this.presenter.actionPlanDetailsPresenter.actionPlanCreated &&
+  //     !this.presenter.actionPlanDetailsPresenter.actionPlanUnderReview
+  //   ) {
+  //     // action plan exists, but has not been submitted
+  //     rows.push({
+  //       key: { text: 'To do' },
+  //       value: {
+  //         html: `<a href="${this.presenter.actionPlanDetailsPresenter.actionPlanFormUrl}" class="govuk-link">Submit action plan</a>`,
+  //       },
+  //     })
+  //   } else if (this.presenter.actionPlanDetailsPresenter.actionPlanUnderReview) {
+  //     // action plan has been submitted; show link to view it
+  //     rows.push({
+  //       key: { text: 'Submitted date' },
+  //       value: {
+  //         text: this.presenter.actionPlanDetailsPresenter.text.actionPlanSubmittedDate,
+  //         classes: 'action-plan-submitted-date',
+  //       },
+  //     })
+  //     rows.push({
+  //       key: { text: 'To do' },
+  //       value: {
+  //         html: `<a href="${this.presenter.actionPlanDetailsPresenter.viewActionPlanUrl}" class="govuk-link">View action plan</a>`,
+  //       },
+  //     })
+  //   } else if (this.presenter.actionPlanDetailsPresenter.actionPlanApproved) {
+  //     // action plan has been approved; show link to view it
+  //     rows.push({
+  //       key: { text: 'Submitted date' },
+  //       value: {
+  //         text: this.presenter.actionPlanDetailsPresenter.text.actionPlanSubmittedDate,
+  //         classes: 'action-plan-submitted-date',
+  //       },
+  //     })
+  //     rows.push({
+  //       key: { text: 'Approval date' },
+  //       value: { text: this.presenter.actionPlanDetailsPresenter.text.actionPlanApprovalDate },
+  //     })
+  //     rows.push({
+  //       key: { text: 'To do' },
+  //       value: {
+  //         html: `<a href="${this.presenter.actionPlanDetailsPresenter.viewActionPlanUrl}" class="govuk-link">View action plan</a>`,
+  //       },
+  //     })
+  //   }
+  //
+  //   return { rows }
+  // }
 
-  private actionPlanSummaryListArgs(tagMacro: (args: TagArgs) => string): SummaryListArgs {
+  actionPlanSummaryListArgs(tagMacro: (args: TagArgs) => string): SummaryListArgs {
     const rows: SummaryListArgsRow[] = [
       {
         key: { text: 'Action plan status' },
@@ -42,16 +116,5 @@ export default class ActionPlanSummaryView {
     ]
 
     return { rows }
-  }
-
-  get renderArgs(): [string, Record<string, unknown>] {
-    return [
-      'shared/actionPlan',
-      {
-        presenter: this.presenter,
-        backLinkArgs: this.backLinkArgs,
-        actionPlanSummaryListArgs: this.actionPlanSummaryListArgs.bind(this),
-      },
-    ]
   }
 }

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -1,0 +1,33 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% block pageTitle %}
+    HMPPS Interventions - GOV.UK
+{% endblock %}
+
+{% block pageContent %}
+    {% block content %}
+        <div class="govuk-!-width-two-thirds">
+        {{ govukBackLink(backLinkArgs) }}
+        <h1 class="govuk-heading-l">View action plan</h1>
+
+        {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
+
+        <h2 class="govuk-heading-m">Desired outcomes and activities</h2>
+
+        {% for activity in presenter.activities %}
+            <ul class="govuk-list">
+                <div class="refer-and-monitor__shaded-list-item">
+                <h3 class="govuk-heading-s">Activity {{ loop.index }}</h3>
+                <p class="govuk-body">{{ activity }}</p>
+                </div>
+            </ul>
+        {% endfor %}
+
+        <h2 class="govuk-heading-m">Suggested number of sessions for the action plan</h2>
+        <p class="govuk-body">Suggested number of sessions: {{ presenter.text.actionPlanNumberOfSessions }}</p>
+        </div>
+    {% endblock %}
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

add simple page for SP to view an under approval action plan

this change is intentionally small and with limited reach. 

i'm gonna refactor various parts of this code to work across PP and SP pages as i go, but don't want a huge change set. 

this means once an SP has submitted the plan they can at least see it by clicking the link. which is kinda an MVP for 'view action plan' IMO.  

![Screenshot 2021-06-16 at 12 17 25](https://user-images.githubusercontent.com/63233073/122226406-db5e8180-cead-11eb-8b86-f4e1cb6b5921.png)