### PR TITLE
Revert "include more ROSH risk information about the SU in the 'risk information' page"

### DIFF
--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -19,9 +19,6 @@ describe('RiskInformationPresenter', () => {
           hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
           labelClasses: 'govuk-label--s',
         },
-        natureOfRisk: 'physically aggressive',
-        riskImminence: 'can happen at the drop of a hat',
-        whoIsAtRisk: undefined,
       })
     })
 

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -34,9 +34,6 @@ export default class RiskInformationPresenter {
           hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
           errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
         },
-    whoIsAtRisk: this.riskSummary?.whoIsAtRisk,
-    natureOfRisk: this.riskSummary?.natureOfRisk,
-    riskImminence: this.riskSummary?.riskImminence,
   }
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -33,27 +33,6 @@
 
         {{ govukDetails(riskLevelDetailsArgs) }}
 
-        {% if presenter.text.whoIsAtRisk or presenter.text.natureOfRisk or presenter.text.riskImminence %}
-          <div class="govuk-inset-text">
-            The following information is not seen by the service provider:
-          </div>
-        {% endif %}
-
-        {% if presenter.text.whoIsAtRisk %}
-          <h3 class="govuk-heading-m">Who is at risk?</h3>
-          <p class="govuk-body">{{ presenter.text.whoIsAtRisk }}</p>
-        {% endif %}
-
-        {% if presenter.text.natureOfRisk %}
-          <h3 class="govuk-heading-m">What is the nature of the risk?</h3>
-          <p class="govuk-body">{{ presenter.text.natureOfRisk }}</p>
-        {% endif %}
-
-        {% if presenter.text.riskImminence %}
-          <h3 class="govuk-heading-m">When is the risk likely to be greatest?</h3>
-          <p class="govuk-body">{{ presenter.text.riskImminence }}</p>
-        {% endif %}
-
       {% endif %}
 
       <form method="post">

--- a/testutils/factories/riskSummary.ts
+++ b/testutils/factories/riskSummary.ts
@@ -7,6 +7,4 @@ export default Factory.define<RiskSummary>(() => ({
     HIGH: ['children', 'known adult'],
     VERY_HIGH: ['staff'],
   },
-  natureOfRisk: 'physically aggressive',
-  riskImminence: 'can happen at the drop of a hat',
 }))


### PR DESCRIPTION
Revert "include more ROSH risk information about the SU in the 'risk information' page"

This reverts commit ef3fd11e61111018b13caf026ca82a4f860d5489.

there is some back and forth about if this conent is going to be included for day 1. right now the concensus is "no".
