### PR TITLE
show action plan summary on PP intervention progress page

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -410,7 +410,7 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('Return to service progress').click()
 
     cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/progress`)
-    cy.get('#action-plan-status').contains('Under review')
+    cy.get('#action-plan-status').contains('Awaiting approval')
     cy.get('.action-plan-submitted-date').contains(/\d{1,2} [A-Z][a-z]{2} \d{4}/)
   })
 

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -10,7 +10,7 @@ describe(InterventionProgressPresenter, () => {
     it('returns an empty list if there are no appointments', () => {
       const referral = sentReferralFactory.build()
       const intervention = interventionFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
       expect(presenter.sessionTableRows).toEqual([])
     })
@@ -19,9 +19,12 @@ describe(InterventionProgressPresenter, () => {
       it('populates the table with formatted session information, with no link text or href', () => {
         const referral = sentReferralFactory.build()
         const intervention = interventionFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, intervention, [
-          actionPlanAppointmentFactory.newlyCreated().build(),
-        ])
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [actionPlanAppointmentFactory.newlyCreated().build()],
+          null
+        )
         expect(presenter.sessionTableRows).toEqual([
           {
             sessionNumber: 1,
@@ -43,13 +46,18 @@ describe(InterventionProgressPresenter, () => {
       it('populates the table with formatted session information, with the "Reschedule session" and "Give feedback" links displayed', () => {
         const referral = sentReferralFactory.build()
         const intervention = interventionFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, intervention, [
-          actionPlanAppointmentFactory.build({
-            sessionNumber: 1,
-            appointmentTime: '2020-12-07T13:00:00.000000Z',
-            durationInMinutes: 120,
-          }),
-        ])
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [
+            actionPlanAppointmentFactory.build({
+              sessionNumber: 1,
+              appointmentTime: '2020-12-07T13:00:00.000000Z',
+              durationInMinutes: 120,
+            }),
+          ],
+          null
+        )
         expect(presenter.sessionTableRows).toEqual([
           {
             sessionNumber: 1,
@@ -72,10 +80,15 @@ describe(InterventionProgressPresenter, () => {
         it('populates the table with the "completed" status against that session and a link to view it', () => {
           const referral = sentReferralFactory.build({ actionPlanId: 'c59809e0-ab78-4723-bbef-bd34bc6df110' })
           const intervention = interventionFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, intervention, [
-            actionPlanAppointmentFactory.attended('yes').build({ sessionNumber: 1 }),
-            actionPlanAppointmentFactory.attended('late').build({ sessionNumber: 2 }),
-          ])
+          const presenter = new InterventionProgressPresenter(
+            referral,
+            intervention,
+            [
+              actionPlanAppointmentFactory.attended('yes').build({ sessionNumber: 1 }),
+              actionPlanAppointmentFactory.attended('late').build({ sessionNumber: 2 }),
+            ],
+            null
+          )
           expect(presenter.sessionTableRows).toEqual([
             {
               sessionNumber: 1,
@@ -109,9 +122,12 @@ describe(InterventionProgressPresenter, () => {
         it('populates the table with the "failure to attend" status against that session and a link to view it', () => {
           const referral = sentReferralFactory.build({ actionPlanId: 'c59809e0-ab78-4723-bbef-bd34bc6df110' })
           const intervention = interventionFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, intervention, [
-            actionPlanAppointmentFactory.attended('no').build(),
-          ])
+          const presenter = new InterventionProgressPresenter(
+            referral,
+            intervention,
+            [actionPlanAppointmentFactory.attended('no').build()],
+            null
+          )
           expect(presenter.sessionTableRows).toEqual([
             {
               sessionNumber: 1,
@@ -136,7 +152,7 @@ describe(InterventionProgressPresenter, () => {
       it('returns a title to be displayed', () => {
         const referral = sentReferralFactory.build()
         const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
-        const presenter = new InterventionProgressPresenter(referral, intervention, [])
+        const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
         expect(presenter.text).toMatchObject({
           title: 'Accommodation progress',
@@ -149,7 +165,7 @@ describe(InterventionProgressPresenter, () => {
     it('returns the url including referral id for the referral cancellation page', () => {
       const referral = sentReferralFactory.build()
       const intervention = interventionFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
       expect(presenter.referralCancellationHref).toEqual(
         `/probation-practitioner/referrals/${referral.id}/cancellation/reason`
@@ -161,14 +177,14 @@ describe(InterventionProgressPresenter, () => {
     it('returns false when the referral has no assignee', () => {
       const referral = sentReferralFactory.unassigned().build()
       const intervention = interventionFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
       expect(presenter.referralAssigned).toEqual(false)
     })
     it('returns true when the referral has an assignee', () => {
       const referral = sentReferralFactory.assigned().build()
       const intervention = interventionFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
       expect(presenter.referralAssigned).toEqual(true)
     })
@@ -178,7 +194,7 @@ describe(InterventionProgressPresenter, () => {
     it('returns true when the referral has ended', () => {
       const referral = sentReferralFactory.endRequested().build()
       const intervention = interventionFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
       expect(presenter.referralEndRequested).toEqual(true)
     })
@@ -187,7 +203,7 @@ describe(InterventionProgressPresenter, () => {
       const referral = sentReferralFactory.build()
       const intervention = interventionFactory.build()
 
-      const presenter = new InterventionProgressPresenter(referral, intervention, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
       expect(presenter.referralEndRequested).toEqual(false)
     })
@@ -197,7 +213,7 @@ describe(InterventionProgressPresenter, () => {
     it('returns the requested end date when an end has been requested', () => {
       const referral = sentReferralFactory.endRequested().build({ endRequestedAt: '2021-04-28T20:45:21.986389Z' })
       const intervention = interventionFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
       expect(presenter.referralEndRequestedText).toEqual('You requested to end this service on 28 Apr 2021.')
     })
@@ -206,7 +222,7 @@ describe(InterventionProgressPresenter, () => {
       const referral = sentReferralFactory.build()
       const intervention = interventionFactory.build()
 
-      const presenter = new InterventionProgressPresenter(referral, intervention, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
       expect(presenter.referralEndRequestedText).toEqual('')
     })
@@ -217,7 +233,7 @@ describe(InterventionProgressPresenter, () => {
       it('returns false', () => {
         const referral = sentReferralFactory.build({ endOfServiceReport: null })
         const intervention = interventionFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, intervention, [])
+        const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
         expect(presenter.hasEndOfServiceReport).toEqual(false)
       })
@@ -229,7 +245,7 @@ describe(InterventionProgressPresenter, () => {
             endOfServiceReport: endOfServiceReportFactory.justCreated().build(),
           })
           const intervention = interventionFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, intervention, [])
+          const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
           expect(presenter.hasEndOfServiceReport).toEqual(false)
         })
@@ -241,7 +257,7 @@ describe(InterventionProgressPresenter, () => {
             endOfServiceReport: endOfServiceReportFactory.submitted().build(),
           })
           const intervention = interventionFactory.build()
-          const presenter = new InterventionProgressPresenter(referral, intervention, [])
+          const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
           expect(presenter.hasEndOfServiceReport).toEqual(true)
         })
@@ -253,7 +269,7 @@ describe(InterventionProgressPresenter, () => {
     it('returns the headers for the end of service report table', () => {
       const referral = sentReferralFactory.build()
       const intervention = interventionFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
       expect(presenter.endOfServiceReportTableHeaders).toEqual(['Caseworker', 'Status', 'Action'])
     })
@@ -267,7 +283,7 @@ describe(InterventionProgressPresenter, () => {
         endOfServiceReport,
       })
       const intervention = interventionFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [])
+      const presenter = new InterventionProgressPresenter(referral, intervention, [], null)
 
       expect(presenter.endOfServiceReportTableRows).toEqual([
         {

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -1,11 +1,12 @@
 import SentReferral from '../../models/sentReferral'
-import { ActionPlanAppointment } from '../../models/actionPlan'
+import ActionPlan, { ActionPlanAppointment } from '../../models/actionPlan'
 import utils from '../../utils/utils'
 import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from '../shared/referralOverviewPagePresenter'
 import DateUtils from '../../utils/dateUtils'
 import sessionStatus, { SessionStatus } from '../../utils/sessionStatus'
 import SessionStatusPresenter from '../shared/sessionStatusPresenter'
 import Intervention from '../../models/intervention'
+import ActionPlanPresenter from '../shared/actionPlanPresenter'
 
 interface ProgressSessionTableRow {
   sessionNumber: number
@@ -22,16 +23,20 @@ interface EndOfServiceTableRow {
 export default class InterventionProgressPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
 
+  actionPlanPresenter: ActionPlanPresenter
+
   constructor(
     private readonly referral: SentReferral,
     private readonly intervention: Intervention,
-    private readonly actionPlanAppointments: ActionPlanAppointment[]
+    private readonly actionPlanAppointments: ActionPlanAppointment[],
+    private readonly actionPlan: ActionPlan | null
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Progress,
       referral.id,
       'probation-practitioner'
     )
+    this.actionPlanPresenter = new ActionPlanPresenter(referral, actionPlan, 'probation-practitioner')
   }
 
   get referralAssigned(): boolean {

--- a/server/routes/probationPractitionerReferrals/interventionProgressView.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressView.ts
@@ -1,9 +1,14 @@
 import { TagArgs, TableArgs } from '../../utils/govukFrontendTypes'
 
 import InterventionProgressPresenter from './interventionProgressPresenter'
+import ActionPlanView from '../shared/actionPlanView'
 
 export default class InterventionProgressView {
-  constructor(private readonly presenter: InterventionProgressPresenter) {}
+  actionPlanView: ActionPlanView
+
+  constructor(private readonly presenter: InterventionProgressPresenter) {
+    this.actionPlanView = new ActionPlanView(presenter.actionPlanPresenter, true)
+  }
 
   private sessionTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
     return {
@@ -58,6 +63,7 @@ export default class InterventionProgressView {
         subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         sessionTableArgs: this.sessionTableArgs.bind(this),
         endOfServiceReportTableArgs: this.endOfServiceReportTableArgs.bind(this),
+        actionPlanSummaryListArgs: this.actionPlanView.actionPlanSummaryListArgs.bind(this.actionPlanView),
       },
     ]
   }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -86,7 +86,7 @@ export default class ProbationPractitionerReferralsController {
       )
     }
 
-    const presenter = new InterventionProgressPresenter(sentReferral, intervention, actionPlanAppointments)
+    const presenter = new InterventionProgressPresenter(sentReferral, intervention, actionPlanAppointments, actionPlan)
     const view = new InterventionProgressView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/shared/actionPlanPresenter.test.ts
+++ b/server/routes/shared/actionPlanPresenter.test.ts
@@ -38,7 +38,7 @@ describe(InterventionProgressPresenter, () => {
         const actionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
         const presenter = new ActionPlanPresenter(referral, actionPlan, 'service-provider')
 
-        expect(presenter.text.actionPlanStatus).toEqual('Under review')
+        expect(presenter.text.actionPlanStatus).toEqual('Awaiting approval')
       })
     })
 

--- a/server/routes/shared/actionPlanPresenter.ts
+++ b/server/routes/shared/actionPlanPresenter.ts
@@ -6,7 +6,7 @@ export default class ActionPlanPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly actionPlan: ActionPlan | null,
-    private readonly userType: 'service-provider' | 'probation-practitioner'
+    readonly userType: 'service-provider' | 'probation-practitioner'
   ) {}
 
   readonly interventionProgressURL = `/${this.userType}/referrals/${this.referral.id}/progress`
@@ -37,7 +37,7 @@ export default class ActionPlanPresenter {
       return 'Approved'
     }
     if (this.actionPlanUnderReview) {
-      return 'Under review'
+      return 'Awaiting approval'
     }
     return 'Not submitted'
   }

--- a/server/routes/shared/actionPlanView.ts
+++ b/server/routes/shared/actionPlanView.ts
@@ -21,7 +21,7 @@ export default class ActionPlanView {
     switch (this.presenter.text.actionPlanStatus) {
       case 'Approved':
         return 'govuk-tag--green'
-      case 'Under review':
+      case 'Awaiting approval':
         return 'govuk-tag- govuk-tag--red'
       default:
         return 'govuk-tag--grey'
@@ -60,30 +60,32 @@ export default class ActionPlanView {
     }
 
     if (this.includeSummaryTodo) {
-      if (!this.presenter.actionPlanCreated) {
-        rows.push({
-          key: { text: 'Action' },
-          value: {
-            html: `<form method="post" action="${ViewUtils.escape(this.presenter.createActionPlanFormAction)}">
-                     <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken!)}">
-                     <button class="govuk-button govuk-button--secondary">Create action plan</button>
-                   </form>`,
-          },
-        })
-      } else if (!this.presenter.actionPlanSubmitted) {
-        rows.push({
-          key: { text: 'Action' },
-          value: {
-            html: `<a href="${this.presenter.actionPlanFormUrl}" class="govuk-link">Submit action plan</a>`,
-          },
-        })
-      } else {
+      if (this.presenter.actionPlanSubmitted) {
         rows.push({
           key: { text: 'Action' },
           value: {
             html: `<a href="${this.presenter.viewActionPlanUrl}" class="govuk-link">View action plan</a>`,
           },
         })
+      } else if (this.presenter.userType === 'service-provider') {
+        if (!this.presenter.actionPlanCreated) {
+          rows.push({
+            key: { text: 'Action' },
+            value: {
+              html: `<form method="post" action="${ViewUtils.escape(this.presenter.createActionPlanFormAction)}">
+                     <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken!)}">
+                     <button class="govuk-button govuk-button--secondary">Create action plan</button>
+                   </form>`,
+            },
+          })
+        } else if (!this.presenter.actionPlanSubmitted) {
+          rows.push({
+            key: { text: 'Action' },
+            value: {
+              html: `<a href="${this.presenter.actionPlanFormUrl}" class="govuk-link">Submit action plan</a>`,
+            },
+          })
+        }
       }
     }
 

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -6,6 +6,13 @@
 
 {% block referralPageSection %}
 
+  <h2 class="govuk-heading-m">Service user's action plan</h2>
+  <p class="govuk-body">
+    This is the action plan created by the service provider. When there are changes submitted by the service provider, you will need to review it and decide if you want to approve it.
+  </p>
+
+  {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
+
   <h2 class="govuk-heading-m">Intervention sessions</h2>
   <p class="govuk-body">
     These show the progress of each intervention session.
@@ -15,7 +22,7 @@
     {{ govukTable(sessionTableArgs(govukTag)) }}
   {% else %}
     <p class="govuk-body">
-      Sessions will appear here when the action plan is ready.
+      Sessions will appear here when the action plan is approved.
     </p>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">


### PR DESCRIPTION
## What does this pull request do?

show action plan summary on PP intervention progress page

what this looks like when there is no action plan:

![Screenshot 2021-06-17 at 14 50 08](https://user-images.githubusercontent.com/63233073/122417958-cc490380-cf81-11eb-9768-957c28da9926.png)

what this looks like when there is an action plan awaiting approval:

<img width="1063" alt="Screenshot 2021-06-17 at 15 36 56" src="https://user-images.githubusercontent.com/63233073/122418035-dbc84c80-cf81-11eb-846d-d6c850fa3068.png">

## What is the intent behind these changes?

allow PPs to see that an action plan has been submitted
