### PR TITLE
IC-1575: Provide PP team email and telephone number on referral details page

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -7,6 +7,7 @@ import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
+import deliusStaffDetailsFactory from '../../testutils/factories/deliusStaffDetails'
 
 describe('Probation practitioner referrals dashboard', () => {
   beforeEach(() => {
@@ -276,6 +277,15 @@ describe('Probation practitioner referrals dashboard', () => {
       },
     })
 
+    const staffDetails = deliusStaffDetailsFactory.build({
+      teams: [
+        {
+          telephone: '07890 123456',
+          emailAddress: 'probation-team4692@justice.gov.uk',
+        },
+      ],
+    })
+
     cy.stubGetSentReferral(referral.id, referral)
     cy.stubGetIntervention(personalWellbeingIntervention.id, personalWellbeingIntervention)
     cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
@@ -283,6 +293,7 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
+    cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
 
     cy.login()
 
@@ -337,5 +348,13 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.contains('She works Mondays 9am - midday')
     cy.contains('Bernard Beaks')
     cy.contains('bernard.beaks@justice.gov.uk')
+
+    cy.contains('Team contact details')
+      .next()
+      .contains('Phone')
+      .next("07890 123456'")
+      .contains()
+      .next('Email address')
+      .contains('probation-team4692@justice.gov.uk')
   })
 })

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -282,6 +282,7 @@ describe('Probation practitioner referrals dashboard', () => {
         {
           telephone: '07890 123456',
           emailAddress: 'probation-team4692@justice.gov.uk',
+          startDate: '2021-01-01',
         },
       ],
     })
@@ -349,12 +350,12 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.contains('Bernard Beaks')
     cy.contains('bernard.beaks@justice.gov.uk')
 
+    cy.contains('Team contact details').next().contains('Phone').next().contains('07890 123456')
+
     cy.contains('Team contact details')
       .next()
-      .contains('Phone')
-      .next("07890 123456'")
-      .contains()
-      .next('Email address')
+      .contains('Email address')
+      .next()
       .contains('probation-team4692@justice.gov.uk')
   })
 })

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -162,6 +162,7 @@ describe('Service provider referrals dashboard', () => {
         {
           telephone: '07890 123456',
           emailAddress: 'probation-team4692@justice.gov.uk',
+          startDate: '2021-01-01',
         },
       ],
     })
@@ -254,12 +255,12 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('Bernard Beaks')
     cy.contains('bernard.beaks@justice.gov.uk')
 
+    cy.contains('Team contact details').next().contains('Phone').next().contains('07890 123456')
+
     cy.contains('Team contact details')
       .next()
-      .contains('Phone')
-      .next("07890 123456'")
-      .contains()
-      .next('Email address')
+      .contains('Email address')
+      .next()
       .contains('probation-team4692@justice.gov.uk')
   })
 

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -10,6 +10,7 @@ import interventionFactory from '../../testutils/factories/intervention'
 import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
+import deliusStaffDetailsFactory from '../../testutils/factories/deliusStaffDetails'
 import supplierAssessmentFactory from '../../testutils/factories/supplierAssessment'
 import appointmentFactory from '../../testutils/factories/appointment'
 
@@ -156,6 +157,15 @@ describe('Service provider referrals dashboard', () => {
       riskSummaryComments: 'They are low risk.',
     })
 
+    const staffDetails = deliusStaffDetailsFactory.build({
+      teams: [
+        {
+          telephone: '07890 123456',
+          emailAddress: 'probation-team4692@justice.gov.uk',
+        },
+      ],
+    })
+
     cy.stubGetIntervention(personalWellbeingIntervention.id, personalWellbeingIntervention)
     cy.stubGetIntervention(socialInclusionIntervention.id, socialInclusionIntervention)
     sentReferrals.forEach(referral => cy.stubGetSentReferral(referral.id, referral))
@@ -165,6 +175,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetExpandedServiceUserByCRN(referralToSelect.referral.serviceUser.crn, expandedDeliusServiceUser)
     cy.stubGetConvictionById(referralToSelect.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetSupplementaryRiskInformation(referralToSelect.supplementaryRiskId, supplementaryRiskInformation)
+    cy.stubGetStaffDetails(referralToSelect.sentBy.username, staffDetails)
 
     cy.login()
 
@@ -242,6 +253,14 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('She works Mondays 9am - midday')
     cy.contains('Bernard Beaks')
     cy.contains('bernard.beaks@justice.gov.uk')
+
+    cy.contains('Team contact details')
+      .next()
+      .contains('Phone')
+      .next("07890 123456'")
+      .contains()
+      .next('Email address')
+      .contains('probation-team4692@justice.gov.uk')
   })
 
   it('User assigns a referral to a caseworker', () => {
@@ -262,6 +281,7 @@ describe('Service provider referrals dashboard', () => {
     const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({ ...deliusServiceUser })
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
     const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+    const staffDetails = deliusStaffDetailsFactory.build()
 
     cy.stubGetIntervention(intervention.id, intervention)
     cy.stubGetSentReferral(referral.id, referral)
@@ -274,6 +294,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubAssignSentReferral(referral.id, referral)
     cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
+    cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
 
     cy.login()
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -55,6 +55,10 @@ module.exports = on => {
       return communityApi.stubGetConvictionById(arg.crn, arg.id, arg.responseJson)
     },
 
+    stubGetStaffDetails: arg => {
+      return communityApi.stubGetStaffDetails(arg.username, arg.responseJson)
+    },
+
     stubGetDraftReferral: arg => {
       return interventionsService.stubGetDraftReferral(arg.id, arg.responseJson)
     },

--- a/integration_tests/support/communityApiStubs.js
+++ b/integration_tests/support/communityApiStubs.js
@@ -17,3 +17,7 @@ Cypress.Commands.add('stubGetActiveConvictionsByCRN', (crn, responseJson) => {
 Cypress.Commands.add('stubGetConvictionById', (crn, id, responseJson) => {
   cy.task('stubGetConvictionById', { crn, id, responseJson })
 })
+
+Cypress.Commands.add('stubGetStaffDetails', (username, responseJson) => {
+  cy.task('stubGetStaffDetails', { username, responseJson })
+})

--- a/mockApis/communityApi.ts
+++ b/mockApis/communityApi.ts
@@ -87,7 +87,7 @@ export default class CommunityApiMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/community-api/staff/username/${username}`,
+        urlPattern: `/community-api/secure/staff/username/${username}`,
       },
       response: {
         status: 200,

--- a/mockApis/communityApi.ts
+++ b/mockApis/communityApi.ts
@@ -82,4 +82,20 @@ export default class CommunityApiMocks {
       },
     })
   }
+
+  stubGetStaffDetails = async (username: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/community-api/staff/username/${username}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/models/delius/deliusStaffDetails.ts
+++ b/server/models/delius/deliusStaffDetails.ts
@@ -1,0 +1,9 @@
+export interface DeliusStaffDetails {
+  username: string
+  teams: DeliusTeam[]
+}
+
+export interface DeliusTeam {
+  telephone: string
+  emailAddress: string
+}

--- a/server/models/delius/deliusStaffDetails.ts
+++ b/server/models/delius/deliusStaffDetails.ts
@@ -1,9 +1,11 @@
 export interface DeliusStaffDetails {
   username: string
-  teams: DeliusTeam[]
+  teams?: DeliusTeam[]
 }
 
 export interface DeliusTeam {
-  telephone: string
-  emailAddress: string
+  telephone?: string | null
+  emailAddress?: string | null
+  startDate: string
+  endDate?: string | null
 }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -152,7 +152,7 @@ export default class ProbationPractitionerReferralsController {
       false,
       expandedServiceUser,
       riskSummary,
-      staffDetails.teams.length === 0 ? null : staffDetails.teams[0]
+      staffDetails
     )
     const view = new ShowReferralView(presenter)
     ControllerUtils.renderWithLayout(res, view, expandedServiceUser)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -139,7 +139,7 @@ export default class ServiceProviderReferralsController {
       true,
       expandedServiceUser,
       riskSummary,
-      staffDetails.teams.length === 0 ? null : staffDetails.teams[0]
+      staffDetails
     )
     const view = new ShowReferralView(presenter)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -95,14 +95,16 @@ export default class ServiceProviderReferralsController {
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
 
     const { crn } = sentReferral.referral.serviceUser
-    const [intervention, sentBy, expandedServiceUser, conviction, riskInformation, riskSummary] = await Promise.all([
-      this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
-      this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
-      this.communityApiService.getExpandedServiceUserByCRN(crn),
-      this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
-      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
-      this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
-    ])
+    const [intervention, sentBy, expandedServiceUser, conviction, riskInformation, riskSummary, staffDetails] =
+      await Promise.all([
+        this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
+        this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
+        this.communityApiService.getExpandedServiceUserByCRN(crn),
+        this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
+        this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
+        this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
+        this.communityApiService.getStaffDetails(sentReferral.sentBy.username),
+      ])
 
     const assignee =
       sentReferral.assignedTo === null
@@ -136,7 +138,8 @@ export default class ServiceProviderReferralsController {
       'service-provider',
       true,
       expandedServiceUser,
-      riskSummary
+      riskSummary,
+      staffDetails.teams.length === 0 ? null : staffDetails.teams[0]
     )
     const view = new ShowReferralView(presenter)
 

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -10,6 +10,7 @@ import deliusConvictionFactory from '../../../testutils/factories/deliusConvicti
 import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
 import riskSummaryFactory from '../../../testutils/factories/riskSummary'
+import deliusStaffDetailsFactory from '../../../testutils/factories/deliusStaffDetails'
 
 describe(ShowReferralPresenter, () => {
   const intervention = interventionFactory.build()
@@ -43,6 +44,7 @@ describe(ShowReferralPresenter, () => {
 
   const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
   const riskSummary = riskSummaryFactory.build()
+  const staffDetails = deliusStaffDetailsFactory.build()
 
   describe('assignmentFormAction', () => {
     it('returns the relative URL for the check assignment page', () => {
@@ -58,7 +60,8 @@ describe(ShowReferralPresenter, () => {
         'service-provider',
         true,
         deliusServiceUser,
-        riskSummary
+        riskSummary,
+        staffDetails.teams[0]
       )
 
       expect(presenter.assignmentFormAction).toEqual(`/service-provider/referrals/${referral.id}/assignment/check`)
@@ -81,7 +84,8 @@ describe(ShowReferralPresenter, () => {
             'service-provider',
             true,
             deliusServiceUser,
-            riskSummary
+            riskSummary,
+            staffDetails.teams[0]
           )
 
           expect(presenter.text.assignedTo).toBeNull()
@@ -102,7 +106,8 @@ describe(ShowReferralPresenter, () => {
             'service-provider',
             true,
             deliusServiceUser,
-            riskSummary
+            riskSummary,
+            staffDetails.teams[0]
           )
 
           expect(presenter.text.assignedTo).toEqual('John Smith')
@@ -125,13 +130,60 @@ describe(ShowReferralPresenter, () => {
         'service-provider',
         true,
         deliusServiceUser,
-        riskSummary
+        riskSummary,
+        staffDetails.teams[0]
       )
 
       expect(presenter.probationPractitionerDetails).toEqual([
         { key: 'Name', lines: ['Bernard Beaks'] },
         { key: 'Email address', lines: ['bernard.beaks@justice.gov.uk'] },
       ])
+    })
+  })
+
+  describe('probationPractitionerTeamDetails', () => {
+    it('returns a summary list of probation practitioner team details', () => {
+      const sentReferral = sentReferralFactory.build(referralParams)
+      const presenter = new ShowReferralPresenter(
+        sentReferral,
+        intervention,
+        deliusConviction,
+        supplementaryRiskInformation,
+        deliusUser,
+        null,
+        null,
+        'service-provider',
+        true,
+        deliusServiceUser,
+        riskSummary,
+        staffDetails.teams[0]
+      )
+
+      expect(presenter.probationPractitionerTeamDetails).toEqual([
+        { key: 'Phone', lines: ['07890 123456'] },
+        { key: 'Email address', lines: ['probation-team4692@justice.gov.uk'] },
+      ])
+    })
+    describe('when no team is found', () => {
+      it('returns an empty summary list', () => {
+        const sentReferral = sentReferralFactory.build(referralParams)
+        const presenter = new ShowReferralPresenter(
+          sentReferral,
+          intervention,
+          deliusConviction,
+          supplementaryRiskInformation,
+          deliusUser,
+          null,
+          null,
+          'service-provider',
+          true,
+          deliusServiceUser,
+          riskSummary,
+          null
+        )
+
+        expect(presenter.probationPractitionerTeamDetails).toEqual([])
+      })
     })
   })
 
@@ -204,7 +256,8 @@ describe(ShowReferralPresenter, () => {
           'service-provider',
           true,
           deliusServiceUser,
-          riskSummary
+          riskSummary,
+          staffDetails.teams[0]
         )
 
         expect(presenter.interventionDetails).toEqual([
@@ -293,7 +346,8 @@ describe(ShowReferralPresenter, () => {
           'service-provider',
           true,
           deliusServiceUser,
-          riskSummary
+          riskSummary,
+          staffDetails.teams[0]
         )
 
         expect(presenter.interventionDetails).toEqual([
@@ -348,7 +402,8 @@ describe(ShowReferralPresenter, () => {
         'service-provider',
         true,
         deliusServiceUser,
-        riskSummary
+        riskSummary,
+        staffDetails.teams[0]
       )
       expect(
         presenter.serviceCategorySection(cohortServiceCategories[0], (args: TagArgs): string => {
@@ -387,7 +442,8 @@ describe(ShowReferralPresenter, () => {
         'service-provider',
         true,
         deliusServiceUser,
-        riskSummary
+        riskSummary,
+        staffDetails.teams[0]
       )
 
       expect(presenter.serviceUserDetails).toEqual([
@@ -429,7 +485,8 @@ describe(ShowReferralPresenter, () => {
         'service-provider',
         true,
         deliusServiceUser,
-        riskSummary
+        riskSummary,
+        staffDetails.teams[0]
       )
 
       expect(presenter.serviceUserRisks).toEqual([
@@ -495,7 +552,8 @@ describe(ShowReferralPresenter, () => {
           'service-provider',
           true,
           deliusServiceUser,
-          riskSummary
+          riskSummary,
+          staffDetails.teams[0]
         )
 
         expect(presenter.serviceUserNeeds).toEqual([
@@ -583,7 +641,8 @@ describe(ShowReferralPresenter, () => {
           'service-provider',
           true,
           deliusServiceUser,
-          riskSummary
+          riskSummary,
+          staffDetails.teams[0]
         )
 
         expect(presenter.serviceUserNeeds).toEqual([

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -19,7 +19,8 @@ import { SupplementaryRiskInformation } from '../../models/assessRisksAndNeeds/s
 import { ExpandedDeliusServiceUser } from '../../models/delius/deliusServiceUser'
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
 import RiskPresenter from './riskPresenter'
-import { DeliusTeam } from '../../models/delius/deliusStaffDetails'
+import { DeliusStaffDetails, DeliusTeam } from '../../models/delius/deliusStaffDetails'
+import CalendarDay from '../../utils/calendarDay'
 
 export default class ShowReferralPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
@@ -38,7 +39,7 @@ export default class ShowReferralPresenter {
     readonly canAssignReferral: boolean,
     private readonly deliusServiceUser: ExpandedDeliusServiceUser,
     private readonly riskSummary: RiskSummary | null,
-    private readonly teamDetails: DeliusTeam | null
+    private readonly staffDetails: DeliusStaffDetails
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,
@@ -61,17 +62,40 @@ export default class ShowReferralPresenter {
     { key: 'Email address', lines: [this.sentBy.email ?? ''] },
   ]
 
-  readonly probationPractitionerTeamDetails: SummaryListItem[] =
-    this.teamDetails == null
+  get probationPractitionerTeamDetails(): SummaryListItem[] {
+    const { activeTeam } = this
+    return activeTeam == null
       ? []
       : [
-          { key: 'Phone', lines: [`${this.teamDetails?.telephone}`] },
-          { key: 'Email address', lines: [`${this.teamDetails?.emailAddress}`] },
+          { key: 'Phone', lines: [`${activeTeam.telephone}`] },
+          { key: 'Email address', lines: [`${activeTeam.emailAddress}`] },
         ]
+  }
 
   get referralServiceCategories(): ServiceCategory[] {
     const { serviceCategoryIds } = this.sentReferral.referral
     return this.intervention.serviceCategories.filter(it => serviceCategoryIds.includes(it.id))
+  }
+
+  private get activeTeam(): DeliusTeam | null {
+    const firstTeam = this.staffDetails.teams
+      ?.filter(team => {
+        if (team.endDate === null || team.endDate === undefined) {
+          return true
+        }
+        const endDate = CalendarDay.parseIso8601Date(team.endDate)?.utcDate
+        if (endDate !== undefined) {
+          return endDate >= new Date()
+        }
+        return true
+      })
+      .sort((teamA, teamB) => {
+        const teamAStartDate = CalendarDay.parseIso8601Date(teamA.startDate)!.utcDate
+        const teamBStartDate = CalendarDay.parseIso8601Date(teamB.startDate)!.utcDate
+        return teamBStartDate.getDate() - teamAStartDate.getDate()
+      })
+      .shift()
+    return firstTeam === undefined ? null : firstTeam
   }
 
   serviceCategorySection(serviceCategory: ServiceCategory, tagMacro: (args: TagArgs) => string): SummaryListItem[] {

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -19,6 +19,7 @@ import { SupplementaryRiskInformation } from '../../models/assessRisksAndNeeds/s
 import { ExpandedDeliusServiceUser } from '../../models/delius/deliusServiceUser'
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
 import RiskPresenter from './riskPresenter'
+import { DeliusTeam } from '../../models/delius/deliusStaffDetails'
 
 export default class ShowReferralPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
@@ -36,7 +37,8 @@ export default class ShowReferralPresenter {
     readonly userType: 'service-provider' | 'probation-practitioner',
     readonly canAssignReferral: boolean,
     private readonly deliusServiceUser: ExpandedDeliusServiceUser,
-    private readonly riskSummary: RiskSummary | null
+    private readonly riskSummary: RiskSummary | null,
+    private readonly teamDetails: DeliusTeam | null
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,
@@ -58,6 +60,14 @@ export default class ShowReferralPresenter {
     { key: 'Name', lines: [`${this.sentBy.firstName} ${this.sentBy.surname}`] },
     { key: 'Email address', lines: [this.sentBy.email ?? ''] },
   ]
+
+  readonly probationPractitionerTeamDetails: SummaryListItem[] =
+    this.teamDetails == null
+      ? []
+      : [
+          { key: 'Phone', lines: [`${this.teamDetails?.telephone}`] },
+          { key: 'Email address', lines: [`${this.teamDetails?.emailAddress}`] },
+        ]
 
   get referralServiceCategories(): ServiceCategory[] {
     const { serviceCategoryIds } = this.sentReferral.referral

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -17,6 +17,10 @@ export default class ShowReferralView {
     this.presenter.probationPractitionerDetails
   )
 
+  private readonly probationPractitionerTeamSummaryListArgs = ViewUtils.summaryListArgs(
+    this.presenter.probationPractitionerTeamDetails
+  )
+
   private readonly interventionDetailsSummaryListArgs = ViewUtils.summaryListArgs(this.presenter.interventionDetails)
 
   private readonly serviceUserDetailsSummaryListArgs = ViewUtils.summaryListArgs(this.presenter.serviceUserDetails)
@@ -59,6 +63,7 @@ export default class ShowReferralView {
         presenter: this.presenter,
         subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         probationPractitionerSummaryListArgs: this.probationPractitionerSummaryListArgs,
+        probationPractitionerTeamSummaryListArgs: this.probationPractitionerTeamSummaryListArgs,
         interventionDetailsSummaryListArgs: this.interventionDetailsSummaryListArgs,
         serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs,
         serviceUserRisksSummaryListArgs: this.serviceUserRisksSummaryListArgs,

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -5,6 +5,7 @@ import logger from '../../log'
 import DeliusUser from '../models/delius/deliusUser'
 import DeliusServiceUser, { ExpandedDeliusServiceUser } from '../models/delius/deliusServiceUser'
 import DeliusConviction from '../models/delius/deliusConviction'
+import { DeliusStaffDetails } from '../models/delius/deliusStaffDetails'
 
 export default class CommunityApiService {
   constructor(private readonly hmppsAuthService: HmppsAuthService, private readonly restClient: RestClient) {}
@@ -57,5 +58,15 @@ export default class CommunityApiService {
       path: `/secure/offenders/crn/${crn}/convictions/${id}`,
       token,
     })) as DeliusConviction
+  }
+
+  async getStaffDetails(username: string): Promise<DeliusStaffDetails> {
+    const token = await this.hmppsAuthService.getApiClientToken()
+
+    logger.info({ username }, 'getting staff details for officer')
+    return (await this.restClient.get({
+      path: `/staff/username/${username}`,
+      token,
+    })) as DeliusStaffDetails
   }
 }

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -65,7 +65,7 @@ export default class CommunityApiService {
 
     logger.info({ username }, 'getting staff details for officer')
     return (await this.restClient.get({
-      path: `/staff/username/${username}`,
+      path: `/secure/staff/username/${username}`,
       token,
     })) as DeliusStaffDetails
   }

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -47,4 +47,10 @@
       {{ govukSummaryList(serviceUserNeedsSummaryListArgs) }}
       <h2 class="govuk-heading-m">Referring probation practitioner details</h2>
       {{ govukSummaryList(probationPractitionerSummaryListArgs) }}
+      {% if probationPractitionerTeamSummaryListArgs.rows|length %}
+          <h2 class="govuk-heading-m">Team contact details</h2>
+          {{ govukSummaryList(probationPractitionerTeamSummaryListArgs) }}
+      {% endif %}
+
+
 {% endblock %}

--- a/testutils/factories/deliusStaffDetails.ts
+++ b/testutils/factories/deliusStaffDetails.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery'
+import { DeliusStaffDetails } from '../../server/models/delius/deliusStaffDetails'
+
+export default Factory.define<DeliusStaffDetails>(() => ({
+  username: 'BERNARD.BEAKS',
+  teams: [
+    {
+      telephone: '07890 123456',
+      emailAddress: 'probation-team4692@justice.gov.uk',
+    },
+  ],
+}))

--- a/testutils/factories/deliusStaffDetails.ts
+++ b/testutils/factories/deliusStaffDetails.ts
@@ -7,6 +7,7 @@ export default Factory.define<DeliusStaffDetails>(() => ({
     {
       telephone: '07890 123456',
       emailAddress: 'probation-team4692@justice.gov.uk',
+      startDate: '2021-01-01',
     },
   ],
 }))

--- a/testutils/factories/deliusTeam.ts
+++ b/testutils/factories/deliusTeam.ts
@@ -1,0 +1,8 @@
+import { Factory } from 'fishery'
+import { DeliusTeam } from '../../server/models/delius/deliusStaffDetails'
+
+export default Factory.define<DeliusTeam>(() => ({
+  telephone: '07890 123456',
+  emailAddress: 'probation-team4692@justice.gov.uk',
+  startDate: '2021-01-01',
+}))


### PR DESCRIPTION
## What does this pull request do?

Gets the team details from Community API to then display on the screen for referral details.

## What is the intent behind these changes?

Provides alternative contact details if PP is unavailable

## Note



![image](https://user-images.githubusercontent.com/83066216/123295947-17c55980-d50e-11eb-8213-2afe1826296c.png)
