### PR TITLE
IC-1471: Add tests for Community API

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -7,9 +7,10 @@ import RestClient from './data/restClient'
 import AssessRisksAndNeedsService from './services/assessRisksAndNeedsService'
 
 const assessRisksAndNeedsRestClient = new RestClient('assessRisksAndNeedsClient', config.apis.assessRisksAndNeedsApi)
+const communityApiRestClient = new RestClient('communityApiClient', config.apis.communityApi)
 
 const hmppsAuthService = new HmppsAuthService()
-const communityApiService = new CommunityApiService(hmppsAuthService)
+const communityApiService = new CommunityApiService(hmppsAuthService, communityApiRestClient)
 const interventionsService = new InterventionsService(config.apis.interventionsService)
 const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthService, assessRisksAndNeedsRestClient)
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -9,10 +9,10 @@ import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import apiConfig from '../../config'
-import MockedHmppsAuthService from '../../services/testutils/hmppsAuthServiceSetup'
 import deliusServiceUser from '../../../testutils/factories/deliusServiceUser'
 import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
 import interventionFactory from '../../../testutils/factories/intervention'
+import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -20,7 +20,7 @@ jest.mock('../../services/communityApiService')
 const interventionsService = new InterventionsService(
   apiConfig.apis.interventionsService
 ) as jest.Mocked<InterventionsService>
-const communityApiService = new CommunityApiService(new MockedHmppsAuthService()) as jest.Mocked<CommunityApiService>
+const communityApiService = new MockCommunityApiService() as jest.Mocked<CommunityApiService>
 
 const serviceUser = {
   crn: 'X123456',

--- a/server/routes/testutils/mocks/mockCommunityApiService.ts
+++ b/server/routes/testutils/mocks/mockCommunityApiService.ts
@@ -1,21 +1,9 @@
 import CommunityApiService from '../../../services/communityApiService'
-import DeliusUser from '../../../models/delius/deliusUser'
 import MockedHmppsAuthService from '../../../services/testutils/hmppsAuthServiceSetup'
+import MockRestClient from '../../../data/testutils/mockRestClient'
 
-export = class MockCommunityApiService extends CommunityApiService {
+export default class MockCommunityApiService extends CommunityApiService {
   constructor() {
-    super(new MockedHmppsAuthService())
-  }
-
-  async getUserByUsername(_username: string): Promise<DeliusUser> {
-    return {
-      userId: '987123876',
-      username: 'maijam',
-      firstName: 'Maija',
-      surname: 'Meikäläinen',
-      email: 'maijamm@justice.gov.uk',
-      enabled: true,
-      roles: [],
-    }
+    super(new MockedHmppsAuthService(), new MockRestClient())
   }
 }

--- a/server/services/communityApiService.test.ts
+++ b/server/services/communityApiService.test.ts
@@ -1,0 +1,94 @@
+import CommunityApiService from './communityApiService'
+import RestClient from '../data/restClient'
+import MockRestClient from '../data/testutils/mockRestClient'
+import HmppsAuthService from './hmppsAuthService'
+import MockedHmppsAuthService from './testutils/hmppsAuthServiceSetup'
+import deliusServiceUser from '../../testutils/factories/deliusServiceUser'
+import deliusUserFactory from '../../testutils/factories/deliusUser'
+import deliusConviction from '../../testutils/factories/deliusConviction'
+
+jest.mock('../data/restClient')
+
+describe(CommunityApiService, () => {
+  const hmppsAuthClientMock = new MockedHmppsAuthService() as jest.Mocked<HmppsAuthService>
+
+  describe('getUserByUsername', () => {
+    it('makes a request to the communityAPI and casts the response as an Delius User', async () => {
+      const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
+      const service = new CommunityApiService(hmppsAuthClientMock, restClientMock)
+      const deliusUser = deliusUserFactory.build({ username: 'p.practitioner' })
+
+      restClientMock.get.mockResolvedValue(deliusUser)
+
+      hmppsAuthClientMock.getApiClientToken.mockResolvedValue('token')
+
+      const result = await service.getUserByUsername('p.practitioner')
+
+      expect(restClientMock.get).toHaveBeenCalledWith({
+        path: `/secure/users/p.practitioner/details`,
+        token: 'token',
+      })
+      expect(result).toMatchObject(deliusUser)
+    })
+  })
+
+  describe('getServiceUserByCRN', () => {
+    it('makes a request to the Community API and casts the response as a Delius Service User', async () => {
+      const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
+      const service = new CommunityApiService(hmppsAuthClientMock, restClientMock)
+      const serviceUser = deliusServiceUser.build({ otherIds: { crn: 'X123456' } })
+
+      restClientMock.get.mockResolvedValue(serviceUser)
+
+      hmppsAuthClientMock.getApiClientToken.mockResolvedValue('token')
+
+      const result = await service.getServiceUserByCRN('X123456')
+
+      expect(restClientMock.get).toHaveBeenCalledWith({
+        path: `/secure/offenders/crn/X123456`,
+        token: 'token',
+      })
+      expect(result).toMatchObject(serviceUser)
+    })
+  })
+
+  describe('getActiveConvictionsByCRN', () => {
+    it('makes a request to the Community API and casts the response as an array of Delius Convictions', async () => {
+      const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
+      const service = new CommunityApiService(hmppsAuthClientMock, restClientMock)
+      const convictions = deliusConviction.buildList(2)
+
+      restClientMock.get.mockResolvedValue(convictions)
+
+      hmppsAuthClientMock.getApiClientToken.mockResolvedValue('token')
+
+      const result = await service.getActiveConvictionsByCRN('X123456')
+      expect(restClientMock.get).toHaveBeenCalledWith({
+        path: `/secure/offenders/crn/X123456/convictions`,
+        token: 'token',
+      })
+
+      expect(result).toMatchObject(convictions)
+    })
+  })
+
+  describe('getConvictionById', () => {
+    it('makes a request to the Community API and casts the response as single Delius Conviction', async () => {
+      const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
+      const service = new CommunityApiService(hmppsAuthClientMock, restClientMock)
+      const conviction = deliusConviction.build({ convictionId: 1 })
+
+      restClientMock.get.mockResolvedValue(conviction)
+
+      hmppsAuthClientMock.getApiClientToken.mockResolvedValue('token')
+
+      const result = await service.getConvictionById('X123456', 1)
+      expect(restClientMock.get).toHaveBeenCalledWith({
+        path: `/secure/offenders/crn/X123456/convictions/1`,
+        token: 'token',
+      })
+
+      expect(result).toMatchObject(conviction)
+    })
+  })
+})

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -1,36 +1,34 @@
 import type HmppsAuthService from './hmppsAuthService'
 import RestClient from '../data/restClient'
-import config from '../config'
 import logger from '../../log'
 import DeliusUser from '../models/delius/deliusUser'
 import DeliusServiceUser from '../models/delius/deliusServiceUser'
 import DeliusConviction from '../models/delius/deliusConviction'
 
 export default class CommunityApiService {
-  constructor(private readonly hmppsAuthService: HmppsAuthService) {}
-
-  private restClient(token: string): RestClient {
-    return new RestClient('Community API Client', config.apis.communityApi, token)
-  }
+  constructor(private readonly hmppsAuthService: HmppsAuthService, private readonly restClient: RestClient) {}
 
   async getUserByUsername(username: string): Promise<DeliusUser> {
     const token = await this.hmppsAuthService.getApiClientToken()
 
     logger.info({ username }, 'getting user details')
-    return (await this.restClient(token).get({ path: `/secure/users/${username}/details` })) as DeliusUser
+    return (await this.restClient.get({ path: `/secure/users/${username}/details`, token })) as DeliusUser
   }
 
   async getServiceUserByCRN(crn: string): Promise<DeliusServiceUser> {
     const token = await this.hmppsAuthService.getApiClientToken()
+
     logger.info({ crn }, 'getting details for offender')
-    return (await this.restClient(token).get({ path: `/secure/offenders/crn/${crn}` })) as DeliusServiceUser
+    return (await this.restClient.get({ path: `/secure/offenders/crn/${crn}`, token })) as DeliusServiceUser
   }
 
   async getActiveConvictionsByCRN(crn: string): Promise<DeliusConviction[]> {
     const token = await this.hmppsAuthService.getApiClientToken()
+
     logger.info({ crn }, 'getting convictions for service user')
-    const convictions = (await this.restClient(token).get({
+    const convictions = (await this.restClient.get({
       path: `/secure/offenders/crn/${crn}/convictions`,
+      token,
     })) as DeliusConviction[]
 
     return convictions.filter(conviction => conviction.active && conviction.sentence)
@@ -38,9 +36,11 @@ export default class CommunityApiService {
 
   async getConvictionById(crn: string, id: number): Promise<DeliusConviction> {
     const token = await this.hmppsAuthService.getApiClientToken()
+
     logger.info({ crn, id }, 'getting conviction for service user')
-    return (await this.restClient(token).get({
+    return (await this.restClient.get({
       path: `/secure/offenders/crn/${crn}/convictions/${id}`,
+      token,
     })) as DeliusConviction
   }
 }


### PR DESCRIPTION
## What does this pull request do?

 Add tests for Community API and stops it instantiating a new instance of `RestClient` with each request, as this made it difficult to test.

## What is the intent behind these changes?

We didn't have any tests for this, and I'm about to introduce some new functionality to the Community API Service to do things with the Service User address, so wanted to make sure we had some tests in place at least.
