### PR TITLE
IC-1461: Refine contracts for supplier assessments

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -191,8 +191,8 @@ module.exports = on => {
       return interventionsService.stubRecordSupplierAssessmentAppointmentBehavior(arg.referralId, arg.responseJson)
     },
 
-    stubGetSupplierAssessmentAppointment: arg => {
-      return interventionsService.stubGetSupplierAssessmentAppointment(arg.referralId, arg.responseJson)
+    stubGetSupplierAssessment: arg => {
+      return interventionsService.stubGetSupplierAssessment(arg.referralId, arg.responseJson)
     },
 
     stubUpdateSupplierAssessmentAppointment: arg => {

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -183,12 +183,12 @@ module.exports = on => {
       return assessRisksAndNeedsService.stubGetSupplementaryRiskInformation(arg.riskId, arg.responseJson)
     },
 
-    stubRecordSupplierAssessmentAppointmentAttendance: arg => {
-      return interventionsService.stubRecordSupplierAssessmentAppointmentAttendance(arg.referralId, arg.responseJson)
+    stubRecordAppointmentAttendance: arg => {
+      return interventionsService.stubRecordAppointmentAttendance(arg.referralId, arg.responseJson)
     },
 
-    stubRecordSupplierAssessmentAppointmentBehavior: arg => {
-      return interventionsService.stubRecordSupplierAssessmentAppointmentBehavior(arg.referralId, arg.responseJson)
+    stubRecordAppointmentBehavior: arg => {
+      return interventionsService.stubRecordAppointmentBehavior(arg.id, arg.responseJson)
     },
 
     stubGetSupplierAssessment: arg => {
@@ -199,8 +199,8 @@ module.exports = on => {
       return interventionsService.stubScheduleSupplierAssessmentAppointment(arg.supplierAssessmentId, arg.responseJson)
     },
 
-    stubSubmitSupplierAssessmentSessionFeedback: arg => {
-      return interventionsService.stubSubmitSupplierAssessmentSessionFeedback(arg.referralId, arg.responseJson)
+    stubSubmitAppointmentFeedback: arg => {
+      return interventionsService.stubSubmitAppointmentFeedback(arg.id, arg.responseJson)
     },
   })
 }

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -195,8 +195,8 @@ module.exports = on => {
       return interventionsService.stubGetSupplierAssessment(arg.referralId, arg.responseJson)
     },
 
-    stubUpdateSupplierAssessmentAppointment: arg => {
-      return interventionsService.stubUpdateSupplierAssessmentAppointment(arg.referralId, arg.responseJson)
+    stubScheduleSupplierAssessmentAppointment: arg => {
+      return interventionsService.stubScheduleSupplierAssessmentAppointment(arg.supplierAssessmentId, arg.responseJson)
     },
 
     stubSubmitSupplierAssessmentSessionFeedback: arg => {

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -130,8 +130,8 @@ Cypress.Commands.add('stubRecordSupplierAssessmentAppointmentBehavior', (referra
   cy.task('stubRecordSupplierAssessmentAppointmentBehavior', { referralId, responseJson })
 })
 
-Cypress.Commands.add('stubGetSupplierAssessmentAppointment', (referralId, responseJson) => {
-  cy.task('stubGetSupplierAssessmentAppointment', { referralId, responseJson })
+Cypress.Commands.add('stubGetSupplierAssessment', (referralId, responseJson) => {
+  cy.task('stubGetSupplierAssessment', { referralId, responseJson })
 })
 
 Cypress.Commands.add('stubUpdateSupplierAssessmentAppointment', (referralId, responseJson) => {

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -134,8 +134,8 @@ Cypress.Commands.add('stubGetSupplierAssessment', (referralId, responseJson) => 
   cy.task('stubGetSupplierAssessment', { referralId, responseJson })
 })
 
-Cypress.Commands.add('stubUpdateSupplierAssessmentAppointment', (referralId, responseJson) => {
-  cy.task('stubUpdateSupplierAssessmentAppointment', { referralId, responseJson })
+Cypress.Commands.add('stubScheduleSupplierAssessmentAppointment', (supplierAssessmentId, responseJson) => {
+  cy.task('stubScheduleSupplierAssessmentAppointment', { supplierAssessmentId, responseJson })
 })
 
 Cypress.Commands.add('stubSubmitSupplierAssessmentSessionFeedback', (referralId, responseJson) => {

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -122,12 +122,12 @@ Cypress.Commands.add('stubGetReferralCancellationReasons', responseJson => {
   cy.task('stubGetReferralCancellationReasons', { responseJson })
 })
 
-Cypress.Commands.add('stubRecordSupplierAssessmentAppointmentAttendance', (referralId, responseJson) => {
-  cy.task('stubRecordSupplierAssessmentAppointmentAttendance', { referralId, responseJson })
+Cypress.Commands.add('stubRecordAppointmentAttendance', (id, responseJson) => {
+  cy.task('stubRecordAppointmentAttendance', { id, responseJson })
 })
 
-Cypress.Commands.add('stubRecordSupplierAssessmentAppointmentBehavior', (referralId, responseJson) => {
-  cy.task('stubRecordSupplierAssessmentAppointmentBehavior', { referralId, responseJson })
+Cypress.Commands.add('stubRecordAppointmentBehavior', (id, responseJson) => {
+  cy.task('stubRecordAppointmentBehavior', { id, responseJson })
 })
 
 Cypress.Commands.add('stubGetSupplierAssessment', (referralId, responseJson) => {
@@ -138,6 +138,6 @@ Cypress.Commands.add('stubScheduleSupplierAssessmentAppointment', (supplierAsses
   cy.task('stubScheduleSupplierAssessmentAppointment', { supplierAssessmentId, responseJson })
 })
 
-Cypress.Commands.add('stubSubmitSupplierAssessmentSessionFeedback', (referralId, responseJson) => {
-  cy.task('stubSubmitSupplierAssessmentSessionFeedback', { referralId, responseJson })
+Cypress.Commands.add('stubSubmitAppointmentFeedback', (id, responseJson) => {
+  cy.task('stubSubmitAppointmentFeedback', { id, responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -503,14 +503,11 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubRecordSupplierAssessmentAppointmentAttendance = async (
-    referralId: string,
-    responseJson: unknown
-  ): Promise<unknown> => {
+  stubRecordAppointmentAttendance = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
-        method: 'POST',
-        urlPattern: `${this.mockPrefix}/sent-referral/${referralId}/supplier-assessment-appointment/record-attendance`,
+        method: 'PUT',
+        urlPattern: `${this.mockPrefix}/appointment/${id}/record-attendance`,
       },
       response: {
         status: 200,
@@ -522,14 +519,11 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubRecordSupplierAssessmentAppointmentBehavior = async (
-    referralId: string,
-    responseJson: unknown
-  ): Promise<unknown> => {
+  stubRecordAppointmentBehavior = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
-        method: 'POST',
-        urlPattern: `${this.mockPrefix}/sent-referral/${referralId}/supplier-assessment-appointment/record-behaviour`,
+        method: 'PUT',
+        urlPattern: `${this.mockPrefix}/appointment/${id}/record-behaviour`,
       },
       response: {
         status: 200,
@@ -576,11 +570,11 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubSubmitSupplierAssessmentSessionFeedback = async (referralId: string, responseJson: unknown): Promise<unknown> => {
+  stubSubmitAppointmentFeedback = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'POST',
-        urlPattern: `${this.mockPrefix}/sent-referral/${referralId}/supplier-assessment-appointment/submit`,
+        urlPattern: `${this.mockPrefix}/appointment/${id}/submit-feedback`,
       },
       response: {
         status: 200,

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -557,11 +557,14 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubUpdateSupplierAssessmentAppointment = async (referralId: string, responseJson: unknown): Promise<unknown> => {
+  stubScheduleSupplierAssessmentAppointment = async (
+    supplierAssessmentId: string,
+    responseJson: unknown
+  ): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
-        method: 'PATCH',
-        urlPattern: `${this.mockPrefix}/sent-referral/${referralId}/supplier-assessment-appointment`,
+        method: 'PUT',
+        urlPattern: `${this.mockPrefix}/supplier-assessment/${supplierAssessmentId}/schedule-appointment`,
       },
       response: {
         status: 200,

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -541,11 +541,11 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubGetSupplierAssessmentAppointment = async (referralId: string, responseJson: unknown): Promise<unknown> => {
+  stubGetSupplierAssessment = async (referralId: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `${this.mockPrefix}/sent-referral/${referralId}/supplier-assessment-appointment`,
+        urlPattern: `${this.mockPrefix}/sent-referral/${referralId}/supplier-assessment`,
       },
       response: {
         status: 200,

--- a/server/models/actionPlan.ts
+++ b/server/models/actionPlan.ts
@@ -1,6 +1,6 @@
 import User from './hmppsAuth/user'
 import DesiredOutcome from './desiredOutcome'
-import Appointment from './appointment'
+import SessionFeedback from './sessionFeedback'
 
 export interface Activity {
   id: string
@@ -9,8 +9,11 @@ export interface Activity {
   createdAt: string
 }
 
-export interface ActionPlanAppointment extends Appointment {
+export interface ActionPlanAppointment {
   sessionNumber: number
+  appointmentTime: string | null
+  durationInMinutes: number | null
+  sessionFeedback: SessionFeedback
 }
 
 export default interface ActionPlan {

--- a/server/models/appointment.ts
+++ b/server/models/appointment.ts
@@ -1,12 +1,8 @@
-import AppointmentAttendance from './appointmentAttendance'
-import AppointmentBehaviour from './appointmentBehaviour'
+import SessionFeedback from './sessionFeedback'
 
 export default interface Appointment {
-  appointmentTime: string | null
-  durationInMinutes: number | null
-  sessionFeedback: {
-    attendance: AppointmentAttendance
-    behaviour: AppointmentBehaviour
-    submitted: boolean
-  }
+  id: string
+  appointmentTime: string
+  durationInMinutes: number
+  sessionFeedback: SessionFeedback
 }

--- a/server/models/sessionFeedback.ts
+++ b/server/models/sessionFeedback.ts
@@ -1,0 +1,8 @@
+import AppointmentAttendance from './appointmentAttendance'
+import AppointmentBehaviour from './appointmentBehaviour'
+
+export default interface SessionFeedback {
+  attendance: AppointmentAttendance
+  behaviour: AppointmentBehaviour
+  submitted: boolean
+}

--- a/server/models/supplierAssessment.ts
+++ b/server/models/supplierAssessment.ts
@@ -1,0 +1,7 @@
+import Appointment from './appointment'
+
+export default interface SupplierAssessment {
+  id: string
+  appointments: Appointment[]
+  currentAppointmentId: string | null
+}

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2629,46 +2629,45 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('updateSupplierAssessmentAppointment', () => {
-    describe('with non-null values', () => {
-      it('returns an updated supplier assessment appointment', async () => {
-        const appointment = appointmentFactory.build({
-          appointmentTime: '2021-05-13T12:30:00Z',
-          durationInMinutes: 60,
-        })
-
-        await provider.addInteraction({
-          state: 'a sent referral with ID fae5df9d-41a9-4be6-98f7-0f1378e85ba1 exists',
-          uponReceiving:
-            'a PATCH request to update the change the duration to an hour for the initial assessment appointment of the sent referral with ID fae5df9d-41a9-4be6-98f7-0f1378e85ba1',
-          withRequest: {
-            method: 'PATCH',
-            path: '/sent-referral/fae5df9d-41a9-4be6-98f7-0f1378e85ba1/supplier-assessment-appointment',
-            body: {
-              durationInMinutes: 60,
-            },
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
-          },
-          // note - this is an exact match
-          willRespondWith: {
-            status: 200,
-            body: appointment,
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          },
-        })
-
-        expect(
-          await interventionsService.updateSupplierAssessmentAppointment(
-            token,
-            'fae5df9d-41a9-4be6-98f7-0f1378e85ba1',
-            {
-              durationInMinutes: 60,
-            }
-          )
-        ).toMatchObject(appointment)
+  describe('scheduleSupplierAssessmentAppointment', () => {
+    it('returns a supplier assessment appointment', async () => {
+      const appointment = appointmentFactory.build({
+        appointmentTime: '2021-05-13T12:30:00Z',
+        durationInMinutes: 60,
       })
+
+      await provider.addInteraction({
+        state: 'a supplier assessment with ID 77f6c5cf-9772-4731-9a9a-97f2f53f2770 exists',
+        uponReceiving:
+          'a PUT request to schedule an appointment the supplier assessment with ID 77f6c5cf-9772-4731-9a9a-97f2f53f2770',
+        withRequest: {
+          method: 'PUT',
+          path: '/supplier-assessment/77f6c5cf-9772-4731-9a9a-97f2f53f2770/schedule-appointment',
+          body: {
+            appointmentTime: '2021-05-13T12:30:00Z',
+            durationInMinutes: 60,
+          },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(appointment),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      expect(
+        await interventionsService.scheduleSupplierAssessmentAppointment(
+          token,
+          '77f6c5cf-9772-4731-9a9a-97f2f53f2770',
+          {
+            appointmentTime: '2021-05-13T12:30:00Z',
+            durationInMinutes: 60,
+          }
+        )
+      ).toMatchObject(appointment)
     })
   })
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2671,8 +2671,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('recordSupplierAssessmentAppointmentAttendance', () => {
-    it('returns an updated supplier assessment appointment with the service user‘s attendance', async () => {
+  describe('recordAppointmentAttendance', () => {
+    it('returns an updated appointment with the service user‘s attendance', async () => {
       const appointment = appointmentFactory.build({
         appointmentTime: '2021-05-13T12:30:00Z',
         durationInMinutes: 60,
@@ -2690,13 +2690,12 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       await provider.addInteraction({
-        state:
-          'a sent referral with ID 060946a4-1574-4581-b539-5df69303c595 exists and no feedback has been recorded for its supplier assessment appointment',
+        state: 'an appointment with ID 578e9360-8938-4fea-8889-19a3309ad840 exists and no feedback has been recorded',
         uponReceiving:
-          'a POST request to set the attendance for the supplier assessment appointment on sent referral with ID 060946a4-1574-4581-b539-5df69303c595',
+          'a PUT request to set the attendance for the appointment with ID 578e9360-8938-4fea-8889-19a3309ad840',
         withRequest: {
-          method: 'POST',
-          path: '/sent-referral/060946a4-1574-4581-b539-5df69303c595/supplier-assessment-appointment/record-attendance',
+          method: 'PUT',
+          path: '/appointment/578e9360-8938-4fea-8889-19a3309ad840/record-attendance',
           body: {
             attended: 'late',
             additionalAttendanceInformation: 'Alex missed the bus',
@@ -2712,9 +2711,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const result = await interventionsService.recordSupplierAssessmentAppointmentAttendance(
+      const result = await interventionsService.recordAppointmentAttendance(
         token,
-        '060946a4-1574-4581-b539-5df69303c595',
+        '578e9360-8938-4fea-8889-19a3309ad840',
         {
           attended: 'late',
           additionalAttendanceInformation: 'Alex missed the bus',
@@ -2725,8 +2724,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('recordSupplierAssessmentAppointmentBehavior', () => {
-    it('returns an updated supplier assessment appointment with the service user‘s behaviour', async () => {
+  describe('recordAppointmentBehavior', () => {
+    it('returns an supplier with the service user‘s behaviour', async () => {
       const appointment = appointmentFactory.build({
         appointmentTime: '2021-05-13T12:30:00Z',
         durationInMinutes: 120,
@@ -2744,12 +2743,12 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       await provider.addInteraction({
-        state: 'a sent referral with ID 184c1150-bbfb-4875-903b-b6e14ae0eb49 exists',
+        state: 'an appointment with ID 578e9360-8938-4fea-8889-19a3309ad840 exists',
         uponReceiving:
-          'a POST request to set the behaviour for the supplier assessment appointment on sent referral with ID 184c1150-bbfb-4875-903b-b6e14ae0eb49',
+          'a PUT request to set the behaviour for the appointment with ID 578e9360-8938-4fea-8889-19a3309ad840',
         withRequest: {
-          method: 'POST',
-          path: '/sent-referral/184c1150-bbfb-4875-903b-b6e14ae0eb49/supplier-assessment-appointment/record-behaviour',
+          method: 'PUT',
+          path: '/appointment/578e9360-8938-4fea-8889-19a3309ad840/record-behaviour',
           body: {
             behaviourDescription: 'Alex was well behaved',
             notifyProbationPractitioner: false,
@@ -2765,9 +2764,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const result = await interventionsService.recordSupplierAssessmentAppointmentBehavior(
+      const result = await interventionsService.recordAppointmentBehavior(
         token,
-        '184c1150-bbfb-4875-903b-b6e14ae0eb49',
+        '578e9360-8938-4fea-8889-19a3309ad840',
         {
           behaviourDescription: 'Alex was well behaved',
           notifyProbationPractitioner: false,
@@ -2778,7 +2777,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('submitSupplierAssessmentSessionFeedback', () => {
+  describe('submitAppointmentFeedback', () => {
     it('submits attendance and behaviour feedback to the PP', async () => {
       const appointment = appointmentFactory.build({
         appointmentTime: '2021-05-13T12:30:00Z',
@@ -2797,12 +2796,12 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       await provider.addInteraction({
-        state: 'a sent referral with ID 3776fd0a-1ee7-47a0-b016-071c986e6f94 exists',
+        state: 'an appointment with ID 86c422b4-4c55-42ec-b9a6-3ae1ab000adb exists',
         uponReceiving:
-          'a POST request to submit the feedback for the supplier assessment for sent referral with ID 3776fd0a-1ee7-47a0-b016-071c986e6f94',
+          'a POST request to submit the feedback for the appointment with ID 86c422b4-4c55-42ec-b9a6-3ae1ab000adb',
         withRequest: {
           method: 'POST',
-          path: '/sent-referral/3776fd0a-1ee7-47a0-b016-071c986e6f94/supplier-assessment-appointment/submit',
+          path: '/appointment/86c422b4-4c55-42ec-b9a6-3ae1ab000adb/submit-feedback',
           headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
         },
         willRespondWith: {
@@ -2814,10 +2813,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const result = await interventionsService.submitSupplierAssessmentSessionFeedback(
-        token,
-        '3776fd0a-1ee7-47a0-b016-071c986e6f94'
-      )
+      const result = await interventionsService.submitAppointmentFeedback(token, '86c422b4-4c55-42ec-b9a6-3ae1ab000adb')
       expect(result.sessionFeedback!.submitted).toEqual(true)
     })
   })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2645,6 +2645,22 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
   describe('recordSupplierAssessmentAppointmentAttendance', () => {
     it('returns an updated supplier assessment appointment with the service user‘s attendance', async () => {
+      const appointment = appointmentFactory.build({
+        appointmentTime: '2021-05-13T12:30:00Z',
+        durationInMinutes: 60,
+        sessionFeedback: {
+          attendance: {
+            attended: 'late',
+            additionalAttendanceInformation: 'Alex missed the bus',
+          },
+          behaviour: {
+            behaviourDescription: null,
+            notifyProbationPractitioner: null,
+          },
+          submitted: false,
+        },
+      })
+
       await provider.addInteraction({
         state:
           'a sent referral with ID 060946a4-1574-4581-b539-5df69303c595 exists and no feedback has been recorded for its supplier assessment appointment',
@@ -2661,28 +2677,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
         willRespondWith: {
           status: 200,
-          body: Matchers.like({
-            appointmentTime: '2021-05-13T12:30:00Z',
-            durationInMinutes: 60,
-            sessionFeedback: {
-              attendance: {
-                attended: 'late',
-                additionalAttendanceInformation: 'Alex missed the bus',
-              },
-              behaviour: {
-                behaviourDescription: null,
-                notifyProbationPractitioner: null,
-              },
-              submitted: false,
-            },
-          }),
+          body: Matchers.like(appointment),
           headers: {
             'Content-Type': 'application/json',
           },
         },
       })
 
-      const appointment = await interventionsService.recordSupplierAssessmentAppointmentAttendance(
+      const result = await interventionsService.recordSupplierAssessmentAppointmentAttendance(
         token,
         '060946a4-1574-4581-b539-5df69303c595',
         {
@@ -2690,13 +2692,29 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           additionalAttendanceInformation: 'Alex missed the bus',
         }
       )
-      expect(appointment.sessionFeedback!.attendance!.attended).toEqual('late')
-      expect(appointment.sessionFeedback!.attendance!.additionalAttendanceInformation).toEqual('Alex missed the bus')
+      expect(result.sessionFeedback!.attendance!.attended).toEqual('late')
+      expect(result.sessionFeedback!.attendance!.additionalAttendanceInformation).toEqual('Alex missed the bus')
     })
   })
 
   describe('recordSupplierAssessmentAppointmentBehavior', () => {
     it('returns an updated supplier assessment appointment with the service user‘s behaviour', async () => {
+      const appointment = appointmentFactory.build({
+        appointmentTime: '2021-05-13T12:30:00Z',
+        durationInMinutes: 120,
+        sessionFeedback: {
+          attendance: {
+            attended: 'late',
+            additionalAttendanceInformation: 'Alex missed the bus',
+          },
+          behaviour: {
+            behaviourDescription: 'Alex was well behaved',
+            notifyProbationPractitioner: false,
+          },
+          submitted: false,
+        },
+      })
+
       await provider.addInteraction({
         state: 'a sent referral with ID 184c1150-bbfb-4875-903b-b6e14ae0eb49 exists',
         uponReceiving:
@@ -2712,28 +2730,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
         willRespondWith: {
           status: 200,
-          body: Matchers.like({
-            appointmentTime: '2021-05-13T12:30:00Z',
-            durationInMinutes: 120,
-            sessionFeedback: {
-              attendance: {
-                attended: 'late',
-                additionalAttendanceInformation: 'Alex missed the bus',
-              },
-              behaviour: {
-                behaviourDescription: 'Alex was well behaved',
-                notifyProbationPractitioner: false,
-              },
-              submitted: false,
-            },
-          }),
+          body: Matchers.like(appointment),
           headers: {
             'Content-Type': 'application/json',
           },
         },
       })
 
-      const appointment = await interventionsService.recordSupplierAssessmentAppointmentBehavior(
+      const result = await interventionsService.recordSupplierAssessmentAppointmentBehavior(
         token,
         '184c1150-bbfb-4875-903b-b6e14ae0eb49',
         {
@@ -2741,13 +2745,29 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           notifyProbationPractitioner: false,
         }
       )
-      expect(appointment.sessionFeedback!.behaviour!.behaviourDescription).toEqual('Alex was well behaved')
-      expect(appointment.sessionFeedback!.behaviour!.notifyProbationPractitioner).toEqual(false)
+      expect(result.sessionFeedback!.behaviour!.behaviourDescription).toEqual('Alex was well behaved')
+      expect(result.sessionFeedback!.behaviour!.notifyProbationPractitioner).toEqual(false)
     })
   })
 
   describe('submitSupplierAssessmentSessionFeedback', () => {
     it('submits attendance and behaviour feedback to the PP', async () => {
+      const appointment = appointmentFactory.build({
+        appointmentTime: '2021-05-13T12:30:00Z',
+        durationInMinutes: 120,
+        sessionFeedback: {
+          attendance: {
+            attended: 'late',
+            additionalAttendanceInformation: 'Alex missed the bus',
+          },
+          behaviour: {
+            behaviourDescription: 'Alex was well behaved',
+            notifyProbationPractitioner: false,
+          },
+          submitted: true,
+        },
+      })
+
       await provider.addInteraction({
         state: 'a sent referral with ID 3776fd0a-1ee7-47a0-b016-071c986e6f94 exists',
         uponReceiving:
@@ -2759,32 +2779,18 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
         willRespondWith: {
           status: 200,
-          body: Matchers.like({
-            appointmentTime: '2021-05-13T12:30:00Z',
-            durationInMinutes: 120,
-            sessionFeedback: {
-              attendance: {
-                attended: 'late',
-                additionalAttendanceInformation: 'Alex missed the bus',
-              },
-              behaviour: {
-                behaviourDescription: 'Alex was well behaved',
-                notifyProbationPractitioner: false,
-              },
-              submitted: true,
-            },
-          }),
+          body: Matchers.like(appointment),
           headers: {
             'Content-Type': 'application/json',
           },
         },
       })
 
-      const appointment = await interventionsService.submitSupplierAssessmentSessionFeedback(
+      const result = await interventionsService.submitSupplierAssessmentSessionFeedback(
         token,
         '3776fd0a-1ee7-47a0-b016-071c986e6f94'
       )
-      expect(appointment.sessionFeedback!.submitted).toEqual(true)
+      expect(result.sessionFeedback!.submitted).toEqual(true)
     })
   })
 })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -18,6 +18,7 @@ import SentReferral from '../models/sentReferral'
 import ReferralDesiredOutcomes from '../models/referralDesiredOutcomes'
 import ReferralComplexityLevel from '../models/referralComplexityLevel'
 import Appointment from '../models/appointment'
+import SupplierAssessment from '../models/supplierAssessment'
 
 export interface InterventionsServiceValidationError {
   field: string
@@ -445,12 +446,12 @@ export default class InterventionsService {
     })) as CancellationReason[]
   }
 
-  async getSupplierAssessmentAppointment(token: string, referralId: string): Promise<Appointment> {
+  async getSupplierAssessment(token: string, referralId: string): Promise<SupplierAssessment> {
     const restClient = this.createRestClient(token)
     return (await restClient.get({
-      path: `/sent-referral/${referralId}/supplier-assessment-appointment`,
+      path: `/sent-referral/${referralId}/supplier-assessment`,
       headers: { Accept: 'application/json' },
-    })) as Appointment
+    })) as SupplierAssessment
   }
 
   async updateSupplierAssessmentAppointment(

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -467,39 +467,39 @@ export default class InterventionsService {
     })) as Appointment
   }
 
-  async recordSupplierAssessmentAppointmentAttendance(
+  async recordAppointmentAttendance(
     token: string,
-    referralId: string,
+    id: string,
     appointmentAttendanceUpdate: Partial<AppointmentAttendance>
   ): Promise<Appointment> {
     const restClient = this.createRestClient(token)
 
-    return (await restClient.post({
-      path: `/sent-referral/${referralId}/supplier-assessment-appointment/record-attendance`,
+    return (await restClient.put({
+      path: `/appointment/${id}/record-attendance`,
       headers: { Accept: 'application/json' },
       data: appointmentAttendanceUpdate,
     })) as Appointment
   }
 
-  async recordSupplierAssessmentAppointmentBehavior(
+  async recordAppointmentBehavior(
     token: string,
-    referralId: string,
+    id: string,
     appointmentBehaviourUpdate: Partial<AppointmentBehaviour>
   ): Promise<Appointment> {
     const restClient = this.createRestClient(token)
 
-    return (await restClient.post({
-      path: `/sent-referral/${referralId}/supplier-assessment-appointment/record-behaviour`,
+    return (await restClient.put({
+      path: `/appointment/${id}/record-behaviour`,
       headers: { Accept: 'application/json' },
       data: appointmentBehaviourUpdate,
     })) as Appointment
   }
 
-  async submitSupplierAssessmentSessionFeedback(token: string, referralId: string): Promise<Appointment> {
+  async submitAppointmentFeedback(token: string, id: string): Promise<Appointment> {
     const restClient = this.createRestClient(token)
 
     return (await restClient.post({
-      path: `/sent-referral/${referralId}/supplier-assessment-appointment/submit`,
+      path: `/appointment/${id}/submit-feedback`,
       headers: { Accept: 'application/json' },
     })) as Appointment
   }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -454,14 +454,14 @@ export default class InterventionsService {
     })) as SupplierAssessment
   }
 
-  async updateSupplierAssessmentAppointment(
+  async scheduleSupplierAssessmentAppointment(
     token: string,
-    referralId: string,
+    supplierAssessmentId: string,
     appointmentUpdate: Partial<AppointmentUpdate>
   ): Promise<Appointment> {
     const restClient = this.createRestClient(token)
-    return (await restClient.patch({
-      path: `/sent-referral/${referralId}/supplier-assessment-appointment`,
+    return (await restClient.put({
+      path: `/supplier-assessment/${supplierAssessmentId}/schedule-appointment`,
       headers: { Accept: 'application/json' },
       data: { ...appointmentUpdate },
     })) as Appointment

--- a/testutils/factories/actionPlanAppointment.ts
+++ b/testutils/factories/actionPlanAppointment.ts
@@ -5,23 +5,25 @@ import appointmentFactory from './appointment'
 
 class ActionPlanAppointmentFactory extends Factory<ActionPlanAppointment> {
   newlyCreated() {
-    return this.params({ ...appointmentFactory.newlyCreated().build() })
+    return this
   }
 
   scheduled() {
     return this.params({
-      ...appointmentFactory.scheduled().build(),
+      ...appointmentFactory.newlyBooked().build(),
     })
   }
 
   attended(attendance: Attended) {
     return this.params({
-      ...appointmentFactory.attended(attendance).build(),
+      sessionFeedback: appointmentFactory.attended(attendance).build().sessionFeedback,
     })
   }
 }
 
 export default ActionPlanAppointmentFactory.define(() => ({
-  ...appointmentFactory.build(),
+  appointmentTime: null,
+  durationInMinutes: null,
+  sessionFeedback: appointmentFactory.newlyBooked().build().sessionFeedback,
   sessionNumber: 1,
 }))

--- a/testutils/factories/appointment.ts
+++ b/testutils/factories/appointment.ts
@@ -3,15 +3,8 @@ import Appointment from '../../server/models/appointment'
 import { Attended } from '../../server/models/appointmentAttendance'
 
 class AppointmentFactory extends Factory<Appointment> {
-  newlyCreated() {
+  newlyBooked() {
     return this.params({})
-  }
-
-  scheduled() {
-    return this.params({
-      appointmentTime: new Date().toISOString(),
-      durationInMinutes: 60,
-    })
   }
 
   attended(attendance: Attended) {
@@ -31,9 +24,10 @@ class AppointmentFactory extends Factory<Appointment> {
   }
 }
 
-export default AppointmentFactory.define(() => ({
-  appointmentTime: null,
-  durationInMinutes: null,
+export default AppointmentFactory.define(({ sequence }) => ({
+  id: sequence.toString(),
+  appointmentTime: new Date().toISOString(),
+  durationInMinutes: 60,
   sessionFeedback: {
     attendance: {
       attended: null,

--- a/testutils/factories/supplierAssessment.ts
+++ b/testutils/factories/supplierAssessment.ts
@@ -1,0 +1,20 @@
+import { Factory } from 'fishery'
+import SupplierAssessment from '../../server/models/supplierAssessment'
+import appointmentFactory from './appointment'
+
+class SupplierAssessmentFactory extends Factory<SupplierAssessment> {
+  get justCreated() {
+    return this
+  }
+
+  get withSingleAppointment() {
+    const appointment = appointmentFactory.build()
+    return this.params({ appointments: [appointment], currentAppointmentId: appointment.id })
+  }
+}
+
+export default SupplierAssessmentFactory.define(({ sequence }) => ({
+  id: sequence.toString(),
+  appointments: [],
+  currentAppointmentId: null,
+}))


### PR DESCRIPTION
## What does this pull request do?

Updates the contracts for supplier assessments, in line with the changes discussed as a team yesterday. See commit messages for more details.

## What is the intent behind these changes?

- expose the separate concepts of an supplier assessment and its appointments
- improve semantics ('scheduling' instead of 'editing')
- provide functionality that works on any generic appointment instead of being supplier assessment specific