### PR TITLE
IC-1829 the never ending (risk) story

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -215,7 +215,7 @@ describe('Referral form', () => {
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/risk-information`)
-      cy.contains('Information for the service provider about Alex’s risks').type('A danger to the elderly')
+      cy.contains('Add information for the service provider').type('A danger to the elderly')
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/needs-and-requirements`)
@@ -548,7 +548,7 @@ describe('Referral form', () => {
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/risk-information`)
-      cy.contains('Information for the service provider about Alex’s risks').type('A danger to the elderly')
+      cy.contains('Add information for the service provider').type('A danger to the elderly')
       cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/needs-and-requirements`)

--- a/server/models/assessRisksAndNeeds/riskSummary.ts
+++ b/server/models/assessRisksAndNeeds/riskSummary.ts
@@ -1,6 +1,21 @@
 export type RiskScore = 'LOW' | 'MEDIUM' | 'HIGH' | 'VERY_HIGH'
 
+export type RiskResponse = 'YES' | 'NO' | 'DK'
+
+export interface Risk {
+  risk: RiskResponse | null
+  current: RiskResponse | null
+  currentConcernsText: string | null
+}
+
 export default interface RiskSummary {
+  riskToSelf: {
+    suicide?: Risk | null
+    selfHarm?: Risk | null
+    custody?: Risk | null
+    hostelSetting?: Risk | null
+    vulnerability?: Risk | null
+  }
   summary: {
     whoIsAtRisk?: string | null
     natureOfRisk?: string | null

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -365,8 +365,6 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
         expect(res.text).toContain("service user's Risk of Serious Harm (ROSH) levels")
         expect(res.text).toContain('Children')
         expect(res.text).toContain('HIGH')
-        expect(res.text).toContain('The following information is not seen by the service provider.')
-        expect(res.text).toContain('can happen at the drop of a hat')
       })
   })
 

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -309,8 +309,6 @@ describe('GET /referrals/:id/risk-information', () => {
         expect(res.text).toContain('HIGH')
         expect(res.text).toContain('Prisoners')
         expect(res.text).toContain('LOW')
-        expect(res.text).toContain('The following information is not seen by the service provider.')
-        expect(res.text).toContain('can happen at the drop of a hat')
       })
 
     expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['token', '1'])

--- a/server/routes/referrals/referralsController.test.ts
+++ b/server/routes/referrals/referralsController.test.ts
@@ -302,13 +302,6 @@ describe('GET /referrals/:id/risk-information', () => {
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Geoffrey’s risk information')
-        expect(res.text).toContain('Risk in community')
-        expect(res.text).toContain('Staff')
-        expect(res.text).toContain('VERY HIGH')
-        expect(res.text).toContain('Children')
-        expect(res.text).toContain('HIGH')
-        expect(res.text).toContain('Prisoners')
-        expect(res.text).toContain('LOW')
       })
 
     expect(interventionsService.getDraftReferral.mock.calls[0]).toEqual(['token', '1'])

--- a/server/routes/referrals/riskInformationPresenter.test.ts
+++ b/server/routes/referrals/riskInformationPresenter.test.ts
@@ -16,9 +16,8 @@ describe('RiskInformationPresenter', () => {
       })
       expect(presenter.additionalRiskInformation).toEqual({
         errorMessage: null,
-        label: 'Additional risk information',
-        hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
-        labelClasses: 'govuk-label--l',
+        label: 'Add information for the service provider',
+        hint: 'Include specific advice or considerations; for example, exclusion zones, restraining orders, or triggers that may lead to risky behaviour. Do not include any sensitive or protected details.',
       })
     })
 

--- a/server/routes/referrals/riskInformationPresenter.ts
+++ b/server/routes/referrals/riskInformationPresenter.ts
@@ -20,6 +20,14 @@ export default class RiskInformationPresenter {
     title: `${this.referral.serviceUser?.firstName}’s risk information`,
   }
 
+  get introText(): string {
+    return `Write a description of risks that will help the service provider. Do not use any sensitive or protected information.${
+      this.riskPresenter.riskInformationAvailable
+        ? ' We will share basic risk information with the service provider, including ROSH levels, categories of those at risk, and risk to self.'
+        : ''
+    }`
+  }
+
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
   private readonly utils = new PresenterUtils(this.userInputData)
@@ -32,18 +40,14 @@ export default class RiskInformationPresenter {
   }
 
   get additionalRiskInformation(): Record<string, string | null> {
-    return this.riskPresenter.riskSummaryNotFound
-      ? {
-          label: `Information for the service provider about ${this.referral.serviceUser?.firstName}’s risks`,
-          labelClasses: 'govuk-label--s',
-          hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
-          errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
-        }
-      : {
-          label: 'Additional risk information',
-          labelClasses: 'govuk-label--l',
-          hint: 'Give any other information that is relevant to this referral. Do not include sensitive information about the individual or third parties.',
-          errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
-        }
+    const hintText = `Include specific advice or considerations${
+      this.riskPresenter.riskInformationAvailable ? ' from the information above' : ''
+    }; for example, exclusion zones, restraining orders, or triggers that may lead to risky behaviour. Do not include any sensitive or protected details.`
+
+    return {
+      label: 'Add information for the service provider',
+      hint: hintText,
+      errorMessage: PresenterUtils.errorMessage(this.error, 'additional-risk-information'),
+    }
   }
 }

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -35,7 +35,6 @@ export default class RiskInformationView {
         additionalRiskInformationTextareaArgs: this.additionalRiskInformationTextareaArgs,
         roshAnalysisTableArgs: this.riskView.roshAnalysisTableArgs.bind(this.riskView),
         riskLevelDetailsArgs: this.riskView.riskLevelDetailsArgs,
-        furtherRiskInformation: this.riskView.furtherRiskInformation,
       },
     ]
   }

--- a/server/routes/referrals/riskInformationView.ts
+++ b/server/routes/referrals/riskInformationView.ts
@@ -16,7 +16,7 @@ export default class RiskInformationView {
       id: 'additional-risk-information',
       label: {
         text: this.presenter.additionalRiskInformation.label,
-        classes: this.presenter.additionalRiskInformation.labelClasses,
+        classes: 'govuk-label--l',
       },
       value: this.presenter.fields.additionalRiskInformation,
       hint: {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -159,7 +159,6 @@ describe('GET /service-provider/referrals/:id/details', () => {
         expect(res.text).toContain("service user's Risk of Serious Harm (ROSH) levels")
         expect(res.text).toContain('Children')
         expect(res.text).toContain('HIGH')
-        expect(res.text).not.toContain('can happen at the drop of a hat')
       })
   })
 

--- a/server/routes/shared/riskPresenter.test.ts
+++ b/server/routes/shared/riskPresenter.test.ts
@@ -1,5 +1,6 @@
 import RiskPresenter from './riskPresenter'
 import riskSummary from '../../../testutils/factories/riskSummary'
+import config from '../../config'
 
 describe(RiskPresenter, () => {
   describe('riskSummaryNotFound', () => {
@@ -11,6 +12,33 @@ describe(RiskPresenter, () => {
     it('is false if riskSummary is not null', () => {
       const presenter = new RiskPresenter(riskSummary.build())
       expect(presenter.riskSummaryNotFound).toEqual(false)
+    })
+  })
+
+  describe('riskInformationAvailable', () => {
+    it('is true if riskSummary is enabled in config and riskSummary is not null', () => {
+      try {
+        config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = true
+        const presenter = new RiskPresenter(riskSummary.build())
+        expect(presenter.riskInformationAvailable).toEqual(true)
+      } finally {
+        config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = false
+      }
+    })
+
+    it('is false if riskSummary is disabled in config', () => {
+      const presenter = new RiskPresenter(riskSummary.build())
+      expect(presenter.riskInformationAvailable).toEqual(false)
+    })
+
+    it('is false if riskSummary is null', () => {
+      try {
+        config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = true
+        const presenter = new RiskPresenter(null)
+        expect(presenter.riskInformationAvailable).toEqual(false)
+      } finally {
+        config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = false
+      }
     })
   })
 

--- a/server/routes/shared/riskPresenter.test.ts
+++ b/server/routes/shared/riskPresenter.test.ts
@@ -30,15 +30,4 @@ describe(RiskPresenter, () => {
       ])
     })
   })
-
-  describe('text', () => {
-    it('contains additional risk information', () => {
-      const presenter = new RiskPresenter(riskSummary.build())
-      expect(presenter.text).toMatchObject({
-        natureOfRisk: 'physically aggressive',
-        riskImminence: 'can happen at the drop of a hat',
-        whoIsAtRisk: undefined,
-      })
-    })
-  })
 })

--- a/server/routes/shared/riskPresenter.ts
+++ b/server/routes/shared/riskPresenter.ts
@@ -13,6 +13,10 @@ export default class RiskPresenter {
 
   readonly riskSummaryNotFound = this.riskSummary === null
 
+  get riskInformationAvailable(): boolean {
+    return this.riskSummaryEnabled && !this.riskSummaryNotFound
+  }
+
   readonly text = {
     whoIsAtRisk: this.riskSummary?.summary.whoIsAtRisk,
     natureOfRisk: this.riskSummary?.summary.natureOfRisk,

--- a/server/routes/shared/riskView.ts
+++ b/server/routes/shared/riskView.ts
@@ -62,43 +62,4 @@ export default class RiskView {
             </ul>`,
     }
   }
-
-  get furtherRiskInformation(): string {
-    if (this.userType === 'service-provider') {
-      return ''
-    }
-
-    if (!(this.presenter.text.whoIsAtRisk || this.presenter.text.natureOfRisk || this.presenter.text.riskImminence)) {
-      return ''
-    }
-
-    const sections = [
-      `<div class="govuk-inset-text">
-       <p class="govuk-body">The following information is not seen by the service provider.<p>`,
-    ]
-
-    if (this.presenter.text.whoIsAtRisk != null) {
-      sections.push(`
-        <h3 class="govuk-heading-m">Who is at risk?</h3>
-        <p class="govuk-body">${this.presenter.text.whoIsAtRisk}</p>
-      `)
-    }
-
-    if (this.presenter.text.natureOfRisk != null) {
-      sections.push(`
-        <h3 class="govuk-heading-m">What is the nature of the risk?</h3>
-        <p class="govuk-body">${this.presenter.text.natureOfRisk}</p>
-      `)
-    }
-
-    if (this.presenter.text.riskImminence != null) {
-      sections.push(`
-        <h3 class="govuk-heading-m">When is the risk likely to be greatest?</h3>
-        <p class="govuk-body">${this.presenter.text.riskImminence}</p>
-      `)
-    }
-
-    sections.push('</div>')
-    return sections.join('')
-  }
 }

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -68,7 +68,6 @@ export default class ShowReferralView {
         backLinkArgs: this.backLinkArgs,
         roshAnalysisTableArgs: this.riskView.roshAnalysisTableArgs.bind(this.riskView),
         riskLevelDetailsArgs: this.riskView.riskLevelDetailsArgs,
-        furtherRiskInformation: this.riskView.furtherRiskInformation,
       },
     ]
   }

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -22,6 +22,7 @@
       {% endif %}
 
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+      <p class="govuk-body">{{ presenter.introText }}</p>
 
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -23,26 +23,6 @@
 
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
 
-      {% if presenter.riskPresenter.riskSummaryEnabled %}
-
-        {% if presenter.riskPresenter.riskSummaryNotFound %}
-
-          <p class="govuk-body">Up to date risk information for this service user was not found in OASys. You can still add additional risk information for the service provider.</p>
-
-          {% else %}
-
-          <p class="govuk-body">This shows the service user's Risk of Serious Harm (ROSH) levels from OASys. You may also add information for the service provider.</p>
-
-          <h2 class="govuk-heading-l">ROSH analysis</h2>
-
-          {{ govukTable(roshAnalysisTableArgs(govukTag)) }}
-
-          {{ govukDetails(riskLevelDetailsArgs) }}
-
-        {% endif %}
-
-      {% endif %}
-
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
 

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -39,8 +39,6 @@
 
           {{ govukDetails(riskLevelDetailsArgs) }}
 
-          {{ furtherRiskInformation | safe }}
-
         {% endif %}
 
       {% endif %}

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -39,8 +39,6 @@
 
         {{ govukDetails(riskLevelDetailsArgs) }}
 
-        {{ furtherRiskInformation | safe }}
-
       {% endif %}
 
       {{ govukSummaryList(serviceUserRisksSummaryListArgs) }}

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -31,7 +31,7 @@
 
       <h2 class="govuk-heading-m">Service user's risk information</h2>
 
-      {% if presenter.riskPresenter.riskSummaryEnabled and not presenter.riskPresenter.riskSummaryNotFound %}
+      {% if presenter.riskPresenter.riskInformationAvailable %}
 
         <p class="govuk-body">This shows the service user's Risk of Serious Harm (ROSH) levels. Additional information from the probation practitioner may also be shown.</p>
 

--- a/testutils/factories/riskSummary.ts
+++ b/testutils/factories/riskSummary.ts
@@ -2,6 +2,23 @@ import { Factory } from 'fishery'
 import RiskSummary from '../../server/models/assessRisksAndNeeds/riskSummary'
 
 export default Factory.define<RiskSummary>(() => ({
+  riskToSelf: {
+    suicide: {
+      risk: 'YES',
+      current: 'YES',
+      currentConcernsText: 'Manic episodes are common.',
+    },
+    hostelSetting: {
+      risk: 'DK',
+      current: null,
+      currentConcernsText: null,
+    },
+    vulnerability: {
+      risk: 'NO',
+      current: null,
+      currentConcernsText: null,
+    },
+  },
   summary: {
     riskInCommunity: {
       LOW: ['prisoners'],


### PR DESCRIPTION
## What does this pull request do?

- no longer shows ROSH data in the PP make a referral screen
- updates the copy for the existing implementation
- no longer shows additional risk summary data in either PP make a referral screen or PP/SP details screen
- adds additional fields to the risk summary model (this isn't required for this PR, it was something coming next, but i was asked to stop working on it, and pulling it out is more work than leaving it in)

the make a referral screen: 

![Screenshot 2021-06-25 at 13 08 27](https://user-images.githubusercontent.com/63233073/123423142-13a14680-d5b7-11eb-9733-fb03f83a7fa3.png)

the referral details screen:

![Screenshot 2021-06-25 at 13 17 28](https://user-images.githubusercontent.com/63233073/123423620-b3f76b00-d5b7-11eb-8421-f1ddfce99054.png)

## What is the intent behind these changes?

wait for risk stuff to get properly tested before moving forward.
