### PR TITLE
add simple page for SP to view an under approval action plan

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -240,5 +240,9 @@ export default function routes(router: Router, services: Services): Router {
     findInterventionsController.viewInterventionDetails(req, res)
   )
 
+  get('/service-provider/referrals/:id/action-plan', (req, res) =>
+    serviceProviderReferralsController.viewActionPlan(req, res)
+  )
+
   return router
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -128,7 +128,6 @@ export default class InterventionProgressView {
           classes: 'action-plan-submitted-date',
         },
       })
-      // FIXME: the 'view action plan' page doesn't exist yet!
       rows.push({
         key: { text: 'To do' },
         value: {

--- a/server/routes/shared/actionPlanDetailsPresenter.ts
+++ b/server/routes/shared/actionPlanDetailsPresenter.ts
@@ -21,6 +21,15 @@ export default class ActionPlanDetailsPresenter {
     actionPlanStatus: this.actionPlanStatus,
     actionPlanSubmittedDate: DateUtils.getDateStringFromDateTimeString(this.actionPlan?.submittedAt || null),
     actionPlanApprovalDate: DateUtils.getDateStringFromDateTimeString(this.actionPlan?.approvedAt || null),
+    actionPlanNumberOfSessions: this.actionPlan?.numberOfSessions,
+  }
+
+  get activities(): string[] {
+    return (
+      this.actionPlan?.activities?.map(it => {
+        return it.description
+      }) || []
+    )
   }
 
   private get actionPlanStatus(): string {

--- a/server/routes/shared/actionPlanDetailsView.ts
+++ b/server/routes/shared/actionPlanDetailsView.ts
@@ -1,4 +1,5 @@
 import ActionPlanDetailsPresenter from './actionPlanDetailsPresenter'
+import { InsetTextArgs, SummaryListArgs, SummaryListArgsRow, TagArgs } from '../../utils/govukFrontendTypes'
 
 export default class ActionPlanDetailsView {
   constructor(private readonly presenter: ActionPlanDetailsPresenter) {}
@@ -6,6 +7,13 @@ export default class ActionPlanDetailsView {
   private readonly backLinkArgs = {
     text: 'Back',
     href: this.presenter.interventionProgressURL,
+  }
+
+  insetTextActivityArgs(index: number, description: string): InsetTextArgs {
+    return {
+      html: `<h3 class="govuk-heading-m govuk-!-font-weight-bold">Activity ${index}</h3><p class="govuk-body">${description}</p>`,
+      classes: 'app-inset-text--grey',
+    }
   }
 
   get actionPlanTagClass(): string {
@@ -19,12 +27,38 @@ export default class ActionPlanDetailsView {
     }
   }
 
+  private actionPlanSummaryListArgs(tagMacro: (args: TagArgs) => string): SummaryListArgs {
+    const rows: SummaryListArgsRow[] = [
+      {
+        key: { text: 'Action plan status' },
+        value: {
+          text: tagMacro({
+            text: this.presenter.text.actionPlanStatus,
+            classes: this.actionPlanTagClass,
+            attributes: { id: 'action-plan-status' },
+          }),
+        },
+      },
+      {
+        key: { text: 'Submitted date' },
+        value: {
+          text: this.presenter.text.actionPlanSubmittedDate,
+          classes: 'action-plan-submitted-date',
+        },
+      },
+    ]
+
+    return { rows }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'shared/actionPlan',
       {
         presenter: this.presenter,
         backLinkArgs: this.backLinkArgs,
+        actionPlanSummaryListArgs: this.actionPlanSummaryListArgs.bind(this),
+        insetTextActivityArgs: this.insetTextActivityArgs.bind(this),
       },
     ]
   }

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -1,0 +1,31 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% block pageTitle %}
+    HMPPS Interventions - GOV.UK
+{% endblock %}
+
+{% block pageContent %}
+    {% block content %}
+    <div class="govuk-!-width-two-thirds">
+        {{ govukBackLink(backLinkArgs) }}
+        <h1 class="govuk-heading-l">View action plan</h1>
+
+        {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
+
+        <h2 class="govuk-heading-m">Desired outcomes and activities</h2>
+
+        <ul class="govuk-list">
+        {% for activity in presenter.activities %}
+            <li>{{ govukInsetText(insetTextActivityArgs(loop.index, activity)) }}</li>
+        {% endfor %}
+        </ul>
+
+        <h2 class="govuk-heading-m">Suggested number of sessions for the action plan</h2>
+        <p class="govuk-body">Suggested number of sessions: {{ presenter.text.actionPlanNumberOfSessions }}</p>
+    </div>
+    {% endblock %}
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

add simple page for SP to view an under approval action plan

![Screenshot 2021-06-17 at 12 20 00](https://user-images.githubusercontent.com/63233073/122387119-7155e300-cf66-11eb-881c-6f22a8a0e8be.png)

## What is the intent behind these changes?

make the link clickable when SP has submitted action plan. 

this PR is intentionally small with limited reach because there is more refactoring coming on top of this.