### PR TITLE
IC-1829 include further risk information for PPs 

### DIFF
--- a/mockApis/assessRisksAndNeedsService.ts
+++ b/mockApis/assessRisksAndNeedsService.ts
@@ -23,7 +23,7 @@ export default class AssessRisksAndNeedsServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/assess-risks-and-needs/risks/crn/${crn}/summary`,
+        urlPattern: `/assess-risks-and-needs/risks/crn/${crn}`,
       },
       response: {
         status: 200,

--- a/server/models/assessRisksAndNeeds/riskSummary.ts
+++ b/server/models/assessRisksAndNeeds/riskSummary.ts
@@ -1,10 +1,12 @@
 export type RiskScore = 'LOW' | 'MEDIUM' | 'HIGH' | 'VERY_HIGH'
 
 export default interface RiskSummary {
-  whoIsAtRisk?: string | null
-  natureOfRisk?: string | null
-  riskImminence?: string | null
-  riskIncreaseFactors?: string | null
-  riskMitigationFactors?: string | null
-  riskInCommunity: Partial<Record<RiskScore, string[]>>
+  summary: {
+    whoIsAtRisk?: string | null
+    natureOfRisk?: string | null
+    riskImminence?: string | null
+    riskIncreaseFactors?: string | null
+    riskMitigationFactors?: string | null
+    riskInCommunity: Partial<Record<RiskScore, string[]>>
+  }
 }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -365,6 +365,8 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
         expect(res.text).toContain("service user's Risk of Serious Harm (ROSH) levels")
         expect(res.text).toContain('Children')
         expect(res.text).toContain('HIGH')
+        expect(res.text).toContain('The following information is not seen by the service provider.')
+        expect(res.text).toContain('can happen at the drop of a hat')
       })
   })
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -309,6 +309,8 @@ describe('GET /referrals/:id/risk-information', () => {
         expect(res.text).toContain('HIGH')
         expect(res.text).toContain('Prisoners')
         expect(res.text).toContain('LOW')
+        expect(res.text).toContain('The following information is not seen by the service provider.')
+        expect(res.text).toContain('can happen at the drop of a hat')
       })
 
     expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['token', '1'])

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -6,7 +6,7 @@ import RiskView from '../shared/riskView'
 export default class RiskInformationView {
   constructor(private readonly presenter: RiskInformationPresenter) {}
 
-  private riskView = new RiskView(this.presenter.riskPresenter)
+  private riskView = new RiskView(this.presenter.riskPresenter, 'probation-practitioner')
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
 

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -35,6 +35,7 @@ export default class RiskInformationView {
         additionalRiskInformationTextareaArgs: this.additionalRiskInformationTextareaArgs,
         roshAnalysisTableArgs: this.riskView.roshAnalysisTableArgs.bind(this.riskView),
         riskLevelDetailsArgs: this.riskView.riskLevelDetailsArgs,
+        furtherRiskInformation: this.riskView.furtherRiskInformation,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -156,6 +156,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
         expect(res.text).toContain("service user's Risk of Serious Harm (ROSH) levels")
         expect(res.text).toContain('Children')
         expect(res.text).toContain('HIGH')
+        expect(res.text).not.toContain('can happen at the drop of a hat')
       })
   })
 

--- a/server/routes/shared/riskPresenter.test.ts
+++ b/server/routes/shared/riskPresenter.test.ts
@@ -18,4 +18,15 @@ describe(RiskPresenter, () => {
       ])
     })
   })
+
+  describe('text', () => {
+    it('contains additional risk information', () => {
+      const presenter = new RiskPresenter(riskSummary.build())
+      expect(presenter.text).toMatchObject({
+        natureOfRisk: 'physically aggressive',
+        riskImminence: 'can happen at the drop of a hat',
+        whoIsAtRisk: undefined,
+      })
+    })
+  })
 })

--- a/server/routes/shared/riskPresenter.ts
+++ b/server/routes/shared/riskPresenter.ts
@@ -10,6 +10,12 @@ export default class RiskPresenter {
 
   readonly riskSummaryEnabled = this.riskSummary !== null
 
+  readonly text = {
+    whoIsAtRisk: this.riskSummary?.summary.whoIsAtRisk,
+    natureOfRisk: this.riskSummary?.summary.natureOfRisk,
+    riskImminence: this.riskSummary?.summary.riskImminence,
+  }
+
   get roshAnalysisHeaders(): string[] {
     return ['Risk to', 'Risk in community']
   }

--- a/server/routes/shared/riskPresenter.ts
+++ b/server/routes/shared/riskPresenter.ts
@@ -17,7 +17,7 @@ export default class RiskPresenter {
   get roshAnalysisRows(): RoshAnalysisTableRow[] {
     if (this.riskSummary === null) return []
 
-    return Object.entries(this.riskSummary.riskInCommunity).flatMap(([riskScore, riskGroups]) => {
+    return Object.entries(this.riskSummary.summary.riskInCommunity).flatMap(([riskScore, riskGroups]) => {
       return riskGroups.map(riskTo => {
         return { riskTo, riskScore }
       })

--- a/server/routes/shared/riskView.ts
+++ b/server/routes/shared/riskView.ts
@@ -3,7 +3,10 @@ import utils from '../../utils/utils'
 import RiskPresenter from './riskPresenter'
 
 export default class RiskView {
-  constructor(private readonly presenter: RiskPresenter) {}
+  constructor(
+    private readonly presenter: RiskPresenter,
+    private readonly userType: 'probation-practitioner' | 'service-provider'
+  ) {}
 
   roshAnalysisTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
     return {

--- a/server/routes/shared/riskView.ts
+++ b/server/routes/shared/riskView.ts
@@ -62,4 +62,43 @@ export default class RiskView {
             </ul>`,
     }
   }
+
+  get furtherRiskInformation(): string {
+    if (this.userType === 'service-provider') {
+      return ''
+    }
+
+    if (!(this.presenter.text.whoIsAtRisk || this.presenter.text.natureOfRisk || this.presenter.text.riskImminence)) {
+      return ''
+    }
+
+    const sections = [
+      `<div class="govuk-inset-text">
+       <p class="govuk-body">The following information is not seen by the service provider.<p>`,
+    ]
+
+    if (this.presenter.text.whoIsAtRisk != null) {
+      sections.push(`
+        <h3 class="govuk-heading-m">Who is at risk?</h3>
+        <p class="govuk-body">${this.presenter.text.whoIsAtRisk}</p>
+      `)
+    }
+
+    if (this.presenter.text.natureOfRisk != null) {
+      sections.push(`
+        <h3 class="govuk-heading-m">What is the nature of the risk?</h3>
+        <p class="govuk-body">${this.presenter.text.natureOfRisk}</p>
+      `)
+    }
+
+    if (this.presenter.text.riskImminence != null) {
+      sections.push(`
+        <h3 class="govuk-heading-m">When is the risk likely to be greatest?</h3>
+        <p class="govuk-body">${this.presenter.text.riskImminence}</p>
+      `)
+    }
+
+    sections.push('</div>')
+    return sections.join('')
+  }
 }

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -33,7 +33,7 @@ export default class ShowReferralPresenter {
     private readonly sentBy: DeliusUser,
     private readonly assignee: AuthUserDetails | null,
     private readonly assignEmailError: FormValidationError | null,
-    subNavUrlPrefix: 'service-provider' | 'probation-practitioner',
+    readonly userType: 'service-provider' | 'probation-practitioner',
     readonly canAssignReferral: boolean,
     private readonly deliusServiceUser: ExpandedDeliusServiceUser,
     private readonly riskSummary: RiskSummary | null
@@ -41,7 +41,7 @@ export default class ShowReferralPresenter {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,
       sentReferral.id,
-      subNavUrlPrefix
+      userType
     )
 
     this.riskPresenter = new RiskPresenter(riskSummary)

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -11,7 +11,7 @@ interface ServiceCategorySection {
 export default class ShowReferralView {
   constructor(private readonly presenter: ShowReferralPresenter) {}
 
-  private readonly riskView = new RiskView(this.presenter.riskPresenter)
+  private readonly riskView = new RiskView(this.presenter.riskPresenter, this.presenter.userType)
 
   private readonly probationPractitionerSummaryListArgs = ViewUtils.summaryListArgs(
     this.presenter.probationPractitionerDetails

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -68,6 +68,7 @@ export default class ShowReferralView {
         backLinkArgs: this.backLinkArgs,
         roshAnalysisTableArgs: this.riskView.roshAnalysisTableArgs.bind(this.riskView),
         riskLevelDetailsArgs: this.riskView.riskLevelDetailsArgs,
+        furtherRiskInformation: this.riskView.furtherRiskInformation,
       },
     ]
   }

--- a/server/services/assessRisksAndNeedsService.test.ts
+++ b/server/services/assessRisksAndNeedsService.test.ts
@@ -43,7 +43,7 @@ describe(AssessRisksAndNeedsService, () => {
       restClientMock.get.mockResolvedValue(riskSummary)
       await assessRisksAndNeedsService.getRiskSummary('crn123', 'token')
 
-      expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/crn/crn123/summary`, token: 'token' })
+      expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/crn/crn123`, token: 'token' })
     })
 
     it('provides a userMessage on failure', async () => {

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -32,7 +32,7 @@ export default class AssessRisksAndNeedsService {
     logger.info({ crn }, 'getting risk summary information')
     try {
       return (await this.restClient.get({
-        path: `/risks/crn/${crn}/summary`,
+        path: `/risks/crn/${crn}`,
         token,
       })) as RiskSummary
     } catch (err) {

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -33,6 +33,8 @@
 
         {{ govukDetails(riskLevelDetailsArgs) }}
 
+        {{ furtherRiskInformation | safe }}
+
       {% endif %}
 
       <form method="post">

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -39,6 +39,8 @@
 
         {{ govukDetails(riskLevelDetailsArgs) }}
 
+        {{ furtherRiskInformation | safe }}
+
       {% endif %}
 
       {{ govukSummaryList(serviceUserRisksSummaryListArgs) }}

--- a/testutils/factories/riskSummary.ts
+++ b/testutils/factories/riskSummary.ts
@@ -2,9 +2,13 @@ import { Factory } from 'fishery'
 import RiskSummary from '../../server/models/assessRisksAndNeeds/riskSummary'
 
 export default Factory.define<RiskSummary>(() => ({
-  riskInCommunity: {
-    LOW: ['prisoners'],
-    HIGH: ['children', 'known adult'],
-    VERY_HIGH: ['staff'],
+  summary: {
+    riskInCommunity: {
+      LOW: ['prisoners'],
+      HIGH: ['children', 'known adult'],
+      VERY_HIGH: ['staff'],
+    },
+    natureOfRisk: 'physically aggressive',
+    riskImminence: 'can happen at the drop of a hat',
   },
 }))


### PR DESCRIPTION
## What does this pull request do?

Adds the following section between 'ROSH analysis' and 'Additional referral information' on the PP facing risk and referral details screens. 

There is some setup code in the first two commits so review commit by commit is recommended. 

<img width="585" alt="Screenshot 2021-06-23 at 21 19 52" src="https://user-images.githubusercontent.com/63233073/123162634-c1520f80-d468-11eb-99ea-a26eb0787c0d.png">

