### PR TITLE
change ARN risk summary endpoint to retrieve rosh summary _and_ risk to self

### DIFF
--- a/mockApis/assessRisksAndNeedsService.ts
+++ b/mockApis/assessRisksAndNeedsService.ts
@@ -23,7 +23,7 @@ export default class AssessRisksAndNeedsServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/assess-risks-and-needs/risks/crn/${crn}/summary`,
+        urlPattern: `/assess-risks-and-needs/risks/crn/${crn}`,
       },
       response: {
         status: 200,

--- a/server/models/assessRisksAndNeeds/riskSummary.ts
+++ b/server/models/assessRisksAndNeeds/riskSummary.ts
@@ -1,10 +1,12 @@
 export type RiskScore = 'LOW' | 'MEDIUM' | 'HIGH' | 'VERY_HIGH'
 
 export default interface RiskSummary {
-  whoIsAtRisk?: string | null
-  natureOfRisk?: string | null
-  riskImminence?: string | null
-  riskIncreaseFactors?: string | null
-  riskMitigationFactors?: string | null
-  riskInCommunity: Partial<Record<RiskScore, string[]>>
+  summary: {
+    whoIsAtRisk?: string | null
+    natureOfRisk?: string | null
+    riskImminence?: string | null
+    riskIncreaseFactors?: string | null
+    riskMitigationFactors?: string | null
+    riskInCommunity: Partial<Record<RiskScore, string[]>>
+  }
 }

--- a/server/routes/shared/riskPresenter.ts
+++ b/server/routes/shared/riskPresenter.ts
@@ -17,7 +17,7 @@ export default class RiskPresenter {
   get roshAnalysisRows(): RoshAnalysisTableRow[] {
     if (this.riskSummary === null) return []
 
-    return Object.entries(this.riskSummary.riskInCommunity).flatMap(([riskScore, riskGroups]) => {
+    return Object.entries(this.riskSummary.summary.riskInCommunity).flatMap(([riskScore, riskGroups]) => {
       return riskGroups.map(riskTo => {
         return { riskTo, riskScore }
       })

--- a/server/services/assessRisksAndNeedsService.test.ts
+++ b/server/services/assessRisksAndNeedsService.test.ts
@@ -43,7 +43,7 @@ describe(AssessRisksAndNeedsService, () => {
       restClientMock.get.mockResolvedValue(riskSummary)
       await assessRisksAndNeedsService.getRiskSummary('crn123', 'token')
 
-      expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/crn/crn123/summary`, token: 'token' })
+      expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/crn/crn123`, token: 'token' })
     })
 
     it('provides a userMessage on failure', async () => {

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -32,7 +32,7 @@ export default class AssessRisksAndNeedsService {
     logger.info({ crn }, 'getting risk summary information')
     try {
       return (await this.restClient.get({
-        path: `/risks/crn/${crn}/summary`,
+        path: `/risks/crn/${crn}`,
         token,
       })) as RiskSummary
     } catch (err) {

--- a/testutils/factories/riskSummary.ts
+++ b/testutils/factories/riskSummary.ts
@@ -2,9 +2,13 @@ import { Factory } from 'fishery'
 import RiskSummary from '../../server/models/assessRisksAndNeeds/riskSummary'
 
 export default Factory.define<RiskSummary>(() => ({
-  riskInCommunity: {
-    LOW: ['prisoners'],
-    HIGH: ['children', 'known adult'],
-    VERY_HIGH: ['staff'],
+  summary: {
+    riskInCommunity: {
+      LOW: ['prisoners'],
+      HIGH: ['children', 'known adult'],
+      VERY_HIGH: ['staff'],
+    },
+    natureOfRisk: 'physically aggressive',
+    riskImminence: 'can happen at the drop of a hat',
   },
 }))


### PR DESCRIPTION


## What does this pull request do?

returns more information in the risk summary endpoint so we don't have to call another endpoint later to get risk to self data.

## What is the intent behind these changes?

prepare for changes which add 'risk to self' 
