### PR TITLE
Fix currentAppointmentId value in supplier assessment contract

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2579,8 +2579,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
 
     it('returns the referral’s supplier assessment, including a list of its appointments', async () => {
+      const appointment = appointmentFactory.newlyBooked().build()
       const supplierAssessment = supplierAssessmentFactory.build({
-        appointments: appointmentFactory.newlyBooked().buildList(1),
+        appointments: [appointment],
+        currentAppointmentId: appointment.id,
       })
 
       await provider.addInteraction({


### PR DESCRIPTION
## What does this pull request do?

Fixes a null `currentAppointmentId` in a contract test.

## What is the intent behind these changes?

To make the contract tests closer to green.
