### PR TITLE
only propagate 403 response codes if they are likely to have come from interventions-service

### DIFF
--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -10,17 +10,13 @@ export default function createErrorHandler(production: boolean) {
     }
 
     if (createError.isHttpError(err)) {
-      // authorization errors cause a special error page to be displayed
-      if (err.status === 403) {
+      // authorization errors from interventions service cause a special error page to be displayed
+      if (err.status === 403 && err.response?.body?.accessErrors) {
         res.status(403)
 
-        const args: Record<string, unknown> = { message: err.message }
-
-        // 403 responses from the interventions service contain further information in the
-        // response; if it's present, the authError template surfaces this to the end user
-        if (err.response) {
-          args.message = err.response.body?.message || args.message
-          args.accessErrors = err.response.body?.accessErrors
+        const args = {
+          message: err.response?.body?.message,
+          accessErrors: err.response?.body?.accessErrors,
         }
 
         return ControllerUtils.renderWithLayout(res, { renderArgs: ['errors/authError', args] }, null)


### PR DESCRIPTION
## What does this pull request do?

makes the error handler a bit more picky about which 403 responses it propagates in its response

## What is the intent behind these changes?

stop 403 errors from downstream services being missed by our monitoring tools
