### PR TITLE
Temporarily comment out appointment feedback service calls

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2671,6 +2671,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  /*
   describe('recordAppointmentAttendance', () => {
     it('returns an updated appointment with the service user‘s attendance', async () => {
       const appointment = appointmentFactory.build({
@@ -2817,6 +2818,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(result.sessionFeedback!.submitted).toEqual(true)
     })
   })
+  */
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -467,6 +467,7 @@ export default class InterventionsService {
     })) as Appointment
   }
 
+  /*
   async recordAppointmentAttendance(
     token: string,
     id: string,
@@ -503,4 +504,5 @@ export default class InterventionsService {
       headers: { Accept: 'application/json' },
     })) as Appointment
   }
+ */
 }


### PR DESCRIPTION
I added these prematurely alongside the service calls for scheduling
appointments. The interventions service hasn’t added this functionality
yet and we don’t want failing contract tests.

I’m commenting out instead of removing, in order to reduce diff noise.
We _will_ be adding this functionality back.
