### PR TITLE
IC-1673 action plan approval process

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -243,8 +243,12 @@ export default function routes(router: Router, services: Services): Router {
   get('/service-provider/referrals/:id/action-plan', (req, res) =>
     serviceProviderReferralsController.viewActionPlan(req, res)
   )
+
   get('/probation-practitioner/referrals/:id/action-plan', (req, res) =>
     probationPractitionerReferralsController.viewActionPlan(req, res)
+  )
+  get('/probation-practitioner/referrals/:id/action-plan/approved', (req, res) =>
+    probationPractitionerReferralsController.actionPlanApproved(req, res)
   )
 
   return router

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -243,6 +243,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/service-provider/referrals/:id/action-plan', (req, res) =>
     serviceProviderReferralsController.viewActionPlan(req, res)
   )
+  get('/probation-practitioner/referrals/:id/action-plan', (req, res) =>
+    probationPractitionerReferralsController.viewActionPlan(req, res)
+  )
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -247,6 +247,9 @@ export default function routes(router: Router, services: Services): Router {
   get('/probation-practitioner/referrals/:id/action-plan', (req, res) =>
     probationPractitionerReferralsController.viewActionPlan(req, res)
   )
+  post('/probation-practitioner/referrals/:id/action-plan/approve', (req, res) =>
+    probationPractitionerReferralsController.approveActionPlan(req, res)
+  )
   get('/probation-practitioner/referrals/:id/action-plan/approved', (req, res) =>
     probationPractitionerReferralsController.actionPlanApproved(req, res)
   )

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import createError from 'http-errors'
 import CommunityApiService from '../../services/communityApiService'
 import InterventionsService from '../../services/interventionsService'
 import { ActionPlanAppointment } from '../../models/actionPlan'
@@ -25,6 +26,8 @@ import ShowReferralPresenter from '../shared/showReferralPresenter'
 import ShowReferralView from '../shared/showReferralView'
 import HmppsAuthService from '../../services/hmppsAuthService'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
+import ActionPlanPresenter from '../shared/actionPlanPresenter'
+import ActionPlanView from '../shared/actionPlanView'
 
 export default class ProbationPractitionerReferralsController {
   constructor(
@@ -275,6 +278,26 @@ export default class ProbationPractitionerReferralsController {
     const presenter = new EndOfServiceReportPresenter(referral, endOfServiceReport, serviceCategories)
     const view = new EndOfServiceReportView(presenter)
 
+    ControllerUtils.renderWithLayout(res, view, serviceUser)
+  }
+
+  async viewActionPlan(req: Request, res: Response): Promise<void> {
+    const { accessToken } = res.locals.user.token
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
+
+    if (sentReferral.actionPlanId === null) {
+      throw createError(500, `could not view action plan for referral with id '${req.params.id}'`, {
+        userMessage: 'No action plan exists for this referral',
+      })
+    }
+
+    const [actionPlan, serviceUser] = await Promise.all([
+      this.interventionsService.getActionPlan(accessToken, sentReferral.actionPlanId),
+      this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
+    ])
+
+    const presenter = new ActionPlanPresenter(sentReferral, actionPlan, 'probation-practitioner')
+    const view = new ActionPlanView(presenter, false)
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -311,7 +311,7 @@ export default class ProbationPractitionerReferralsController {
       })
     }
 
-    await this.interventionsService.approveActionPlan(res.locals.user.token.accessToken, sentReferral.actionPlanId)
+    await this.interventionsService.approveActionPlan(accessToken, sentReferral.actionPlanId)
     return res.redirect(`/probation-practitioner/referrals/${sentReferral.id}/action-plan/approved`)
   }
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -300,4 +300,27 @@ export default class ProbationPractitionerReferralsController {
     const view = new ActionPlanView(presenter, false)
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
+
+  async actionPlanApproved(req: Request, res: Response): Promise<void> {
+    const { accessToken } = res.locals.user.token
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
+
+    const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
+
+    ControllerUtils.renderWithLayout(
+      res,
+      {
+        renderArgs: [
+          'probationPractitionerReferrals/actionPlanApproved',
+          {
+            backButtonArgs: {
+              text: 'Return to intervention progress',
+              href: `/probation-practitioner/referrals/${sentReferral.id}/progress`,
+            },
+          },
+        ],
+      },
+      serviceUser
+    )
+  }
 }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -301,6 +301,20 @@ export default class ProbationPractitionerReferralsController {
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
+  async approveActionPlan(req: Request, res: Response): Promise<void> {
+    const { accessToken } = res.locals.user.token
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
+
+    if (sentReferral.actionPlanId === null) {
+      throw createError(500, `could not approve action plan for referral with id '${sentReferral.id}'`, {
+        userMessage: 'No action plan exists for this referral',
+      })
+    }
+
+    await this.interventionsService.approveActionPlan(res.locals.user.token.accessToken, sentReferral.actionPlanId)
+    return res.redirect(`/probation-practitioner/referrals/${sentReferral.id}/action-plan/approved`)
+  }
+
   async actionPlanApproved(req: Request, res: Response): Promise<void> {
     const { accessToken } = res.locals.user.token
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)

--- a/server/routes/shared/actionPlanPresenter.ts
+++ b/server/routes/shared/actionPlanPresenter.ts
@@ -17,11 +17,14 @@ export default class ActionPlanPresenter {
 
   readonly actionPlanFormUrl = `/service-provider/action-plan/${this.actionPlan?.id}/add-activities`
 
+  readonly actionPlanApprovalUrl = `/probation-practitioner/referrals/${this.referral.id}/action-plan/approve`
+
   readonly text = {
     actionPlanStatus: this.actionPlanStatus,
     actionPlanSubmittedDate: DateUtils.getDateStringFromDateTimeString(this.actionPlan?.submittedAt || null),
     actionPlanApprovalDate: DateUtils.getDateStringFromDateTimeString(this.actionPlan?.approvedAt || null),
     actionPlanNumberOfSessions: this.actionPlan?.numberOfSessions,
+    spEmailAddress: this.actionPlan?.submittedBy?.username?.toLowerCase(),
   }
 
   get activities(): string[] {
@@ -56,5 +59,9 @@ export default class ActionPlanPresenter {
 
   get actionPlanApproved(): boolean {
     return this.actionPlan?.approvedAt != null
+  }
+
+  get showApprovalForm(): boolean {
+    return this.userType === 'probation-practitioner' && this.actionPlanUnderReview
   }
 }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2008,6 +2008,26 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('approveActionPlan', () => {
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: 'an action plan exists with ID 7a165933-d851-48c1-9ab0-ff5b8da12695, and it has been submitted',
+        uponReceiving: 'a POST request to approve the action plan with ID 7a165933-d851-48c1-9ab0-ff5b8da12695',
+        withRequest: {
+          method: 'POST',
+          path: '/action-plan/7a165933-d851-48c1-9ab0-ff5b8da12695/approve',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+    })
+    it('returns successfully', async () => {
+      await interventionsService.approveActionPlan(token, '7a165933-d851-48c1-9ab0-ff5b8da12695')
+    })
+  })
+
   describe('getActionPlanAppointments', () => {
     const actionPlanAppointments = [
       actionPlanAppointmentFactory.build({

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -440,4 +440,12 @@ export default class InterventionsService {
       headers: { Accept: 'application/json' },
     })) as CancellationReason[]
   }
+
+  async approveActionPlan(token: string, actionPlanId: string): Promise<void> {
+    const restClient = this.createRestClient(token)
+    await restClient.post({
+      path: `/action-plan/${actionPlanId}/approve`,
+      headers: { Accept: 'application/json' },
+    })
+  }
 }

--- a/server/views/probationPractitionerReferrals/actionPlanApproved.njk
+++ b/server/views/probationPractitionerReferrals/actionPlanApproved.njk
@@ -1,0 +1,20 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block pageTitle %}
+    HMPPS Interventions - GOV.UK
+{% endblock %}
+
+{% block pageContent %}
+    {% block content %}
+    <div class="govuk-grid-column-two-thirds">
+        {{ govukPanel({ titleText: "Action plan approved" }) }}
+
+        <h2 class="govuk-heading-m">What happens next?</h2>
+        <p class="govuk-body">The service provider will be able to start adding details to the sessions suggested in the action plan.</p>
+
+        {{ govukButton(backButtonArgs) }}
+    </div>
+    {% endblock %}
+{% endblock %}

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/button/macro.njk" import govukButton %}%}
 
 {% block pageTitle %}
     HMPPS Interventions - GOV.UK
@@ -26,6 +27,16 @@
 
         <h2 class="govuk-heading-m">Suggested number of sessions for the action plan</h2>
         <p class="govuk-body">Suggested number of sessions: {{ presenter.text.actionPlanNumberOfSessions }}</p>
+
+        {% if presenter.showApprovalForm %}
+            <h2 class="govuk-heading-m">Do you want to approve this action plan?</h2>
+            <p class="govuk-body">Note: If you want to suggest any changes, contact <i>{{ presenter.text.spEmailAddress }}</i> before approving this action plan.</p>
+
+            <form method="post" action="{{ presenter.actionPlanApprovalUrl }}">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+                {{ govukButton({ text: "Approve" }) }}
+            </form>
+        {% endif %}
     </div>
     {% endblock %}
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

simple version of PP action plan approval journey. it's not complete. e.g. the checkbox in the proposed design is missing. but this is a functional MVP of the approval process. note the suspicious lack of tests. they are coming, i just want to keep the PRs small and the momentum high so we have this in place ASAP. 

the flow is as follows:

1) pp intervention progress page with an outstanding action plan 

<img width="778" alt="Screenshot 2021-06-17 at 23 37 45" src="https://user-images.githubusercontent.com/63233073/122481633-ed801300-cfc6-11eb-8d94-6b64d85813ca.png">

2) pp clicks 'view action plan' link to get to the action plan page

<img width="778" alt="Screenshot 2021-06-17 at 23 47 14" src="https://user-images.githubusercontent.com/63233073/122481662-ff61b600-cfc6-11eb-8ce0-2a1407c1c0ea.png">

3) pp clicks 'approve action plan' button and end up at this page

<img width="778" alt="Screenshot 2021-06-17 at 23 37 52" src="https://user-images.githubusercontent.com/63233073/122481696-130d1c80-cfc7-11eb-941d-30b21876d9e2.png">

4) pp clicks 'return to intervention progress' button and gets back to the progress page where the action plan status has been updated and the empty sessions have been created

<img width="778" alt="Screenshot 2021-06-17 at 23 37 56" src="https://user-images.githubusercontent.com/63233073/122481731-27511980-cfc7-11eb-9204-376ccfe64aad.png">

5) if they click 'view' again, they see the updated status, and there's no longer the approval button

<img width="778" alt="Screenshot 2021-06-17 at 23 37 59" src="https://user-images.githubusercontent.com/63233073/122481767-3768f900-cfc7-11eb-9863-1d5ae1e460f5.png">



