### PR TITLE
IC-1829 display more information from ROSH summary endpoint

### DIFF
--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -310,6 +310,8 @@ describe('GET /referrals/:id/risk-information', () => {
       .expect(res => {
         expect(res.text).toContain('Geoffrey’s risk information')
         expect(res.text).toContain('Risk in community')
+        expect(res.text).toContain('Staff')
+        expect(res.text).toContain('VERY HIGH')
         expect(res.text).toContain('Children')
         expect(res.text).toContain('HIGH')
         expect(res.text).toContain('Prisoners')

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -16,6 +16,8 @@ describe('RiskInformationPresenter', () => {
         additionalRiskInformation: {
           errorMessage: null,
           label: 'Information for the service provider about Geoffrey’s risks',
+          hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
+          labelClasses: 'govuk-label--s',
         },
         natureOfRisk: 'physically aggressive',
         riskImminence: 'can happen at the drop of a hat',

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -17,6 +17,9 @@ describe('RiskInformationPresenter', () => {
           errorMessage: null,
           label: 'Information for the service provider about Geoffrey’s risks',
         },
+        natureOfRisk: 'physically aggressive',
+        riskImminence: 'can happen at the drop of a hat',
+        whoIsAtRisk: undefined,
       })
     })
 

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -17,18 +17,27 @@ export default class RiskInformationPresenter {
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
+  readonly riskSummaryEnabled = config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
+
   readonly text = {
     title: `${this.referral.serviceUser?.firstName}’s risk information`,
-    additionalRiskInformation: {
-      label: `Information for the service provider about ${this.referral.serviceUser?.firstName}’s risks`,
-      errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
-    },
+    additionalRiskInformation: this.riskSummaryEnabled
+      ? {
+          label: 'Additional risk information',
+          labelClasses: 'govuk-label--l',
+          hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
+          errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
+        }
+      : {
+          label: `Information for the service provider about ${this.referral.serviceUser?.firstName}’s risks`,
+          labelClasses: 'govuk-label--s',
+          hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
+          errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
+        },
     whoIsAtRisk: this.riskSummary?.whoIsAtRisk,
     natureOfRisk: this.riskSummary?.natureOfRisk,
     riskImminence: this.riskSummary?.riskImminence,
   }
-
-  readonly riskSummaryEnabled = config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
 

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -23,6 +23,9 @@ export default class RiskInformationPresenter {
       label: `Information for the service provider about ${this.referral.serviceUser?.firstName}’s risks`,
       errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
     },
+    whoIsAtRisk: this.riskSummary?.whoIsAtRisk,
+    natureOfRisk: this.riskSummary?.natureOfRisk,
+    riskImminence: this.riskSummary?.riskImminence,
   }
 
   readonly riskSummaryEnabled = config.apis.assessRisksAndNeedsApi.riskSummaryEnabled

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -32,7 +32,12 @@ export default class RiskInformationView {
       rows: this.presenter.roshAnalysisRows.map(row => {
         return [
           { text: utils.convertToProperCase(row.riskTo) },
-          { text: tagMacro({ text: row.riskScore, classes: this.tagClassForRiskScore(row.riskScore) }) },
+          {
+            text: tagMacro({
+              text: row.riskScore.replace('_', ' '),
+              classes: this.tagClassForRiskScore(row.riskScore),
+            }),
+          },
         ]
       }),
     }

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -14,11 +14,11 @@ export default class RiskInformationView {
       id: 'additional-risk-information',
       label: {
         text: this.presenter.text.additionalRiskInformation.label,
-        classes: 'govuk-label--s',
+        classes: this.presenter.text.additionalRiskInformation.labelClasses,
       },
       value: this.presenter.fields.additionalRiskInformation,
       hint: {
-        text: 'Provide relevant risk information to share with the service provider.',
+        text: this.presenter.text.additionalRiskInformation.hint,
       },
       errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.additionalRiskInformation.errorMessage),
     }

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -33,6 +33,27 @@
 
         {{ govukDetails(riskLevelDetailsArgs) }}
 
+        {% if presenter.text.whoIsAtRisk or presenter.text.natureOfRisk or presenter.text.riskImminence %}
+          <div class="govuk-inset-text">
+            The following information is not seen by the service provider:
+          </div>
+        {% endif %}
+
+        {% if presenter.text.whoIsAtRisk %}
+          <h3 class="govuk-heading-m">Who is at risk?</h3>
+          <p class="govuk-body">{{ presenter.text.whoIsAtRisk }}</p>
+        {% endif %}
+
+        {% if presenter.text.natureOfRisk %}
+          <h3 class="govuk-heading-m">What is the nature of the risk?</h3>
+          <p class="govuk-body">{{ presenter.text.natureOfRisk }}</p>
+        {% endif %}
+
+        {% if presenter.text.riskImminence %}
+          <h3 class="govuk-heading-m">When is the risk likely to be greatest?</h3>
+          <p class="govuk-body">{{ presenter.text.riskImminence }}</p>
+        {% endif %}
+
       {% endif %}
 
       <form method="post">

--- a/testutils/factories/riskSummary.ts
+++ b/testutils/factories/riskSummary.ts
@@ -6,4 +6,6 @@ export default Factory.define<RiskSummary>(() => ({
     LOW: ['prisoners'],
     HIGH: ['children', 'known adult'],
   },
+  natureOfRisk: 'physically aggressive',
+  riskImminence: 'can happen at the drop of a hat',
 }))

--- a/testutils/factories/riskSummary.ts
+++ b/testutils/factories/riskSummary.ts
@@ -5,6 +5,7 @@ export default Factory.define<RiskSummary>(() => ({
   riskInCommunity: {
     LOW: ['prisoners'],
     HIGH: ['children', 'known adult'],
+    VERY_HIGH: ['staff'],
   },
   natureOfRisk: 'physically aggressive',
   riskImminence: 'can happen at the drop of a hat',


### PR DESCRIPTION
## What does this pull request do?

shows the additional fields from the risk summary endpoint in the PP risk information page.

**there are a few small changes here so please review commit by commit to avoid confusion.**

<img width="663" alt="Screenshot 2021-06-21 at 19 50 05" src="https://user-images.githubusercontent.com/63233073/122812689-e78d7900-d2c9-11eb-891e-2f669d0996cd.png">

## What is the intent behind these changes?

continue the work on risks.
