### PR TITLE
tell appinsights that only 500 errors returned from the ui should be marked as errors

### DIFF
--- a/server/azureAppInsights.ts
+++ b/server/azureAppInsights.ts
@@ -37,18 +37,18 @@ function addUsernameProcessor(
   return true
 }
 
-// function errorStatusCodeProcessor(
-//   envelope: Contracts.EnvelopeTelemetry,
-//   _contextObjects: { [name: string]: unknown } | undefined
-// ): boolean {
-//   if (envelope.data.baseType === Contracts.TelemetryTypeString.Request && envelope.data.baseData !== undefined) {
-//     // eslint-disable-next-line no-param-reassign
-//     envelope.data.baseData.success = !(
-//       envelope.data.baseData.responseCode in config.applicationInsights.errorStatusCodes
-//     )
-//   }
-//   return true
-// }
+function errorStatusCodeProcessor(
+  envelope: Contracts.EnvelopeTelemetry,
+  _contextObjects: { [name: string]: unknown } | undefined
+): boolean {
+  if (envelope.data.baseType === Contracts.TelemetryTypeString.Request && envelope.data.baseData !== undefined) {
+    // only mark 5xx response codes as failures. the application serves 4xx
+    // responses to indicate authorization/validation errors and the like.
+    // eslint-disable-next-line no-param-reassign
+    envelope.data.baseData.success = envelope.data.baseData.responseCode < 500
+  }
+  return true
+}
 
 export default function initialiseAppInsights(): void {
   const { connectionString } = config.applicationInsights
@@ -64,5 +64,6 @@ export default function initialiseAppInsights(): void {
     // custom processors to fine tune behaviour
     defaultClient.addTelemetryProcessor(ignoreExcludedRequestsProcessor)
     defaultClient.addTelemetryProcessor(addUsernameProcessor)
+    defaultClient.addTelemetryProcessor(errorStatusCodeProcessor)
   }
 }


### PR DESCRIPTION
tell appinsights that only 500 errors returned from the ui should be marked as errors

the reason for this is the the UI is free to serve up client error code like bad request (400) or forbidden (403), but these are not errors. we do not want these intentional non-2xx status codes being counted as errors in app insights as it is really confusing.