### PR TITLE
PPD-299: Fixing npm security audit threshold

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,5 @@
 {
-  "medium": true,
+  "moderate": true,
   "package-manager": "auto",
   "registry": "https://registry.npmjs.org"
 }


### PR DESCRIPTION
## What does this pull request do?

Corrects the threshold used to flag the nightly npm security audit as a pass or failure

## What is the intent behind these changes?

To make security vulnerabilities more visible
