### PR TITLE
IC-1830 do not error on missing risk data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,21 @@ services:
     environment:
       - SERVER_PORT=8080
       - OAUTH_ENDPOINT_URL=http://hmpps-auth:8090/auth
+      - ASSESSMENTAPI_BASEURL=http://offender-assessments-api:8080
+
+  offender-assessments-api:
+    image: quay.io/hmpps/offender-assessments-api:latest
+    networks:
+      - hmpps
+    container_name: offender-assessments-api
+    restart: always
+    ports:
+      - "8095:8080"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+    environment:
+      - SERVER_PORT=8080
+      - OAUTH_ENDPOINT_URL=http://hmpps-auth:8090/auth
 
 networks:
   hmpps:

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -32,16 +32,16 @@ export default class RiskInformationPresenter {
   }
 
   get additionalRiskInformation(): Record<string, string | null> {
-    return this.riskPresenter.riskSummaryEnabled
+    return this.riskPresenter.riskSummaryNotFound
       ? {
-          label: 'Additional risk information',
-          labelClasses: 'govuk-label--l',
+          label: `Information for the service provider about ${this.referral.serviceUser?.firstName}’s risks`,
+          labelClasses: 'govuk-label--s',
           hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
           errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
         }
       : {
-          label: `Information for the service provider about ${this.referral.serviceUser?.firstName}’s risks`,
-          labelClasses: 'govuk-label--s',
+          label: 'Additional risk information',
+          labelClasses: 'govuk-label--l',
           hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
           errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
         }

--- a/server/routes/shared/riskPresenter.test.ts
+++ b/server/routes/shared/riskPresenter.test.ts
@@ -2,6 +2,18 @@ import RiskPresenter from './riskPresenter'
 import riskSummary from '../../../testutils/factories/riskSummary'
 
 describe(RiskPresenter, () => {
+  describe('riskSummaryNotFound', () => {
+    it('is true if riskSummary is null', () => {
+      const presenter = new RiskPresenter(null)
+      expect(presenter.riskSummaryNotFound).toEqual(true)
+    })
+
+    it('is false if riskSummary is not null', () => {
+      const presenter = new RiskPresenter(riskSummary.build())
+      expect(presenter.riskSummaryNotFound).toEqual(false)
+    })
+  })
+
   describe('roshAnalysisRows', () => {
     it('returns empty list if there is no risk summary', () => {
       const presenter = new RiskPresenter(null)

--- a/server/routes/shared/riskPresenter.ts
+++ b/server/routes/shared/riskPresenter.ts
@@ -1,4 +1,5 @@
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
+import config from '../../config'
 
 export interface RoshAnalysisTableRow {
   riskTo: string
@@ -8,7 +9,9 @@ export interface RoshAnalysisTableRow {
 export default class RiskPresenter {
   constructor(private readonly riskSummary: RiskSummary | null) {}
 
-  readonly riskSummaryEnabled = this.riskSummary !== null
+  readonly riskSummaryEnabled = config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
+
+  readonly riskSummaryNotFound = this.riskSummary === null
 
   readonly text = {
     whoIsAtRisk: this.riskSummary?.summary.whoIsAtRisk,

--- a/server/services/assessRisksAndNeedsService.test.ts
+++ b/server/services/assessRisksAndNeedsService.test.ts
@@ -39,14 +39,30 @@ describe(AssessRisksAndNeedsService, () => {
       expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/crn/crn123`, token: 'token' })
     })
 
-    it('provides a userMessage on failure', async () => {
-      restClientMock.get.mockRejectedValue(createError(404))
+    it('provides a userMessage on 4xx failure', async () => {
+      restClientMock.get.mockRejectedValue(createError(409))
       try {
         await assessRisksAndNeedsService.getRiskSummary('crn123', 'token')
       } catch (err) {
-        expect(err.status).toBe(404)
-        expect(err.userMessage).toBe('Could not get service user risk scores from OASys.')
+        expect(err.status).toBe(409)
+        expect(err.userMessage).toBe("Could not get service user's risk scores from OASys.")
       }
+    })
+
+    it('provides a userMessage on 5xx failure', async () => {
+      restClientMock.get.mockRejectedValue(createError(500))
+      try {
+        await assessRisksAndNeedsService.getRiskSummary('crn123', 'token')
+      } catch (err) {
+        expect(err.status).toBe(500)
+        expect(err.userMessage).toBe("Could not get service user's risk scores from OASys.")
+      }
+    })
+
+    it('return null when the risk information does not exist', async () => {
+      restClientMock.get.mockRejectedValue(createError(404))
+      const result = await assessRisksAndNeedsService.getRiskSummary('crn123', 'token')
+      expect(result).toEqual(null)
     })
   })
 

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -28,7 +28,12 @@ export default class AssessRisksAndNeedsService {
         token,
       })) as RiskSummary
     } catch (err) {
-      throw createError(err.status, err, { userMessage: 'Could not get service user risk scores from OASys.' })
+      if (err.status === 404) {
+        // missing (or out of date) risk information is expected and does not constitute an error
+        return null
+      }
+
+      throw createError(err.status, err, { userMessage: "Could not get service user's risk scores from OASys." })
     }
   }
 }

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -25,15 +25,23 @@
 
       {% if presenter.riskPresenter.riskSummaryEnabled %}
 
-        <p class="govuk-body">This shows the current ROSH levels and risk to self information from OASys. You can add information for the service provider.</p>
+        {% if presenter.riskPresenter.riskSummaryNotFound %}
 
-        <h2 class="govuk-heading-l">ROSH analysis</h2>
+          <p class="govuk-body">Up to date risk information for this service user was not found in OASys. You can still add additional risk information for the service provider.</p>
 
-        {{ govukTable(roshAnalysisTableArgs(govukTag)) }}
+          {% else %}
 
-        {{ govukDetails(riskLevelDetailsArgs) }}
+          <p class="govuk-body">This shows the service user's Risk of Serious Harm (ROSH) levels from OASys. You may also add information for the service provider.</p>
 
-        {{ furtherRiskInformation | safe }}
+          <h2 class="govuk-heading-l">ROSH analysis</h2>
+
+          {{ govukTable(roshAnalysisTableArgs(govukTag)) }}
+
+          {{ govukDetails(riskLevelDetailsArgs) }}
+
+          {{ furtherRiskInformation | safe }}
+
+        {% endif %}
 
       {% endif %}
 

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -31,7 +31,7 @@
 
       <h2 class="govuk-heading-m">Service user's risk information</h2>
 
-      {% if presenter.riskPresenter.riskSummaryEnabled %}
+      {% if presenter.riskPresenter.riskSummaryEnabled and not presenter.riskPresenter.riskSummaryNotFound %}
 
         <p class="govuk-body">This shows the service user's Risk of Serious Harm (ROSH) levels. Additional information from the probation practitioner may also be shown.</p>
 


### PR DESCRIPTION
## What does this pull request do?

instead of returning an error page for 404s, show some copy to the PP in the make screen saying the risk information doesn't exist, and then just don't show it in the referral details screens.

after discussing this with ARN team, we decided that it is not ok to continue as normal on unexpected errors from ARN (e.g. oasys down, or duplicate CRNs in oasys etc). these errors could mask serious risks. the case we want to handle is that the risk data is just not present or out of date. and in this case we show the PP (only) a message informing them as such. they can then enter the additional risk information and continue the referral as normal.

## What is the intent behind these changes?

Allow referrals to be made for SUs with out of date or otherwise missing risk data.
