### PR TITLE
IC-1901: Order service categories alphabetically

### DIFF
--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -191,6 +191,28 @@ three lines.`,
           const item = summary.find(anItem => anItem.key === 'Service categories')
           expect(item).toMatchObject({ lines: ['Accommodation', 'Emotional wellbeing'], listStyle: ListStyle.bulleted })
         })
+        it('sorts service categories alphabetically', () => {
+          const summary = summaryForParams({
+            serviceCategories: [
+              serviceCategoryFactory.build({ name: 'social inclusion' }),
+              serviceCategoryFactory.build({ name: 'emotional wellbeing' }),
+              serviceCategoryFactory.build({ name: 'accommodation' }),
+              serviceCategoryFactory.build({ name: 'family and significant others' }),
+              serviceCategoryFactory.build({ name: 'lifestyle and associates' }),
+            ],
+          })
+          const item = summary.find(anItem => anItem.key === 'Service categories')
+          expect(item).toMatchObject({
+            lines: [
+              'Accommodation',
+              'Emotional wellbeing',
+              'Family and significant others',
+              'Lifestyle and associates',
+              'Social inclusion',
+            ],
+            listStyle: ListStyle.bulleted,
+          })
+        })
       })
     })
 

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -49,9 +49,9 @@ export default class InterventionDetailsPresenter {
       },
       {
         key: this.intervention.serviceCategories.length > 1 ? 'Service categories' : 'Service category',
-        lines: this.intervention.serviceCategories.map(serviceCategory =>
-          utils.convertToProperCase(serviceCategory.name)
-        ),
+        lines: this.intervention.serviceCategories
+          .map(serviceCategory => utils.convertToProperCase(serviceCategory.name))
+          .sort(),
         listStyle: this.intervention.serviceCategories.length > 1 ? ListStyle.bulleted : undefined,
       },
       {


### PR DESCRIPTION
## What does this pull request do?

Order service categories alphabetically for cohort interventions on 'Find interventions' screen

## What is the intent behind these changes?

Ensures that service categories are always ordered in the same order rather than random.
