### PR TITLE
IC-1829 PP can see SU's risk scores

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -21,6 +21,7 @@ env:
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
   INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
   ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
+  ASSESS_RISKS_AND_NEEDS_API_RISK_SUMMARY_ENABLED: true
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true
   REDIS_TLS_ENABLED: true

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -6,6 +6,7 @@ import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 import interventionFactory from '../../testutils/factories/intervention'
 // eslint-disable-next-line import/no-named-as-default,import/no-named-as-default-member
 import ReferralSectionVerifier from './make_a_referral/referralSectionVerifier'
+import riskSummaryFactory from '../../testutils/factories/riskSummary'
 
 describe('Referral form', () => {
   const deliusServiceUser = deliusServiceUserFactory.build({
@@ -134,6 +135,7 @@ describe('Referral form', () => {
       cy.stubGetIntervention(draftReferral.interventionId, intervention)
       cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
       cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
+      cy.stubGetRiskSummary(draftReferral.serviceUser.crn, riskSummaryFactory.build())
 
       cy.login()
 
@@ -442,6 +444,7 @@ describe('Referral form', () => {
       cy.stubGetIntervention(draftReferral.interventionId, intervention)
       cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
       cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
+      cy.stubGetRiskSummary(draftReferral.serviceUser.crn, riskSummaryFactory.build())
 
       cy.login()
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -174,5 +174,9 @@ module.exports = on => {
     stubGetSupplementaryRiskInformation: arg => {
       return assessRisksAndNeedsService.stubGetSupplementaryRiskInformation(arg.riskId, arg.responseJson)
     },
+
+    stubGetRiskSummary: arg => {
+      return assessRisksAndNeedsService.stubGetRiskSummary(arg.crn, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/assessRisksAndNeedsServiceStubs.js
+++ b/integration_tests/support/assessRisksAndNeedsServiceStubs.js
@@ -1,3 +1,7 @@
 Cypress.Commands.add('stubGetSupplementaryRiskInformation', (riskId, responseJson) => {
   cy.task('stubGetSupplementaryRiskInformation', { riskId, responseJson })
 })
+
+Cypress.Commands.add('stubGetRiskSummary', (crn, responseJson) => {
+  cy.task('stubGetRiskSummary', { crn, responseJson })
+})

--- a/mockApis/assessRisksAndNeedsService.ts
+++ b/mockApis/assessRisksAndNeedsService.ts
@@ -18,4 +18,20 @@ export default class AssessRisksAndNeedsServiceMocks {
       },
     })
   }
+
+  stubGetRiskSummary = async (crn: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/assess-risks-and-needs/risks/crn/${crn}/summary`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -71,6 +71,7 @@ export default {
         deadline: Number(get('ASSESS_RISKS_AND_NEEDS_API_TIMEOUT_DEADLINE', 20000)),
       },
       agent: new AgentConfig(),
+      riskSummaryEnabled: get('ASSESS_RISKS_AND_NEEDS_API_RISK_SUMMARY_ENABLED', false),
     },
     hmppsAuth: {
       url: get('HMPPS_AUTH_URL', 'http://hmpps-auth:8090/auth', requiredInProduction),

--- a/server/models/assessRisksAndNeeds/riskSummary.ts
+++ b/server/models/assessRisksAndNeeds/riskSummary.ts
@@ -1,0 +1,10 @@
+export type RiskScore = 'LOW' | 'MEDIUM' | 'HIGH' | 'VERY_HIGH'
+
+export default interface RiskSummary {
+  whoIsAtRisk?: string | null
+  natureOfRisk?: string | null
+  riskImminence?: string | null
+  riskIncreaseFactors?: string | null
+  riskMitigationFactors?: string | null
+  riskInCommunity: Partial<Record<RiskScore, string[]>>
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -29,7 +29,11 @@ export default function routes(router: Router, services: Services): Router {
     services.hmppsAuthService,
     services.assessRisksAndNeedsService
   )
-  const referralsController = new ReferralsController(services.interventionsService, services.communityApiService)
+  const referralsController = new ReferralsController(
+    services.interventionsService,
+    services.communityApiService,
+    services.assessRisksAndNeedsService
+  )
   const staticContentController = new StaticContentController()
   const serviceProviderReferralsController = new ServiceProviderReferralsController(
     services.interventionsService,

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -8,19 +8,24 @@ import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
+import riskSummaryFactory from '../../../testutils/factories/riskSummary'
 import apiConfig from '../../config'
 import deliusServiceUser from '../../../testutils/factories/deliusServiceUser'
 import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
 import interventionFactory from '../../../testutils/factories/intervention'
 import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
+import MockAssessRisksAndNeedsService from '../testutils/mocks/mockAssessRisksAndNeedsService'
+import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
+jest.mock('../../services/assessRisksAndNeedsService')
 
 const interventionsService = new InterventionsService(
   apiConfig.apis.interventionsService
 ) as jest.Mocked<InterventionsService>
 const communityApiService = new MockCommunityApiService() as jest.Mocked<CommunityApiService>
+const assessRisksAndNeedsService = new MockAssessRisksAndNeedsService() as jest.Mocked<AssessRisksAndNeedsService>
 
 const serviceUser = {
   crn: 'X123456',
@@ -39,7 +44,7 @@ let app: Express
 
 beforeEach(() => {
   app = appWithAllRoutes({
-    overrides: { interventionsService, communityApiService },
+    overrides: { interventionsService, communityApiService, assessRisksAndNeedsService },
     userType: AppSetupUserType.probationPractitioner,
   })
 
@@ -284,7 +289,9 @@ describe('POST /referrals/:id/confirm-service-user-details', () => {
 describe('GET /referrals/:id/risk-information', () => {
   beforeEach(() => {
     const referral = draftReferralFactory.serviceUserSelected().build({ serviceUser: { firstName: 'Geoffrey' } })
+    const riskSummary = riskSummaryFactory.build()
 
+    assessRisksAndNeedsService.getRiskSummaryScores.mockResolvedValue(riskSummary)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
@@ -314,7 +321,9 @@ describe('GET /referrals/:id/risk-information', () => {
 describe('POST /referrals/:id/risk-information', () => {
   beforeEach(() => {
     const referral = draftReferralFactory.serviceUserSelected().build({ serviceUser: { firstName: 'Geoffrey' } })
+    const riskSummary = riskSummaryFactory.build()
 
+    assessRisksAndNeedsService.getRiskSummaryScores.mockResolvedValue(riskSummary)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -291,7 +291,7 @@ describe('GET /referrals/:id/risk-information', () => {
     const referral = draftReferralFactory.serviceUserSelected().build({ serviceUser: { firstName: 'Geoffrey' } })
     const riskSummary = riskSummaryFactory.build()
 
-    assessRisksAndNeedsService.getRiskSummaryScores.mockResolvedValue(riskSummary)
+    assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
@@ -312,7 +312,7 @@ describe('GET /referrals/:id/risk-information', () => {
   })
 
   it('renders an error when the get risk summary call fails', async () => {
-    assessRisksAndNeedsService.getRiskSummaryScores.mockRejectedValue(new Error('failed to get risk summary'))
+    assessRisksAndNeedsService.getRiskSummary.mockRejectedValue(new Error('failed to get risk summary'))
     await request(app)
       .get('/referrals/1/risk-information')
       .expect(500)
@@ -338,7 +338,7 @@ describe('POST /referrals/:id/risk-information', () => {
     const referral = draftReferralFactory.serviceUserSelected().build({ serviceUser: { firstName: 'Geoffrey' } })
     const riskSummary = riskSummaryFactory.build()
 
-    assessRisksAndNeedsService.getRiskSummaryScores.mockResolvedValue(riskSummary)
+    assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -295,6 +295,14 @@ describe('GET /referrals/:id/risk-information', () => {
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
+  beforeAll(() => {
+    apiConfig.apis.assessRisksAndNeedsApi.riskSummaryEnabled = true
+  })
+
+  afterAll(() => {
+    apiConfig.apis.assessRisksAndNeedsApi.riskSummaryEnabled = false
+  })
+
   it('renders a form page', async () => {
     await request(app)
       .get('/referrals/1/risk-information')

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -301,9 +301,24 @@ describe('GET /referrals/:id/risk-information', () => {
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Geoffrey’s risk information')
+        expect(res.text).toContain('Risk in community')
+        expect(res.text).toContain('Children')
+        expect(res.text).toContain('HIGH')
+        expect(res.text).toContain('Prisoners')
+        expect(res.text).toContain('LOW')
       })
 
     expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['token', '1'])
+  })
+
+  it('renders an error when the get risk summary call fails', async () => {
+    assessRisksAndNeedsService.getRiskSummaryScores.mockRejectedValue(new Error('failed to get risk summary'))
+    await request(app)
+      .get('/referrals/1/risk-information')
+      .expect(500)
+      .expect(res => {
+        expect(res.text).toContain('failed to get risk summary')
+      })
   })
 
   it('renders an error when the get referral call fails', async () => {

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -45,11 +45,13 @@ import EnforceableDaysForm from './enforceableDaysForm'
 import EnforceableDaysPresenter from './enforceableDaysPresenter'
 import EnforceableDaysView from './enforceableDaysView'
 import RiskInformationForm from './riskInformationForm'
+import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 
 export default class ReferralsController {
   constructor(
     private readonly interventionsService: InterventionsService,
-    private readonly communityApiService: CommunityApiService
+    private readonly communityApiService: CommunityApiService,
+    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService
   ) {}
 
   async startReferral(req: Request, res: Response): Promise<void> {
@@ -479,8 +481,12 @@ export default class ReferralsController {
 
   async viewRiskInformation(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
-    const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn)
-    const presenter = new RiskInformationPresenter(referral)
+    const [serviceUser, riskSummary] = await Promise.all([
+      this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
+      this.assessRisksAndNeedsService.getRiskSummaryScores(referral.serviceUser.crn, res.locals.user.token.accessToken),
+    ])
+
+    const presenter = new RiskInformationPresenter(referral, riskSummary)
     const view = new RiskInformationView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)
@@ -511,9 +517,15 @@ export default class ReferralsController {
         res.locals.user.token.accessToken,
         req.params.id
       )
-      const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn)
+      const [serviceUser, riskSummary] = await Promise.all([
+        this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
+        this.assessRisksAndNeedsService.getRiskSummaryScores(
+          referral.serviceUser.crn,
+          res.locals.user.token.accessToken
+        ),
+      ])
 
-      const presenter = new RiskInformationPresenter(referral, error, req.body)
+      const presenter = new RiskInformationPresenter(referral, riskSummary, error, req.body)
       const view = new RiskInformationView(presenter)
 
       res.status(400)

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -483,7 +483,7 @@ export default class ReferralsController {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
     const [serviceUser, riskSummary] = await Promise.all([
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
-      this.assessRisksAndNeedsService.getRiskSummaryScores(referral.serviceUser.crn, res.locals.user.token.accessToken),
+      this.assessRisksAndNeedsService.getRiskSummary(referral.serviceUser.crn, res.locals.user.token.accessToken),
     ])
 
     const presenter = new RiskInformationPresenter(referral, riskSummary)
@@ -519,10 +519,7 @@ export default class ReferralsController {
       )
       const [serviceUser, riskSummary] = await Promise.all([
         this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
-        this.assessRisksAndNeedsService.getRiskSummaryScores(
-          referral.serviceUser.crn,
-          res.locals.user.token.accessToken
-        ),
+        this.assessRisksAndNeedsService.getRiskSummary(referral.serviceUser.crn, res.locals.user.token.accessToken),
       ])
 
       const presenter = new RiskInformationPresenter(referral, riskSummary, error, req.body)

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -1,5 +1,6 @@
 import RiskInformationPresenter from './riskInformationPresenter'
 import draftReferralFactory from '../../../testutils/factories/draftReferral'
+import riskSummaryFactory from '../../../testutils/factories/riskSummary'
 
 describe('RiskInformationPresenter', () => {
   describe('text', () => {
@@ -8,7 +9,7 @@ describe('RiskInformationPresenter', () => {
         .serviceCategorySelected()
         .serviceUserSelected()
         .build({ serviceUser: { firstName: 'Geoffrey' } })
-      const presenter = new RiskInformationPresenter(referral)
+      const presenter = new RiskInformationPresenter(referral, riskSummaryFactory.build())
 
       expect(presenter.text).toEqual({
         title: 'Geoffrey’s risk information',
@@ -25,7 +26,7 @@ describe('RiskInformationPresenter', () => {
           .serviceCategorySelected()
           .serviceUserSelected()
           .build({ serviceUser: { firstName: 'Geoffrey' } })
-        const presenter = new RiskInformationPresenter(referral, {
+        const presenter = new RiskInformationPresenter(referral, riskSummaryFactory.build(), {
           errors: [
             {
               formFields: ['additional-risk-information'],
@@ -50,7 +51,7 @@ describe('RiskInformationPresenter', () => {
     describe('when the referral has no additional risk information', () => {
       it('replays empty answers', () => {
         const referral = draftReferralFactory.serviceUserSelected().build()
-        const presenter = new RiskInformationPresenter(referral)
+        const presenter = new RiskInformationPresenter(referral, riskSummaryFactory.build())
 
         expect(presenter.fields).toEqual({
           additionalRiskInformation: '',
@@ -63,7 +64,7 @@ describe('RiskInformationPresenter', () => {
         const referral = draftReferralFactory
           .serviceUserSelected()
           .build({ additionalRiskInformation: 'Risk to the elderly' })
-        const presenter = new RiskInformationPresenter(referral)
+        const presenter = new RiskInformationPresenter(referral, riskSummaryFactory.build())
 
         expect(presenter.fields).toEqual({
           additionalRiskInformation: 'Risk to the elderly',
@@ -74,7 +75,7 @@ describe('RiskInformationPresenter', () => {
     describe('when there’s user input', () => {
       it('replays the user input', () => {
         const referral = draftReferralFactory.serviceUserSelected().build()
-        const presenter = new RiskInformationPresenter(referral, null, {
+        const presenter = new RiskInformationPresenter(referral, riskSummaryFactory.build(), null, {
           'additional-risk-information': 'Risk to the vulnerable',
         })
 
@@ -89,7 +90,7 @@ describe('RiskInformationPresenter', () => {
     describe('when error is null', () => {
       it('returns null', () => {
         const referral = draftReferralFactory.serviceUserSelected().build()
-        const presenter = new RiskInformationPresenter(referral, null)
+        const presenter = new RiskInformationPresenter(referral, riskSummaryFactory.build(), null)
 
         expect(presenter.errorSummary).toBeNull()
       })
@@ -98,7 +99,7 @@ describe('RiskInformationPresenter', () => {
     describe('when error is not null', () => {
       it('returns the errors', () => {
         const referral = draftReferralFactory.serviceUserSelected().build()
-        const presenter = new RiskInformationPresenter(referral, {
+        const presenter = new RiskInformationPresenter(referral, riskSummaryFactory.build(), {
           errors: [
             {
               formFields: ['additional-risk-information'],

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -2,6 +2,7 @@ import DraftReferral from '../../models/draftReferral'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
+import config from '../../config'
 
 export interface RoshAnalysisTableRow {
   riskTo: string
@@ -11,7 +12,7 @@ export interface RoshAnalysisTableRow {
 export default class RiskInformationPresenter {
   constructor(
     private readonly referral: DraftReferral,
-    private readonly riskSummary: RiskSummary,
+    private readonly riskSummary: RiskSummary | null,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
@@ -23,6 +24,8 @@ export default class RiskInformationPresenter {
       errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
     },
   }
+
+  readonly riskSummaryEnabled = config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
@@ -40,6 +43,8 @@ export default class RiskInformationPresenter {
   }
 
   get roshAnalysisRows(): RoshAnalysisTableRow[] {
+    if (this.riskSummary === null) return []
+
     return Object.entries(this.riskSummary.riskInCommunity).flatMap(([riskScore, riskGroups]) => {
       return riskGroups.map(riskTo => {
         return { riskTo, riskScore }

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -1,10 +1,17 @@
 import DraftReferral from '../../models/draftReferral'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
+import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
+
+export interface RoshAnalysisTableRow {
+  riskTo: string
+  riskScore: string
+}
 
 export default class RiskInformationPresenter {
   constructor(
     private readonly referral: DraftReferral,
+    private readonly riskSummary: RiskSummary,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
@@ -26,5 +33,17 @@ export default class RiskInformationPresenter {
       this.referral.additionalRiskInformation,
       'additional-risk-information'
     ),
+  }
+
+  get roshAnalysisHeaders(): string[] {
+    return ['Risk to', 'Risk in community']
+  }
+
+  get roshAnalysisRows(): RoshAnalysisTableRow[] {
+    return Object.entries(this.riskSummary.riskInCommunity).flatMap(([riskScore, riskGroups]) => {
+      return riskGroups.map(riskTo => {
+        return { riskTo, riskScore }
+      })
+    })
   }
 }

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -1,6 +1,7 @@
 import RiskInformationPresenter from './riskInformationPresenter'
 import ViewUtils from '../../utils/viewUtils'
-import { TextareaArgs } from '../../utils/govukFrontendTypes'
+import { TableArgs, TagArgs, TextareaArgs } from '../../utils/govukFrontendTypes'
+import utils from '../../utils/utils'
 
 export default class RiskInformationView {
   constructor(private readonly presenter: RiskInformationPresenter) {}
@@ -23,6 +24,35 @@ export default class RiskInformationView {
     }
   }
 
+  roshAnalysisTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
+    return {
+      head: this.presenter.roshAnalysisHeaders.map((header: string) => {
+        return { text: header }
+      }),
+      rows: this.presenter.roshAnalysisRows.map(row => {
+        return [
+          { text: utils.convertToProperCase(row.riskTo) },
+          { text: tagMacro({ text: row.riskScore, classes: this.tagClassForRiskScore(row.riskScore) }) },
+        ]
+      }),
+    }
+  }
+
+  private tagClassForRiskScore(riskScore: string): string {
+    switch (riskScore) {
+      case 'LOW':
+        return 'govuk-tag--green'
+      case 'MEDIUM':
+        return 'govuk-tag--blue'
+      case 'HIGH':
+        return 'govuk-tag--red'
+      case 'VERY_HIGH':
+        return 'govuk-tag--purple'
+      default:
+        return ''
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/riskInformation',
@@ -30,6 +60,7 @@ export default class RiskInformationView {
         presenter: this.presenter,
         errorSummaryArgs: this.errorSummaryArgs,
         additionalRiskInformationTextareaArgs: this.additionalRiskInformationTextareaArgs,
+        roshAnalysisTableArgs: this.roshAnalysisTableArgs.bind(this),
       },
     ]
   }

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -1,6 +1,6 @@
 import RiskInformationPresenter from './riskInformationPresenter'
 import ViewUtils from '../../utils/viewUtils'
-import { TableArgs, TagArgs, TextareaArgs } from '../../utils/govukFrontendTypes'
+import { DetailsArgs, TableArgs, TagArgs, TextareaArgs } from '../../utils/govukFrontendTypes'
 import utils from '../../utils/utils'
 
 export default class RiskInformationView {
@@ -53,6 +53,27 @@ export default class RiskInformationView {
     }
   }
 
+  get riskLevelDetailsArgs(): DetailsArgs {
+    return {
+      summaryText: 'Definitions of risk levels',
+      html: `
+            <ul class="govuk-list govuk-list--bullet">
+              <li>
+                <strong>Low</strong> - Current evidence does not indicate likelihood of causing serious harm.
+              </li>
+              <li>
+                <strong>Medium</strong> - There are identifiable indicators of risk of serious harm. The person has the potential to cause serious harm but is unlikely to do so unless there is a change in circumstances.
+              </li>
+              <li>
+                <strong>High</strong> - There are identifiable indicators of risk of serious harm. The potential event could happen at any time and the impact would be serious.
+              </li>
+              <li>
+                <strong>Very high</strong> - There is an imminent risk of serious harm. The potential event is more likely than not to happen imminently and the impact would be serious.
+              </li>
+            </ul>`,
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'referrals/riskInformation',
@@ -61,6 +82,7 @@ export default class RiskInformationView {
         errorSummaryArgs: this.errorSummaryArgs,
         additionalRiskInformationTextareaArgs: this.additionalRiskInformationTextareaArgs,
         roshAnalysisTableArgs: this.roshAnalysisTableArgs.bind(this),
+        riskLevelDetailsArgs: this.riskLevelDetailsArgs,
       },
     ]
   }

--- a/server/services/assessRisksAndNeedsService.test.ts
+++ b/server/services/assessRisksAndNeedsService.test.ts
@@ -7,6 +7,7 @@ import HmppsAuthService from './hmppsAuthService'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 import MockRestClient from '../data/testutils/mockRestClient'
 import riskSummaryFactory from '../../testutils/factories/riskSummary'
+import config from '../config'
 
 // wraps mocking API around the class exported by the module
 jest.mock('../data/restClient')
@@ -38,6 +39,14 @@ describe(AssessRisksAndNeedsService, () => {
     const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock)
 
     const riskSummary = riskSummaryFactory.build()
+
+    beforeAll(() => {
+      config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = true
+    })
+
+    afterAll(() => {
+      config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = false
+    })
 
     it('makes a request to the Assess Risks and Needs API', async () => {
       restClientMock.get.mockResolvedValue(riskSummary)

--- a/server/services/assessRisksAndNeedsService.test.ts
+++ b/server/services/assessRisksAndNeedsService.test.ts
@@ -1,3 +1,4 @@
+import createError from 'http-errors'
 import AssessRisksAndNeedsService from './assessRisksAndNeedsService'
 
 import RestClient from '../data/restClient'
@@ -5,6 +6,7 @@ import MockedHmppsAuthService from './testutils/hmppsAuthServiceSetup'
 import HmppsAuthService from './hmppsAuthService'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 import MockRestClient from '../data/testutils/mockRestClient'
+import riskSummaryFactory from '../../testutils/factories/riskSummary'
 
 // wraps mocking API around the class exported by the module
 jest.mock('../data/restClient')
@@ -25,6 +27,33 @@ describe(AssessRisksAndNeedsService, () => {
       await assessRisksAndNeedsService.getSupplementaryRiskInformation('riskId')
 
       expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/supplementary/riskId`, token: 'testToken' })
+    })
+  })
+
+  describe('getRiskSummary', () => {
+    const hmppsAuthServiceMock = new MockedHmppsAuthService() as jest.Mocked<HmppsAuthService>
+
+    const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
+
+    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock)
+
+    const riskSummary = riskSummaryFactory.build()
+
+    it('makes a request to the Assess Risks and Needs API', async () => {
+      restClientMock.get.mockResolvedValue(riskSummary)
+      await assessRisksAndNeedsService.getRiskSummary('crn123', 'token')
+
+      expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/crn/crn123/summary`, token: 'token' })
+    })
+
+    it('provides a userMessage on failure', async () => {
+      restClientMock.get.mockRejectedValue(createError(404))
+      try {
+        await assessRisksAndNeedsService.getRiskSummary('crn123', 'token')
+      } catch (err) {
+        expect(err.status).toBe(404)
+        expect(err.userMessage).toBe('Could not get service user risk scores from OASys.')
+      }
     })
   })
 })

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -4,6 +4,7 @@ import HmppsAuthService from './hmppsAuthService'
 import logger from '../../log'
 import { SupplementaryRiskInformation } from '../models/assessRisksAndNeeds/supplementaryRiskInformation'
 import RiskSummary from '../models/assessRisksAndNeeds/riskSummary'
+import config from '../config'
 
 export default class AssessRisksAndNeedsService {
   constructor(private readonly hmppsAuthService: HmppsAuthService, private readonly restClient: RestClient) {}
@@ -19,7 +20,12 @@ export default class AssessRisksAndNeedsService {
     })) as SupplementaryRiskInformation
   }
 
-  async getRiskSummary(crn: string, token: string): Promise<RiskSummary> {
+  async getRiskSummary(crn: string, token: string): Promise<RiskSummary | null> {
+    if (!config.apis.assessRisksAndNeedsApi.riskSummaryEnabled) {
+      logger.info('not getting risk summary information; disabled')
+      return null
+    }
+
     logger.info({ crn }, 'getting risk summary information')
     try {
       return (await this.restClient.get({

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -1,3 +1,4 @@
+import createError from 'http-errors'
 import RestClient from '../data/restClient'
 import HmppsAuthService from './hmppsAuthService'
 import logger from '../../log'
@@ -20,9 +21,13 @@ export default class AssessRisksAndNeedsService {
 
   async getRiskSummary(crn: string, token: string): Promise<RiskSummary> {
     logger.info({ crn }, 'getting risk summary information')
-    return (await this.restClient.get({
-      path: `/risks/crn/${crn}/summary`,
-      token,
-    })) as RiskSummary
+    try {
+      return (await this.restClient.get({
+        path: `/risks/crn/${crn}/summary`,
+        token,
+      })) as RiskSummary
+    } catch (err) {
+      throw createError(500, err, { userMessage: 'Could not get service user risk scores from OASys.' })
+    }
   }
 }

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -6,13 +6,16 @@ import { SupplementaryRiskInformation } from '../models/assessRisksAndNeeds/supp
 export default class AssessRisksAndNeedsService {
   constructor(private readonly hmppsAuthService: HmppsAuthService, private readonly restClient: RestClient) {}
 
-  async getSupplementaryRiskInformation(riskId: string): Promise<SupplementaryRiskInformation> {
-    const token = await this.hmppsAuthService.getApiClientToken()
-
+  async getSupplementaryRiskInformation(
+    riskId: string,
+    token: string | null = null
+  ): Promise<SupplementaryRiskInformation> {
     logger.info({ riskId }, 'getting supplementary risk information')
     return (await this.restClient.get({
       path: `/risks/supplementary/${riskId}`,
-      token,
+      token: token || (await this.hmppsAuthService.getApiClientToken()),
     })) as SupplementaryRiskInformation
   }
+
+  get;
 }

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -27,7 +27,7 @@ export default class AssessRisksAndNeedsService {
         token,
       })) as RiskSummary
     } catch (err) {
-      throw createError(500, err, { userMessage: 'Could not get service user risk scores from OASys.' })
+      throw createError(err.status, err, { userMessage: 'Could not get service user risk scores from OASys.' })
     }
   }
 }

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -18,7 +18,7 @@ export default class AssessRisksAndNeedsService {
     })) as SupplementaryRiskInformation
   }
 
-  async getRiskSummaryScores(crn: string, token: string): Promise<RiskSummary> {
+  async getRiskSummary(crn: string, token: string): Promise<RiskSummary> {
     logger.info({ crn }, 'getting risk summary information')
     return (await this.restClient.get({
       path: `/risks/crn/${crn}/summary`,

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -2,6 +2,7 @@ import RestClient from '../data/restClient'
 import HmppsAuthService from './hmppsAuthService'
 import logger from '../../log'
 import { SupplementaryRiskInformation } from '../models/assessRisksAndNeeds/supplementaryRiskInformation'
+import RiskSummary from '../models/assessRisksAndNeeds/riskSummary'
 
 export default class AssessRisksAndNeedsService {
   constructor(private readonly hmppsAuthService: HmppsAuthService, private readonly restClient: RestClient) {}
@@ -17,5 +18,11 @@ export default class AssessRisksAndNeedsService {
     })) as SupplementaryRiskInformation
   }
 
-  get;
+  async getRiskSummaryScores(crn: string, token: string): Promise<RiskSummary> {
+    logger.info({ crn }, 'getting risk summary information')
+    return (await this.restClient.get({
+      path: `/risks/crn/${crn}/summary`,
+      token,
+    })) as RiskSummary
+  }
 }

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -2,6 +2,8 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -19,6 +21,12 @@
       {% endif %}
 
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      <p class="govuk-body">This shows the current ROSH levels and risk to self information from OASys. You can add information for the service provider.</p>
+
+      <h2 class="govuk-heading-l">ROSH analysis</h2>
+
+      {{ govukTable(roshAnalysisTableArgs(govukTag)) }}
 
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -27,6 +28,8 @@
       <h2 class="govuk-heading-l">ROSH analysis</h2>
 
       {{ govukTable(roshAnalysisTableArgs(govukTag)) }}
+
+      {{ govukDetails(riskLevelDetailsArgs) }}
 
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -23,13 +23,17 @@
 
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
 
-      <p class="govuk-body">This shows the current ROSH levels and risk to self information from OASys. You can add information for the service provider.</p>
+      {% if presenter.riskSummaryEnabled %}
 
-      <h2 class="govuk-heading-l">ROSH analysis</h2>
+        <p class="govuk-body">This shows the current ROSH levels and risk to self information from OASys. You can add information for the service provider.</p>
 
-      {{ govukTable(roshAnalysisTableArgs(govukTag)) }}
+        <h2 class="govuk-heading-l">ROSH analysis</h2>
 
-      {{ govukDetails(riskLevelDetailsArgs) }}
+        {{ govukTable(roshAnalysisTableArgs(govukTag)) }}
+
+        {{ govukDetails(riskLevelDetailsArgs) }}
+
+      {% endif %}
 
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">

--- a/testutils/factories/riskSummary.ts
+++ b/testutils/factories/riskSummary.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery'
+import RiskSummary from '../../server/models/assessRisksAndNeeds/riskSummary'
+
+export default Factory.define<RiskSummary>(() => ({
+  riskInCommunity: {
+    LOW: ['prisoners'],
+    HIGH: ['children', 'known adult'],
+  },
+}))


### PR DESCRIPTION
## What does this pull request do?

This is the first part of this ticket which shows the 'ROSH analysis' table to the PP in the risk information part of the referral form.

![Screenshot 2021-06-21 at 13 38 21](https://user-images.githubusercontent.com/63233073/122763225-ff4b0a00-d295-11eb-9611-2ad9562976a2.png)

![Screenshot 2021-06-21 at 13 38 29](https://user-images.githubusercontent.com/63233073/122763233-007c3700-d296-11eb-8708-57d4458eb87b.png)

## What is the intent behind these changes?

show PP's the risk info from ARN.
