### PR TITLE
IC-1954: Add confirmation box for action plan approval

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -12,6 +12,7 @@ $path: "/assets/images/"
 @import './components/primary-navigation'
 @import './components/service-user-banner'
 @import './components/task-list'
+@import './components/checkboxes'
 
 @import './layout/grid'
 

--- a/assets/sass/components/_checkboxes.scss
+++ b/assets/sass/components/_checkboxes.scss
@@ -1,0 +1,11 @@
+.govuk-checkboxes__inset--grey {
+  background: #f3f2f1;
+  padding-bottom: 30px;
+  padding-left: 30px;
+  padding-top: 30px;
+
+  .govuk-checkboxes__label::before {
+    background: white;
+  }
+
+}

--- a/server/routes/shared/actionPlanPresenter.test.ts
+++ b/server/routes/shared/actionPlanPresenter.test.ts
@@ -70,4 +70,28 @@ describe(InterventionProgressPresenter, () => {
       })
     })
   })
+
+  describe('errorSummary', () => {
+    describe('when a validation error is passed in', () => {
+      it('should add the error to the error summary and field errors', () => {
+        const actionPlan = actionPlanFactory.approved().build({ referralId: referral.id })
+        const validationError = {
+          errors: [
+            {
+              errorSummaryLinkedField: 'confirm-approval',
+              formFields: ['confirm-approval'],
+              message: 'Select the checkbox to confirm before you approve the action plan',
+            },
+          ],
+        }
+        const presenter = new ActionPlanPresenter(referral, actionPlan, 'service-provider', validationError)
+        expect(presenter.errorSummary).toEqual([
+          { field: 'confirm-approval', message: 'Select the checkbox to confirm before you approve the action plan' },
+        ])
+        expect(presenter.fieldErrors.confirmApproval).toEqual(
+          'Select the checkbox to confirm before you approve the action plan'
+        )
+      })
+    })
+  })
 })

--- a/server/routes/shared/actionPlanPresenter.ts
+++ b/server/routes/shared/actionPlanPresenter.ts
@@ -1,12 +1,15 @@
 import ActionPlan from '../../models/actionPlan'
 import DateUtils from '../../utils/dateUtils'
 import SentReferral from '../../models/sentReferral'
+import { FormValidationError } from '../../utils/formValidationError'
+import PresenterUtils from '../../utils/presenterUtils'
 
 export default class ActionPlanPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly actionPlan: ActionPlan | null,
-    readonly userType: 'service-provider' | 'probation-practitioner'
+    readonly userType: 'service-provider' | 'probation-practitioner',
+    private readonly validationError: FormValidationError | null = null
   ) {}
 
   readonly interventionProgressURL = `/${this.userType}/referrals/${this.referral.id}/progress`
@@ -25,6 +28,12 @@ export default class ActionPlanPresenter {
     actionPlanApprovalDate: DateUtils.getDateStringFromDateTimeString(this.actionPlan?.approvedAt || null),
     actionPlanNumberOfSessions: this.actionPlan?.numberOfSessions,
     spEmailAddress: this.actionPlan?.submittedBy?.username?.toLowerCase(),
+  }
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.validationError)
+
+  readonly fieldErrors = {
+    confirmApproval: PresenterUtils.errorMessage(this.validationError, 'confirm-approval'),
   }
 
   get activities(): string[] {

--- a/server/routes/shared/actionPlanView.ts
+++ b/server/routes/shared/actionPlanView.ts
@@ -1,5 +1,11 @@
 import ActionPlanPresenter from './actionPlanPresenter'
-import { InsetTextArgs, SummaryListArgs, SummaryListArgsRow, TagArgs } from '../../utils/govukFrontendTypes'
+import {
+  CheckboxesArgs,
+  InsetTextArgs,
+  SummaryListArgs,
+  SummaryListArgsRow,
+  TagArgs,
+} from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
 
 export default class ActionPlanView {
@@ -9,6 +15,8 @@ export default class ActionPlanView {
     text: 'Back',
     href: this.presenter.interventionProgressURL,
   }
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
   insetTextActivityArgs(index: number, description: string): InsetTextArgs {
     return {
@@ -92,14 +100,31 @@ export default class ActionPlanView {
     return { rows }
   }
 
+  get confirmApprovalCheckboxArgs(): CheckboxesArgs {
+    return {
+      idPrefix: 'confirm-approval',
+      name: 'confirm-approval[]',
+      items: [
+        {
+          value: 'confirmed',
+          text: 'I confirm that I want to approve the action plan',
+        },
+      ],
+      classes: 'govuk-checkboxes__inset--grey',
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fieldErrors.confirmApproval),
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'shared/actionPlan',
       {
         presenter: this.presenter,
         backLinkArgs: this.backLinkArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
         actionPlanSummaryListArgs: this.actionPlanSummaryListArgs.bind(this),
         insetTextActivityArgs: this.insetTextActivityArgs.bind(this),
+        confirmApprovalCheckboxArgs: this.confirmApprovalCheckboxArgs,
       },
     ]
   }

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -64,6 +64,9 @@ export default {
     notWholeNumber: 'The number of sessions must be a whole number, like 5',
     tooSmall: 'The number of sessions must be 1 or more',
   },
+  actionPlanApproval: {
+    notConfirmed: 'Select the checkbox to confirm before you approve the action plan',
+  },
   attendedAppointment: {
     empty: 'Select whether the service user attended or not',
   },

--- a/server/utils/forms/inputs/confirmationCheckboxInput.test.ts
+++ b/server/utils/forms/inputs/confirmationCheckboxInput.test.ts
@@ -1,0 +1,48 @@
+import TestUtils from '../../../../testutils/testUtils'
+import ConfirmationCheckboxInput from './confirmationCheckboxInput'
+
+describe(ConfirmationCheckboxInput, () => {
+  const errorMessage = 'error'
+
+  describe('validate', () => {
+    describe('checkbox has been checked', () => {
+      it('returns a true value with no error', async () => {
+        const request = TestUtils.createRequest({
+          'confirm-approval': ['confirmed'],
+        })
+
+        const result = await new ConfirmationCheckboxInput(
+          request,
+          'confirm-approval',
+          'confirmed',
+          errorMessage
+        ).validate()
+
+        expect(result.value).toBe(true)
+      })
+    })
+
+    describe('checkbox has not been checked', () => {
+      it('returns an error', async () => {
+        const request = TestUtils.createRequest({})
+
+        const result = await new ConfirmationCheckboxInput(
+          request,
+          'confirm-approval',
+          'confirmed',
+          errorMessage
+        ).validate()
+
+        expect(result.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'confirm-approval',
+              formFields: ['confirm-approval'],
+              message: errorMessage,
+            },
+          ],
+        })
+      })
+    })
+  })
+})

--- a/server/utils/forms/inputs/confirmationCheckboxInput.ts
+++ b/server/utils/forms/inputs/confirmationCheckboxInput.ts
@@ -1,0 +1,26 @@
+import * as ExpressValidator from 'express-validator'
+import { Request } from 'express'
+import { FormValidationResult } from '../formValidationResult'
+import FormUtils from '../../formUtils'
+
+export default class ConfirmationCheckboxInput {
+  constructor(
+    private readonly request: Request,
+    private readonly key: string,
+    private readonly confirmValue: string,
+    private readonly errorMessage: string
+  ) {}
+
+  async validate(): Promise<FormValidationResult<boolean>> {
+    const validations = [ExpressValidator.body(this.key).contains(this.confirmValue).withMessage(this.errorMessage)]
+    const result = await FormUtils.runValidations({ request: this.request, validations })
+    const error = FormUtils.validationErrorFromResult(result)
+    if (error) {
+      return { value: null, error: { errors: [error.errors[0]] } }
+    }
+    return {
+      value: true,
+      error: null,
+    }
+  }
+}

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -1,9 +1,12 @@
 {% extends "../partials/layout.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}%}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
 
 {% block pageTitle %}
     HMPPS Interventions - GOV.UK
@@ -13,6 +16,9 @@
     {% block content %}
     <div class="govuk-!-width-two-thirds">
         {{ govukBackLink(backLinkArgs) }}
+        {% if errorSummaryArgs !== null %}
+            {{ govukErrorSummary(errorSummaryArgs) }}
+        {% endif %}
         <h1 class="govuk-heading-l">View action plan</h1>
 
         {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
@@ -33,6 +39,7 @@
             <p class="govuk-body">Note: If you want to suggest any changes, contact <i>{{ presenter.text.spEmailAddress }}</i> before approving this action plan.</p>
 
             <form method="post" action="{{ presenter.actionPlanApprovalUrl }}">
+                {{ govukCheckboxes(confirmApprovalCheckboxArgs) }}
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}">
                 {{ govukButton({ text: "Approve" }) }}
             </form>


### PR DESCRIPTION
## What does this pull request do?

Adds a confirmation checkbox before approving action plan

## What is the intent behind these changes?

Ensure that the user doesn't accidentally click on approval


## Additional information

Checkbox looks like this:

![image](https://user-images.githubusercontent.com/83066216/122561355-ad0dad00-d039-11eb-892a-02f1d962ca12.png)

When submitting without checking:
![image](https://user-images.githubusercontent.com/83066216/122561457-c878b800-d039-11eb-9bfa-9c620eb933e6.png)

![image](https://user-images.githubusercontent.com/83066216/122561422-c0207d00-d039-11eb-9565-8c31167c121f.png)
