### PR TITLE
IC-1962: Display time-sensitive message to all users

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -11,6 +11,7 @@ $path: "/assets/images/"
 @import './components/notification-banner'
 @import './components/primary-navigation'
 @import './components/service-user-banner'
+@import './components/broadcast-message'
 @import './components/task-list'
 @import './components/checkboxes'
 @import './components/button-link'

--- a/assets/sass/components/_broadcast-message.scss
+++ b/assets/sass/components/_broadcast-message.scss
@@ -1,0 +1,4 @@
+.broadcast-message {
+  background-color: govuk-colour('yellow');
+  padding: 10px;
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -25,6 +25,7 @@ import HmppsAuthService from './services/hmppsAuthService'
 import passportSetup from './authentication/passport'
 import AssessRisksAndNeedsService from './services/assessRisksAndNeedsService'
 import ControllerUtils from './utils/controllerUtils'
+import broadcastMessageConfig from './broadcast-message-config.json'
 
 const RedisStore = connectRedis(session)
 
@@ -110,6 +111,17 @@ export default function createApp(
       rolling: true,
     })
   )
+
+  // Determine whether or not to display broadcast message
+  app.use((_req, res, next) => {
+    const startTime = new Date(broadcastMessageConfig.start).getTime()
+    const endTime = new Date(broadcastMessageConfig.end).getTime()
+    const currentTime = Date.now()
+
+    res.locals.broadcastMessage =
+      currentTime >= startTime && currentTime <= endTime ? broadcastMessageConfig.message : null
+    next()
+  })
 
   // Request Processing Configuration
   app.use(bodyParser.json())

--- a/server/broadcast-message-config.json
+++ b/server/broadcast-message-config.json
@@ -1,0 +1,5 @@
+{
+  "start": "2021-06-23T09:00:00+01:00",
+  "end": "2021-06-26T21:00:00+01:00",
+  "message": "Some parts of Refer and monitor an intervention are unavailable until 9:00pm. You can read referral and intervention information but any updates you make will not be recorded."
+}

--- a/server/views/partials/broadcastMessage.njk
+++ b/server/views/partials/broadcastMessage.njk
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="broadcast-message govuk-body-m">
+      {{ broadcastMessage }}
+    </p>
+  </div>
+</div>

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -29,6 +29,9 @@
 {% block pageTitle %}HMPPS Interventions{% endblock %}
 
 {% block content %} 
+  {% if broadcastMessage %}
+    {% include "./broadcastMessage.njk" %}
+  {% endif %}
   {% block pageContent %}
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a yellow notification banner to all screens for all users between the hours of 9am and 9pm on Saturday 26th June to let them know that Delius is in read-only mode during scheduled maintenance.

The functionality should be fairly easy to extend if we want to do this again in future.

## What is the intent behind these changes?

To notify users that Delius is down for scheduled maintenance so they know that the service won't function as expected.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/123101519-0f94ed80-d42c-11eb-89e4-d293737354e1.png)
