### PR TITLE
Merge `main` (which adds appointment method / address) into `feature/schedule-supplier-assessment`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/frontend": "0.0.21",
-        "@sentry/node": "^6.2.5",
+        "@sentry/node": "^6.7.2",
         "@types/connect-flash": "0.0.36",
         "agentkeepalive": "^4.1.3",
-        "applicationinsights": "^2.1.2",
+        "applicationinsights": "^2.1.3",
         "body-parser": "^1.19.0",
         "bunyan": "^1.8.15",
         "compression": "^1.7.4",
@@ -2786,14 +2786,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.5.1.tgz",
-      "integrity": "sha512-Mh3sl/iUOT1myHmM6RlDy2ARzkUClx/g4DAt1rJ/IpQBOlDYQraplXSIW80i/hzRgQDfwhwgf4wUa5DicKBjKw==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.7.2.tgz",
+      "integrity": "sha512-NTZqwN5nR94yrXmSfekoPs1mIFuKvf8esdIW/DadwSKWAdLJwQTJY9xK/8PQv+SEzd7wiitPAx+mCw2By1xiNQ==",
       "dependencies": {
-        "@sentry/hub": "6.5.1",
-        "@sentry/minimal": "6.5.1",
-        "@sentry/types": "6.5.1",
-        "@sentry/utils": "6.5.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/minimal": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2801,12 +2801,12 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.5.1.tgz",
-      "integrity": "sha512-lBRMBVMYP8B4PfRiM70murbtJAXiIAao/asDEMIRNGMP6pI2ArqXfJCBYDkStukhikYD0Kqb4trXq+JYF07Hbg==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.7.2.tgz",
+      "integrity": "sha512-05qVW6ymChJsXag4+fYCQokW3AcABIgcqrVYZUBf6GMU/Gbz5SJqpV7y1+njwWvnPZydMncP9LaDVpMKbE7UYQ==",
       "dependencies": {
-        "@sentry/types": "6.5.1",
-        "@sentry/utils": "6.5.1",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2814,12 +2814,12 @@
       }
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.5.1.tgz",
-      "integrity": "sha512-q9Do/oreu1RP695CXCLowVDuQyk7ilE6FGdz2QLpTXAfx8247qOwk6+zy9Kea/Djk93+BoSDVQUSneNiVwl0nQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.7.2.tgz",
+      "integrity": "sha512-jkpwFv2GFHoVl5vnK+9/Q+Ea8eVdbJ3hn3/Dqq9MOLFnVK7ED6MhdHKLT79puGSFj+85OuhM5m2Q44mIhyS5mw==",
       "dependencies": {
-        "@sentry/hub": "6.5.1",
-        "@sentry/types": "6.5.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/types": "6.7.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2827,15 +2827,15 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.5.1.tgz",
-      "integrity": "sha512-Yh8J/QJ5e8gRBVL9VLCDpUvmiaxsxVZm0CInPHw3V/smgMkrzSKEiqxSeMq8ImPlaJrCFECqdpv4gnvYKI+mQQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.7.2.tgz",
+      "integrity": "sha512-vfNTmxBbHthAKPDBo0gVk/aNHdgUfXLzmaK7FgWO7cISiI2soCfvKEIP61XqIFZru06teqcRuDsYlR4wSeyWpg==",
       "dependencies": {
-        "@sentry/core": "6.5.1",
-        "@sentry/hub": "6.5.1",
-        "@sentry/tracing": "6.5.1",
-        "@sentry/types": "6.5.1",
-        "@sentry/utils": "6.5.1",
+        "@sentry/core": "6.7.2",
+        "@sentry/hub": "6.7.2",
+        "@sentry/tracing": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -2846,14 +2846,14 @@
       }
     },
     "node_modules/@sentry/tracing": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.5.1.tgz",
-      "integrity": "sha512-y1W/xFC2hAuKqSuuaovkElHY4pbli3XoXrreesg8PtO7ilX6ZbatOQbHsEsHQyoUv0F6aVA+MABOxWH2jt7tfw==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.7.2.tgz",
+      "integrity": "sha512-juKlI7FICKONWJFJxDxerj0A+8mNRhmtrdR+OXFqOkqSAy/QXlSFZcA/j//O19k2CfwK1BrvoMcQ/4gnffUOVg==",
       "dependencies": {
-        "@sentry/hub": "6.5.1",
-        "@sentry/minimal": "6.5.1",
-        "@sentry/types": "6.5.1",
-        "@sentry/utils": "6.5.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/minimal": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2861,19 +2861,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.5.1.tgz",
-      "integrity": "sha512-b/7a6CMoytaeFPx4IBjfxPw3nPvsQh7ui1C8Vw0LxNNDgBwVhPLzUOWeLWbo5YZCVbGEMIWwtCUQYWxneceZSA==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.7.2.tgz",
+      "integrity": "sha512-h21Go/PfstUN+ZV6SbwRSZVg9GXRJWdLfHoO5PSVb3TVEMckuxk8tAE57/u+UZDwX8wu+Xyon2TgsKpiWKxqUg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.5.1.tgz",
-      "integrity": "sha512-Wv86JYGQH+ZJ5XGFQX7h6ijl32667ikenoL9EyXMn8UoOYX/MLwZoQZin1P60wmKkYR9ifTNVmpaI9OoTaH+UQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.7.2.tgz",
+      "integrity": "sha512-9COL7aaBbe61Hp5BlArtXZ1o/cxli1NGONLPrVT4fMyeQFmLonhUiy77NdsW19XnvhvaA+2IoV5dg3dnFiF/og==",
       "dependencies": {
-        "@sentry/types": "6.5.1",
+        "@sentry/types": "6.7.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3995,9 +3995,9 @@
       }
     },
     "node_modules/applicationinsights": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.1.2.tgz",
-      "integrity": "sha512-dH1A7f321eNq5aCUG0bpkBGs5fSAW/4sPnVREdog/ST46akpxEeS2vTBMcOfF/5OfDcLSEIsFdth5/0wEklA/Q==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.1.3.tgz",
+      "integrity": "sha512-ERyPf5iuOs3gblRnt1bWD8aW/Uiv3L/Z17SkVqYrCyNueDe+2g/kDrwLRENQ3+S7ieCdwicQ0ZmLBei5/ZqQaA==",
       "dependencies": {
         "@azure/core-http": "^1.2.5",
         "@opentelemetry/api": "^0.18.1",
@@ -22821,47 +22821,47 @@
       }
     },
     "@sentry/core": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.5.1.tgz",
-      "integrity": "sha512-Mh3sl/iUOT1myHmM6RlDy2ARzkUClx/g4DAt1rJ/IpQBOlDYQraplXSIW80i/hzRgQDfwhwgf4wUa5DicKBjKw==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.7.2.tgz",
+      "integrity": "sha512-NTZqwN5nR94yrXmSfekoPs1mIFuKvf8esdIW/DadwSKWAdLJwQTJY9xK/8PQv+SEzd7wiitPAx+mCw2By1xiNQ==",
       "requires": {
-        "@sentry/hub": "6.5.1",
-        "@sentry/minimal": "6.5.1",
-        "@sentry/types": "6.5.1",
-        "@sentry/utils": "6.5.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/minimal": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.5.1.tgz",
-      "integrity": "sha512-lBRMBVMYP8B4PfRiM70murbtJAXiIAao/asDEMIRNGMP6pI2ArqXfJCBYDkStukhikYD0Kqb4trXq+JYF07Hbg==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.7.2.tgz",
+      "integrity": "sha512-05qVW6ymChJsXag4+fYCQokW3AcABIgcqrVYZUBf6GMU/Gbz5SJqpV7y1+njwWvnPZydMncP9LaDVpMKbE7UYQ==",
       "requires": {
-        "@sentry/types": "6.5.1",
-        "@sentry/utils": "6.5.1",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.5.1.tgz",
-      "integrity": "sha512-q9Do/oreu1RP695CXCLowVDuQyk7ilE6FGdz2QLpTXAfx8247qOwk6+zy9Kea/Djk93+BoSDVQUSneNiVwl0nQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.7.2.tgz",
+      "integrity": "sha512-jkpwFv2GFHoVl5vnK+9/Q+Ea8eVdbJ3hn3/Dqq9MOLFnVK7ED6MhdHKLT79puGSFj+85OuhM5m2Q44mIhyS5mw==",
       "requires": {
-        "@sentry/hub": "6.5.1",
-        "@sentry/types": "6.5.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/types": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.5.1.tgz",
-      "integrity": "sha512-Yh8J/QJ5e8gRBVL9VLCDpUvmiaxsxVZm0CInPHw3V/smgMkrzSKEiqxSeMq8ImPlaJrCFECqdpv4gnvYKI+mQQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.7.2.tgz",
+      "integrity": "sha512-vfNTmxBbHthAKPDBo0gVk/aNHdgUfXLzmaK7FgWO7cISiI2soCfvKEIP61XqIFZru06teqcRuDsYlR4wSeyWpg==",
       "requires": {
-        "@sentry/core": "6.5.1",
-        "@sentry/hub": "6.5.1",
-        "@sentry/tracing": "6.5.1",
-        "@sentry/types": "6.5.1",
-        "@sentry/utils": "6.5.1",
+        "@sentry/core": "6.7.2",
+        "@sentry/hub": "6.7.2",
+        "@sentry/tracing": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -22869,28 +22869,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.5.1.tgz",
-      "integrity": "sha512-y1W/xFC2hAuKqSuuaovkElHY4pbli3XoXrreesg8PtO7ilX6ZbatOQbHsEsHQyoUv0F6aVA+MABOxWH2jt7tfw==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.7.2.tgz",
+      "integrity": "sha512-juKlI7FICKONWJFJxDxerj0A+8mNRhmtrdR+OXFqOkqSAy/QXlSFZcA/j//O19k2CfwK1BrvoMcQ/4gnffUOVg==",
       "requires": {
-        "@sentry/hub": "6.5.1",
-        "@sentry/minimal": "6.5.1",
-        "@sentry/types": "6.5.1",
-        "@sentry/utils": "6.5.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/minimal": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.5.1.tgz",
-      "integrity": "sha512-b/7a6CMoytaeFPx4IBjfxPw3nPvsQh7ui1C8Vw0LxNNDgBwVhPLzUOWeLWbo5YZCVbGEMIWwtCUQYWxneceZSA=="
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.7.2.tgz",
+      "integrity": "sha512-h21Go/PfstUN+ZV6SbwRSZVg9GXRJWdLfHoO5PSVb3TVEMckuxk8tAE57/u+UZDwX8wu+Xyon2TgsKpiWKxqUg=="
     },
     "@sentry/utils": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.5.1.tgz",
-      "integrity": "sha512-Wv86JYGQH+ZJ5XGFQX7h6ijl32667ikenoL9EyXMn8UoOYX/MLwZoQZin1P60wmKkYR9ifTNVmpaI9OoTaH+UQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.7.2.tgz",
+      "integrity": "sha512-9COL7aaBbe61Hp5BlArtXZ1o/cxli1NGONLPrVT4fMyeQFmLonhUiy77NdsW19XnvhvaA+2IoV5dg3dnFiF/og==",
       "requires": {
-        "@sentry/types": "6.5.1",
+        "@sentry/types": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
@@ -23858,9 +23858,9 @@
       }
     },
     "applicationinsights": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.1.2.tgz",
-      "integrity": "sha512-dH1A7f321eNq5aCUG0bpkBGs5fSAW/4sPnVREdog/ST46akpxEeS2vTBMcOfF/5OfDcLSEIsFdth5/0wEklA/Q==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.1.3.tgz",
+      "integrity": "sha512-ERyPf5iuOs3gblRnt1bWD8aW/Uiv3L/Z17SkVqYrCyNueDe+2g/kDrwLRENQ3+S7ieCdwicQ0ZmLBei5/ZqQaA==",
       "requires": {
         "@azure/core-http": "^1.2.5",
         "@opentelemetry/api": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -95,10 +95,10 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "0.0.21",
-    "@sentry/node": "^6.2.5",
+    "@sentry/node": "^6.7.2",
     "@types/connect-flash": "0.0.36",
     "agentkeepalive": "^4.1.3",
-    "applicationinsights": "^2.1.2",
+    "applicationinsights": "^2.1.3",
     "body-parser": "^1.19.0",
     "bunyan": "^1.8.15",
     "compression": "^1.7.4",

--- a/server/models/actionPlan.ts
+++ b/server/models/actionPlan.ts
@@ -1,3 +1,5 @@
+import Address from './address'
+import { AppointmentDeliveryType } from './appointmentDeliveryType'
 import User from './hmppsAuth/user'
 import SessionFeedback from './sessionFeedback'
 
@@ -11,6 +13,8 @@ export interface ActionPlanAppointment {
   sessionNumber: number
   appointmentTime: string | null
   durationInMinutes: number | null
+  appointmentDeliveryType: AppointmentDeliveryType | null
+  appointmentDeliveryAddress: Address | null
   sessionFeedback: SessionFeedback
 }
 

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -1,0 +1,7 @@
+export default interface Address {
+  firstAddressLine: string
+  secondAddressLine: string | null
+  townOrCity: string
+  county: string
+  postCode: string
+}

--- a/server/models/appointment.ts
+++ b/server/models/appointment.ts
@@ -1,8 +1,12 @@
+import Address from './address'
+import { AppointmentDeliveryType } from './appointmentDeliveryType'
 import SessionFeedback from './sessionFeedback'
 
 export default interface Appointment {
   id: string
   appointmentTime: string
   durationInMinutes: number
+  appointmentDeliveryType: AppointmentDeliveryType
+  appointmentDeliveryAddress: Address | null
   sessionFeedback: SessionFeedback
 }

--- a/server/models/appointmentDeliveryType.ts
+++ b/server/models/appointmentDeliveryType.ts
@@ -1,0 +1,5 @@
+export type AppointmentDeliveryType =
+  | 'PHONE_CALL'
+  | 'VIDEO_CALL'
+  | 'IN_PERSON_MEETING_PROBATION_OFFICE'
+  | 'IN_PERSON_MEETING_OTHER'

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
@@ -4,21 +4,98 @@ import TestUtils from '../../../testutils/testUtils'
 describe(ScheduleAppointmentForm, () => {
   describe('data', () => {
     describe('with valid data', () => {
-      it('returns a paramsForUpdate with the completionDeadline key and an ISO-formatted date', async () => {
-        const request = TestUtils.createRequest({
-          'date-year': '2021',
-          'date-month': '09',
-          'date-day': '12',
-          'time-hour': '1',
-          'time-minute': '05',
-          'time-part-of-day': 'pm',
-          'duration-hours': '1',
-          'duration-minutes': '30',
+      describe('with a phone call appointment', () => {
+        it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
+          const request = TestUtils.createRequest({
+            'date-year': '2021',
+            'date-month': '09',
+            'date-day': '12',
+            'time-hour': '1',
+            'time-minute': '05',
+            'time-part-of-day': 'pm',
+            'duration-hours': '1',
+            'duration-minutes': '30',
+            'meeting-method': 'PHONE_CALL',
+          })
+
+          const data = await new ScheduleAppointmentForm(request).data()
+
+          expect(data.paramsForUpdate).toEqual({
+            appointmentTime: '2021-09-12T12:05:00.000Z',
+            durationInMinutes: 90,
+            appointmentDeliveryType: 'PHONE_CALL',
+            appointmentDeliveryAddress: null,
+          })
+        })
+      })
+      describe('with an other locations appointment', () => {
+        it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
+          const request = TestUtils.createRequest({
+            'date-year': '2021',
+            'date-month': '09',
+            'date-day': '12',
+            'time-hour': '1',
+            'time-minute': '05',
+            'time-part-of-day': 'pm',
+            'duration-hours': '1',
+            'duration-minutes': '30',
+            'meeting-method': 'IN_PERSON_MEETING_OTHER',
+            'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+            'method-other-location-address-line-2': '44 Bouverie Road',
+            'method-other-location-address-town-or-city': 'Blackpool',
+            'method-other-location-address-county': 'Lancashire',
+            'method-other-location-address-postcode': 'SY4 0RE',
+          })
+
+          const data = await new ScheduleAppointmentForm(request).data()
+
+          expect(data.paramsForUpdate).toEqual({
+            appointmentTime: '2021-09-12T12:05:00.000Z',
+            durationInMinutes: 90,
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+            appointmentDeliveryAddress: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY4 0RE',
+            },
+          })
         })
 
-        const data = await new ScheduleAppointmentForm(request).data()
+        describe('with a missing second address line', () => {
+          it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
+            const request = TestUtils.createRequest({
+              'date-year': '2021',
+              'date-month': '09',
+              'date-day': '12',
+              'time-hour': '1',
+              'time-minute': '05',
+              'time-part-of-day': 'pm',
+              'duration-hours': '1',
+              'duration-minutes': '30',
+              'meeting-method': 'IN_PERSON_MEETING_OTHER',
+              'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+              'method-other-location-address-town-or-city': 'Blackpool',
+              'method-other-location-address-county': 'Lancashire',
+              'method-other-location-address-postcode': 'SY4 0RE',
+            })
 
-        expect(data.paramsForUpdate).toEqual({ appointmentTime: '2021-09-12T12:05:00.000Z', durationInMinutes: 90 })
+            const data = await new ScheduleAppointmentForm(request).data()
+            expect(data.paramsForUpdate).toEqual({
+              appointmentTime: '2021-09-12T12:05:00.000Z',
+              durationInMinutes: 90,
+              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+              appointmentDeliveryAddress: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY4 0RE',
+              },
+            })
+          })
+        })
       })
     })
 
@@ -53,6 +130,11 @@ describe(ScheduleAppointmentForm, () => {
               errorSummaryLinkedField: 'duration-hours',
               formFields: ['duration-hours', 'duration-minutes'],
               message: 'Enter a duration',
+            },
+            {
+              errorSummaryLinkedField: 'meeting-method',
+              formFields: ['meeting-method'],
+              message: 'Select a meeting method',
             },
           ],
         })

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
@@ -4,12 +4,16 @@ import TwelveHourBritishDateTimeInput from '../../utils/forms/inputs/twelveHourB
 import { FormData } from '../../utils/forms/formData'
 import DurationInput from '../../utils/forms/inputs/durationInput'
 import errorMessages from '../../utils/errorMessages'
+import MeetingMethodInput from '../../utils/forms/inputs/meetingMethodInput'
+import AddressInput from '../../utils/forms/inputs/addressInput'
+import { FormValidationResult } from '../../utils/forms/formValidationResult'
+import Address from '../../models/address'
 
 export default class ScheduleAppointmentForm {
   constructor(private readonly request: Request) {}
 
   async data(): Promise<FormData<AppointmentUpdate>> {
-    const [dateResult, durationResult] = await Promise.all([
+    const [dateResult, durationResult, appointmentDeliveryType] = await Promise.all([
       new TwelveHourBritishDateTimeInput(
         this.request,
         'date',
@@ -17,12 +21,32 @@ export default class ScheduleAppointmentForm {
         errorMessages.scheduleAppointment.time
       ).validate(),
       new DurationInput(this.request, 'duration', errorMessages.scheduleAppointment.duration).validate(),
+      new MeetingMethodInput(
+        this.request,
+        'meeting-method',
+        errorMessages.scheduleAppointment.meetingMethod
+      ).validate(),
     ])
+    let appointmentDeliveryAddress: FormValidationResult<Address | null> = { value: null, error: null }
+    if (appointmentDeliveryType.value === 'IN_PERSON_MEETING_OTHER') {
+      appointmentDeliveryAddress = await new AddressInput(
+        this.request,
+        'method-other-location',
+        errorMessages.scheduleAppointment.address
+      ).validate()
+    }
 
-    if (dateResult.error || durationResult.error) {
+    if (dateResult.error || durationResult.error || appointmentDeliveryType.error || appointmentDeliveryAddress.error) {
       return {
         paramsForUpdate: null,
-        error: { errors: [...(dateResult.error?.errors ?? []), ...(durationResult.error?.errors ?? [])] },
+        error: {
+          errors: [
+            ...(dateResult.error?.errors ?? []),
+            ...(durationResult.error?.errors ?? []),
+            ...(appointmentDeliveryType.error?.errors ?? []),
+            ...(appointmentDeliveryAddress.error?.errors ?? []),
+          ],
+        },
       }
     }
 
@@ -31,6 +55,8 @@ export default class ScheduleAppointmentForm {
       paramsForUpdate: {
         appointmentTime: dateResult.value.toISOString(),
         durationInMinutes: durationResult.value.minutes!,
+        appointmentDeliveryType: appointmentDeliveryType.value!,
+        appointmentDeliveryAddress: appointmentDeliveryAddress.value,
       },
     }
   }

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -123,6 +123,14 @@ describe(ScheduleAppointmentPresenter, () => {
             hours: { value: '', hasError: false },
             minutes: { value: '', hasError: false },
           },
+          meetingMethod: { value: null, errorMessage: null },
+          address: {
+            value: null,
+            errors: {
+              firstAddressLine: null,
+              postcode: null,
+            },
+          },
         })
       })
     })
@@ -132,6 +140,14 @@ describe(ScheduleAppointmentPresenter, () => {
         const appointment = appointmentFactory.build({
           appointmentTime: '2021-03-24T10:30:00Z',
           durationInMinutes: 75,
+          appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+          appointmentDeliveryAddress: {
+            firstAddressLine: 'Harmony Living Office, Room 4',
+            secondAddressLine: '44 Bouverie Road',
+            townOrCity: 'Blackpool',
+            county: 'Lancashire',
+            postCode: 'SY4 0RE',
+          },
         })
         const presenter = new ScheduleAppointmentPresenter(referral, appointment)
 
@@ -155,6 +171,20 @@ describe(ScheduleAppointmentPresenter, () => {
             errorMessage: null,
             hours: { value: '1', hasError: false },
             minutes: { value: '15', hasError: false },
+          },
+          meetingMethod: { value: 'IN_PERSON_MEETING_OTHER', errorMessage: null },
+          address: {
+            value: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY4 0RE',
+            },
+            errors: {
+              firstAddressLine: null,
+              postcode: null,
+            },
           },
         })
       })

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -35,6 +35,16 @@ export default class ScheduleAppointmentPresenter {
     date: this.utils.dateValue(this.appointmentDecorator?.britishDay ?? null, 'date', this.validationError),
     time: this.utils.twelveHourTimeValue(this.appointmentDecorator?.britishTime ?? null, 'time', this.validationError),
     duration: this.utils.durationValue(this.appointmentDecorator?.duration ?? null, 'duration', this.validationError),
+    meetingMethod: this.utils.meetingMethodValue(
+      this.currentAppointment?.appointmentDeliveryType ?? null,
+      'meeting-method',
+      this.validationError
+    ),
+    address: this.utils.addressValue(
+      this.currentAppointment?.appointmentDeliveryAddress ?? null,
+      'method-other-location',
+      this.validationError
+    ),
   }
 
   readonly backLinkHref = this.overrideBackLinkHref ?? `/service-provider/referrals/${this.referral.id}/progress`

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
@@ -1,9 +1,12 @@
-import { BackLinkArgs, DateInputArgs, TimeInputArgs } from '../../utils/govukFrontendTypes'
+import { BackLinkArgs, DateInputArgs, RadiosArgs, TimeInputArgs } from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
 import ScheduleAppointmentPresenter from './scheduleAppointmentPresenter'
+import AddressFormComponent from '../shared/addressFormComponent'
 
 export default class ScheduleAppointmentView {
   constructor(private readonly presenter: ScheduleAppointmentPresenter) {}
+
+  addressFormView = new AddressFormComponent(this.presenter.fields.address, 'method-other-location')
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [
@@ -15,6 +18,8 @@ export default class ScheduleAppointmentView {
         durationDateInputArgs: this.durationDateInputArgs,
         errorSummaryArgs: this.errorSummaryArgs,
         serverError: this.serverError,
+        address: this.addressFormView.inputArgs,
+        meetingMethodRadioInputArgs: this.meetingMethodRadioInputArgs.bind(this),
         backLinkArgs: this.backLinkArgs,
       },
     ]
@@ -131,6 +136,44 @@ export default class ScheduleAppointmentView {
           }`,
           name: 'minutes',
           value: this.presenter.fields.duration.minutes.value,
+        },
+      ],
+    }
+  }
+
+  private meetingMethodRadioInputArgs(otherLocationHTML: string): RadiosArgs {
+    return {
+      idPrefix: 'meeting-method',
+      name: 'meeting-method',
+      fieldset: {
+        legend: {
+          text: 'Method',
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--m',
+        },
+      },
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.meetingMethod.errorMessage),
+      hint: {
+        text: 'Select one option.',
+      },
+      items: [
+        {
+          value: 'PHONE_CALL',
+          text: 'Phone call',
+          checked: this.presenter.fields.meetingMethod.value === 'PHONE_CALL',
+        },
+        {
+          value: 'VIDEO_CALL',
+          text: 'Video call',
+          checked: this.presenter.fields.meetingMethod.value === 'VIDEO_CALL',
+        },
+        {
+          value: 'IN_PERSON_MEETING_OTHER',
+          text: 'In-person meeting',
+          checked: this.presenter.fields.meetingMethod.value === 'IN_PERSON_MEETING_OTHER',
+          conditional: {
+            html: otherLocationHTML,
+          },
         },
       ],
     }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -664,6 +664,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
           'time-part-of-day': 'am',
           'duration-hours': '1',
           'duration-minutes': '15',
+          'meeting-method': 'PHONE_CALL',
         })
         .expect(302)
         .expect('Location', `/service-provider/referrals/${actionPlan.referralId}/progress`)
@@ -671,6 +672,8 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
       expect(interventionsService.updateActionPlanAppointment).toHaveBeenCalledWith('token', actionPlan.id, 1, {
         appointmentTime: '2021-03-24T09:02:00.000Z',
         durationInMinutes: 75,
+        appointmentDeliveryType: 'PHONE_CALL',
+        appointmentDeliveryAddress: null,
       })
     })
 
@@ -694,6 +697,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'meeting-method': 'PHONE_CALL',
           })
           .expect(400)
           .expect(res => {
@@ -720,6 +724,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'meeting-method': 'PHONE_CALL',
           })
           .expect(500)
           .expect(res => {
@@ -750,6 +755,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
           'time-part-of-day': 'am',
           'duration-hours': '1',
           'duration-minutes': '15',
+          'meeting-method': 'PHONE_CALL',
         })
         .expect(400)
         .expect(res => {
@@ -1556,6 +1562,8 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
         const scheduledAppointment = appointmentFactory.build({
           appointmentTime: '2021-03-24T09:02:02Z',
           durationInMinutes: 75,
+          appointmentDeliveryType: 'PHONE_CALL',
+          appointmentDeliveryAddress: null,
         })
 
         interventionsService.getSentReferral.mockResolvedValue(referral)
@@ -1574,6 +1582,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'meeting-method': 'PHONE_CALL',
           })
           .expect(302)
           .expect('Location', `/service-provider/referrals/${referral.id}/supplier-assessment/scheduled-confirmation`)
@@ -1584,6 +1593,8 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
           {
             appointmentTime: '2021-03-24T09:02:00.000Z',
             durationInMinutes: 75,
+            appointmentDeliveryType: 'PHONE_CALL',
+            appointmentDeliveryAddress: null,
           }
         )
       })
@@ -1597,6 +1608,8 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
         const scheduledAppointment = appointmentFactory.build({
           appointmentTime: '2021-03-24T09:02:02Z',
           durationInMinutes: 75,
+          appointmentDeliveryType: 'PHONE_CALL',
+          appointmentDeliveryAddress: null,
         })
 
         interventionsService.getSentReferral.mockResolvedValue(referral)
@@ -1615,6 +1628,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'meeting-method': 'PHONE_CALL',
           })
           .expect(302)
           .expect('Location', `/service-provider/referrals/${referral.id}/supplier-assessment/rescheduled-confirmation`)
@@ -1625,6 +1639,8 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
           {
             appointmentTime: '2021-03-24T09:02:00.000Z',
             durationInMinutes: 75,
+            appointmentDeliveryType: 'PHONE_CALL',
+            appointmentDeliveryAddress: null,
           }
         )
       })
@@ -1649,6 +1665,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'meeting-method': 'PHONE_CALL',
           })
           .expect(400)
           .expect(res => {
@@ -1676,6 +1693,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'meeting-method': 'PHONE_CALL',
           })
           .expect(500)
           .expect(res => {
@@ -1702,6 +1720,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
           'time-part-of-day': 'am',
           'duration-hours': '1',
           'duration-minutes': '15',
+          'meeting-method': 'PHONE_CALL',
         })
         .expect(400)
         .expect(res => {

--- a/server/routes/shared/addressFormComponent.ts
+++ b/server/routes/shared/addressFormComponent.ts
@@ -1,0 +1,77 @@
+import { InputArgs } from '../../utils/govukFrontendTypes'
+import { AddressInputPresenter } from '../../utils/presenterUtils'
+import ViewUtils from '../../utils/viewUtils'
+
+export default class AddressFormComponent {
+  constructor(private address: AddressInputPresenter, private key: string) {}
+
+  get inputArgs(): Record<string, InputArgs> {
+    return {
+      firstAddressLineInputArgs: this.firstAddressLineInputArgs,
+      secondAddressLineInputArgs: this.secondAddressLineInputArgs,
+      townOrCityInputArgs: this.townOrCityInputArgs,
+      countyInputArgs: this.countyInputArgs,
+      postCodeInputArgs: this.postCodeInputArgs,
+    }
+  }
+
+  private get firstAddressLineInputArgs(): InputArgs {
+    return {
+      label: {
+        html: 'Address line 1<span class="govuk-visually-hidden">line 1 of 2</span>',
+      },
+      errorMessage: ViewUtils.govukErrorMessage(this.address.errors.firstAddressLine),
+      id: `${this.key}-address-line-1`,
+      name: `${this.key}-address-line-1`,
+      value: this.address.value?.firstAddressLine,
+    }
+  }
+
+  private get secondAddressLineInputArgs(): InputArgs {
+    return {
+      label: {
+        html: 'Address line 2 (optional) <span class="govuk-visually-hidden">line 2 of 2</span>',
+      },
+      id: `${this.key}-address-line-2`,
+      name: `${this.key}-address-line-2`,
+      value: this.address.value?.secondAddressLine,
+    }
+  }
+
+  private get townOrCityInputArgs(): InputArgs {
+    return {
+      label: {
+        text: 'Town or city (optional)',
+      },
+      classes: 'govuk-!-width-two-thirds',
+      id: `${this.key}-address-town-or-city`,
+      name: `${this.key}-address-town-or-city`,
+      value: this.address.value?.townOrCity,
+    }
+  }
+
+  private get countyInputArgs(): InputArgs {
+    return {
+      label: {
+        text: 'County (optional)',
+      },
+      classes: 'govuk-!-width-two-thirds',
+      id: `${this.key}-address-county`,
+      name: `${this.key}-address-county`,
+      value: this.address.value?.county,
+    }
+  }
+
+  private get postCodeInputArgs(): InputArgs {
+    return {
+      label: {
+        text: 'Postcode',
+      },
+      errorMessage: ViewUtils.govukErrorMessage(this.address.errors.postcode),
+      classes: 'govuk-input--width-10',
+      id: `${this.key}-address-postcode`,
+      name: `${this.key}-address-postcode`,
+      value: this.address.value?.postCode,
+    }
+  }
+}

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2036,16 +2036,19 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         sessionNumber: 1,
         appointmentTime: '2021-05-13T12:30:00Z',
         durationInMinutes: 120,
+        appointmentDeliveryType: 'PHONE_CALL',
       }),
       actionPlanAppointmentFactory.build({
         sessionNumber: 2,
         appointmentTime: '2021-05-20T12:30:00Z',
         durationInMinutes: 120,
+        appointmentDeliveryType: 'PHONE_CALL',
       }),
       actionPlanAppointmentFactory.build({
         sessionNumber: 3,
         appointmentTime: '2021-05-27T12:30:00Z',
         durationInMinutes: 120,
+        appointmentDeliveryType: 'PHONE_CALL',
       }),
     ]
 
@@ -2080,6 +2083,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       sessionNumber: 1,
       appointmentTime: '2021-05-13T12:30:00Z',
       durationInMinutes: 120,
+      appointmentDeliveryType: 'PHONE_CALL',
     })
 
     beforeEach(async () => {
@@ -2112,6 +2116,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(appointment.sessionNumber).toEqual(1)
       expect(appointment.appointmentTime).toEqual('2021-05-13T12:30:00Z')
       expect(appointment.durationInMinutes).toEqual(120)
+      expect(appointment.appointmentDeliveryType).toEqual('PHONE_CALL')
     })
   })
 
@@ -2158,6 +2163,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           sessionNumber: 2,
           appointmentTime: '2021-05-13T12:30:00Z',
           durationInMinutes: 60,
+          appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+          appointmentDeliveryAddress: {
+            firstAddressLine: 'Harmony Living Office, Room 4',
+            secondAddressLine: '44 Bouverie Road',
+            townOrCity: 'Blackpool',
+            county: 'Lancashire',
+            postCode: 'SY40RE',
+          },
         })
 
         await provider.addInteraction({
@@ -2171,6 +2184,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             body: {
               appointmentTime: '2021-05-13T12:30:00Z',
               durationInMinutes: 60,
+              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+              appointmentDeliveryAddress: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '44 Bouverie Road',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY40RE',
+              },
             },
             headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
           },
@@ -2188,6 +2209,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           await interventionsService.updateActionPlanAppointment(token, '345059d4-1697-467b-8914-fedec9957279', 2, {
             appointmentTime: '2021-05-13T12:30:00Z',
             durationInMinutes: 60,
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+            appointmentDeliveryAddress: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY40RE',
+            },
           })
         ).toMatchObject(actionPlanAppointment)
       })
@@ -2216,6 +2245,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             sessionNumber: 2,
             appointmentTime: '2021-05-13T12:30:00Z',
             durationInMinutes: 60,
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+            appointmentDeliveryAddress: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY40RE',
+            },
             sessionFeedback: {
               attendance: {
                 attended: 'late',

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -13,6 +13,8 @@ import ServiceCategory from '../models/serviceCategory'
 import ActionPlan, { ActionPlanAppointment } from '../models/actionPlan'
 import AppointmentAttendance from '../models/appointmentAttendance'
 import AppointmentBehaviour from '../models/appointmentBehaviour'
+import Address from '../models/address'
+import { AppointmentDeliveryType } from '../models/appointmentDeliveryType'
 import DraftReferral from '../models/draftReferral'
 import SentReferral from '../models/sentReferral'
 import ReferralDesiredOutcomes from '../models/referralDesiredOutcomes'
@@ -44,6 +46,8 @@ export interface UpdateDraftActionPlanParams {
 export interface AppointmentUpdate {
   appointmentTime: string
   durationInMinutes: number
+  appointmentDeliveryType: AppointmentDeliveryType
+  appointmentDeliveryAddress: Address | null
 }
 
 export interface CreateEndOfServiceReportOutcome {

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -94,6 +94,16 @@ export default {
       empty: 'Enter a duration',
       invalidDuration: 'The session duration must be a real duration',
     },
+    meetingMethod: {
+      empty: 'Select a meeting method',
+    },
+    address: {
+      addressLine1Empty: 'Enter a value for address line 1',
+      townOrCityEmpty: 'Enter a town or city',
+      countyEmpty: 'Enter a county',
+      postCodeEmpty: 'Enter a postcode',
+      postCodeInvalid: 'Enter a valid postcode',
+    },
   },
   endOfServiceReportOutcome: {
     achievementLevel: {

--- a/server/utils/forms/inputs/addressInput.test.ts
+++ b/server/utils/forms/inputs/addressInput.test.ts
@@ -1,0 +1,148 @@
+import AddressInput from './addressInput'
+import TestUtils from '../../../../testutils/testUtils'
+
+describe(AddressInput, () => {
+  const errorMessages = {
+    addressLine1Empty: 'Enter a value for address line 1',
+    townOrCityEmpty: 'Enter a town or city',
+    countyEmpty: 'Enter a county',
+    postCodeEmpty: 'Enter a postcode',
+    postCodeInvalid: 'Enter a valid postcode',
+  }
+  describe('validate', () => {
+    describe('with valid data', () => {
+      it('returns an address value when all fields are provided', async () => {
+        const request = TestUtils.createRequest({
+          'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+          'method-other-location-address-line-2': '44 Bouverie Road',
+          'method-other-location-address-town-or-city': 'Blackpool',
+          'method-other-location-address-county': 'Lancashire',
+          'method-other-location-address-postcode': 'EC1A 1BB',
+        })
+        const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
+        expect(result.value).toEqual({
+          firstAddressLine: 'Harmony Living Office, Room 4',
+          secondAddressLine: '44 Bouverie Road',
+          townOrCity: 'Blackpool',
+          county: 'Lancashire',
+          postCode: 'EC1A 1BB',
+        })
+      })
+      it('returns an address value when only address line 1 and postcode is provided', async () => {
+        const request = TestUtils.createRequest({
+          'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+          'method-other-location-address-postcode': 'SY4 0RE',
+        })
+        const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
+        expect(result.value).toEqual({
+          firstAddressLine: 'Harmony Living Office, Room 4',
+          secondAddressLine: '',
+          townOrCity: '',
+          county: '',
+          postCode: 'SY4 0RE',
+        })
+      })
+      describe('postcode validation', () => {
+        function createRequest(postCode: string): Record<string, string> {
+          return {
+            'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+            'method-other-location-address-town-or-city': 'Blackpool',
+            'method-other-location-address-county': 'Lancashire',
+            'method-other-location-address-postcode': postCode,
+          }
+        }
+        async function validatePostCode(postCode: string): Promise<void> {
+          const request = TestUtils.createRequest(createRequest(postCode))
+          const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
+          expect(result.value?.postCode).toEqual(postCode)
+        }
+        it('returns an address value when all postcode is valid', async () => {
+          await validatePostCode('aa9a 9aa')
+          await validatePostCode('a9a 9aa')
+          await validatePostCode('a9 9aa')
+          await validatePostCode('a99 9aa')
+          await validatePostCode('aa9 9aa')
+          await validatePostCode('aa99 9aa')
+          await validatePostCode(' aa999aa ')
+        })
+      })
+    })
+    describe('with invalid data', () => {
+      it('returns an error when address details are not entered', async () => {
+        const request = TestUtils.createRequest({})
+        const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
+        expect(result.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'method-other-location-address-line-1',
+              formFields: ['method-other-location-address-line-1'],
+              message: 'Enter a value for address line 1',
+            },
+            {
+              errorSummaryLinkedField: 'method-other-location-address-postcode',
+              formFields: ['method-other-location-address-postcode'],
+              message: 'Enter a postcode',
+            },
+            {
+              errorSummaryLinkedField: 'method-other-location-address-postcode',
+              formFields: ['method-other-location-address-postcode'],
+              message: 'Enter a valid postcode',
+            },
+          ],
+        })
+      })
+      it('returns an error when address details have blank values', async () => {
+        const request = TestUtils.createRequest({
+          'method-other-location-address-line-1': '',
+          'method-other-location-address-town-or-city': '',
+          'method-other-location-address-county': '',
+          'method-other-location-address-postcode': '',
+        })
+        const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
+        expect(result.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'method-other-location-address-line-1',
+              formFields: ['method-other-location-address-line-1'],
+              message: 'Enter a value for address line 1',
+            },
+            {
+              errorSummaryLinkedField: 'method-other-location-address-postcode',
+              formFields: ['method-other-location-address-postcode'],
+              message: 'Enter a postcode',
+            },
+            {
+              errorSummaryLinkedField: 'method-other-location-address-postcode',
+              formFields: ['method-other-location-address-postcode'],
+              message: 'Enter a valid postcode',
+            },
+          ],
+        })
+      })
+
+      describe('post code validation', () => {
+        it('returns an error when postcode is invalid', async () => {
+          const result = await new AddressInput(
+            TestUtils.createRequest({
+              'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
+              'method-other-location-address-town-or-city': 'Blackpool',
+              'method-other-location-address-county': 'Lancashire',
+              'method-other-location-address-postcode': 'aaa1 1aa',
+            }),
+            'method-other-location',
+            errorMessages
+          ).validate()
+          expect(result.error).toEqual({
+            errors: [
+              {
+                errorSummaryLinkedField: 'method-other-location-address-postcode',
+                formFields: ['method-other-location-address-postcode'],
+                message: 'Enter a valid postcode',
+              },
+            ],
+          })
+        })
+      })
+    })
+  })
+})

--- a/server/utils/forms/inputs/addressInput.ts
+++ b/server/utils/forms/inputs/addressInput.ts
@@ -1,0 +1,76 @@
+import { Request } from 'express'
+import * as ExpressValidator from 'express-validator'
+import { FormValidationResult } from '../formValidationResult'
+import Address from '../../../models/address'
+import { FormValidationError } from '../../formValidationError'
+import FormUtils from '../../formUtils'
+import PresenterUtils from '../../presenterUtils'
+
+export interface AddressErrorMessages {
+  addressLine1Empty: string
+  townOrCityEmpty: string
+  countyEmpty: string
+  postCodeEmpty: string
+  postCodeInvalid: string
+}
+
+export default class AddressInput {
+  constructor(
+    private readonly request: Request,
+    private readonly key: string,
+    private readonly errorMessages: AddressErrorMessages
+  ) {}
+
+  private readonly utils = new PresenterUtils(this.request.body)
+
+  private get keys() {
+    return {
+      addressLine1: `${this.key}-address-line-1`,
+      addressLine2: `${this.key}-address-line-2`,
+      townOrCity: `${this.key}-address-town-or-city`,
+      county: `${this.key}-address-county`,
+      postCode: `${this.key}-address-postcode`,
+    }
+  }
+
+  async validate(): Promise<FormValidationResult<Address>> {
+    const validationResult = await FormUtils.runValidations({ request: this.request, validations: this.validations })
+    const error = this.extractErrors(validationResult)
+    if (error) {
+      return { value: null, error }
+    }
+
+    return {
+      value: this.address!,
+      error: null,
+    }
+  }
+
+  private get validations(): ExpressValidator.ValidationChain[] {
+    return [
+      ExpressValidator.body(this.keys.addressLine1)
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(this.errorMessages.addressLine1Empty),
+
+      ExpressValidator.body(this.keys.postCode)
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(this.errorMessages.postCodeEmpty),
+
+      ExpressValidator.body(this.keys.postCode)
+        .matches(/^\s*[A-Za-z]{1,2}\d[A-Za-z\d]? ?\d[A-Za-z]{2}\s*$/)
+        .withMessage(this.errorMessages.postCodeInvalid),
+    ]
+  }
+
+  private extractErrors(result: ExpressValidator.Result): FormValidationError | null {
+    const formValidationError = FormUtils.validationErrorFromResult(result)
+    if (formValidationError !== null) {
+      return formValidationError
+    }
+    return null
+  }
+
+  private get address(): Address | null {
+    return this.utils.addressValue(null, 'method-other-location', null).value ?? null
+  }
+}

--- a/server/utils/forms/inputs/meetingMethodInput.test.ts
+++ b/server/utils/forms/inputs/meetingMethodInput.test.ts
@@ -1,0 +1,53 @@
+import AddressInput from './addressInput'
+import TestUtils from '../../../../testutils/testUtils'
+import MeetingMethodInput from './meetingMethodInput'
+
+describe(AddressInput, () => {
+  const errorMessages = {
+    empty: 'Select a meeting method',
+  }
+  describe('validate', () => {
+    describe('with valid data', () => {
+      it('returns a meeting method', async () => {
+        const request = TestUtils.createRequest({
+          'meeting-method': 'PHONE_CALL',
+        })
+        const result = await new MeetingMethodInput(request, 'meeting-method', errorMessages).validate()
+        expect(result.value).toEqual('PHONE_CALL')
+      })
+    })
+    describe('with invalid data', () => {
+      describe('with empty selection', () => {
+        it('should present an error', async () => {
+          const request = TestUtils.createRequest({})
+          const result = await new MeetingMethodInput(request, 'meeting-method', errorMessages).validate()
+          expect(result.error).toEqual({
+            errors: [
+              {
+                errorSummaryLinkedField: 'meeting-method',
+                formFields: ['meeting-method'],
+                message: 'Select a meeting method',
+              },
+            ],
+          })
+        })
+      })
+
+      describe('with an invalid selection', () => {
+        it('should present an error', async () => {
+          const request = TestUtils.createRequest({ 'meeting-method': 'INVALID' })
+          const result = await new MeetingMethodInput(request, 'meeting-method', errorMessages).validate()
+          expect(result.error).toEqual({
+            errors: [
+              {
+                errorSummaryLinkedField: 'meeting-method',
+                formFields: ['meeting-method'],
+                message: 'Select a meeting method',
+              },
+            ],
+          })
+        })
+      })
+    })
+  })
+})

--- a/server/utils/forms/inputs/meetingMethodInput.ts
+++ b/server/utils/forms/inputs/meetingMethodInput.ts
@@ -1,0 +1,62 @@
+import { Request } from 'express'
+import * as ExpressValidator from 'express-validator'
+import { FormValidationResult } from '../formValidationResult'
+import { FormValidationError } from '../../formValidationError'
+import FormUtils from '../../formUtils'
+import { AppointmentDeliveryType } from '../../../models/appointmentDeliveryType'
+import PresenterUtils from '../../presenterUtils'
+
+export interface MeetingMethodErrorMessages {
+  empty: string
+}
+
+export default class MeetingMethodInput {
+  constructor(
+    private readonly request: Request,
+    private readonly key: string,
+    private readonly errorMessages: MeetingMethodErrorMessages
+  ) {}
+
+  private readonly utils = new PresenterUtils(this.request.body)
+
+  async validate(): Promise<FormValidationResult<AppointmentDeliveryType>> {
+    const validationResult = await FormUtils.runValidations({ request: this.request, validations: this.validations })
+    const error = this.extractErrors(validationResult)
+    if (error) {
+      return { value: null, error }
+    }
+    return {
+      value: this.meetingMethod!,
+      error: null,
+    }
+  }
+
+  private get meetingMethod(): AppointmentDeliveryType | null {
+    return this.utils.meetingMethodValue(null, this.key, null).value
+  }
+
+  private get validations(): ExpressValidator.ValidationChain[] {
+    return [ExpressValidator.body(this.key).notEmpty({ ignore_whitespace: true }).withMessage(this.errorMessages.empty)]
+  }
+
+  private extractErrors(result: ExpressValidator.Result): FormValidationError | null {
+    const formValidationError = FormUtils.validationErrorFromResult(result)
+    if (formValidationError !== null) {
+      return formValidationError
+    }
+
+    if (this.meetingMethod === null) {
+      return {
+        errors: [
+          {
+            errorSummaryLinkedField: this.key,
+            formFields: [this.key],
+            message: 'Select a meeting method',
+          },
+        ],
+      }
+    }
+
+    return null
+  }
+}

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -3,6 +3,7 @@ import draftReferralFactory from '../../testutils/factories/draftReferral'
 import CalendarDay from './calendarDay'
 import Duration from './duration'
 import ClockTime from './clockTime'
+import { FormValidationError } from './formValidationError'
 
 describe(PresenterUtils, () => {
   describe('stringValue', () => {
@@ -555,6 +556,134 @@ describe(PresenterUtils, () => {
           expect(value.hour.hasError).toEqual(true)
           expect(value.minute.hasError).toEqual(false)
           expect(value.partOfDay.hasError).toEqual(true)
+        })
+      })
+    })
+  })
+
+  describe('meetingMethod', () => {
+    describe('when there is no user input data', () => {
+      describe('and the model has a null value', () => {
+        it('returns a null value', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.meetingMethodValue(null, 'meeting-method', null)
+          expect(value).toMatchObject({ errorMessage: null, value: null })
+        })
+      })
+      describe('and the model has a value', () => {
+        it('returns the model value', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.meetingMethodValue('PHONE_CALL', 'meeting-method', null)
+          expect(value).toMatchObject({ errorMessage: null, value: 'PHONE_CALL' })
+        })
+      })
+    })
+
+    describe('when there is user input data', () => {
+      describe('and the data is valid', () => {
+        it('returns a meeting method', () => {
+          const utils = new PresenterUtils({ 'meeting-method': 'PHONE_CALL' })
+          const value = utils.meetingMethodValue(null, 'meeting-method', null)
+          expect(value).toMatchObject({ errorMessage: null, value: 'PHONE_CALL' })
+        })
+      })
+      describe('and the data is invalid', () => {
+        it('returns a null value', () => {
+          const utils = new PresenterUtils({ 'meeting-method': 'INVALID' })
+          const value = utils.meetingMethodValue(null, 'meeting-method', null)
+          expect(value).toMatchObject({ errorMessage: null, value: null })
+        })
+      })
+    })
+  })
+
+  describe('address', () => {
+    describe('when there are errors', () => {
+      it('they should be linked to the correct field', () => {
+        const utils = new PresenterUtils(null)
+        const errors: FormValidationError = {
+          errors: [
+            {
+              formFields: ['method-other-location-address-line-1'],
+              errorSummaryLinkedField: 'method-other-location-address-line-1',
+              message: 'address-line-1 error',
+            },
+            {
+              formFields: ['method-other-location-address-postcode'],
+              errorSummaryLinkedField: 'method-other-location-address-postcode',
+              message: 'address-postcode error',
+            },
+          ],
+        }
+        const value = utils.addressValue(null, 'method-other-location', errors)
+        expect(value).toMatchObject({
+          errors: {
+            firstAddressLine: 'address-line-1 error',
+            postcode: 'address-postcode error',
+          },
+        })
+      })
+    })
+
+    describe('when there is no user input data', () => {
+      describe('and the model has a null value', () => {
+        it('returns a null value', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.addressValue(null, 'method-other-location', null)
+          expect(value).toMatchObject({ value: null })
+        })
+      })
+      describe('and the model has a value', () => {
+        it('returns the model value', () => {
+          const utils = new PresenterUtils(null)
+          const address = {
+            firstAddressLine: 'Harmony Living Office, Room 4',
+            secondAddressLine: '44 Bouverie Road',
+            townOrCity: 'Blackpool',
+            county: 'Lancashire',
+            postCode: 'SY4 0RE',
+          }
+          const value = utils.addressValue(address, 'method-other-location', null)
+          expect(value).toMatchObject({ value: address })
+        })
+      })
+    })
+
+    describe('when there is user input data', () => {
+      describe('and the data is valid', () => {
+        it('returns an address', () => {
+          const utils = new PresenterUtils({
+            'method-other-location-address-line-1': 'a',
+            'method-other-location-address-line-2': 'b',
+            'method-other-location-address-town-or-city': 'c',
+            'method-other-location-address-county': 'd',
+            'method-other-location-address-postcode': 'e',
+          })
+          const value = utils.addressValue(null, 'method-other-location', null)
+          expect(value).toMatchObject({
+            value: {
+              firstAddressLine: 'a',
+              secondAddressLine: 'b',
+              townOrCity: 'c',
+              county: 'd',
+              postCode: 'e',
+            },
+          })
+        })
+      })
+      describe('and the data is invalid', () => {
+        it('returns a empty values', () => {
+          const utils = new PresenterUtils({ invalid: 'INVALID' })
+          const value = utils.addressValue(null, 'method-other-location', null)
+          expect(value).toMatchObject({
+            value: {
+              firstAddressLine: '',
+              secondAddressLine: '',
+              townOrCity: '',
+              county: '',
+              postCode: '',
+            },
+          })
         })
       })
     })

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -7,6 +7,8 @@ import utils from './utils'
 import AuthUserDetails from '../models/hmppsAuth/authUserDetails'
 import ComplexityLevel from '../models/complexityLevel'
 import { TagArgs } from './govukFrontendTypes'
+import { AppointmentDeliveryType } from '../models/appointmentDeliveryType'
+import Address from '../models/address'
 
 interface DateTimeComponentInputPresenter {
   value: string
@@ -36,6 +38,19 @@ interface TwelveHourTimeInputPresenter {
   hour: DateTimeComponentInputPresenter
   minute: DateTimeComponentInputPresenter
   partOfDay: PartOfDayInputPresenter
+}
+
+interface MeetingMethodInputPresenter {
+  errorMessage: string | null
+  value: AppointmentDeliveryType | null
+}
+
+export interface AddressInputPresenter {
+  value: Address | null
+  errors: {
+    firstAddressLine: string | null
+    postcode: string | null
+  }
 }
 
 export default class PresenterUtils {
@@ -103,6 +118,62 @@ export default class PresenterUtils {
         value: yearValue,
         hasError: PresenterUtils.hasError(error, yearKey),
       },
+    }
+  }
+
+  addressValue(
+    modelValue: Address | null,
+    userInputKey: string,
+    error: FormValidationError | null
+  ): AddressInputPresenter {
+    let address: Address | null
+    if (this.userInputData === null) {
+      address = modelValue
+    } else {
+      const [firstAddressLine, secondAddressLine, townOrCity, county, postCode] = [
+        'address-line-1',
+        'address-line-2',
+        'address-town-or-city',
+        'address-county',
+        'address-postcode',
+      ]
+        .map(suffix => `${userInputKey}-${suffix}`)
+        .map(key => (this.userInputData![key] as string) ?? '')
+      address = {
+        firstAddressLine,
+        secondAddressLine,
+        townOrCity,
+        county,
+        postCode,
+      }
+    }
+    return {
+      value: address,
+      errors: {
+        firstAddressLine: PresenterUtils.errorMessage(error, `${userInputKey}-address-line-1`),
+        postcode: PresenterUtils.errorMessage(error, `${userInputKey}-address-postcode`),
+      },
+    }
+  }
+
+  meetingMethodValue(
+    modelValue: AppointmentDeliveryType | null,
+    userInputKey: string,
+    error: FormValidationError | null
+  ): MeetingMethodInputPresenter {
+    const errorMessage = PresenterUtils.errorMessage(error, userInputKey)
+    let appointmentDeliveryType: AppointmentDeliveryType | null = null
+    if (this.userInputData === null) {
+      appointmentDeliveryType = modelValue
+    } else {
+      const radioButtonValue = this.userInputData['meeting-method']
+      if (['PHONE_CALL', 'VIDEO_CALL', 'IN_PERSON_MEETING_OTHER'].includes(radioButtonValue as string)) {
+        appointmentDeliveryType = radioButtonValue as AppointmentDeliveryType
+      }
+    }
+    return {
+      errorMessage,
+      value: appointmentDeliveryType,
     }
   }
 

--- a/server/views/serviceProviderReferrals/scheduleAppointment.njk
+++ b/server/views/serviceProviderReferrals/scheduleAppointment.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "components/time-input/macro.njk" import appTimeInput %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -36,8 +38,15 @@
           {{ govukDateInput(dateInputArgs) }}
           {{ appTimeInput(timeInputArgs) }}
           {{ govukDateInput(durationDateInputArgs) }}
+          {% set otherLocationHtml %}
+              {{ govukInput(address.firstAddressLineInputArgs) }}
+              {{ govukInput(address.secondAddressLineInputArgs) }}
+              {{ govukInput(address.townOrCityInputArgs) }}
+              {{ govukInput(address.countyInputArgs) }}
+              {{ govukInput(address.postCodeInputArgs) }}
+          {% endset -%}
+          {{ govukRadios(meetingMethodRadioInputArgs(otherLocationHtml)) }}
         </div>
-
         {{ govukButton({ text: "Save and continue" }) }}
       </form>
     </div>

--- a/testutils/factories/actionPlanAppointment.ts
+++ b/testutils/factories/actionPlanAppointment.ts
@@ -22,8 +22,10 @@ class ActionPlanAppointmentFactory extends Factory<ActionPlanAppointment> {
 }
 
 export default ActionPlanAppointmentFactory.define(() => ({
+  sessionNumber: 1,
   appointmentTime: null,
   durationInMinutes: null,
+  appointmentDeliveryType: null,
+  appointmentDeliveryAddress: null,
   sessionFeedback: appointmentFactory.newlyBooked().build().sessionFeedback,
-  sessionNumber: 1,
 }))

--- a/testutils/factories/appointment.ts
+++ b/testutils/factories/appointment.ts
@@ -1,6 +1,7 @@
 import { Factory } from 'fishery'
 import Appointment from '../../server/models/appointment'
 import { Attended } from '../../server/models/appointmentAttendance'
+import { AppointmentDeliveryType } from '../../server/models/appointmentDeliveryType'
 
 class AppointmentFactory extends Factory<Appointment> {
   newlyBooked() {
@@ -24,10 +25,15 @@ class AppointmentFactory extends Factory<Appointment> {
   }
 }
 
+const defaultAppointmentDeliveryType: AppointmentDeliveryType = 'VIDEO_CALL'
+
 export default AppointmentFactory.define(({ sequence }) => ({
   id: sequence.toString(),
   appointmentTime: new Date().toISOString(),
   durationInMinutes: 60,
+  // For some reason the compiler complains if I write 'VIDEO_CALL' inline
+  appointmentDeliveryType: defaultAppointmentDeliveryType,
+  appointmentDeliveryAddress: null,
   sessionFeedback: {
     attendance: {
       attended: null,


### PR DESCRIPTION
## What does this pull request do?

Merges `main` into the `feature/schedule-supplier-assessments` branch.

The merge commit here actually introduces a functionality change and a contract change - namely, it starts to add the ability to specify appointment delivery method / address on a supplier assessment appointment. See the commit message for https://github.com/ministryofjustice/hmpps-interventions-ui/commit/69b0bc261e62e31071c0ef735570066b63d395c5 for more details.

## What is the intent behind these changes?

To bring the supplier assessments branch in line with `main` (fixing merge conflicts).
