### PR TITLE
fix creation of action plans by ensuring the referral ID is always valid

### DIFF
--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -38,7 +38,7 @@ export default class InterventionProgressPresenter {
       referral.id,
       subNavUrlPrefix
     )
-    this.actionPlanDetailsPresenter = new ActionPlanDetailsPresenter(actionPlan, subNavUrlPrefix)
+    this.actionPlanDetailsPresenter = new ActionPlanDetailsPresenter(referral, actionPlan, subNavUrlPrefix)
   }
 
   get referralAssigned(): boolean {

--- a/server/routes/shared/actionPlanDetailsPresenter.test.ts
+++ b/server/routes/shared/actionPlanDetailsPresenter.test.ts
@@ -1,12 +1,14 @@
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
+import referralFactory from '../../../testutils/factories/sentReferral'
 import ActionPlanDetailsPresenter from './actionPlanDetailsPresenter'
 import InterventionProgressPresenter from '../serviceProviderReferrals/interventionProgressPresenter'
 
 describe(InterventionProgressPresenter, () => {
+  const referral = referralFactory.build()
   describe('createActionPlanFormAction', () => {
     it('returns the relative URL for creating a draft action plan', () => {
-      const actionPlan = actionPlanFactory.approved().build()
-      const presenter = new ActionPlanDetailsPresenter(actionPlan, 'service-provider')
+      const actionPlan = actionPlanFactory.approved().build({ referralId: referral.id })
+      const presenter = new ActionPlanDetailsPresenter(referral, actionPlan, 'service-provider')
 
       expect(presenter.createActionPlanFormAction).toEqual(
         `/service-provider/referrals/${actionPlan.referralId}/action-plan`
@@ -17,15 +19,15 @@ describe(InterventionProgressPresenter, () => {
   describe('actionPlanStatus', () => {
     describe('when there is no action plan', () => {
       it('returns the correct status', () => {
-        const presenter = new ActionPlanDetailsPresenter(null, 'service-provider')
+        const presenter = new ActionPlanDetailsPresenter(referral, null, 'service-provider')
         expect(presenter.text.actionPlanStatus).toEqual('Not submitted')
       })
     })
 
     describe('when the action plan has not been submitted', () => {
       it('returns the correct status', () => {
-        const actionPlan = actionPlanFactory.notSubmitted().build()
-        const presenter = new ActionPlanDetailsPresenter(actionPlan, 'service-provider')
+        const actionPlan = actionPlanFactory.notSubmitted().build({ referralId: referral.id })
+        const presenter = new ActionPlanDetailsPresenter(referral, actionPlan, 'service-provider')
 
         expect(presenter.text.actionPlanStatus).toEqual('Not submitted')
       })
@@ -33,8 +35,8 @@ describe(InterventionProgressPresenter, () => {
 
     describe('when the action plan has been submitted', () => {
       it('returns the correct status', () => {
-        const actionPlan = actionPlanFactory.submitted().build()
-        const presenter = new ActionPlanDetailsPresenter(actionPlan, 'service-provider')
+        const actionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+        const presenter = new ActionPlanDetailsPresenter(referral, actionPlan, 'service-provider')
 
         expect(presenter.text.actionPlanStatus).toEqual('Under review')
       })
@@ -42,8 +44,8 @@ describe(InterventionProgressPresenter, () => {
 
     describe('when the action plan has been approved', () => {
       it('returns the correct status', () => {
-        const actionPlan = actionPlanFactory.approved().build()
-        const presenter = new ActionPlanDetailsPresenter(actionPlan, 'service-provider')
+        const actionPlan = actionPlanFactory.approved().build({ referralId: referral.id })
+        const presenter = new ActionPlanDetailsPresenter(referral, actionPlan, 'service-provider')
 
         expect(presenter.text.actionPlanStatus).toEqual('Approved')
       })
@@ -53,7 +55,7 @@ describe(InterventionProgressPresenter, () => {
   describe('actionPlanCreated', () => {
     describe('when there is no action plan', () => {
       it('returns false', () => {
-        const presenter = new ActionPlanDetailsPresenter(null, 'service-provider')
+        const presenter = new ActionPlanDetailsPresenter(referral, null, 'service-provider')
 
         expect(presenter.actionPlanCreated).toEqual(false)
       })
@@ -61,8 +63,8 @@ describe(InterventionProgressPresenter, () => {
 
     describe('when there is an action plan', () => {
       it('returns true', () => {
-        const actionPlan = actionPlanFactory.notSubmitted().build()
-        const presenter = new ActionPlanDetailsPresenter(actionPlan, 'service-provider')
+        const actionPlan = actionPlanFactory.notSubmitted().build({ referralId: referral.id })
+        const presenter = new ActionPlanDetailsPresenter(referral, actionPlan, 'service-provider')
 
         expect(presenter.actionPlanCreated).toEqual(true)
       })

--- a/server/routes/shared/actionPlanDetailsPresenter.ts
+++ b/server/routes/shared/actionPlanDetailsPresenter.ts
@@ -1,19 +1,21 @@
 import ActionPlan from '../../models/actionPlan'
 import DateUtils from '../../utils/dateUtils'
+import SentReferral from '../../models/sentReferral'
 
 export default class ActionPlanDetailsPresenter {
   constructor(
+    private readonly referral: SentReferral,
     private readonly actionPlan: ActionPlan | null,
     private readonly subNavUrlPrefix: 'service-provider' | 'probation-practitioner'
   ) {}
 
-  readonly interventionProgressURL = `/${this.subNavUrlPrefix}/referrals/${this.actionPlan?.referralId}/progress`
+  readonly interventionProgressURL = `/${this.subNavUrlPrefix}/referrals/${this.referral.id}/progress`
+
+  readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
+
+  readonly viewActionPlanUrl = `/service-provider/referrals/${this.referral.id}/action-plan`
 
   readonly actionPlanFormUrl = `/service-provider/action-plan/${this.actionPlan?.id}/add-activities`
-
-  readonly createActionPlanFormAction = `/service-provider/referrals/${this.actionPlan?.referralId}/action-plan`
-
-  readonly viewActionPlanUrl = `/service-provider/referrals/${this.actionPlan?.referralId}/action-plan`
 
   readonly text = {
     actionPlanStatus: this.actionPlanStatus,


### PR DESCRIPTION
## What does this pull request do?

fix creation of action plans by ensuring the referral ID is always valid

## What is the intent behind these changes?

allow users to create action plans
