### PR TITLE
IC-1975: Use intervention title rather than contract type in SP & PP dashboards

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -18,8 +18,14 @@ describe('Probation practitioner referrals dashboard', () => {
 
   it("user logs in and sees 'My cases' screen with list of sent referrals", () => {
     const serviceCategory = serviceCategoryFactory.build()
-    const accommodationIntervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
-    const womensServicesIntervention = interventionFactory.build({ contractType: { name: "womens' services" } })
+    const accommodationIntervention = interventionFactory.build({
+      contractType: { name: 'accommodation' },
+      title: 'accommodation services - west midlands',
+    })
+    const womensServicesIntervention = interventionFactory.build({
+      contractType: { name: "women's services" },
+      title: "women's services - west midlands",
+    })
 
     const sentReferrals = [
       sentReferralFactory.build({
@@ -80,7 +86,7 @@ describe('Probation practitioner referrals dashboard', () => {
         {
           Referral: 'ABCABCA1',
           'Service user': 'George Michael',
-          'Service category': 'Accommodation',
+          'Intervention type': 'Accommodation Services - West Midlands',
           Provider: 'Harmony Living',
           Caseworker: 'Unassigned',
           Action: 'View',
@@ -88,7 +94,7 @@ describe('Probation practitioner referrals dashboard', () => {
         {
           Referral: 'ABCABCA2',
           'Service user': 'Jenny Jones',
-          'Service category': "Womens' services",
+          'Intervention type': "Women's Services - West Midlands",
           Provider: 'Harmony Living',
           Caseworker: 'A. Caseworker',
           Action: 'View',

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -25,11 +25,13 @@ describe('Service provider referrals dashboard', () => {
 
     const personalWellbeingIntervention = interventionFactory.build({
       contractType: { code: 'PWB', name: 'Personal wellbeing' },
+      title: 'personal wellbeing - west midlands',
       serviceCategories: [accommodationServiceCategory, socialInclusionServiceCategory],
     })
 
     const socialInclusionIntervention = interventionFactory.build({
       contractType: { code: 'SOC', name: 'Social inclusion' },
+      title: 'social inclusion - west midlands',
       serviceCategories: [socialInclusionServiceCategory],
     })
 
@@ -171,7 +173,7 @@ describe('Service provider referrals dashboard', () => {
       .should('deep.equal', [
         {
           'Date received': '26 Jan 2021',
-          'Intervention type': 'Social inclusion',
+          'Intervention type': 'Social Inclusion - West Midlands',
           Referral: 'ABCABCA1',
           'Service user': 'George Michael',
           Caseworker: '',
@@ -179,7 +181,7 @@ describe('Service provider referrals dashboard', () => {
         },
         {
           'Date received': '13 Sep 2020',
-          'Intervention type': 'Personal wellbeing',
+          'Intervention type': 'Personal Wellbeing - West Midlands',
           Referral: 'ABCABCA2',
           'Service user': 'Jenny Jones',
           Caseworker: '',

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.test.ts
@@ -4,8 +4,8 @@ import MyCasesPresenter from './myCasesPresenter'
 
 describe('MyCasesPresenter', () => {
   const interventions = [
-    interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } }),
-    interventionFactory.build({ id: '2', contractType: { name: "womens' services" } }),
+    interventionFactory.build({ id: '1', title: 'accommodation services - west midlands' }),
+    interventionFactory.build({ id: '2', title: "women's services - west midlands" }),
   ]
   const referrals = [
     SentReferralFactory.assigned().build({
@@ -45,17 +45,25 @@ describe('MyCasesPresenter', () => {
         expect.arrayContaining([
           { text: 'Rob Shah-Brookes', sortValue: 'shah-brookes, rob', href: null },
           { text: 'UserABC', sortValue: 'AUserABC', href: null },
-          { text: 'Accommodation', sortValue: 'accommodation', href: null },
+          {
+            text: 'Accommodation Services - West Midlands',
+            sortValue: 'accommodation services - west midlands',
+            href: null,
+          },
         ]),
         expect.arrayContaining([
           { text: 'Hardip Fraiser', sortValue: 'fraiser, hardip', href: null },
           { text: 'Unassigned', sortValue: 'Unassigned', href: null },
-          { text: "Womens' services", sortValue: "womens' services", href: null },
+          { text: "Women's Services - West Midlands", sortValue: "women's services - west midlands", href: null },
         ]),
         expect.arrayContaining([
           { text: 'Jenny Catherine', sortValue: 'catherine, jenny', href: null },
           { text: 'UserABC', sortValue: 'AUserABC', href: null },
-          { text: 'Accommodation', sortValue: 'accommodation', href: null },
+          {
+            text: 'Accommodation Services - West Midlands',
+            sortValue: 'accommodation services - west midlands',
+            href: null,
+          },
         ]),
       ])
     })

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.test.ts
@@ -47,21 +47,21 @@ describe('MyCasesPresenter', () => {
           { text: 'UserABC', sortValue: 'AUserABC', href: null },
           {
             text: 'Accommodation Services - West Midlands',
-            sortValue: 'accommodation services - west midlands',
+            sortValue: null,
             href: null,
           },
         ]),
         expect.arrayContaining([
           { text: 'Hardip Fraiser', sortValue: 'fraiser, hardip', href: null },
           { text: 'Unassigned', sortValue: 'Unassigned', href: null },
-          { text: "Women's Services - West Midlands", sortValue: "women's services - west midlands", href: null },
+          { text: "Women's Services - West Midlands", sortValue: null, href: null },
         ]),
         expect.arrayContaining([
           { text: 'Jenny Catherine', sortValue: 'catherine, jenny', href: null },
           { text: 'UserABC', sortValue: 'AUserABC', href: null },
           {
             text: 'Accommodation Services - West Midlands',
-            sortValue: 'accommodation services - west midlands',
+            sortValue: null,
             href: null,
           },
         ]),

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
@@ -13,7 +13,7 @@ export default class MyCasesPresenter {
   readonly tableHeadings: SortableTableHeaders = [
     { text: 'Referral', sort: 'none' },
     { text: 'Service user', sort: 'ascending' },
-    { text: 'Service category', sort: 'none' },
+    { text: 'Intervention type', sort: 'none' },
     { text: 'Provider', sort: 'none' },
     { text: 'Caseworker', sort: 'none' },
     { text: 'Action', sort: 'none' },
@@ -42,8 +42,8 @@ export default class MyCasesPresenter {
         href: null,
       },
       {
-        text: utils.convertToProperCase(interventionForReferral.contractType.name),
-        sortValue: interventionForReferral.contractType.name,
+        text: utils.convertToTitleCase(interventionForReferral.title),
+        sortValue: interventionForReferral.title,
         href: null,
       },
       {

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
@@ -43,7 +43,7 @@ export default class MyCasesPresenter {
       },
       {
         text: utils.convertToTitleCase(interventionForReferral.title),
-        sortValue: interventionForReferral.title,
+        sortValue: null,
         href: null,
       },
       {

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -72,7 +72,7 @@ describe('GET /probation-practitioner/find', () => {
 
 describe('GET /probation-practitioner/dashboard', () => {
   it('displays a dashboard page', async () => {
-    const intervention = interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } })
+    const intervention = interventionFactory.build({ id: '1', title: 'accommodation services - west midlands' })
     const referrals = [
       sentReferralFactory.assigned().build({
         referral: {
@@ -93,7 +93,7 @@ describe('GET /probation-practitioner/dashboard', () => {
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Alex River')
-        expect(res.text).toContain('Accommodation')
+        expect(res.text).toContain('Accommodation Services - West Midlands')
       })
   })
 })

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -6,8 +6,14 @@ describe(DashboardPresenter, () => {
   describe('tableRows', () => {
     it('returns the table’s rows', () => {
       const interventions = [
-        interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } }),
-        interventionFactory.build({ id: '2', contractType: { name: "women's services" } }),
+        interventionFactory.build({
+          id: '1',
+          title: 'accommodation services - west midlands',
+        }),
+        interventionFactory.build({
+          id: '2',
+          title: "women's services - west midlands",
+        }),
       ]
       const sentReferrals = [
         sentReferralFactory.build({
@@ -35,7 +41,7 @@ describe(DashboardPresenter, () => {
           { text: '26 Jan 2021', sortValue: '2021-01-26', href: null },
           { text: 'ABCABCA1', sortValue: null, href: null },
           { text: 'George Michael', sortValue: 'michael, george', href: null },
-          { text: 'Accommodation', sortValue: null, href: null },
+          { text: 'Accommodation Services - West Midlands', sortValue: null, href: null },
           { text: '', sortValue: null, href: null },
           { text: 'View', sortValue: null, href: `/service-provider/referrals/${sentReferrals[0].id}/details` },
         ],
@@ -43,7 +49,7 @@ describe(DashboardPresenter, () => {
           { text: '13 Sep 2020', sortValue: '2020-09-13', href: null },
           { text: 'ABCABCA2', sortValue: null, href: null },
           { text: 'Jenny Jones', sortValue: 'jones, jenny', href: null },
-          { text: "Women's services", sortValue: null, href: null },
+          { text: "Women's Services - West Midlands", sortValue: null, href: null },
           { text: '', sortValue: null, href: null },
           { text: 'View', sortValue: null, href: `/service-provider/referrals/${sentReferrals[1].id}/details` },
         ],

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -41,7 +41,7 @@ export default class DashboardPresenter {
         sortValue: PresenterUtils.fullNameSortValue(serviceUser),
         href: null,
       },
-      { text: utils.convertToProperCase(interventionForReferral.contractType.name), sortValue: null, href: null },
+      { text: utils.convertToTitleCase(interventionForReferral.title), sortValue: null, href: null },
       { text: referral.assignedTo?.username ?? '', sortValue: null, href: null },
       { text: 'View', sortValue: null, href: DashboardPresenter.hrefForViewing(referral) },
     ]

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -53,10 +53,13 @@ afterEach(() => {
 
 describe('GET /service-provider/dashboard', () => {
   it('displays a list of all sent referrals', async () => {
-    const accommodationIntervention = interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } })
+    const accommodationIntervention = interventionFactory.build({
+      id: '1',
+      title: 'accommodation services - west midlands',
+    })
     const womensServicesIntervention = interventionFactory.build({
       id: '2',
-      contractType: { name: "women's services" },
+      title: "women's services - west midlands",
     })
 
     const sentReferrals = [
@@ -87,7 +90,7 @@ describe('GET /service-provider/dashboard', () => {
         expect(res.text).toContain('George Michael')
         expect(res.text).toContain('Accommodation')
         expect(res.text).toContain('Jenny Jones')
-        expect(res.text).toContain('Women&#39;s services')
+        expect(res.text).toContain('Women&#39;s Services - West Midlands')
       })
   })
 })


### PR DESCRIPTION
## What does this pull request do?

Uses intervention title rather than contract type in SP & PP dashboards

## What is the intent behind these changes?

Intervention titles often include the region, which should make it easier for users to see, at a glance, where each referral is for.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/123136476-de77e580-d44a-11eb-92bf-084b91823745.png)
