### PR TITLE
User can view supplier assessment delivery type and address

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1222,6 +1222,12 @@ describe('Service provider referrals dashboard', () => {
 
       cy.contains('24 March 2021')
       cy.contains('9:02am to 10:17am')
+      cy.contains('In-person meeting')
+      cy.contains('Harmony Living Office, Room 4')
+      cy.contains('44 Bouverie Road')
+      cy.contains('Blackpool')
+      cy.contains('Lancashire')
+      cy.contains('SY4 0RE')
     })
 
     it('User reschedules a supplier assessment appointment', () => {

--- a/server/routes/serviceProviderReferrals/supplierAssessmentAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/supplierAssessmentAppointmentPresenter.test.ts
@@ -1,22 +1,87 @@
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 import appointmentFactory from '../../../testutils/factories/appointment'
 import SupplierAssessmentAppointmentPresenter from './supplierAssessmentAppointmentPresenter'
+import { AppointmentDeliveryType } from '../../models/appointmentDeliveryType'
 
 describe(SupplierAssessmentAppointmentPresenter, () => {
   const referral = sentReferralFactory.build()
 
   describe('summary', () => {
-    it('returns a summary of the appointment', () => {
+    it('contains the date and time of the appointment', () => {
       const appointment = appointmentFactory.build({
         appointmentTime: '2021-03-09T11:00:00Z',
         durationInMinutes: 60,
       })
       const presenter = new SupplierAssessmentAppointmentPresenter(referral, appointment)
 
-      expect(presenter.summary).toEqual([
+      expect(presenter.summary.slice(0, 2)).toEqual([
         { key: 'Date', lines: ['9 March 2021'] },
         { key: 'Time', lines: ['11:00am to 12:00pm'] },
       ])
+    })
+
+    const deliveryTypesTable: [string, AppointmentDeliveryType, string][] = [
+      ['phone call appointment', 'PHONE_CALL', 'Phone call'],
+      ['video call appointment', 'VIDEO_CALL', 'Video call'],
+      [
+        'in-person appointment in a probation office',
+        'IN_PERSON_MEETING_PROBATION_OFFICE',
+        'In-person meeting (probation office)',
+      ],
+      ['in-person appointment in some other location', 'IN_PERSON_MEETING_OTHER', 'In-person meeting'],
+    ]
+    describe.each(deliveryTypesTable)('for a %s', (_, deliveryType, expectedDisplayValue) => {
+      it('contains the method of the appointment', () => {
+        const appointment = appointmentFactory.build({ appointmentDeliveryType: deliveryType })
+        const presenter = new SupplierAssessmentAppointmentPresenter(referral, appointment)
+
+        expect(presenter.summary[2]).toEqual({ key: 'Method', lines: [expectedDisplayValue] })
+      })
+    })
+
+    describe('when the appointment does not have a delivery address', () => {
+      it('does not contain a row for the address', () => {
+        const appointment = appointmentFactory.build({ appointmentDeliveryAddress: null })
+        const presenter = new SupplierAssessmentAppointmentPresenter(referral, appointment)
+
+        expect(presenter.summary.map(row => row.key)).toEqual(['Date', 'Time', 'Method'])
+      })
+    })
+
+    describe('when the appointment has a delivery address', () => {
+      const address = {
+        firstAddressLine: '123 Fake Street',
+        secondAddressLine: 'Fakesvillage',
+        townOrCity: 'Manchester',
+        county: 'Greater Manchester',
+        postCode: 'N4 1HG',
+      }
+
+      it('contains the address', () => {
+        const appointment = appointmentFactory.build({
+          appointmentDeliveryAddress: address,
+        })
+        const presenter = new SupplierAssessmentAppointmentPresenter(referral, appointment)
+
+        expect(presenter.summary[3]).toEqual({
+          key: 'Address',
+          lines: ['123 Fake Street', 'Fakesvillage', 'Manchester', 'Greater Manchester', 'N4 1HG'],
+        })
+      })
+
+      describe('when the second address line is absent', () => {
+        it('doesn’t contain a line for the second address line', () => {
+          const appointment = appointmentFactory.build({
+            appointmentDeliveryAddress: { ...address, secondAddressLine: null },
+          })
+          const presenter = new SupplierAssessmentAppointmentPresenter(referral, appointment)
+
+          expect(presenter.summary[3]).toEqual({
+            key: 'Address',
+            lines: ['123 Fake Street', 'Manchester', 'Greater Manchester', 'N4 1HG'],
+          })
+        })
+      })
     })
   })
 

--- a/server/routes/serviceProviderReferrals/supplierAssessmentAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/supplierAssessmentAppointmentPresenter.ts
@@ -10,18 +10,56 @@ export default class SupplierAssessmentAppointmentPresenter {
 
   private readonly appointmentDecorator = new AppointmentDecorator(this.appointment)
 
-  summary: SummaryListItem[] = [
-    { key: 'Date', lines: [PresenterUtils.govukFormattedDate(this.appointmentDecorator.britishDay!)] },
-    {
-      key: 'Time',
-      lines: [
-        PresenterUtils.formattedTimeRange(
-          this.appointmentDecorator.britishTime!,
-          this.appointmentDecorator.britishEndsAtTime!
-        ),
-      ],
-    },
-  ]
+  get summary(): SummaryListItem[] {
+    return [
+      { key: 'Date', lines: [PresenterUtils.govukFormattedDate(this.appointmentDecorator.britishDay!)] },
+      {
+        key: 'Time',
+        lines: [
+          PresenterUtils.formattedTimeRange(
+            this.appointmentDecorator.britishTime!,
+            this.appointmentDecorator.britishEndsAtTime!
+          ),
+        ],
+      },
+      {
+        key: 'Method',
+        lines: [this.deliveryMethod],
+      },
+      this.addressLines === null ? null : { key: 'Address', lines: this.addressLines },
+    ].flatMap(val => (val === null ? [] : [val]))
+  }
+
+  private get deliveryMethod(): string {
+    switch (this.appointment.appointmentDeliveryType) {
+      case 'PHONE_CALL':
+        return 'Phone call'
+      case 'VIDEO_CALL':
+        return 'Video call'
+      case 'IN_PERSON_MEETING_PROBATION_OFFICE':
+        // We've not added this option to the input form yet so this is just a guess
+        return 'In-person meeting (probation office)'
+      case 'IN_PERSON_MEETING_OTHER':
+        return 'In-person meeting'
+      default:
+        throw new Error(`Unexpected delivery type ${this.appointment.appointmentDeliveryType}`)
+    }
+  }
+
+  private get addressLines(): string[] | null {
+    if (this.appointment.appointmentDeliveryAddress === null) {
+      return null
+    }
+
+    const address = this.appointment.appointmentDeliveryAddress
+    return [
+      address.firstAddressLine,
+      address.secondAddressLine,
+      address.townOrCity,
+      address.county,
+      address.postCode,
+    ].flatMap(val => (val === null ? [] : [val]))
+  }
 
   readonly actionLink: { href: string; text: string } | null =
     sessionStatus.forAppointment(this.appointment) === SessionStatus.scheduled


### PR DESCRIPTION
## What does this pull request do?

Adds the supplier assessment method, and address if applicable, to the service provider "show supplier assessment details" page.

<img width="656" alt="Screenshot 2021-06-24 at 09 40 09" src="https://user-images.githubusercontent.com/53756884/123231767-68b65d00-d4d0-11eb-8d49-89a334124e97.png">

## What is the intent behind these changes?

To let a service provider caseworker know how / where to deliver the supplier assessment.
