### PR TITLE
use user token to make calls to ARN supplementary risk API

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -13,7 +13,6 @@ const hmppsAuthService = new HmppsAuthService()
 const communityApiService = new CommunityApiService(hmppsAuthService, communityApiRestClient)
 const interventionsService = new InterventionsService(config.apis.interventionsService)
 const assessRisksAndNeedsService = new AssessRisksAndNeedsService(
-  hmppsAuthService,
   assessRisksAndNeedsRestClient,
   config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
 )

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -107,7 +107,7 @@ export default class ProbationPractitionerReferralsController {
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
       this.communityApiService.getExpandedServiceUserByCRN(crn),
       this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
-      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId),
+      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
       this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
     ])
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -93,7 +93,7 @@ export default class ServiceProviderReferralsController {
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
       this.communityApiService.getExpandedServiceUserByCRN(crn),
       this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
-      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId),
+      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
       this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
     ])
 

--- a/server/routes/testutils/mocks/mockAssessRisksAndNeedsService.ts
+++ b/server/routes/testutils/mocks/mockAssessRisksAndNeedsService.ts
@@ -1,9 +1,8 @@
 import MockRestClient from '../../../data/testutils/mockRestClient'
 import AssessRisksAndNeedsService from '../../../services/assessRisksAndNeedsService'
-import MockedHmppsAuthService from '../../../services/testutils/hmppsAuthServiceSetup'
 
 export default class MockAssessRisksAndNeedsService extends AssessRisksAndNeedsService {
   constructor() {
-    super(new MockedHmppsAuthService(), new MockRestClient(), true)
+    super(new MockRestClient(), true)
   }
 }

--- a/server/services/assessRisksAndNeedsService.test.ts
+++ b/server/services/assessRisksAndNeedsService.test.ts
@@ -2,8 +2,6 @@ import createError from 'http-errors'
 import AssessRisksAndNeedsService from './assessRisksAndNeedsService'
 
 import RestClient from '../data/restClient'
-import MockedHmppsAuthService from './testutils/hmppsAuthServiceSetup'
-import HmppsAuthService from './hmppsAuthService'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 import MockRestClient from '../data/testutils/mockRestClient'
 import riskSummaryFactory from '../../testutils/factories/riskSummary'
@@ -13,29 +11,24 @@ jest.mock('../data/restClient')
 
 describe(AssessRisksAndNeedsService, () => {
   describe('getSupplementaryRiskInformation', () => {
-    const hmppsAuthServiceMock = new MockedHmppsAuthService() as jest.Mocked<HmppsAuthService>
-
     const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
 
-    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock, true)
+    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(restClientMock, true)
 
     const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
 
     it('makes a request to the Assess Risks and Needs API', async () => {
-      hmppsAuthServiceMock.getApiClientToken.mockResolvedValue('testToken')
       restClientMock.get.mockResolvedValue(supplementaryRiskInformation)
-      await assessRisksAndNeedsService.getSupplementaryRiskInformation('riskId')
+      await assessRisksAndNeedsService.getSupplementaryRiskInformation('riskId', 'token')
 
-      expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/supplementary/riskId`, token: 'testToken' })
+      expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/supplementary/riskId`, token: 'token' })
     })
   })
 
   describe('getRiskSummary', () => {
-    const hmppsAuthServiceMock = new MockedHmppsAuthService() as jest.Mocked<HmppsAuthService>
-
     const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
 
-    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock, true)
+    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(restClientMock, true)
 
     const riskSummary = riskSummaryFactory.build()
 
@@ -58,11 +51,9 @@ describe(AssessRisksAndNeedsService, () => {
   })
 
   describe('getRiskSummary when riskSummaryEnabled is false', () => {
-    const hmppsAuthServiceMock = new MockedHmppsAuthService() as jest.Mocked<HmppsAuthService>
-
     const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
 
-    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(hmppsAuthServiceMock, restClientMock, false)
+    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(restClientMock, false)
 
     it('returns null and does not call Assess Risks and Needs API', async () => {
       const result = await assessRisksAndNeedsService.getRiskSummary('crn123', 'token')

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -1,25 +1,17 @@
 import createError from 'http-errors'
 import RestClient from '../data/restClient'
-import HmppsAuthService from './hmppsAuthService'
 import logger from '../../log'
 import { SupplementaryRiskInformation } from '../models/assessRisksAndNeeds/supplementaryRiskInformation'
 import RiskSummary from '../models/assessRisksAndNeeds/riskSummary'
 
 export default class AssessRisksAndNeedsService {
-  constructor(
-    private readonly hmppsAuthService: HmppsAuthService,
-    private readonly restClient: RestClient,
-    private readonly riskSummaryEnabled: boolean
-  ) {}
+  constructor(private readonly restClient: RestClient, private readonly riskSummaryEnabled: boolean) {}
 
-  async getSupplementaryRiskInformation(
-    riskId: string,
-    token: string | null = null
-  ): Promise<SupplementaryRiskInformation> {
+  async getSupplementaryRiskInformation(riskId: string, token: string): Promise<SupplementaryRiskInformation> {
     logger.info({ riskId }, 'getting supplementary risk information')
     return (await this.restClient.get({
       path: `/risks/supplementary/${riskId}`,
-      token: token || (await this.hmppsAuthService.getApiClientToken()),
+      token,
     })) as SupplementaryRiskInformation
   }
 


### PR DESCRIPTION
**DO NOT MERGE YET**

## What does this pull request do?

use user token to make calls to ARN supplementary risk API instead of the client credentials token

## What is the intent behind these changes?

ARN API is moving to a different auth model, where permissions are based on user tokens, not client tokens. 
