### PR TITLE
IC-1830 Show risk summary in referral details

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -73,7 +73,7 @@ export default {
         deadline: Number(get('ASSESS_RISKS_AND_NEEDS_API_TIMEOUT_DEADLINE', 20000)),
       },
       agent: new AgentConfig(),
-      riskSummaryEnabled: get('ASSESS_RISKS_AND_NEEDS_API_RISK_SUMMARY_ENABLED', false),
+      riskSummaryEnabled: get('ASSESS_RISKS_AND_NEEDS_API_RISK_SUMMARY_ENABLED', 'false') === 'true',
     },
     hmppsAuth: {
       url: get('HMPPS_AUTH_URL', 'http://hmpps-auth:8090/auth', requiredInProduction),

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,7 +12,11 @@ const communityApiRestClient = new RestClient('communityApiClient', config.apis.
 const hmppsAuthService = new HmppsAuthService()
 const communityApiService = new CommunityApiService(hmppsAuthService, communityApiRestClient)
 const interventionsService = new InterventionsService(config.apis.interventionsService)
-const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthService, assessRisksAndNeedsRestClient)
+const assessRisksAndNeedsService = new AssessRisksAndNeedsService(
+  hmppsAuthService,
+  assessRisksAndNeedsRestClient,
+  config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
+)
 
 const app = createApp(communityApiService, interventionsService, hmppsAuthService, assessRisksAndNeedsService)
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -23,6 +23,7 @@ import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsServic
 import MockAssessRisksAndNeedsService from '../testutils/mocks/mockAssessRisksAndNeedsService'
 import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
+import riskSummaryFactory from '../../../testutils/factories/riskSummary'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -348,6 +349,7 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
     communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(expandedDeliusServiceUser)
     communityApiService.getConvictionById.mockResolvedValue(conviction)
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
+    assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummaryFactory.build())
 
     await request(app)
       .get(`/probation-practitioner/referrals/${sentReferral.id}/details`)
@@ -360,6 +362,9 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
         expect(res.text).toContain('07123456789')
         expect(res.text).toContain('Alex River')
         expect(res.text).toContain('Alex is low risk to others.')
+        expect(res.text).toContain("service user's Risk of Serious Harm (ROSH) levels")
+        expect(res.text).toContain('Children')
+        expect(res.text).toContain('HIGH')
       })
   })
 
@@ -370,6 +375,7 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
       const deliusUser = deliusUserFactory.build()
       const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const deliusServiceUser = expandedDeliusServiceUserFactory.build()
+      const riskSummary = riskSummaryFactory.build()
       const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
       const conviction = deliusConvictionFactory.build()
 
@@ -380,6 +386,7 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
       hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
       communityApiService.getConvictionById.mockResolvedValue(conviction)
       assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
+      assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
 
       await request(app)
         .get(`/probation-practitioner/referrals/${sentReferral.id}/details`)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -98,22 +98,17 @@ export default class ProbationPractitionerReferralsController {
   }
 
   async showReferral(req: Request, res: Response): Promise<void> {
-    const sentReferral = await this.interventionsService.getSentReferral(
-      res.locals.user.token.accessToken,
-      req.params.id
-    )
-    const [intervention, sentBy, expandedServiceUser, conviction, riskInformation] = await Promise.all([
-      this.interventionsService.getIntervention(
-        res.locals.user.token.accessToken,
-        sentReferral.referral.interventionId
-      ),
+    const { accessToken } = res.locals.user.token
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
+
+    const { crn } = sentReferral.referral.serviceUser
+    const [intervention, sentBy, expandedServiceUser, conviction, riskInformation, riskSummary] = await Promise.all([
+      this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
-      this.communityApiService.getExpandedServiceUserByCRN(sentReferral.referral.serviceUser.crn),
-      this.communityApiService.getConvictionById(
-        sentReferral.referral.serviceUser.crn,
-        sentReferral.referral.relevantSentenceId
-      ),
+      this.communityApiService.getExpandedServiceUserByCRN(crn),
+      this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
       this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId),
+      this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
     ])
 
     const assignee =
@@ -134,7 +129,8 @@ export default class ProbationPractitionerReferralsController {
       null,
       'probation-practitioner',
       false,
-      expandedServiceUser
+      expandedServiceUser,
+      riskSummary
     )
     const view = new ShowReferralView(presenter)
     ControllerUtils.renderWithLayout(res, view, expandedServiceUser)

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -296,14 +296,6 @@ describe('GET /referrals/:id/risk-information', () => {
     interventionsService.getDraftReferral.mockResolvedValue(referral)
   })
 
-  beforeAll(() => {
-    apiConfig.apis.assessRisksAndNeedsApi.riskSummaryEnabled = true
-  })
-
-  afterAll(() => {
-    apiConfig.apis.assessRisksAndNeedsApi.riskSummaryEnabled = false
-  })
-
   it('renders a form page', async () => {
     await request(app)
       .get('/referrals/1/risk-information')

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -13,12 +13,12 @@ describe('RiskInformationPresenter', () => {
 
       expect(presenter.text).toEqual({
         title: 'Geoffrey’s risk information',
-        additionalRiskInformation: {
-          errorMessage: null,
-          label: 'Additional risk information',
-          hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
-          labelClasses: 'govuk-label--l',
-        },
+      })
+      expect(presenter.additionalRiskInformation).toEqual({
+        errorMessage: null,
+        label: 'Additional risk information',
+        hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
+        labelClasses: 'govuk-label--l',
       })
     })
 
@@ -38,10 +38,8 @@ describe('RiskInformationPresenter', () => {
           ],
         })
 
-        expect(presenter.text).toMatchObject({
-          additionalRiskInformation: {
-            errorMessage: 'additionalRiskInformation msg',
-          },
+        expect(presenter.additionalRiskInformation).toMatchObject({
+          errorMessage: 'additionalRiskInformation msg',
         })
       })
     })

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -15,9 +15,9 @@ describe('RiskInformationPresenter', () => {
         title: 'Geoffrey’s risk information',
         additionalRiskInformation: {
           errorMessage: null,
-          label: 'Information for the service provider about Geoffrey’s risks',
+          label: 'Additional risk information',
           hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
-          labelClasses: 'govuk-label--s',
+          labelClasses: 'govuk-label--l',
         },
       })
     })

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -2,7 +2,6 @@ import DraftReferral from '../../models/draftReferral'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
-import config from '../../config'
 
 export interface RoshAnalysisTableRow {
   riskTo: string
@@ -17,7 +16,7 @@ export default class RiskInformationPresenter {
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
-  readonly riskSummaryEnabled = config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
+  readonly riskSummaryEnabled = this.riskSummary !== null
 
   readonly text = {
     title: `${this.referral.serviceUser?.firstName}’s risk information`,

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -2,37 +2,22 @@ import DraftReferral from '../../models/draftReferral'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
-
-export interface RoshAnalysisTableRow {
-  riskTo: string
-  riskScore: string
-}
+import RiskPresenter from '../shared/riskPresenter'
 
 export default class RiskInformationPresenter {
+  riskPresenter: RiskPresenter
+
   constructor(
     private readonly referral: DraftReferral,
     private readonly riskSummary: RiskSummary | null,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
-  ) {}
-
-  readonly riskSummaryEnabled = this.riskSummary !== null
+  ) {
+    this.riskPresenter = new RiskPresenter(riskSummary)
+  }
 
   readonly text = {
     title: `${this.referral.serviceUser?.firstName}’s risk information`,
-    additionalRiskInformation: this.riskSummaryEnabled
-      ? {
-          label: 'Additional risk information',
-          labelClasses: 'govuk-label--l',
-          hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
-          errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
-        }
-      : {
-          label: `Information for the service provider about ${this.referral.serviceUser?.firstName}’s risks`,
-          labelClasses: 'govuk-label--s',
-          hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
-          errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
-        },
   }
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
@@ -46,17 +31,19 @@ export default class RiskInformationPresenter {
     ),
   }
 
-  get roshAnalysisHeaders(): string[] {
-    return ['Risk to', 'Risk in community']
-  }
-
-  get roshAnalysisRows(): RoshAnalysisTableRow[] {
-    if (this.riskSummary === null) return []
-
-    return Object.entries(this.riskSummary.riskInCommunity).flatMap(([riskScore, riskGroups]) => {
-      return riskGroups.map(riskTo => {
-        return { riskTo, riskScore }
-      })
-    })
+  get additionalRiskInformation(): Record<string, string | null> {
+    return this.riskPresenter.riskSummaryEnabled
+      ? {
+          label: 'Additional risk information',
+          labelClasses: 'govuk-label--l',
+          hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
+          errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
+        }
+      : {
+          label: `Information for the service provider about ${this.referral.serviceUser?.firstName}’s risks`,
+          labelClasses: 'govuk-label--s',
+          hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
+          errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
+        }
   }
 }

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -1,10 +1,12 @@
 import RiskInformationPresenter from './riskInformationPresenter'
 import ViewUtils from '../../utils/viewUtils'
-import { DetailsArgs, TableArgs, TagArgs, TextareaArgs } from '../../utils/govukFrontendTypes'
-import utils from '../../utils/utils'
+import { TextareaArgs } from '../../utils/govukFrontendTypes'
+import RiskView from '../shared/riskView'
 
 export default class RiskInformationView {
   constructor(private readonly presenter: RiskInformationPresenter) {}
+
+  private riskView = new RiskView(this.presenter.riskPresenter)
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 
@@ -13,69 +15,14 @@ export default class RiskInformationView {
       name: 'additional-risk-information',
       id: 'additional-risk-information',
       label: {
-        text: this.presenter.text.additionalRiskInformation.label,
-        classes: this.presenter.text.additionalRiskInformation.labelClasses,
+        text: this.presenter.additionalRiskInformation.label,
+        classes: this.presenter.additionalRiskInformation.labelClasses,
       },
       value: this.presenter.fields.additionalRiskInformation,
       hint: {
-        text: this.presenter.text.additionalRiskInformation.hint,
+        text: this.presenter.additionalRiskInformation.hint,
       },
-      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.additionalRiskInformation.errorMessage),
-    }
-  }
-
-  roshAnalysisTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
-    return {
-      head: this.presenter.roshAnalysisHeaders.map((header: string) => {
-        return { text: header }
-      }),
-      rows: this.presenter.roshAnalysisRows.map(row => {
-        return [
-          { text: utils.convertToProperCase(row.riskTo) },
-          {
-            text: tagMacro({
-              text: row.riskScore.replace('_', ' '),
-              classes: this.tagClassForRiskScore(row.riskScore),
-            }),
-          },
-        ]
-      }),
-    }
-  }
-
-  private tagClassForRiskScore(riskScore: string): string {
-    switch (riskScore) {
-      case 'LOW':
-        return 'govuk-tag--green'
-      case 'MEDIUM':
-        return 'govuk-tag--blue'
-      case 'HIGH':
-        return 'govuk-tag--red'
-      case 'VERY_HIGH':
-        return 'govuk-tag--purple'
-      default:
-        return ''
-    }
-  }
-
-  get riskLevelDetailsArgs(): DetailsArgs {
-    return {
-      summaryText: 'Definitions of risk levels',
-      html: `
-            <ul class="govuk-list govuk-list--bullet">
-              <li>
-                <strong>Low</strong> - Current evidence does not indicate likelihood of causing serious harm.
-              </li>
-              <li>
-                <strong>Medium</strong> - There are identifiable indicators of risk of serious harm. The person has the potential to cause serious harm but is unlikely to do so unless there is a change in circumstances.
-              </li>
-              <li>
-                <strong>High</strong> - There are identifiable indicators of risk of serious harm. The potential event could happen at any time and the impact would be serious.
-              </li>
-              <li>
-                <strong>Very high</strong> - There is an imminent risk of serious harm. The potential event is more likely than not to happen imminently and the impact would be serious.
-              </li>
-            </ul>`,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.additionalRiskInformation.errorMessage),
     }
   }
 
@@ -86,8 +33,8 @@ export default class RiskInformationView {
         presenter: this.presenter,
         errorSummaryArgs: this.errorSummaryArgs,
         additionalRiskInformationTextareaArgs: this.additionalRiskInformationTextareaArgs,
-        roshAnalysisTableArgs: this.roshAnalysisTableArgs.bind(this),
-        riskLevelDetailsArgs: this.riskLevelDetailsArgs,
+        roshAnalysisTableArgs: this.riskView.roshAnalysisTableArgs.bind(this.riskView),
+        riskLevelDetailsArgs: this.riskView.riskLevelDetailsArgs,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -21,6 +21,7 @@ import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsServic
 import MockAssessRisksAndNeedsService from '../testutils/mocks/mockAssessRisksAndNeedsService'
 import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
+import riskSummaryFactory from '../../../testutils/factories/riskSummary'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -98,6 +99,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
     const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
       riskSummaryComments: 'Alex is low risk to others.',
     })
+    const riskSummary = riskSummaryFactory.build()
     const deliusUser = deliusUserFactory.build({
       firstName: 'Bernard',
       surname: 'Beaks',
@@ -138,6 +140,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
     communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(deliusServiceUser)
     communityApiService.getConvictionById.mockResolvedValue(conviction)
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
+    assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
 
     await request(app)
       .get(`/service-provider/referrals/${sentReferral.id}/details`)
@@ -150,6 +153,9 @@ describe('GET /service-provider/referrals/:id/details', () => {
         expect(res.text).toContain('07123456789')
         expect(res.text).toContain('Alex River')
         expect(res.text).toContain('Alex is low risk to others.')
+        expect(res.text).toContain("service user's Risk of Serious Harm (ROSH) levels")
+        expect(res.text).toContain('Children')
+        expect(res.text).toContain('HIGH')
       })
   })
 
@@ -170,6 +176,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
       hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
       communityApiService.getConvictionById.mockResolvedValue(conviction)
       assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
+      assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummaryFactory.build())
 
       await request(app)
         .get(`/service-provider/referrals/${sentReferral.id}/details`)

--- a/server/routes/shared/riskPresenter.test.ts
+++ b/server/routes/shared/riskPresenter.test.ts
@@ -1,0 +1,21 @@
+import RiskPresenter from './riskPresenter'
+import riskSummary from '../../../testutils/factories/riskSummary'
+
+describe(RiskPresenter, () => {
+  describe('roshAnalysisRows', () => {
+    it('returns empty list if there is no risk summary', () => {
+      const presenter = new RiskPresenter(null)
+      expect(presenter.roshAnalysisRows).toEqual([])
+    })
+
+    it('returns rows for each risk group', () => {
+      const presenter = new RiskPresenter(riskSummary.build())
+      expect(presenter.roshAnalysisRows).toEqual([
+        { riskTo: 'prisoners', riskScore: 'LOW' },
+        { riskTo: 'children', riskScore: 'HIGH' },
+        { riskTo: 'known adult', riskScore: 'HIGH' },
+        { riskTo: 'staff', riskScore: 'VERY_HIGH' },
+      ])
+    })
+  })
+})

--- a/server/routes/shared/riskPresenter.ts
+++ b/server/routes/shared/riskPresenter.ts
@@ -1,0 +1,27 @@
+import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
+import config from '../../config'
+
+export interface RoshAnalysisTableRow {
+  riskTo: string
+  riskScore: string
+}
+
+export default class RiskPresenter {
+  constructor(private readonly riskSummary: RiskSummary | null) {}
+
+  readonly riskSummaryEnabled = config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
+
+  get roshAnalysisHeaders(): string[] {
+    return ['Risk to', 'Risk in community']
+  }
+
+  get roshAnalysisRows(): RoshAnalysisTableRow[] {
+    if (this.riskSummary === null) return []
+
+    return Object.entries(this.riskSummary.riskInCommunity).flatMap(([riskScore, riskGroups]) => {
+      return riskGroups.map(riskTo => {
+        return { riskTo, riskScore }
+      })
+    })
+  }
+}

--- a/server/routes/shared/riskPresenter.ts
+++ b/server/routes/shared/riskPresenter.ts
@@ -1,5 +1,4 @@
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
-import config from '../../config'
 
 export interface RoshAnalysisTableRow {
   riskTo: string
@@ -9,7 +8,7 @@ export interface RoshAnalysisTableRow {
 export default class RiskPresenter {
   constructor(private readonly riskSummary: RiskSummary | null) {}
 
-  readonly riskSummaryEnabled = config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
+  readonly riskSummaryEnabled = this.riskSummary !== null
 
   get roshAnalysisHeaders(): string[] {
     return ['Risk to', 'Risk in community']

--- a/server/routes/shared/riskView.ts
+++ b/server/routes/shared/riskView.ts
@@ -1,0 +1,62 @@
+import { DetailsArgs, TableArgs, TagArgs } from '../../utils/govukFrontendTypes'
+import utils from '../../utils/utils'
+import RiskPresenter from './riskPresenter'
+
+export default class RiskView {
+  constructor(private readonly presenter: RiskPresenter) {}
+
+  roshAnalysisTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
+    return {
+      head: this.presenter.roshAnalysisHeaders.map((header: string) => {
+        return { text: header }
+      }),
+      rows: this.presenter.roshAnalysisRows.map(row => {
+        return [
+          { text: utils.convertToProperCase(row.riskTo) },
+          {
+            text: tagMacro({
+              text: row.riskScore.replace('_', ' '),
+              classes: this.tagClassForRiskScore(row.riskScore),
+            }),
+          },
+        ]
+      }),
+    }
+  }
+
+  private tagClassForRiskScore(riskScore: string): string {
+    switch (riskScore) {
+      case 'LOW':
+        return 'govuk-tag--green'
+      case 'MEDIUM':
+        return 'govuk-tag--blue'
+      case 'HIGH':
+        return 'govuk-tag--red'
+      case 'VERY_HIGH':
+        return 'govuk-tag--purple'
+      default:
+        return ''
+    }
+  }
+
+  get riskLevelDetailsArgs(): DetailsArgs {
+    return {
+      summaryText: 'Definitions of risk levels',
+      html: `
+            <ul class="govuk-list govuk-list--bullet">
+              <li>
+                <strong>Low</strong> - Current evidence does not indicate likelihood of causing serious harm.
+              </li>
+              <li>
+                <strong>Medium</strong> - There are identifiable indicators of risk of serious harm. The person has the potential to cause serious harm but is unlikely to do so unless there is a change in circumstances.
+              </li>
+              <li>
+                <strong>High</strong> - There are identifiable indicators of risk of serious harm. The potential event could happen at any time and the impact would be serious.
+              </li>
+              <li>
+                <strong>Very high</strong> - There is an imminent risk of serious harm. The potential event is more likely than not to happen imminently and the impact would be serious.
+              </li>
+            </ul>`,
+    }
+  }
+}

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -9,6 +9,7 @@ import { TagArgs } from '../../utils/govukFrontendTypes'
 import deliusConvictionFactory from '../../../testutils/factories/deliusConviction'
 import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
+import riskSummaryFactory from '../../../testutils/factories/riskSummary'
 
 describe(ShowReferralPresenter, () => {
   const intervention = interventionFactory.build()
@@ -41,6 +42,7 @@ describe(ShowReferralPresenter, () => {
   const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
 
   const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+  const riskSummary = riskSummaryFactory.build()
 
   describe('assignmentFormAction', () => {
     it('returns the relative URL for the check assignment page', () => {
@@ -55,7 +57,8 @@ describe(ShowReferralPresenter, () => {
         null,
         'service-provider',
         true,
-        deliusServiceUser
+        deliusServiceUser,
+        riskSummary
       )
 
       expect(presenter.assignmentFormAction).toEqual(`/service-provider/referrals/${referral.id}/assignment/check`)
@@ -77,7 +80,8 @@ describe(ShowReferralPresenter, () => {
             null,
             'service-provider',
             true,
-            deliusServiceUser
+            deliusServiceUser,
+            riskSummary
           )
 
           expect(presenter.text.assignedTo).toBeNull()
@@ -97,7 +101,8 @@ describe(ShowReferralPresenter, () => {
             null,
             'service-provider',
             true,
-            deliusServiceUser
+            deliusServiceUser,
+            riskSummary
           )
 
           expect(presenter.text.assignedTo).toEqual('John Smith')
@@ -119,7 +124,8 @@ describe(ShowReferralPresenter, () => {
         null,
         'service-provider',
         true,
-        deliusServiceUser
+        deliusServiceUser,
+        riskSummary
       )
 
       expect(presenter.probationPractitionerDetails).toEqual([
@@ -197,7 +203,8 @@ describe(ShowReferralPresenter, () => {
           null,
           'service-provider',
           true,
-          deliusServiceUser
+          deliusServiceUser,
+          riskSummary
         )
 
         expect(presenter.interventionDetails).toEqual([
@@ -285,7 +292,8 @@ describe(ShowReferralPresenter, () => {
           null,
           'service-provider',
           true,
-          deliusServiceUser
+          deliusServiceUser,
+          riskSummary
         )
 
         expect(presenter.interventionDetails).toEqual([
@@ -339,7 +347,8 @@ describe(ShowReferralPresenter, () => {
         null,
         'service-provider',
         true,
-        deliusServiceUser
+        deliusServiceUser,
+        riskSummary
       )
       expect(
         presenter.serviceCategorySection(cohortServiceCategories[0], (args: TagArgs): string => {
@@ -377,7 +386,8 @@ describe(ShowReferralPresenter, () => {
         null,
         'service-provider',
         true,
-        deliusServiceUser
+        deliusServiceUser,
+        riskSummary
       )
 
       expect(presenter.serviceUserDetails).toEqual([
@@ -418,7 +428,8 @@ describe(ShowReferralPresenter, () => {
         null,
         'service-provider',
         true,
-        deliusServiceUser
+        deliusServiceUser,
+        riskSummary
       )
 
       expect(presenter.serviceUserRisks).toEqual([
@@ -483,7 +494,8 @@ describe(ShowReferralPresenter, () => {
           null,
           'service-provider',
           true,
-          deliusServiceUser
+          deliusServiceUser,
+          riskSummary
         )
 
         expect(presenter.serviceUserNeeds).toEqual([
@@ -570,7 +582,8 @@ describe(ShowReferralPresenter, () => {
           null,
           'service-provider',
           true,
-          deliusServiceUser
+          deliusServiceUser,
+          riskSummary
         )
 
         expect(presenter.serviceUserNeeds).toEqual([

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -17,9 +17,13 @@ import DeliusConviction from '../../models/delius/deliusConviction'
 import SentencePresenter from '../referrals/sentencePresenter'
 import { SupplementaryRiskInformation } from '../../models/assessRisksAndNeeds/supplementaryRiskInformation'
 import { ExpandedDeliusServiceUser } from '../../models/delius/deliusServiceUser'
+import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
+import RiskPresenter from './riskPresenter'
 
 export default class ShowReferralPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
+
+  riskPresenter: RiskPresenter
 
   constructor(
     private readonly sentReferral: SentReferral,
@@ -31,13 +35,16 @@ export default class ShowReferralPresenter {
     private readonly assignEmailError: FormValidationError | null,
     subNavUrlPrefix: 'service-provider' | 'probation-practitioner',
     readonly canAssignReferral: boolean,
-    private readonly deliusServiceUser: ExpandedDeliusServiceUser
+    private readonly deliusServiceUser: ExpandedDeliusServiceUser,
+    private readonly riskSummary: RiskSummary | null
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,
       sentReferral.id,
       subNavUrlPrefix
     )
+
+    this.riskPresenter = new RiskPresenter(riskSummary)
   }
 
   readonly assignmentFormAction = `/service-provider/referrals/${this.sentReferral.id}/assignment/check`

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -1,6 +1,7 @@
 import ShowReferralPresenter from './showReferralPresenter'
 import ViewUtils from '../../utils/viewUtils'
 import { InputArgs, SummaryListArgs, TagArgs } from '../../utils/govukFrontendTypes'
+import RiskView from './riskView'
 
 interface ServiceCategorySection {
   name: string
@@ -9,6 +10,8 @@ interface ServiceCategorySection {
 
 export default class ShowReferralView {
   constructor(private readonly presenter: ShowReferralPresenter) {}
+
+  private readonly riskView = new RiskView(this.presenter.riskPresenter)
 
   private readonly probationPractitionerSummaryListArgs = ViewUtils.summaryListArgs(
     this.presenter.probationPractitionerDetails
@@ -63,6 +66,8 @@ export default class ShowReferralView {
         serviceCategorySections: this.serviceCategorySections,
         emailInputArgs: this.emailInputArgs,
         backLinkArgs: this.backLinkArgs,
+        roshAnalysisTableArgs: this.riskView.roshAnalysisTableArgs.bind(this.riskView),
+        riskLevelDetailsArgs: this.riskView.riskLevelDetailsArgs,
       },
     ]
   }

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -12,6 +12,7 @@ import InterventionsService from '../../services/interventionsService'
 import MockedHmppsAuthService from '../../services/testutils/hmppsAuthServiceSetup'
 import LoggedInUserFactory from '../../../testutils/factories/loggedInUser'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
+import config from '../../config'
 
 export enum AppSetupUserType {
   probationPractitioner = 'delius',
@@ -46,6 +47,8 @@ function appSetup(route: Router, production: boolean, userType: AppSetupUserType
   app.use(bodyParser.urlencoded({ extended: true }))
   app.use('/', route)
   app.use(createErrorHandler(production))
+
+  config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = true
 
   return app
 }

--- a/server/routes/testutils/mocks/mockAssessRisksAndNeedsService.ts
+++ b/server/routes/testutils/mocks/mockAssessRisksAndNeedsService.ts
@@ -4,6 +4,6 @@ import MockedHmppsAuthService from '../../../services/testutils/hmppsAuthService
 
 export default class MockAssessRisksAndNeedsService extends AssessRisksAndNeedsService {
   constructor() {
-    super(new MockedHmppsAuthService(), new MockRestClient())
+    super(new MockedHmppsAuthService(), new MockRestClient(), true)
   }
 }

--- a/server/services/assessRisksAndNeedsService.test.ts
+++ b/server/services/assessRisksAndNeedsService.test.ts
@@ -7,7 +7,6 @@ import HmppsAuthService from './hmppsAuthService'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 import MockRestClient from '../data/testutils/mockRestClient'
 import riskSummaryFactory from '../../testutils/factories/riskSummary'
-import config from '../config'
 
 // wraps mocking API around the class exported by the module
 jest.mock('../data/restClient')
@@ -18,7 +17,7 @@ describe(AssessRisksAndNeedsService, () => {
 
     const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
 
-    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock)
+    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock, true)
 
     const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
 
@@ -36,17 +35,9 @@ describe(AssessRisksAndNeedsService, () => {
 
     const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
 
-    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock)
+    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock, true)
 
     const riskSummary = riskSummaryFactory.build()
-
-    beforeAll(() => {
-      config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = true
-    })
-
-    afterAll(() => {
-      config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = false
-    })
 
     it('makes a request to the Assess Risks and Needs API', async () => {
       restClientMock.get.mockResolvedValue(riskSummary)
@@ -63,6 +54,21 @@ describe(AssessRisksAndNeedsService, () => {
         expect(err.status).toBe(404)
         expect(err.userMessage).toBe('Could not get service user risk scores from OASys.')
       }
+    })
+  })
+
+  describe('getRiskSummary when riskSummaryEnabled is false', () => {
+    const hmppsAuthServiceMock = new MockedHmppsAuthService() as jest.Mocked<HmppsAuthService>
+
+    const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
+
+    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock, false)
+
+    it('returns null and does not call Assess Risks and Needs API', async () => {
+      const result = await assessRisksAndNeedsService.getRiskSummary('crn123', 'token')
+
+      expect(restClientMock.get).not.toHaveBeenCalled()
+      expect(result).toBeNull()
     })
   })
 })

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -4,10 +4,13 @@ import HmppsAuthService from './hmppsAuthService'
 import logger from '../../log'
 import { SupplementaryRiskInformation } from '../models/assessRisksAndNeeds/supplementaryRiskInformation'
 import RiskSummary from '../models/assessRisksAndNeeds/riskSummary'
-import config from '../config'
 
 export default class AssessRisksAndNeedsService {
-  constructor(private readonly hmppsAuthService: HmppsAuthService, private readonly restClient: RestClient) {}
+  constructor(
+    private readonly hmppsAuthService: HmppsAuthService,
+    private readonly restClient: RestClient,
+    private readonly riskSummaryEnabled: boolean
+  ) {}
 
   async getSupplementaryRiskInformation(
     riskId: string,
@@ -21,7 +24,7 @@ export default class AssessRisksAndNeedsService {
   }
 
   async getRiskSummary(crn: string, token: string): Promise<RiskSummary | null> {
-    if (!config.apis.assessRisksAndNeedsApi.riskSummaryEnabled) {
+    if (!this.riskSummaryEnabled) {
       logger.info('not getting risk summary information; disabled')
       return null
     }

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -23,7 +23,7 @@
 
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
 
-      {% if presenter.riskSummaryEnabled %}
+      {% if presenter.riskPresenter.riskSummaryEnabled %}
 
         <p class="govuk-body">This shows the current ROSH levels and risk to self information from OASys. You can add information for the service provider.</p>
 

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -1,5 +1,7 @@
 {% extends "../partials/referralNavigationTemplate.njk" %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% block referralPageSection %}
       {% if presenter.text.assignedTo == null %}
@@ -26,8 +28,21 @@
 
       <h2 class="govuk-heading-m">Service user's personal details</h2>
       {{ govukSummaryList(serviceUserDetailsSummaryListArgs) }}
+
       <h2 class="govuk-heading-m">Service user's risk information</h2>
+
+      {% if presenter.riskPresenter.riskSummaryEnabled %}
+
+        <p class="govuk-body">This shows the service user's Risk of Serious Harm (ROSH) levels. Additional information from the probation practitioner may also be shown.</p>
+
+        {{ govukTable(roshAnalysisTableArgs(govukTag)) }}
+
+        {{ govukDetails(riskLevelDetailsArgs) }}
+
+      {% endif %}
+
       {{ govukSummaryList(serviceUserRisksSummaryListArgs) }}
+
       <h2 class="govuk-heading-m">Service user's needs</h2>
       {{ govukSummaryList(serviceUserNeedsSummaryListArgs) }}
       <h2 class="govuk-heading-m">Referring probation practitioner details</h2>


### PR DESCRIPTION
## What does this pull request do?

Show risk summary in referral details for SPs and PPs

<img width="758" alt="Screenshot 2021-06-23 at 16 44 08" src="https://user-images.githubusercontent.com/63233073/123127508-4118b380-d442-11eb-9fb6-75e272eb2371.png">

## What is the intent behind these changes?

tie up the new risk summary info into the referral details screens. 