### PR TITLE
IC-1745 SPs can edit submitted action plans

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -276,5 +276,12 @@ export default function routes(router: Router, services: Services): Router {
     probationPractitionerReferralsController.actionPlanApproved(req, res)
   )
 
+  get('/service-provider/referrals/:id/action-plan/edit', (req, res) =>
+    serviceProviderReferralsController.actionPlanEditConfirmation(req, res)
+  )
+  post('/service-provider/referrals/:id/action-plan/edit', (req, res) =>
+    serviceProviderReferralsController.createDraftActionPlan(req, res)
+  )
+
   return router
 }

--- a/server/routes/serviceProviderReferrals/actionPlanEditConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/actionPlanEditConfirmationPresenter.ts
@@ -1,0 +1,11 @@
+import SentReferral from '../../models/sentReferral'
+
+export default class ActionPlanEditConfirmationPresenter {
+  constructor(private readonly sentReferral: SentReferral) {}
+
+  readonly viewActionPlanUrl = `/service-provider/referrals/${this.sentReferral.id}/action-plan`
+
+  readonly confirmAction = `/service-provider/referrals/${this.sentReferral.id}/action-plan/edit`
+
+  readonly actionPlanId = this.sentReferral.actionPlanId
+}

--- a/server/routes/serviceProviderReferrals/actionPlanEditConfirmationView.ts
+++ b/server/routes/serviceProviderReferrals/actionPlanEditConfirmationView.ts
@@ -1,0 +1,18 @@
+import ActionPlanEditConfirmationPresenter from './actionPlanEditConfirmationPresenter'
+
+export default class ActionPlanEditConfirmationView {
+  constructor(private readonly presenter: ActionPlanEditConfirmationPresenter) {}
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/actionPlan/actionPlanEditConfirmation',
+      {
+        presenter: this.presenter,
+        backLinkArgs: {
+          text: 'Back',
+          href: this.presenter.viewActionPlanUrl,
+        },
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -66,6 +66,8 @@ import SupplierAssessmentAppointmentPresenter from '../shared/supplierAssessment
 import SupplierAssessmentAppointmentView from '../shared/supplierAssessmentAppointmentView'
 import SupplierAssessmentAppointmentConfirmationPresenter from './supplierAssessmentAppointmentConfirmationPresenter'
 import SupplierAssessmentAppointmentConfirmationView from './supplierAssessmentAppointmentConfirmationView'
+import ActionPlanEditConfirmationPresenter from './actionPlanEditConfirmationPresenter'
+import ActionPlanEditConfirmationView from './actionPlanEditConfirmationView'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -998,5 +1000,24 @@ export default class ServiceProviderReferralsController {
       throw new Error('Expected service categories are missing in intervention')
     }
     return serviceCategories
+  }
+
+  async actionPlanEditConfirmation(req: Request, res: Response): Promise<void> {
+    const sentReferral = await this.interventionsService.getSentReferral(
+      res.locals.user.token.accessToken,
+      req.params.id
+    )
+
+    if (sentReferral.actionPlanId === null) {
+      throw createError(500, `could not edit action plan for referral with id '${req.params.id}'`, {
+        userMessage: 'No action plan exists for this referral',
+      })
+    }
+
+    const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
+
+    const presenter = new ActionPlanEditConfirmationPresenter(sentReferral)
+    const view = new ActionPlanEditConfirmationView(presenter)
+    ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 }

--- a/server/routes/shared/actionPlanPresenter.ts
+++ b/server/routes/shared/actionPlanPresenter.ts
@@ -22,6 +22,8 @@ export default class ActionPlanPresenter {
 
   readonly actionPlanApprovalUrl = `/probation-practitioner/referrals/${this.referral.id}/action-plan/approve`
 
+  readonly actionPlanEditConfirmationUrl = `/service-provider/referrals/${this.referral.id}/action-plan/edit`
+
   readonly text = {
     actionPlanStatus: this.actionPlanStatus,
     actionPlanSubmittedDate: DateUtils.getDateStringFromDateTimeString(this.actionPlan?.submittedAt || null),
@@ -72,5 +74,9 @@ export default class ActionPlanPresenter {
 
   get showApprovalForm(): boolean {
     return this.userType === 'probation-practitioner' && this.actionPlanUnderReview
+  }
+
+  get showEditButton(): boolean {
+    return this.userType === 'service-provider' && this.actionPlanUnderReview
   }
 }

--- a/server/routes/shared/actionPlanPresenter.ts
+++ b/server/routes/shared/actionPlanPresenter.ts
@@ -79,4 +79,9 @@ export default class ActionPlanPresenter {
   get showEditButton(): boolean {
     return this.userType === 'service-provider' && this.actionPlanUnderReview
   }
+
+  get probationPractitionerBlockedFromViewing(): boolean {
+    // probation practitioners can only view submitted action plans
+    return this.userType === 'probation-practitioner' && !this.actionPlanSubmitted
+  }
 }

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanEditConfirmation.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanEditConfirmation.njk
@@ -1,0 +1,23 @@
+{% extends "../../partials/layout.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}%}
+
+{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
+
+{% block pageContent %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukBackLink(backLinkArgs) }}
+
+            <h1 class="govuk-heading-l">Are you sure you want to change the action plan while it is being reviewed?</h1>
+
+            <p class="govuk-body">Note: This will withdraw the current action plan and the probation practitioner will no longer be able to view it.</p>
+
+            <form action="{{ presenter.confirmAction }}" method="post">
+                <input type="hidden" name="_csrf" value="{{csrfToken}}">
+                <input type="hidden" name="action-plan-id" value="{{ presenter.actionPlanId }}">
+                {{ govukButton({ text: "Confirm and continue", preventDoubleClick: true }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}%}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% block pageTitle %}
     HMPPS Interventions - GOV.UK
@@ -15,40 +15,57 @@
 {% block pageContent %}
     {% block content %}
     <div class="govuk-!-width-two-thirds">
-        {{ govukBackLink(backLinkArgs) }}
-        {% if errorSummaryArgs !== null %}
-            {{ govukErrorSummary(errorSummaryArgs) }}
-        {% endif %}
-        <h1 class="govuk-heading-l">View action plan</h1>
+        {% if presenter.probationPractitionerBlockedFromViewing %}
 
-        {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
+            {{ govukWarningText({
+                text: "Action plan cannot be reviewed.",
+                iconFallbackText: "Warning"
+            }) }}
 
-        {% if presenter.showEditButton %}
-            <a href="{{ presenter.actionPlanEditConfirmationUrl }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
-                Edit action plan
-            </a>
-        {% endif %}
+            <p class="govuk-body">
+                If you arrived at this page after clicking a link in an email, it is likely the service provider has withdrawn the action plan for editing.
+                You will receive another email when the action plan is resubmitted and ready for approval.
+            </p>
 
-        <h2 class="govuk-heading-m">Desired outcomes and activities</h2>
+            <p class="govuk-body"><a href="{{ presenter.interventionProgressURL }}">Return to intervention progress</a></p>
 
-        <ul class="govuk-list">
-        {% for activity in presenter.activities %}
-            <li>{{ govukInsetText(insetTextActivityArgs(loop.index, activity)) }}</li>
-        {% endfor %}
-        </ul>
+        {% else %}
+            {{ govukBackLink(backLinkArgs) }}
 
-        <h2 class="govuk-heading-m">Suggested number of sessions for the action plan</h2>
-        <p class="govuk-body">Suggested number of sessions: {{ presenter.text.actionPlanNumberOfSessions }}</p>
+            {% if errorSummaryArgs !== null %}
+                {{ govukErrorSummary(errorSummaryArgs) }}
+            {% endif %}
+            <h1 class="govuk-heading-l">View action plan</h1>
 
-        {% if presenter.showApprovalForm %}
-            <h2 class="govuk-heading-m">Do you want to approve this action plan?</h2>
-            <p class="govuk-body">Note: If you want to suggest any changes, contact <i>{{ presenter.text.spEmailAddress }}</i> before approving this action plan.</p>
+            {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
 
-            <form method="post" action="{{ presenter.actionPlanApprovalUrl }}">
-                {{ govukCheckboxes(confirmApprovalCheckboxArgs) }}
-                <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-                {{ govukButton({ text: "Approve", preventDoubleClick: true }) }}
-            </form>
+            {% if presenter.showEditButton %}
+                <a href="{{ presenter.actionPlanEditConfirmationUrl }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+                    Edit action plan
+                </a>
+            {% endif %}
+
+            <h2 class="govuk-heading-m">Desired outcomes and activities</h2>
+
+            <ul class="govuk-list">
+            {% for activity in presenter.activities %}
+                <li>{{ govukInsetText(insetTextActivityArgs(loop.index, activity)) }}</li>
+            {% endfor %}
+            </ul>
+
+            <h2 class="govuk-heading-m">Suggested number of sessions for the action plan</h2>
+            <p class="govuk-body">Suggested number of sessions: {{ presenter.text.actionPlanNumberOfSessions }}</p>
+
+            {% if presenter.showApprovalForm %}
+                <h2 class="govuk-heading-m">Do you want to approve this action plan?</h2>
+                <p class="govuk-body">Note: If you want to suggest any changes, contact <i>{{ presenter.text.spEmailAddress }}</i> before approving this action plan.</p>
+
+                <form method="post" action="{{ presenter.actionPlanApprovalUrl }}">
+                    {{ govukCheckboxes(confirmApprovalCheckboxArgs) }}
+                    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+                    {{ govukButton({ text: "Approve", preventDoubleClick: true }) }}
+                </form>
+            {% endif %}
         {% endif %}
     </div>
     {% endblock %}

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -23,6 +23,12 @@
 
         {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
 
+        {% if presenter.showEditButton %}
+            <a href="{{ presenter.actionPlanEditConfirmationUrl }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+                Edit action plan
+            </a>
+        {% endif %}
+
         <h2 class="govuk-heading-m">Desired outcomes and activities</h2>
 
         <ul class="govuk-list">


### PR DESCRIPTION
## What does this pull request do?

1a94efa263c8c0f807a8fcd2172fc5a0f075c40b adds a simple button link to the SP action plan screen which goes to the edit confirmation screen

<img width="1272" alt="Screenshot 2021-06-26 at 11 14 14" src="https://user-images.githubusercontent.com/63233073/123509890-0eec9900-d670-11eb-8ca1-ed84c33c2cd3.png">

5d4a773cb26193ace1946e726b4c3648f036fe43 adds a page with a confirm button that posts a form to start the editing process wires up the confirmation button to create a new draft action plan

<img width="1316" alt="Screenshot 2021-06-26 at 11 50 38" src="https://user-images.githubusercontent.com/63233073/123510685-cc798b00-d674-11eb-99f4-9211632d8556.png"> 

f3f764c33043158779f31220228090a23fc7f985 stops PPs from viewing withdrawn action plans when they click on the direct link

![Screenshot 2021-06-29 at 12 12 50](https://user-images.githubusercontent.com/63233073/123787936-545cd080-d8d3-11eb-9255-01a92812fce1.png)
