### PR TITLE
IC-1902 & IC-1596: Fetch SU address from Community API and display throughout the service

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -4,6 +4,7 @@ import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUse
 import actionPlanFactory from '../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../testutils/factories/actionPlanAppointment'
 import interventionFactory from '../../testutils/factories/intervention'
+import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
 
 describe('Probation Practitioner monitor journey', () => {
   beforeEach(() => {
@@ -21,6 +22,7 @@ describe('Probation Practitioner monitor journey', () => {
         referral: { interventionId: intervention.id },
       }
       const deliusServiceUser = deliusServiceUserFactory.build()
+      const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build
       const probationPractitioner = deliusUserFactory.build({
         firstName: 'John',
         surname: 'Smith',
@@ -64,6 +66,7 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+      cy.stubGetExpandedServiceUserByCRN(assignedReferral.referral.serviceUser.crn, expandedDeliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
 
       cy.stubGetActionPlanAppointments(actionPlan.id, appointments)

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -6,6 +6,7 @@ import interventionFactory from '../../testutils/factories/intervention'
 import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
+import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
 
 describe('Probation practitioner referrals dashboard', () => {
   beforeEach(() => {
@@ -242,9 +243,37 @@ describe('Probation practitioner referrals dashboard', () => {
       },
     })
 
+    const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({
+      ...deliusServiceUser,
+      contactDetails: {
+        emailAddresses: ['jenny.jones@example.com'],
+        phoneNumbers: [
+          {
+            number: '07123456789',
+            type: 'MOBILE',
+          },
+        ],
+        addresses: [
+          {
+            addressNumber: 'Flat 2',
+            buildingName: null,
+            streetName: 'Test Walk',
+            postcode: 'SW16 1AQ',
+            town: 'London',
+            district: 'City of London',
+            county: 'Greater London',
+            from: '2019-01-01',
+            to: null,
+            noFixedAbode: false,
+          },
+        ],
+      },
+    })
+
     cy.stubGetSentReferral(referral.id, referral)
     cy.stubGetIntervention(personalWellbeingIntervention.id, personalWellbeingIntervention)
     cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetExpandedServiceUserByCRN(referral.referral.serviceUser.crn, expandedDeliusServiceUser)
     cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
@@ -257,6 +286,12 @@ describe('Probation practitioner referrals dashboard', () => {
 
     cy.contains('07123456789')
     cy.contains('jenny.jones@example.com')
+    cy.contains('Flat 2')
+    cy.contains('Test Walk')
+    cy.contains('London')
+    cy.contains('City of London')
+    cy.contains('Greater London')
+    cy.contains('SW16 1AQ')
 
     cy.contains('Intervention details')
     cy.contains('Personal wellbeing')

--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -7,6 +7,7 @@ import interventionFactory from '../../testutils/factories/intervention'
 // eslint-disable-next-line import/no-named-as-default,import/no-named-as-default-member
 import ReferralSectionVerifier from './make_a_referral/referralSectionVerifier'
 import riskSummaryFactory from '../../testutils/factories/riskSummary'
+import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
 
 describe('Referral form', () => {
   const deliusServiceUser = deliusServiceUserFactory.build({
@@ -168,6 +169,28 @@ describe('Referral form', () => {
         })
         .checkYourAnswers({ checkAnswers: false })
 
+      const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({
+        ...deliusServiceUser,
+        contactDetails: {
+          addresses: [
+            {
+              addressNumber: 'Flat 2',
+              buildingName: null,
+              streetName: 'Test Walk',
+              postcode: 'SW16 1AQ',
+              town: 'London',
+              district: 'City of London',
+              county: 'Greater London',
+              from: '2019-01-01',
+              to: null,
+              noFixedAbode: false,
+            },
+          ],
+        },
+      })
+
+      cy.stubGetExpandedServiceUserByCRN('X123456', expandedDeliusServiceUser)
+
       cy.contains('Confirm service user’s personal details').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/service-user-details`)
@@ -176,6 +199,11 @@ describe('Referral form', () => {
       cy.contains('Mr')
       cy.contains('River')
       cy.contains('1 January 1980')
+      cy.contains('Flat 2 Test Walk')
+      cy.contains('London')
+      cy.contains('City of London')
+      cy.contains('Greater London')
+      cy.contains('SW16 1AQ')
       cy.contains('Male')
       cy.contains('British')
       cy.contains('English')
@@ -314,6 +342,11 @@ describe('Referral form', () => {
       cy.contains('Mr')
       cy.contains('River')
       cy.contains('1 January 1980')
+      cy.contains('Flat 2 Test Walk')
+      cy.contains('London')
+      cy.contains('City of London')
+      cy.contains('Greater London')
+      cy.contains('SW16 1AQ')
       cy.contains('Male')
       cy.contains('British')
       cy.contains('English')
@@ -471,6 +504,28 @@ describe('Referral form', () => {
         .disabledCohortInterventionReferralDetails()
         .checkYourAnswers({ checkAnswers: false })
 
+      const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({
+        ...deliusServiceUser,
+        contactDetails: {
+          addresses: [
+            {
+              addressNumber: 'Flat 2',
+              buildingName: null,
+              streetName: 'Test Walk',
+              postcode: 'SW16 1AQ',
+              town: 'London',
+              district: 'City of London',
+              county: 'Greater London',
+              from: '2019-01-01',
+              to: null,
+              noFixedAbode: false,
+            },
+          ],
+        },
+      })
+
+      cy.stubGetExpandedServiceUserByCRN('X123456', expandedDeliusServiceUser)
+
       cy.contains('Confirm service user’s personal details').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/service-user-details`)
@@ -479,6 +534,11 @@ describe('Referral form', () => {
       cy.contains('Mr')
       cy.contains('River')
       cy.contains('1 January 1980')
+      cy.contains('Flat 2 Test Walk')
+      cy.contains('London')
+      cy.contains('City of London')
+      cy.contains('Greater London')
+      cy.contains('SW16 1AQ')
       cy.contains('Male')
       cy.contains('British')
       cy.contains('English')

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -9,6 +9,7 @@ import endOfServiceReportFactory from '../../testutils/factories/endOfServiceRep
 import interventionFactory from '../../testutils/factories/intervention'
 import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
+import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
 
 describe('Service provider referrals dashboard', () => {
   beforeEach(() => {
@@ -114,6 +115,37 @@ describe('Service provider referrals dashboard', () => {
       },
     })
 
+    const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({
+      ...deliusServiceUser,
+      contactDetails: {
+        emailAddresses: ['jenny.jones@example.com', 'JJ@example.com'],
+        phoneNumbers: [
+          {
+            number: '07123456789',
+            type: 'MOBILE',
+          },
+          {
+            number: '0798765432',
+            type: 'MOBILE',
+          },
+        ],
+        addresses: [
+          {
+            addressNumber: 'Flat 2',
+            buildingName: null,
+            streetName: 'Test Walk',
+            postcode: 'SW16 1AQ',
+            town: 'London',
+            district: 'City of London',
+            county: 'Greater London',
+            from: '2019-01-01',
+            to: null,
+            noFixedAbode: false,
+          },
+        ],
+      },
+    })
+
     const referralToSelect = sentReferrals[1]
 
     const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
@@ -126,6 +158,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetSentReferralsForUserToken(sentReferrals)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetServiceUserByCRN(referralToSelect.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetExpandedServiceUserByCRN(referralToSelect.referral.serviceUser.crn, expandedDeliusServiceUser)
     cy.stubGetConvictionById(referralToSelect.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetSupplementaryRiskInformation(referralToSelect.supplementaryRiskId, supplementaryRiskInformation)
 
@@ -191,6 +224,11 @@ describe('Service provider referrals dashboard', () => {
       .next()
       .contains('jenny.jones@example.com')
     cy.contains("Service user's personal details").next().contains('Phone number').next().contains('07123456789')
+    cy.contains('Flat 2 Test Walk')
+    cy.contains('London')
+    cy.contains('City of London')
+    cy.contains('Greater London')
+    cy.contains('SW16 1AQ')
     cy.contains("Service user's risk information")
     cy.contains('They are low risk.')
     cy.contains("Service user's needs")
@@ -217,6 +255,7 @@ describe('Service provider referrals dashboard', () => {
     const referral = sentReferralFactory.build(referralParams)
     const deliusUser = deliusUserFactory.build()
     const deliusServiceUser = deliusServiceUserFactory.build()
+    const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({ ...deliusServiceUser })
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
     const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
 
@@ -225,6 +264,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetSentReferralsForUserToken([referral])
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetExpandedServiceUserByCRN(referral.referral.serviceUser.crn, expandedDeliusServiceUser)
     cy.stubGetAuthUserByEmailAddress([hmppsAuthUser])
     cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
     cy.stubAssignSentReferral(referral.id, referral)

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -39,6 +39,10 @@ module.exports = on => {
       return communityApi.stubGetServiceUserByCRN(arg.crn, arg.responseJson)
     },
 
+    stubGetExpandedServiceUserByCRN: arg => {
+      return communityApi.stubGetExpandedServiceUserByCRN(arg.crn, arg.responseJson)
+    },
+
     stubGetUserByUsername: arg => {
       return communityApi.stubGetUserByUsername(arg.username, arg.responseJson)
     },

--- a/integration_tests/support/communityApiStubs.js
+++ b/integration_tests/support/communityApiStubs.js
@@ -2,6 +2,10 @@ Cypress.Commands.add('stubGetServiceUserByCRN', (crn, responseJson) => {
   cy.task('stubGetServiceUserByCRN', { crn, responseJson })
 })
 
+Cypress.Commands.add('stubGetExpandedServiceUserByCRN', (crn, responseJson) => {
+  cy.task('stubGetExpandedServiceUserByCRN', { crn, responseJson })
+})
+
 Cypress.Commands.add('stubGetUserByUsername', (username, responseJson) => {
   cy.task('stubGetUserByUsername', { username, responseJson })
 })

--- a/mockApis/communityApi.ts
+++ b/mockApis/communityApi.ts
@@ -19,6 +19,22 @@ export default class CommunityApiMocks {
     })
   }
 
+  stubGetExpandedServiceUserByCRN = async (crn: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/community-api/secure/offenders/crn/${crn}/all`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
   stubGetUserByUsername = async (username: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/decorators/expandedDeliusServiceUserDecorator.test.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.test.ts
@@ -1,0 +1,292 @@
+import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
+import ExpandedDeliusServiceUserDecorator from './expandedDeliusServiceUserDecorator'
+
+describe(ExpandedDeliusServiceUserDecorator, () => {
+  describe('address', () => {
+    describe('selecting the current address', () => {
+      describe('when there is only one address returned from nDelius', () => {
+        it('uses that address as the current address', () => {
+          const serviceUser = new ExpandedDeliusServiceUserDecorator(
+            expandedDeliusServiceUserFactory.build({
+              contactDetails: {
+                addresses: [
+                  {
+                    addressNumber: 'Flat 2',
+                    buildingName: null,
+                    streetName: 'Test Walk',
+                    postcode: 'SW16 1AQ',
+                    town: 'London',
+                    district: 'City of London',
+                    county: 'Greater London',
+                    from: '2019-01-01',
+                    to: null,
+                    noFixedAbode: false,
+                  },
+                ],
+              },
+            })
+          )
+
+          expect(serviceUser.address).toEqual([
+            'Flat 2 Test Walk',
+            'London',
+            'City of London',
+            'Greater London',
+            'SW16 1AQ',
+          ])
+        })
+      })
+
+      describe('when there are multiple addresses returned from nDelius', () => {
+        describe('when all addresses have a non-null "from" field', () => {
+          it('uses the address with the most recent "from" date', () => {
+            const oldAddress = {
+              addressNumber: 'Flat 2',
+              buildingName: null,
+              streetName: 'Test Walk',
+              postcode: 'SW16 1AQ',
+              town: 'London',
+              district: 'City of London',
+              county: 'Greater London',
+              from: '2019-01-01',
+              to: null,
+              noFixedAbode: false,
+            }
+
+            const newAddress = {
+              addressNumber: 'Flat 10',
+              buildingName: null,
+              streetName: 'Test Walk',
+              postcode: 'SW16 1AQ',
+              town: 'London',
+              district: 'City of London',
+              county: 'Greater London',
+              from: '2021-01-01',
+              to: null,
+              noFixedAbode: false,
+            }
+
+            const serviceUser = new ExpandedDeliusServiceUserDecorator(
+              expandedDeliusServiceUserFactory.build({
+                contactDetails: {
+                  addresses: [oldAddress, newAddress],
+                },
+              })
+            )
+
+            expect(serviceUser.address).toEqual([
+              'Flat 10 Test Walk',
+              'London',
+              'City of London',
+              'Greater London',
+              'SW16 1AQ',
+            ])
+          })
+        })
+
+        describe('when one address has a null "from" field', () => {
+          it('returns the address with the most recent "from" field, ignoring the null value', () => {
+            const oldAddress = {
+              addressNumber: 'Flat 10',
+              buildingName: null,
+              streetName: 'Test Walk',
+              postcode: 'SW16 1AQ',
+              town: 'London',
+              district: 'City of London',
+              county: 'Greater London',
+              from: '2020-01-01',
+              to: null,
+              noFixedAbode: false,
+            }
+            const newAddress = {
+              addressNumber: 'Flat 10',
+              buildingName: null,
+              streetName: 'Test Walk',
+              postcode: 'SW16 1AQ',
+              town: 'London',
+              district: 'City of London',
+              county: 'Greater London',
+              from: '2021-01-01',
+              to: null,
+              noFixedAbode: false,
+            }
+            const addressWithNullFromValue = {
+              addressNumber: 'Flat 10',
+              buildingName: null,
+              streetName: 'Test Walk',
+              postcode: 'SW16 1AQ',
+              town: 'London',
+              district: 'City of London',
+              county: 'Greater London',
+              from: null,
+              to: null,
+              noFixedAbode: false,
+            }
+
+            const serviceUser = new ExpandedDeliusServiceUserDecorator(
+              expandedDeliusServiceUserFactory.build({
+                contactDetails: {
+                  addresses: [oldAddress, newAddress, addressWithNullFromValue],
+                },
+              })
+            )
+
+            expect(serviceUser.address).toEqual([
+              'Flat 10 Test Walk',
+              'London',
+              'City of London',
+              'Greater London',
+              'SW16 1AQ',
+            ])
+          })
+        })
+
+        describe('when all addresses have a null or undefined "from" field', () => {
+          it('returns "null" as we are unable to determine the most recent', () => {
+            const firstAddressNullFromDate = {
+              addressNumber: 'Flat 10',
+              buildingName: null,
+              streetName: 'Test Walk',
+              postcode: 'SW16 1AQ',
+              town: 'London',
+              district: 'City of London',
+              county: 'Greater London',
+              from: null,
+              to: null,
+              noFixedAbode: false,
+            }
+            const secondAddressUndefinedFromDate = {
+              addressNumber: 'Flat 10',
+              buildingName: null,
+              streetName: 'Test Walk',
+              postcode: 'SW16 1AQ',
+              town: 'London',
+              district: 'City of London',
+              county: 'Greater London',
+              to: null,
+              noFixedAbode: false,
+            }
+
+            const serviceUser = new ExpandedDeliusServiceUserDecorator(
+              expandedDeliusServiceUserFactory.build({
+                contactDetails: {
+                  addresses: [firstAddressNullFromDate, secondAddressUndefinedFromDate],
+                },
+              })
+            )
+
+            expect(serviceUser.address).toBeNull()
+          })
+        })
+      })
+
+      describe('when there is no address returned from nDelius', () => {
+        it('returns null', () => {
+          const serviceUser = new ExpandedDeliusServiceUserDecorator(
+            expandedDeliusServiceUserFactory.build({
+              contactDetails: {
+                addresses: [],
+              },
+            })
+          )
+
+          expect(serviceUser.address).toBeNull()
+        })
+      })
+    })
+    describe('formatting', () => {
+      describe('when there is an address number but no building name', () => {
+        it('returns an array of the address fields with address number prefixed to street name', () => {
+          const serviceUser = expandedDeliusServiceUserFactory.build({
+            contactDetails: {
+              addresses: [
+                {
+                  addressNumber: 'Flat 2',
+                  buildingName: null,
+                  streetName: 'Test Walk',
+                  postcode: 'SW16 1AQ',
+                  town: 'London',
+                  district: 'City of London',
+                  county: 'Greater London',
+                  from: '2019-01-01',
+                  to: null,
+                  noFixedAbode: false,
+                },
+              ],
+            },
+          })
+
+          expect(new ExpandedDeliusServiceUserDecorator(serviceUser).address).toEqual([
+            'Flat 2 Test Walk',
+            'London',
+            'City of London',
+            'Greater London',
+            'SW16 1AQ',
+          ])
+        })
+      })
+
+      describe('when there is a building name but no address number', () => {
+        it('returns an array of the address fields with building name prefixed to street name', () => {
+          const serviceUser = expandedDeliusServiceUserFactory.build({
+            contactDetails: {
+              addresses: [
+                {
+                  addressNumber: null,
+                  buildingName: 'Classic House',
+                  streetName: 'Test Walk',
+                  postcode: 'SW16 1AQ',
+                  town: 'London',
+                  district: 'City of London',
+                  county: 'Greater London',
+                  from: '2019-01-01',
+                  to: null,
+                  noFixedAbode: false,
+                },
+              ],
+            },
+          })
+
+          expect(new ExpandedDeliusServiceUserDecorator(serviceUser).address).toEqual([
+            'Classic House, Test Walk',
+            'London',
+            'City of London',
+            'Greater London',
+            'SW16 1AQ',
+          ])
+        })
+      })
+
+      describe('when there is both an address number and building name', () => {
+        it('returns an array of the address fields with address and building name prefixed to street name', () => {
+          const serviceUser = expandedDeliusServiceUserFactory.build({
+            contactDetails: {
+              addresses: [
+                {
+                  addressNumber: '4',
+                  buildingName: 'Classic House',
+                  streetName: 'Test Walk',
+                  postcode: 'SW16 1AQ',
+                  town: 'London',
+                  district: 'City of London',
+                  county: 'Greater London',
+                  from: '2019-01-01',
+                  to: null,
+                  noFixedAbode: false,
+                },
+              ],
+            },
+          })
+
+          expect(new ExpandedDeliusServiceUserDecorator(serviceUser).address).toEqual([
+            '4 Classic House, Test Walk',
+            'London',
+            'City of London',
+            'Greater London',
+            'SW16 1AQ',
+          ])
+        })
+      })
+    })
+  })
+})

--- a/server/decorators/expandedDeliusServiceUserDecorator.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.ts
@@ -1,0 +1,45 @@
+import logger from '../../log'
+import { Address, ExpandedDeliusServiceUser } from '../models/delius/deliusServiceUser'
+
+export default class ExpandedDeliusServiceUserDecorator {
+  constructor(private readonly deliusServiceUser: ExpandedDeliusServiceUser) {}
+
+  get address(): string[] | null {
+    const { addresses } = this.deliusServiceUser.contactDetails
+
+    if (!addresses) {
+      return null
+    }
+
+    if (addresses.length === 1) {
+      return this.deliusAddressToArray(addresses[0])
+    }
+
+    // If we have no "from" date, how do we know which is the most recent?
+    if (addresses.every(address => address.from === null || address.from === undefined)) {
+      logger.error({ err: `No 'from' value in addresses for user ${this.deliusServiceUser.otherIds.crn}.` })
+      return null
+    }
+
+    const mostRecentAddress = addresses.sort((a, b) => new Date(b.from!).getTime() - new Date(a.from!).getTime())[0]
+
+    return this.deliusAddressToArray(mostRecentAddress)
+  }
+
+  private deliusAddressToArray(address: Address): string[] {
+    // required to force removal of null from (string | null)[] and stop compiler complaining
+    // taken from https://stackoverflow.com/questions/43118692/typescript-filter-out-nulls-from-an-array
+    function notEmpty(value: string | null | undefined): value is string {
+      return value !== null && value !== undefined
+    }
+
+    const numberAndOrBuildingName =
+      address.addressNumber && address.buildingName
+        ? `${address.addressNumber} ${address.buildingName},`
+        : (address.addressNumber || `${address.buildingName},`) ?? ''
+
+    const firstLine = `${numberAndOrBuildingName} ${address.streetName}`.trim()
+
+    return [firstLine, address.town, address.district, address.county, address.postcode].filter(notEmpty)
+  }
+}

--- a/server/models/delius/deliusServiceUser.ts
+++ b/server/models/delius/deliusServiceUser.ts
@@ -11,9 +11,26 @@ interface OffenderLanguages {
   primaryLanguage: string
 }
 
+interface Address {
+  addressNumber?: string | null
+  buildingName?: string | null
+  streetName?: string | null
+  postcode?: string | null
+  town?: string | null
+  district?: string | null
+  county?: string | null
+  from?: string | null
+  to?: string | null
+  noFixedAbode?: boolean | null
+}
+
 interface ContactDetails {
   emailAddresses?: string[] | null
   phoneNumbers?: PhoneNumber[] | null
+}
+
+interface ExpandedContactDetails extends ContactDetails {
+  addresses: Address[] | null
 }
 
 interface PhoneNumber {
@@ -42,4 +59,8 @@ export default interface DeliusServiceUser {
   dateOfBirth: string | null
   gender: string | null
   contactDetails: ContactDetails
+}
+
+export interface ExpandedDeliusServiceUser extends DeliusServiceUser {
+  contactDetails: ExpandedContactDetails
 }

--- a/server/models/delius/deliusServiceUser.ts
+++ b/server/models/delius/deliusServiceUser.ts
@@ -11,7 +11,7 @@ interface OffenderLanguages {
   primaryLanguage: string
 }
 
-interface Address {
+export interface Address {
   addressNumber?: string | null
   buildingName?: string | null
   streetName?: string | null

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -22,6 +22,7 @@ import deliusConvictionFactory from '../../../testutils/factories/deliusConvicti
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 import MockAssessRisksAndNeedsService from '../testutils/mocks/mockAssessRisksAndNeedsService'
 import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
+import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -312,7 +313,7 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
       surname: 'Beaks',
       email: 'bernard.beaks@justice.gov.uk',
     })
-    const deliusServiceUser = deliusServiceUserFactory.build({
+    const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({
       firstName: 'Alex',
       surname: 'River',
       contactDetails: {
@@ -323,6 +324,20 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
             type: 'MOBILE',
           },
         ],
+        addresses: [
+          {
+            addressNumber: 'Flat 10',
+            buildingName: null,
+            streetName: 'Test Walk',
+            postcode: 'SW16 1AQ',
+            town: 'London',
+            district: 'City of London',
+            county: 'Greater London',
+            from: '2021-01-01',
+            to: null,
+            noFixedAbode: false,
+          },
+        ],
       },
     })
     const conviction = deliusConvictionFactory.build()
@@ -330,7 +345,7 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
     interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
-    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+    communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(expandedDeliusServiceUser)
     communityApiService.getConvictionById.mockResolvedValue(conviction)
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
 
@@ -354,14 +369,14 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
       const sentReferral = sentReferralFactory.assigned().build()
       const deliusUser = deliusUserFactory.build()
       const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const deliusServiceUser = deliusServiceUserFactory.build()
+      const deliusServiceUser = expandedDeliusServiceUserFactory.build()
       const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
       const conviction = deliusConvictionFactory.build()
 
       interventionsService.getIntervention.mockResolvedValue(intervention)
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
       communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+      communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(deliusServiceUser)
       hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
       communityApiService.getConvictionById.mockResolvedValue(conviction)
       assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -102,13 +102,13 @@ export default class ProbationPractitionerReferralsController {
       res.locals.user.token.accessToken,
       req.params.id
     )
-    const [intervention, sentBy, serviceUser, conviction, riskInformation] = await Promise.all([
+    const [intervention, sentBy, expandedServiceUser, conviction, riskInformation] = await Promise.all([
       this.interventionsService.getIntervention(
         res.locals.user.token.accessToken,
         sentReferral.referral.interventionId
       ),
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
-      this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
+      this.communityApiService.getExpandedServiceUserByCRN(sentReferral.referral.serviceUser.crn),
       this.communityApiService.getConvictionById(
         sentReferral.referral.serviceUser.crn,
         sentReferral.referral.relevantSentenceId
@@ -134,10 +134,10 @@ export default class ProbationPractitionerReferralsController {
       null,
       'probation-practitioner',
       false,
-      serviceUser
+      expandedServiceUser
     )
     const view = new ShowReferralView(presenter)
-    ControllerUtils.renderWithLayout(res, view, serviceUser)
+    ControllerUtils.renderWithLayout(res, view, expandedServiceUser)
   }
 
   async viewSubmittedPostSessionFeedback(req: Request, res: Response): Promise<void> {

--- a/server/routes/referrals/checkAnswersPresenter.test.ts
+++ b/server/routes/referrals/checkAnswersPresenter.test.ts
@@ -6,7 +6,7 @@ import deliusConvictionFactory from '../../../testutils/factories/deliusConvicti
 import deliusOffenceFactory from '../../../testutils/factories/deliusOffence'
 import deliusSentenceFactory from '../../../testutils/factories/deliusSentence'
 import { ListStyle } from '../../utils/summaryList'
-import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
 
 describe(CheckAnswersPresenter, () => {
   const parameterisedDraftReferralFactory = draftReferralFactory.params({
@@ -23,13 +23,27 @@ describe(CheckAnswersPresenter, () => {
       disabilities: ['Autism spectrum condition', 'sciatica'],
     },
   })
-  const deliusServiceUser = deliusServiceUserFactory.build({
+  const deliusServiceUser = expandedDeliusServiceUserFactory.build({
     contactDetails: {
       emailAddresses: ['alex.river@example.com'],
       phoneNumbers: [
         {
           number: '0123456789',
           type: 'MOBILE',
+        },
+      ],
+      addresses: [
+        {
+          addressNumber: 'Flat 10',
+          buildingName: null,
+          streetName: 'Test Walk',
+          postcode: 'SW16 1AQ',
+          town: 'London',
+          district: 'City of London',
+          county: 'Greater London',
+          from: '2021-01-01',
+          to: null,
+          noFixedAbode: false,
         },
       ],
     },
@@ -60,6 +74,11 @@ describe(CheckAnswersPresenter, () => {
           { key: 'First name', lines: ['Alex'] },
           { key: 'Last name', lines: ['River'] },
           { key: 'Date of birth', lines: ['1 January 1980'] },
+          {
+            key: 'Address',
+            lines: ['Flat 10 Test Walk', 'London', 'City of London', 'Greater London', 'SW16 1AQ'],
+            listStyle: ListStyle.noMarkers,
+          },
           { key: 'Gender', lines: ['Male'] },
           { key: 'Ethnicity', lines: ['British'] },
           { key: 'Preferred language', lines: ['English'] },

--- a/server/routes/referrals/checkAnswersPresenter.ts
+++ b/server/routes/referrals/checkAnswersPresenter.ts
@@ -11,14 +11,14 @@ import InterventionDecorator from '../../decorators/interventionDecorator'
 import DeliusConviction from '../../models/delius/deliusConviction'
 import SentencePresenter from './sentencePresenter'
 import PresenterUtils from '../../utils/presenterUtils'
-import DeliusServiceUser from '../../models/delius/deliusServiceUser'
+import { ExpandedDeliusServiceUser } from '../../models/delius/deliusServiceUser'
 
 export default class CheckAnswersPresenter {
   constructor(
     private readonly referral: DraftReferral,
     private readonly intervention: Intervention,
     private readonly conviction: DeliusConviction,
-    private readonly deliusServiceUser: DeliusServiceUser
+    private readonly deliusServiceUser: ExpandedDeliusServiceUser
   ) {}
 
   get serviceUserDetailsSection(): { title: string; summary: SummaryListItem[] } {

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -16,6 +16,7 @@ import interventionFactory from '../../../testutils/factories/intervention'
 import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
 import MockAssessRisksAndNeedsService from '../testutils/mocks/mockAssessRisksAndNeedsService'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
+import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -261,7 +262,7 @@ describe('GET /referrals/:id/service-user-details', () => {
   beforeEach(() => {
     const serviceCategory = serviceCategoryFactory.build()
     const referral = draftReferralFactory.serviceUserSelected().build({ id: '1' })
-    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser.build())
+    communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(expandedDeliusServiceUserFactory.build())
     interventionsService.getDraftReferral.mockResolvedValue(referral)
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
   })
@@ -1294,7 +1295,7 @@ describe('GET /referrals/:id/check-answers', () => {
 
     interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getDraftReferral.mockResolvedValue(referral)
-    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser.build())
+    communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(expandedDeliusServiceUserFactory.build())
     communityApiService.getConvictionById.mockResolvedValue(conviction)
   })
 

--- a/server/routes/referrals/referralsController.ts
+++ b/server/routes/referrals/referralsController.ts
@@ -128,7 +128,7 @@ export default class ReferralsController {
 
   async viewServiceUserDetails(req: Request, res: Response): Promise<void> {
     const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
-    const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn)
+    const serviceUser = await this.communityApiService.getExpandedServiceUserByCRN(referral.serviceUser.crn)
 
     const presenter = new ServiceUserDetailsPresenter(referral.serviceUser, serviceUser)
     const view = new ServiceUserDetailsView(presenter)
@@ -583,16 +583,16 @@ export default class ReferralsController {
       throw new Error('Attempting to check answers without relevant sentence selected')
     }
 
-    const [intervention, serviceUser, conviction] = await Promise.all([
+    const [intervention, expandedDeliusServiceUser, conviction] = await Promise.all([
       this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
-      this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
+      this.communityApiService.getExpandedServiceUserByCRN(referral.serviceUser.crn),
       this.communityApiService.getConvictionById(referral.serviceUser.crn, referral.relevantSentenceId),
     ])
 
-    const presenter = new CheckAnswersPresenter(referral, intervention, conviction, serviceUser)
+    const presenter = new CheckAnswersPresenter(referral, intervention, conviction, expandedDeliusServiceUser)
     const view = new CheckAnswersView(presenter)
 
-    ControllerUtils.renderWithLayout(res, view, serviceUser)
+    ControllerUtils.renderWithLayout(res, view, expandedDeliusServiceUser)
   }
 
   async sendDraftReferral(req: Request, res: Response): Promise<void> {

--- a/server/routes/referrals/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.test.ts
@@ -1,6 +1,6 @@
 import { ListStyle } from '../../utils/summaryList'
 import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
-import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
 
 describe(ServiceUserDetailsPresenter, () => {
   const serviceUser = {
@@ -29,9 +29,26 @@ describe(ServiceUserDetailsPresenter, () => {
     disabilities: null,
   }
 
-  const deliusServiceUser = deliusServiceUserFactory.build()
-  const nullFieldsDeliusServiceUser = deliusServiceUserFactory.build({
-    contactDetails: { emailAddresses: null, phoneNumbers: null },
+  const deliusServiceUser = expandedDeliusServiceUserFactory.build({
+    contactDetails: {
+      addresses: [
+        {
+          addressNumber: 'Flat 10',
+          buildingName: null,
+          streetName: 'Test Walk',
+          postcode: 'SW16 1AQ',
+          town: 'London',
+          district: 'City of London',
+          county: 'Greater London',
+          from: '2021-01-01',
+          to: null,
+          noFixedAbode: false,
+        },
+      ],
+    },
+  })
+  const nullFieldsDeliusServiceUser = expandedDeliusServiceUserFactory.build({
+    contactDetails: { emailAddresses: null, phoneNumbers: null, addresses: null },
   })
 
   describe('title', () => {
@@ -58,6 +75,11 @@ describe(ServiceUserDetailsPresenter, () => {
         { key: 'First name', lines: ['Alex'] },
         { key: 'Last name', lines: ['River'] },
         { key: 'Date of birth', lines: ['1 January 1980'] },
+        {
+          key: 'Address',
+          lines: ['Flat 10 Test Walk', 'London', 'City of London', 'Greater London', 'SW16 1AQ'],
+          listStyle: ListStyle.noMarkers,
+        },
         { key: 'Gender', lines: ['Male'] },
         { key: 'Ethnicity', lines: ['British'] },
         { key: 'Preferred language', lines: ['English'] },
@@ -77,6 +99,11 @@ describe(ServiceUserDetailsPresenter, () => {
         { key: 'First name', lines: [''] },
         { key: 'Last name', lines: [''] },
         { key: 'Date of birth', lines: [''] },
+        {
+          key: 'Address',
+          lines: ['Not found'],
+          listStyle: ListStyle.noMarkers,
+        },
         { key: 'Gender', lines: [''] },
         { key: 'Ethnicity', lines: [''] },
         { key: 'Preferred language', lines: [''] },
@@ -89,7 +116,7 @@ describe(ServiceUserDetailsPresenter, () => {
 
     describe('phone number validation', () => {
       it('returns an empty values for phone number when number is null', () => {
-        const nullNumberDeliusServiceUser = deliusServiceUserFactory.build({
+        const nullNumberDeliusServiceUser = expandedDeliusServiceUserFactory.build({
           contactDetails: { emailAddresses: null, phoneNumbers: [{ number: null, type: null }] },
         })
         const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser, nullNumberDeliusServiceUser)
@@ -98,7 +125,7 @@ describe(ServiceUserDetailsPresenter, () => {
       })
 
       it('returns multiple phone numbers when provided', () => {
-        const user = deliusServiceUserFactory.build({
+        const user = expandedDeliusServiceUserFactory.build({
           contactDetails: {
             phoneNumbers: [
               { number: '123456789', type: null },
@@ -116,7 +143,7 @@ describe(ServiceUserDetailsPresenter, () => {
       })
 
       it('filters non-unique phone numbers', () => {
-        const user = deliusServiceUserFactory.build({
+        const user = expandedDeliusServiceUserFactory.build({
           contactDetails: {
             phoneNumbers: [
               { number: '123456789', type: null },
@@ -136,7 +163,7 @@ describe(ServiceUserDetailsPresenter, () => {
 
     describe('email validation', () => {
       it('returns multiple emails when provided', () => {
-        const user = deliusServiceUserFactory.build({
+        const user = expandedDeliusServiceUserFactory.build({
           contactDetails: { emailAddresses: ['alex.river@example.com', 'a.r@example.com'] },
         })
         const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser, user)

--- a/server/routes/referrals/serviceUserDetailsPresenter.ts
+++ b/server/routes/referrals/serviceUserDetailsPresenter.ts
@@ -2,12 +2,13 @@ import ServiceUser from '../../models/serviceUser'
 import CalendarDay from '../../utils/calendarDay'
 import PresenterUtils from '../../utils/presenterUtils'
 import { ListStyle, SummaryListItem } from '../../utils/summaryList'
-import DeliusServiceUser from '../../models/delius/deliusServiceUser'
+import { ExpandedDeliusServiceUser } from '../../models/delius/deliusServiceUser'
+import ExpandedDeliusServiceUserDecorator from '../../decorators/expandedDeliusServiceUserDecorator'
 
 export default class ServiceUserDetailsPresenter {
   constructor(
     private readonly serviceUser: ServiceUser,
-    private readonly deliusServiceUserDetails: DeliusServiceUser
+    private readonly deliusServiceUserDetails: ExpandedDeliusServiceUser
   ) {}
 
   readonly title = `${this.serviceUser.firstName || 'Service user'}'s information`
@@ -31,12 +32,18 @@ export default class ServiceUserDetailsPresenter {
   get summary(): SummaryListItem[] {
     const emails = this.deliusServiceUserDetails.contactDetails.emailAddresses ?? []
     const phoneNumbers = this.findUniqueNumbers()
+    const { address } = new ExpandedDeliusServiceUserDecorator(this.deliusServiceUserDetails)
     const summary = [
       { key: 'CRN', lines: [this.serviceUser.crn] },
       { key: 'Title', lines: [this.serviceUser.title ?? ''] },
       { key: 'First name', lines: [this.serviceUser.firstName ?? ''] },
       { key: 'Last name', lines: [this.serviceUser.lastName ?? ''] },
       { key: 'Date of birth', lines: [this.dateOfBirth] },
+      {
+        key: 'Address',
+        lines: address || ['Not found'],
+        listStyle: ListStyle.noMarkers,
+      },
       { key: 'Gender', lines: [this.serviceUser.gender ?? ''] },
       { key: 'Ethnicity', lines: [this.serviceUser.ethnicity ?? ''] },
       { key: 'Preferred language', lines: [this.serviceUser.preferredLanguage ?? ''] },

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -20,6 +20,7 @@ import deliusConvictionFactory from '../../../testutils/factories/deliusConvicti
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 import MockAssessRisksAndNeedsService from '../testutils/mocks/mockAssessRisksAndNeedsService'
 import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
+import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -102,7 +103,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
       surname: 'Beaks',
       email: 'bernard.beaks@justice.gov.uk',
     })
-    const deliusServiceUser = deliusServiceUserFactory.build({
+    const deliusServiceUser = expandedDeliusServiceUserFactory.build({
       firstName: 'Alex',
       surname: 'River',
       contactDetails: {
@@ -113,6 +114,20 @@ describe('GET /service-provider/referrals/:id/details', () => {
             type: 'MOBILE',
           },
         ],
+        addresses: [
+          {
+            addressNumber: 'Flat 10',
+            buildingName: null,
+            streetName: 'Test Walk',
+            postcode: 'SW16 1AQ',
+            town: 'London',
+            district: 'City of London',
+            county: 'Greater London',
+            from: '2021-01-01',
+            to: null,
+            noFixedAbode: false,
+          },
+        ],
       },
     })
     const conviction = deliusConvictionFactory.build()
@@ -120,7 +135,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
     interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
-    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+    communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(deliusServiceUser)
     communityApiService.getConvictionById.mockResolvedValue(conviction)
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
 
@@ -143,7 +158,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
       const intervention = interventionFactory.build()
       const sentReferral = sentReferralFactory.assigned().build()
       const deliusUser = deliusUserFactory.build()
-      const deliusServiceUser = deliusServiceUserFactory.build()
+      const deliusServiceUser = expandedDeliusServiceUserFactory.build()
       const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
       const conviction = deliusConvictionFactory.build()
       const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
@@ -151,7 +166,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
       interventionsService.getIntervention.mockResolvedValue(intervention)
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
       communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+      communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(deliusServiceUser)
       hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
       communityApiService.getConvictionById.mockResolvedValue(conviction)
       assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -89,13 +89,13 @@ export default class ServiceProviderReferralsController {
       req.params.id
     )
 
-    const [intervention, sentBy, serviceUser, conviction, riskInformation] = await Promise.all([
+    const [intervention, sentBy, expandedServiceUser, conviction, riskInformation] = await Promise.all([
       this.interventionsService.getIntervention(
         res.locals.user.token.accessToken,
         sentReferral.referral.interventionId
       ),
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
-      this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
+      this.communityApiService.getExpandedServiceUserByCRN(sentReferral.referral.serviceUser.crn),
       this.communityApiService.getConvictionById(
         sentReferral.referral.serviceUser.crn,
         sentReferral.referral.relevantSentenceId
@@ -137,11 +137,11 @@ export default class ServiceProviderReferralsController {
       formError,
       'service-provider',
       true,
-      serviceUser
+      expandedServiceUser
     )
     const view = new ShowReferralView(presenter)
 
-    ControllerUtils.renderWithLayout(res, view, serviceUser)
+    ControllerUtils.renderWithLayout(res, view, expandedServiceUser)
   }
 
   async showInterventionProgress(req: Request, res: Response): Promise<void> {

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -7,8 +7,8 @@ import interventionFactory from '../../../testutils/factories/intervention'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import { TagArgs } from '../../utils/govukFrontendTypes'
 import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
-import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
 import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
+import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
 
 describe(ShowReferralPresenter, () => {
   const intervention = interventionFactory.build()
@@ -37,7 +37,7 @@ describe(ShowReferralPresenter, () => {
     surname: 'Beaks',
     email: 'bernard.beaks@justice.gov.uk',
   })
-  const deliusServiceUser = deliusServiceUserFactory.build()
+  const deliusServiceUser = expandedDeliusServiceUserFactory.build()
   const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
 
   const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
@@ -386,6 +386,11 @@ describe(ShowReferralPresenter, () => {
         { key: 'First name', lines: ['Jenny'] },
         { key: 'Last name', lines: ['Jones'] },
         { key: 'Date of birth', lines: ['1 January 1980'] },
+        {
+          key: 'Address',
+          lines: ['Flat 2 Test Walk', 'London', 'City of London', 'Greater London', 'SW16 1AQ'],
+          listStyle: ListStyle.noMarkers,
+        },
         { key: 'Gender', lines: ['Male'] },
         { key: 'Ethnicity', lines: ['British'] },
         { key: 'Preferred language', lines: ['English'] },

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -16,7 +16,7 @@ import logger from '../../../log'
 import DeliusConviction from '../../models/delius/deliusConviction'
 import SentencePresenter from '../referrals/sentencePresenter'
 import { SupplementaryRiskInformation } from '../../models/assessRisksAndNeeds/supplementaryRiskInformation'
-import DeliusServiceUser from '../../models/delius/deliusServiceUser'
+import { ExpandedDeliusServiceUser } from '../../models/delius/deliusServiceUser'
 
 export default class ShowReferralPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
@@ -31,7 +31,7 @@ export default class ShowReferralPresenter {
     private readonly assignEmailError: FormValidationError | null,
     subNavUrlPrefix: 'service-provider' | 'probation-practitioner',
     readonly canAssignReferral: boolean,
-    private readonly deliusServiceUser: DeliusServiceUser
+    private readonly deliusServiceUser: ExpandedDeliusServiceUser
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,

--- a/server/services/communityApiService.test.ts
+++ b/server/services/communityApiService.test.ts
@@ -6,6 +6,7 @@ import MockedHmppsAuthService from './testutils/hmppsAuthServiceSetup'
 import deliusServiceUser from '../../testutils/factories/deliusServiceUser'
 import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusConviction from '../../testutils/factories/deliusConviction'
+import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
 
 jest.mock('../data/restClient')
 
@@ -46,6 +47,26 @@ describe(CommunityApiService, () => {
 
       expect(restClientMock.get).toHaveBeenCalledWith({
         path: `/secure/offenders/crn/X123456`,
+        token: 'token',
+      })
+      expect(result).toMatchObject(serviceUser)
+    })
+  })
+
+  describe('getExpandedServiceUserByCRN', () => {
+    it('makes a request to the Community API and casts the response as an Expanded Delius Service User', async () => {
+      const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
+      const service = new CommunityApiService(hmppsAuthClientMock, restClientMock)
+      const serviceUser = expandedDeliusServiceUserFactory.build({ otherIds: { crn: 'X123456' } })
+
+      restClientMock.get.mockResolvedValue(serviceUser)
+
+      hmppsAuthClientMock.getApiClientToken.mockResolvedValue('token')
+
+      const result = await service.getExpandedServiceUserByCRN('X123456')
+
+      expect(restClientMock.get).toHaveBeenCalledWith({
+        path: `/secure/offenders/crn/X123456/all`,
         token: 'token',
       })
       expect(result).toMatchObject(serviceUser)

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -1,8 +1,9 @@
+import createError from 'http-errors'
 import type HmppsAuthService from './hmppsAuthService'
 import RestClient from '../data/restClient'
 import logger from '../../log'
 import DeliusUser from '../models/delius/deliusUser'
-import DeliusServiceUser from '../models/delius/deliusServiceUser'
+import DeliusServiceUser, { ExpandedDeliusServiceUser } from '../models/delius/deliusServiceUser'
 import DeliusConviction from '../models/delius/deliusConviction'
 
 export default class CommunityApiService {
@@ -20,6 +21,20 @@ export default class CommunityApiService {
 
     logger.info({ crn }, 'getting details for offender')
     return (await this.restClient.get({ path: `/secure/offenders/crn/${crn}`, token })) as DeliusServiceUser
+  }
+
+  async getExpandedServiceUserByCRN(crn: string): Promise<ExpandedDeliusServiceUser> {
+    const token = await this.hmppsAuthService.getApiClientToken()
+
+    logger.info({ crn }, 'getting all details for offender')
+    try {
+      return (await this.restClient.get({
+        path: `/secure/offenders/crn/${crn}/all`,
+        token,
+      })) as ExpandedDeliusServiceUser
+    } catch (err) {
+      throw createError(err.status, err, { userMessage: 'Could not retrieve service user details from nDelius.' })
+    }
   }
 
   async getActiveConvictionsByCRN(crn: string): Promise<DeliusConviction[]> {

--- a/testutils/factories/expandedDeliusServiceUser.ts
+++ b/testutils/factories/expandedDeliusServiceUser.ts
@@ -1,0 +1,53 @@
+import { Factory } from 'fishery'
+import { ExpandedDeliusServiceUser } from '../../server/models/delius/deliusServiceUser'
+
+export default Factory.define<ExpandedDeliusServiceUser>(() => ({
+  otherIds: {
+    crn: 'X123456',
+  },
+  offenderProfile: {
+    ethnicity: 'British',
+    religion: 'Agnostic',
+    disabilities: [
+      {
+        disabilityType: {
+          description: 'Autism',
+        },
+        endDate: '',
+        notes: 'Some notes',
+        startDate: '2019-01-22',
+      },
+    ],
+    offenderLanguages: {
+      primaryLanguage: 'English',
+    },
+  },
+  title: 'Mr',
+  firstName: 'Alex',
+  surname: 'River',
+  dateOfBirth: '1980-01-01',
+  gender: 'Male',
+  contactDetails: {
+    addresses: [
+      {
+        addressNumber: 'Flat 2',
+        buildingName: null,
+        streetName: 'Test Walk',
+        postcode: 'SW16 1AQ',
+        town: 'London',
+        district: 'City of London',
+        county: 'Greater London',
+        from: '2019-01-01',
+        to: null,
+        noFixedAbode: false,
+      },
+    ],
+    emailAddresses: ['alex.river@example.com'],
+    phoneNumbers: [
+      {
+        number: '0123456789',
+        type: 'MOBILE',
+      },
+    ],
+  },
+}))


### PR DESCRIPTION
## What does this pull request do?

Adds call to the community API endpoint for `/all` to fetch additional SU data, particularly the SU's address history.

We don't want to use this endpoint everywhere, as the payload might be huge, so this replaces the usual call for SU details on the pages we display the address.

## What is the intent behind these changes?

To display the SU address to PPs and SPs so they know where the referred user is located.

## Screenshots

### Refer journey: Confirm service user details
<img width="763" alt="image" src="https://user-images.githubusercontent.com/19826940/122794079-c588fc00-d2b3-11eb-9aa6-c9ff879559ba.png">

### Monitor/record journey: Show referral page
<img width="828" alt="image" src="https://user-images.githubusercontent.com/19826940/122794088-c7eb5600-d2b3-11eb-8f9e-a3bac899a5fa.png">

