### PR TITLE
Use ephemeral session-based draft objects for multi page journeys that aren't backed by API calls

### DIFF
--- a/doc/architecture/decisions/0011-use-session-based-drafts.md
+++ b/doc/architecture/decisions/0011-use-session-based-drafts.md
@@ -1,0 +1,76 @@
+# 11. Use session-based drafts
+
+Date: 2021-06-28
+
+## Status
+
+Accepted
+
+## Context
+
+### Background
+
+Our service frequently needs to take a user through a journey which involves asking them a series of questions over multiple pages, and then playing all the answers back to the user before finally submitting all the answers to the interventions service API.
+
+This means that we need somewhere to store the user’s answers as they progress through the journey. For some journeys, the interventions service provides this storage. For example, in the journey of submitting a referral, the interventions service provides endpoints for creating and updating a draft referral.
+
+However, we have other journeys where the interventions service does not provide this storage. For example, assigning a referral to a caseworker, or cancelling a referral. For these journeys, the UI application needs to provide its own storage.
+
+### Why not have the interventions service store everything?
+
+We _could_ make the interventions service provide an endpoint for every page of every journey in the UI. However, this would be very tied to the user journeys of this UI and less of a general-purpose interventions API. We should reserve interventions service storage for long journeys which the user might want to complete in multiple sittings.
+
+### The solution so far
+
+We pass data from page A to page B to page C of a journey by making sure that the HTTP request for page C includes all of the data that was submitted on pages A and B. We do this either by:
+
+- accepting the data from previous pages as data encoded in the request URL’s query, and then passing it in a GET request to subsequent pages by placing the data from previous pages into the query of the URL that’s used for navigating to the next page
+- accepting the data from previous pages as `application/x-www-form-urlencoded` form data, and then passing it in a POST request to subsequent pages by placing `<input type="hidden">` fields on each page, replaying the data from the previous pages
+
+### The problem with this solution
+
+Using a GET request limits the amount of data a user can submit on a page, since many clients and servers do not support URLs over 2000 bytes long.
+
+Using a POST request means that we cannot redirect to different pages in the journey (for example, check your answers) based on the user’s input, since a redirect response cannot instruct the browser to make a POST request.
+
+Also, the approach of embedding the data in the HTML is laborious. We have to make sure that every possible route through the pages in the journey preserves the data. This becomes particularly easy to get wrong when we have non-linear sequences of pages — for example, a link on the check your answers page that allows the user to edit a previous answer.
+
+### Other requirements for a solution
+
+The solution must also:
+
+- not prevent the user from performing the same journey multiple times concurrently — for example, they should be able to assign two different interventions at the same time in different browser tabs
+- preserve the data that the user entered on previous pages when they use the browser’s Back button
+
+It would also be good if the solution could:
+
+- not introduce new dependencies to the service — for example a database
+- allow us to continue using the same kinds of coding patterns as we do when interacting with the interventions service API — creating and updating a resource
+- allow us to identify and clean up old data
+
+## Decision
+
+We will use the Express `session` object as our storage. It’s backed by a Redis instance and allows us to store essentially unlimited amounts of data. The data is private to the current browsing session and is not accessible by other users.
+
+In the session, we will store “draft” objects. These are containers of arbitrary data, along with:
+
+- a globally unique identifier
+- timestamps of creation and last update
+- an identifier explaining what type of data the draft represents
+
+We’ll:
+
+- provide a “CRUD” API for creating, fetching, updating and deleting these draft objects
+- include the draft’s ID in all URLs in a journey
+- allow these drafts to be created by a GET request, so that we can use `<a>` tags to link to journeys
+- prefer to use POSTs to pass data to a page instead of GET, so we don't have to worry about body size constraints
+
+## Consequences
+
+Draft data will be lost after around 16 hours of inactivity, [which is when the session cookie expires](../../../server/app.ts#110). We should inform the user when this has happened, so that they can start the journey again. If this time limit proves to be a problem then we may need to reconsider the expiry duration.
+
+The URLs for some pages in our service will become longer.
+
+If we forget to delete a draft when the journey is complete, then it will continue to take up space in Redis. The metadata that we’re including on the drafts will allow us to clean this up later if need be, though.
+
+The draft data will only be as secure as our Redis instance.

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -284,7 +284,10 @@ describe('Service provider referrals dashboard', () => {
     cy.get('#email').type('john@harmonyliving.org.uk')
     cy.contains('Save and continue').click()
 
-    cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/check`)
+    cy.location('pathname').should(
+      'match',
+      new RegExp(`/service-provider/referrals/${referral.id}/assignment/[a-z0-9-]+/check`)
+    )
     cy.get('h1').contains('Confirm the Accommodation referral assignment')
     cy.contains('John Smith')
 
@@ -294,6 +297,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
     cy.stubGetSentReferralsForUserToken([assignedReferral])
 
+    cy.get('h1').contains('Confirm the Accommodation referral assignment')
     cy.contains('Confirm assignment').click()
 
     cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/confirmation`)

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -312,6 +312,18 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('This intervention is assigned to John Smith.')
   })
 
+  it('User tries to continue a draft assignment that no longer exists', () => {
+    cy.stubGetSentReferralsForUserToken([])
+
+    cy.login()
+
+    cy.visit('/service-provider/referrals/abc123/assignment/some-fake-id/check', { failOnStatusCode: false })
+    // TODO IC-2021 check this gives a 404 response too
+    cy.get('#user-error-message').contains(
+      'Too much time has passed since started entering your answers. Your answers have not been saved, and you will need to start again.'
+    )
+  })
+
   it('User creates an action plan and submits it for approval', () => {
     const desiredOutcomes = [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@ministryofjustice/frontend": "0.0.21",
         "@sentry/node": "^6.8.0",
         "@types/connect-flash": "0.0.36",
+        "@types/uuid": "^8.3.0",
         "agentkeepalive": "^4.1.3",
         "applicationinsights": "^2.1.3",
         "body-parser": "^1.19.0",
@@ -40,7 +41,8 @@
         "passport-oauth2": "^1.5.0",
         "redis": "^3.1.1",
         "superagent": "^6.1.0",
-        "timezone-support": "^2.0.2"
+        "timezone-support": "^2.0.2",
+        "uuid": "^3.4.0"
       },
       "devDependencies": {
         "@pact-foundation/pact": "^9.16.0",
@@ -3487,6 +3489,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "node_modules/@types/yargs": {
       "version": "15.0.13",
@@ -23209,6 +23216,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@types/yargs": {
       "version": "15.0.13",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@ministryofjustice/frontend": "0.0.21",
     "@sentry/node": "^6.8.0",
     "@types/connect-flash": "0.0.36",
+    "@types/uuid": "^8.3.0",
     "agentkeepalive": "^4.1.3",
     "applicationinsights": "^2.1.3",
     "body-parser": "^1.19.0",
@@ -126,7 +127,8 @@
     "passport-oauth2": "^1.5.0",
     "redis": "^3.1.1",
     "superagent": "^6.1.0",
-    "timezone-support": "^2.0.2"
+    "timezone-support": "^2.0.2",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "@pact-foundation/pact": "^9.16.0",

--- a/server/app.ts
+++ b/server/app.ts
@@ -26,6 +26,7 @@ import passportSetup from './authentication/passport'
 import AssessRisksAndNeedsService from './services/assessRisksAndNeedsService'
 import ControllerUtils from './utils/controllerUtils'
 import broadcastMessageConfig from './broadcast-message-config.json'
+import DraftsService from './services/draftsService'
 
 const RedisStore = connectRedis(session)
 
@@ -33,7 +34,8 @@ export default function createApp(
   communityApiService: CommunityApiService,
   interventionsService: InterventionsService,
   hmppsAuthService: HmppsAuthService,
-  assessRisksAndNeedsService: AssessRisksAndNeedsService
+  assessRisksAndNeedsService: AssessRisksAndNeedsService,
+  draftsService: DraftsService
 ): express.Application {
   const app = express()
 
@@ -203,6 +205,7 @@ export default function createApp(
       interventionsService,
       hmppsAuthService,
       assessRisksAndNeedsService,
+      draftsService,
     })
   )
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import config from './config'
 import InterventionsService from './services/interventionsService'
 import RestClient from './data/restClient'
 import AssessRisksAndNeedsService from './services/assessRisksAndNeedsService'
+import DraftsService from './services/draftsService'
 
 const assessRisksAndNeedsRestClient = new RestClient('assessRisksAndNeedsClient', config.apis.assessRisksAndNeedsApi)
 const communityApiRestClient = new RestClient('communityApiClient', config.apis.communityApi)
@@ -16,7 +17,15 @@ const assessRisksAndNeedsService = new AssessRisksAndNeedsService(
   assessRisksAndNeedsRestClient,
   config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
 )
+const clock = { now: () => new Date() }
+const draftsService = new DraftsService(clock)
 
-const app = createApp(communityApiService, interventionsService, hmppsAuthService, assessRisksAndNeedsService)
+const app = createApp(
+  communityApiService,
+  interventionsService,
+  hmppsAuthService,
+  assessRisksAndNeedsService,
+  draftsService
+)
 
 export default app

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -11,12 +11,14 @@ import FindInterventionsController from './findInterventions/findInterventionsCo
 import ProbationPractitionerReferralsController from './probationPractitionerReferrals/probationPractitionerReferralsController'
 import CommonController from './common/commonController'
 import AssessRisksAndNeedsService from '../services/assessRisksAndNeedsService'
+import DraftsService from '../services/draftsService'
 
 export interface Services {
   communityApiService: CommunityApiService
   interventionsService: InterventionsService
   hmppsAuthService: HmppsAuthService
   assessRisksAndNeedsService: AssessRisksAndNeedsService
+  draftsService: DraftsService
 }
 
 export default function routes(router: Router, services: Services): Router {
@@ -39,7 +41,8 @@ export default function routes(router: Router, services: Services): Router {
     services.interventionsService,
     services.communityApiService,
     services.hmppsAuthService,
-    services.assessRisksAndNeedsService
+    services.assessRisksAndNeedsService,
+    services.draftsService
   )
   const findInterventionsController = new FindInterventionsController(services.interventionsService)
   const commonController = new CommonController()
@@ -61,10 +64,21 @@ export default function routes(router: Router, services: Services): Router {
     serviceProviderReferralsController.showInterventionProgress(req, res)
   )
   get('/service-provider/referrals/:id/assignment/check', (req, res) =>
+    // This keeps the assign button on any pre-drafts version of the referral details page working
+    serviceProviderReferralsController.backwardsCompatibilityStartAssignment(req, res)
+  )
+  post('/service-provider/referrals/:id/assignment/start', (req, res) =>
+    serviceProviderReferralsController.startAssignment(req, res)
+  )
+  get('/service-provider/referrals/:id/assignment/:draftAssignmentId/check', (req, res) =>
     serviceProviderReferralsController.checkAssignment(req, res)
   )
   post('/service-provider/referrals/:id/assignment', (req, res) =>
-    serviceProviderReferralsController.assignReferral(req, res)
+    // This keeps a submission of the any pre-drafts version of the assignment check your answers page working
+    serviceProviderReferralsController.backwardsCompatibilitySubmitAssignment(req, res)
+  )
+  post('/service-provider/referrals/:id/assignment/:draftAssignmentId/submit', (req, res) =>
+    serviceProviderReferralsController.submitAssignment(req, res)
   )
   get('/service-provider/referrals/:id/assignment/confirmation', (req, res) =>
     serviceProviderReferralsController.confirmAssignment(req, res)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -223,7 +223,7 @@ export default function routes(router: Router, services: Services): Router {
 
   get('/probation-practitioner/referrals/:id/cancellation/reason', (req, res) =>
     // This keeps the cancel link on any pre-drafts version of the intervention progress page working
-    probationPractitionerReferralsController.backwardsCompatibilityStartCancellation(req, res)
+    probationPractitionerReferralsController.startCancellation(req, res)
   )
   get('/probation-practitioner/referrals/:id/cancellation/start', (req, res) =>
     probationPractitionerReferralsController.startCancellation(req, res)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -29,7 +29,8 @@ export default function routes(router: Router, services: Services): Router {
     services.interventionsService,
     services.communityApiService,
     services.hmppsAuthService,
-    services.assessRisksAndNeedsService
+    services.assessRisksAndNeedsService,
+    services.draftsService
   )
   const referralsController = new ReferralsController(
     services.interventionsService,
@@ -221,13 +222,31 @@ export default function routes(router: Router, services: Services): Router {
   )
 
   get('/probation-practitioner/referrals/:id/cancellation/reason', (req, res) =>
-    probationPractitionerReferralsController.showReferralCancellationReasonPage(req, res)
+    // This keeps the cancel link on any pre-drafts version of the intervention progress page working
+    probationPractitionerReferralsController.backwardsCompatibilityStartCancellation(req, res)
+  )
+  get('/probation-practitioner/referrals/:id/cancellation/start', (req, res) =>
+    probationPractitionerReferralsController.startCancellation(req, res)
+  )
+  get('/probation-practitioner/referrals/:id/cancellation/:draftCancellationId/reason', (req, res) =>
+    probationPractitionerReferralsController.editCancellationReason(req, res)
   )
   post('/probation-practitioner/referrals/:id/cancellation/check-your-answers', (req, res) =>
-    probationPractitionerReferralsController.submitFormAndShowCancellationCheckAnswersPage(req, res)
+    // This keeps a submission of any pre-drafts version of the cancellation reason form working
+    probationPractitionerReferralsController.backwardsCompatibilityUpdateCancellationReason(req, res)
+  )
+  post('/probation-practitioner/referrals/:id/cancellation/:draftCancellationId/reason', (req, res) =>
+    probationPractitionerReferralsController.editCancellationReason(req, res)
+  )
+  get('/probation-practitioner/referrals/:id/cancellation/:draftCancellationId/check-your-answers', (req, res) =>
+    probationPractitionerReferralsController.cancellationCheckAnswers(req, res)
   )
   post('/probation-practitioner/referrals/:id/cancellation/submit', (req, res) =>
-    probationPractitionerReferralsController.cancelReferral(req, res)
+    // This keeps a submission of any pre-drafts version of the cancellation check your answers page working
+    probationPractitionerReferralsController.backwardsCompatibilitySubmitCancellation(req, res)
+  )
+  post('/probation-practitioner/referrals/:id/cancellation/:draftCancellationId/submit', (req, res) =>
+    probationPractitionerReferralsController.submitCancellation(req, res)
   )
   get('/probation-practitioner/referrals/:id/cancellation/confirmation', (req, res) =>
     probationPractitionerReferralsController.showCancellationConfirmationPage(req, res)

--- a/server/routes/probationPractitionerReferrals/draftCancellationData.ts
+++ b/server/routes/probationPractitionerReferrals/draftCancellationData.ts
@@ -1,0 +1,4 @@
+export default interface DraftCancellationData {
+  cancellationReason: string | null
+  cancellationComments: string | null
+}

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -178,7 +178,7 @@ describe(InterventionProgressPresenter, () => {
       const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
 
       expect(presenter.referralCancellationHref).toEqual(
-        `/probation-practitioner/referrals/${referral.id}/cancellation/reason`
+        `/probation-practitioner/referrals/${referral.id}/cancellation/start`
       )
     })
   })

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -73,7 +73,7 @@ export default class InterventionProgressPresenter {
     title: `${utils.convertToTitleCase(this.intervention.contractType.name)} progress`,
   }
 
-  readonly referralCancellationHref = `/probation-practitioner/referrals/${this.referral.id}/cancellation/reason`
+  readonly referralCancellationHref = `/probation-practitioner/referrals/${this.referral.id}/cancellation/start`
 
   readonly hasSessions = this.actionPlanAppointments.length !== 0
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -335,6 +335,34 @@ describe('POST /probation-practitioner/referrals/:id/cancellation/check-your-ans
       expect.anything()
     )
   })
+
+  describe('with invalid data', () => {
+    it('renders an error message', async () => {
+      const draftCancellation = draftCancellationFactory.build()
+      draftsService.createDraft.mockReturnValue(draftCancellation)
+
+      const referral = sentReferralFactory.assigned().build()
+      const intervention = interventionFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+
+      interventionsService.getSentReferral.mockResolvedValue(referral)
+      communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+      interventionsService.getIntervention.mockResolvedValue(intervention)
+      interventionsService.getReferralCancellationReasons.mockResolvedValue([
+        { code: 'MIS', description: 'Referral was made by mistake' },
+        { code: 'MOV', description: 'Service user has moved out of delivery area' },
+      ])
+
+      await request(app)
+        .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/check-your-answers`)
+        .type('form')
+        .send({ 'cancellation-comments': 'Alex has moved out of the area' })
+        .expect(400)
+        .expect(res => {
+          expect(res.text).toContain('Select a reason for cancelling the referral')
+        })
+    })
+  })
 })
 
 describe('POST /probation-practitioner/referrals/:id/cancellation/:draftCancellationId/reason', () => {
@@ -361,6 +389,36 @@ describe('POST /probation-practitioner/referrals/:id/cancellation/:draftCancella
       { cancellationReason: 'MOV', cancellationComments: 'Alex has moved out of the area' },
       expect.anything()
     )
+  })
+
+  describe('with invalid data', () => {
+    it('renders an error message', async () => {
+      const draftCancellation = draftCancellationFactory.build({
+        data: { cancellationReason: null, cancellationComments: null },
+      })
+      draftsService.fetchDraft.mockReturnValue(draftCancellation)
+
+      const referral = sentReferralFactory.assigned().build()
+      const intervention = interventionFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+
+      interventionsService.getSentReferral.mockResolvedValue(referral)
+      communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+      interventionsService.getIntervention.mockResolvedValue(intervention)
+      interventionsService.getReferralCancellationReasons.mockResolvedValue([
+        { code: 'MIS', description: 'Referral was made by mistake' },
+        { code: 'MOV', description: 'Service user has moved out of delivery area' },
+      ])
+
+      await request(app)
+        .post(`/probation-practitioner/referrals/${referral.id}/cancellation/${draftCancellation.id}/reason`)
+        .type('form')
+        .send({ 'cancellation-comments': 'Alex has moved out of the area' })
+        .expect(400)
+        .expect(res => {
+          expect(res.text).toContain('Select a reason for cancelling the referral')
+        })
+    })
   })
 })
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -33,13 +33,16 @@ import errorMessages from '../../utils/errorMessages'
 import SupplierAssessmentDecorator from '../../decorators/supplierAssessmentDecorator'
 import SupplierAssessmentAppointmentPresenter from '../shared/supplierAssessmentAppointmentPresenter'
 import SupplierAssessmentAppointmentView from '../shared/supplierAssessmentAppointmentView'
+import DraftsService from '../../services/draftsService'
+import DraftCancellationData from './draftCancellationData'
 
 export default class ProbationPractitionerReferralsController {
   constructor(
     private readonly interventionsService: InterventionsService,
     private readonly communityApiService: CommunityApiService,
     private readonly hmppsAuthService: HmppsAuthService,
-    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService
+    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService,
+    private readonly draftsService: DraftsService
   ) {}
 
   async showMyCases(req: Request, res: Response): Promise<void> {
@@ -181,11 +184,43 @@ export default class ProbationPractitionerReferralsController {
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async showReferralCancellationReasonPage(req: Request, res: Response): Promise<void> {
+  async startCancellation(req: Request, res: Response): Promise<void> {
+    const draftCancellation = this.draftsService.createDraft<DraftCancellationData>(
+      'cancellation',
+      {
+        cancellationReason: null,
+        cancellationComments: null,
+      },
+      req
+    )
+    res.redirect(`/probation-practitioner/referrals/${req.params.id}/cancellation/${draftCancellation.id}/reason`)
+  }
+
+  async editCancellationReason(req: Request, res: Response): Promise<void> {
     const { user } = res.locals
     const { accessToken } = user.token
+    const referralId = req.params.id
 
-    const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
+    const draftCancellation = this.draftsService.fetchDraft<DraftCancellationData>(req.params.draftCancellationId, req)
+
+    const data = await new ReferralCancellationReasonForm(req).data()
+
+    let formError: FormValidationError | null = null
+
+    if (req.method === 'POST') {
+      if (!data.error) {
+        this.draftsService.updateDraft(draftCancellation.id, data.paramsForUpdate, req)
+
+        return res.redirect(
+          `/probation-practitioner/referrals/${referralId}/cancellation/${draftCancellation.id}/check-your-answers`
+        )
+      }
+
+      res.status(400)
+      formError = data.error
+    }
+
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, referralId)
     const intervention = await this.interventionsService.getIntervention(
       accessToken,
       sentReferral.referral.interventionId
@@ -194,70 +229,52 @@ export default class ProbationPractitionerReferralsController {
     const cancellationReasons = await this.interventionsService.getReferralCancellationReasons(accessToken)
 
     const presenter = new ReferralCancellationReasonPresenter(
+      draftCancellation,
       sentReferral,
       intervention,
       serviceUser,
-      cancellationReasons
+      cancellationReasons,
+      formError
     )
     const view = new ReferralCancellationReasonView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async submitFormAndShowCancellationCheckAnswersPage(req: Request, res: Response): Promise<void> {
+  async cancellationCheckAnswers(req: Request, res: Response): Promise<void> {
     const { user } = res.locals
     const { accessToken } = user.token
-    let formError: FormValidationError | null = null
+
+    const draftCancellation = this.draftsService.fetchDraft<DraftCancellationData>(req.params.draftCancellationId, req)
 
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
     const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
 
-    const data = await new ReferralCancellationReasonForm(req).data()
-
-    if (data.error) {
-      res.status(400)
-      formError = data.error
-
-      const intervention = await this.interventionsService.getIntervention(
-        accessToken,
-        sentReferral.referral.interventionId
-      )
-      const cancellationReasons = await this.interventionsService.getReferralCancellationReasons(accessToken)
-
-      const presenter = new ReferralCancellationReasonPresenter(
-        sentReferral,
-        intervention,
-        serviceUser,
-        cancellationReasons,
-        formError
-      )
-      const view = new ReferralCancellationReasonView(presenter)
-
-      return ControllerUtils.renderWithLayout(res, view, serviceUser)
-    }
-
-    const { cancellationReason, cancellationComments } = data.paramsForUpdate
-
-    const presenter = new ReferralCancellationCheckAnswersPresenter(
-      req.params.id,
-      cancellationReason,
-      cancellationComments
-    )
-
+    const presenter = new ReferralCancellationCheckAnswersPresenter(req.params.id, draftCancellation.id)
     const view = new ReferralCancellationCheckAnswersView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async cancelReferral(req: Request, res: Response): Promise<void> {
+  async submitCancellation(req: Request, res: Response): Promise<void> {
     const { user } = res.locals
     const { accessToken } = user.token
     const referralId = req.params.id
 
-    const cancellationReason = req.body['cancellation-reason']
-    const cancellationComments = req.body['cancellation-comments']
+    const draftCancellation = this.draftsService.fetchDraft<DraftCancellationData>(req.params.draftCancellationId, req)
+
+    const { cancellationReason, cancellationComments } = draftCancellation.data
+
+    if (cancellationReason === null) {
+      throw new Error('Got unexpectedly null cancellationReason')
+    }
+    if (cancellationComments === null) {
+      throw new Error('Got unexpectedly null cancellationComments')
+    }
 
     await this.interventionsService.endReferral(accessToken, referralId, cancellationReason, cancellationComments)
+
+    this.draftsService.deleteDraft(draftCancellation.id, req)
 
     return res.redirect(`/probation-practitioner/referrals/${referralId}/cancellation/confirmation`)
   }

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.test.ts
@@ -3,7 +3,7 @@ import ReferralCancellationCheckAnswersPresenter from './referralCancellationChe
 describe(ReferralCancellationCheckAnswersPresenter, () => {
   describe('text', () => {
     it('contains a title and confirmation question', () => {
-      const presenter = new ReferralCancellationCheckAnswersPresenter('89047822-1014-4f8f-a52c-c348137c89a5')
+      const presenter = new ReferralCancellationCheckAnswersPresenter('', '')
 
       expect(presenter.text).toMatchObject({
         title: 'Referral Cancellation',
@@ -14,25 +14,13 @@ describe(ReferralCancellationCheckAnswersPresenter, () => {
 
   describe('confirmCancellationHref', () => {
     it('contains a reference to the referral cancellation endpoint', () => {
-      const presenter = new ReferralCancellationCheckAnswersPresenter('89047822-1014-4f8f-a52c-c348137c89a5')
-      expect(presenter.confirmCancellationHref).toEqual(
-        '/probation-practitioner/referrals/89047822-1014-4f8f-a52c-c348137c89a5/cancellation/submit'
-      )
-    })
-  })
-
-  describe('hiddenFields', () => {
-    it('contains the cancellation code and comments', () => {
       const presenter = new ReferralCancellationCheckAnswersPresenter(
         '89047822-1014-4f8f-a52c-c348137c89a5',
-        'MOV',
-        'Alex moved out of the area'
+        'e3eac95b-787b-4ab9-93fd-39df32aabc41'
       )
-
-      expect(presenter.hiddenFields).toMatchObject({
-        cancellationReason: 'MOV',
-        cancellationComments: 'Alex moved out of the area',
-      })
+      expect(presenter.confirmCancellationHref).toEqual(
+        '/probation-practitioner/referrals/89047822-1014-4f8f-a52c-c348137c89a5/cancellation/e3eac95b-787b-4ab9-93fd-39df32aabc41/submit'
+      )
     })
   })
 })

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.ts
@@ -1,19 +1,10 @@
 export default class ReferralCancellationCheckAnswersPresenter {
-  constructor(
-    private readonly referralId: string,
-    private readonly cancellationReason?: string,
-    private readonly cancellationComments?: string
-  ) {}
+  constructor(private readonly referralId: string, private readonly draftCancellationId: string) {}
 
   readonly text = {
     title: 'Referral Cancellation',
     confirmationQuestion: 'Are you sure you want to cancel this referral?',
   }
 
-  readonly confirmCancellationHref = `/probation-practitioner/referrals/${this.referralId}/cancellation/submit`
-
-  readonly hiddenFields = {
-    cancellationReason: this.cancellationReason,
-    cancellationComments: this.cancellationComments,
-  }
+  readonly confirmCancellationHref = `/probation-practitioner/referrals/${this.referralId}/cancellation/${this.draftCancellationId}/submit`
 }

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersView.ts
@@ -8,7 +8,6 @@ export default class ReferralCancellationCheckAnswersView {
       'probationPractitionerReferrals/referralCancellationCheckAnswers',
       {
         presenter: this.presenter,
-        hiddenFields: this.presenter.hiddenFields,
       },
     ]
   }

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonForm.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonForm.ts
@@ -8,7 +8,7 @@ import { FormValidationError } from '../../utils/formValidationError'
 export default class ReferralCancellationReasonForm {
   constructor(private readonly request: Request) {}
 
-  async data(): Promise<FormData<Partial<{ cancellationReason: string; cancellationComments: string }>>> {
+  async data(): Promise<FormData<{ cancellationReason: string; cancellationComments: string }>> {
     const validationResult = await FormUtils.runValidations({
       request: this.request,
       validations: ReferralCancellationReasonForm.validations,

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
@@ -75,6 +75,44 @@ describe(ReferralCancellationReasonPresenter, () => {
     })
   })
 
+  describe('fields', () => {
+    describe('cancellationComments', () => {
+      const sentReferral = sentReferralFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+      const intervention = interventionFactory.build()
+
+      describe('when the draft cancellation has null cancellationComments', () => {
+        it('returns an empty string', () => {
+          const presenter = new ReferralCancellationReasonPresenter(
+            draftFactory.build({ data: draftCancellationDataFactory.build({ cancellationComments: null }) }),
+            sentReferral,
+            intervention,
+            serviceUser,
+            []
+          )
+
+          expect(presenter.fields.cancellationComments).toEqual('')
+        })
+      })
+
+      describe('when the draft cancellation has a non-null cancellationComments', () => {
+        it('returns that value', () => {
+          const presenter = new ReferralCancellationReasonPresenter(
+            draftFactory.build({
+              data: draftCancellationDataFactory.build({ cancellationComments: 'David has been recalled' }),
+            }),
+            sentReferral,
+            intervention,
+            serviceUser,
+            []
+          )
+
+          expect(presenter.fields.cancellationComments).toEqual('David has been recalled')
+        })
+      })
+    })
+  })
+
   describe('errorSummary', () => {
     const sentReferral = sentReferralFactory.build()
     const serviceUser = deliusServiceUserFactory.build()

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
@@ -4,6 +4,10 @@ import interventionFactory from '../../../testutils/factories/intervention'
 import serviceProviderFactory from '../../../testutils/factories/serviceProvider'
 import CancellationReason from '../../models/cancellationReason'
 import ReferralCancellationReasonPresenter from './referralCancellationReasonPresenter'
+import { createDraftFactory } from '../../../testutils/factories/draft'
+import draftCancellationDataFactory from '../../../testutils/factories/draftCancellationData'
+
+const draftFactory = createDraftFactory(draftCancellationDataFactory.build())
 
 describe(ReferralCancellationReasonPresenter, () => {
   describe('text', () => {
@@ -15,6 +19,7 @@ describe(ReferralCancellationReasonPresenter, () => {
       const cancellationReasons: CancellationReason[] = []
 
       const presenter = new ReferralCancellationReasonPresenter(
+        draftFactory.build({ data: draftCancellationDataFactory.build() }),
         sentReferral,
         intervention,
         serviceUser,
@@ -39,6 +44,7 @@ describe(ReferralCancellationReasonPresenter, () => {
       ]
 
       const presenter = new ReferralCancellationReasonPresenter(
+        draftFactory.build({ data: draftCancellationDataFactory.build() }),
         sentReferral,
         intervention,
         serviceUser,
@@ -61,6 +67,7 @@ describe(ReferralCancellationReasonPresenter, () => {
     describe('when there is an error', () => {
       it('returns a summary of the error', () => {
         const presenter = new ReferralCancellationReasonPresenter(
+          draftFactory.build({ data: draftCancellationDataFactory.build() }),
           sentReferral,
           intervention,
           serviceUser,
@@ -85,6 +92,7 @@ describe(ReferralCancellationReasonPresenter, () => {
     describe('when there is no error', () => {
       it('returns null', () => {
         const presenter = new ReferralCancellationReasonPresenter(
+          draftFactory.build({ data: draftCancellationDataFactory.build() }),
           sentReferral,
           intervention,
           serviceUser,
@@ -105,6 +113,7 @@ describe(ReferralCancellationReasonPresenter, () => {
     describe('when there is an error', () => {
       it('returns the error message', () => {
         const presenter = new ReferralCancellationReasonPresenter(
+          draftFactory.build({ data: draftCancellationDataFactory.build() }),
           sentReferral,
           intervention,
           serviceUser,
@@ -127,6 +136,7 @@ describe(ReferralCancellationReasonPresenter, () => {
     describe('when there is no error', () => {
       it('returns null', () => {
         const presenter = new ReferralCancellationReasonPresenter(
+          draftFactory.build({ data: draftCancellationDataFactory.build() }),
           sentReferral,
           intervention,
           serviceUser,

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
@@ -34,17 +34,17 @@ describe(ReferralCancellationReasonPresenter, () => {
   })
 
   describe('referralCancellationFields', () => {
-    it('returns an array of fields to be passed as radio button args', () => {
-      const sentReferral = sentReferralFactory.build()
-      const serviceUser = deliusServiceUserFactory.build()
-      const intervention = interventionFactory.build()
-      const cancellationReasons: CancellationReason[] = [
-        { code: 'MIS', description: 'Referral was made by mistake' },
-        { code: 'MOV', description: 'Service user has moved out of delivery area' },
-      ]
+    const sentReferral = sentReferralFactory.build()
+    const serviceUser = deliusServiceUserFactory.build()
+    const intervention = interventionFactory.build()
+    const cancellationReasons: CancellationReason[] = [
+      { code: 'MIS', description: 'Referral was made by mistake' },
+      { code: 'MOV', description: 'Service user has moved out of delivery area' },
+    ]
 
+    it('returns an array of fields to be passed as radio button args', () => {
       const presenter = new ReferralCancellationReasonPresenter(
-        draftFactory.build({ data: draftCancellationDataFactory.build() }),
+        draftFactory.build({ data: draftCancellationDataFactory.build({ cancellationReason: null }) }),
         sentReferral,
         intervention,
         serviceUser,
@@ -55,6 +55,23 @@ describe(ReferralCancellationReasonPresenter, () => {
         { value: 'MIS', text: 'Referral was made by mistake', checked: false },
         { value: 'MOV', text: 'Service user has moved out of delivery area', checked: false },
       ])
+    })
+
+    describe('when the draft cancellation has a non-null cancellationReason', () => {
+      it('sets checked to true for that reason', () => {
+        const presenter = new ReferralCancellationReasonPresenter(
+          draftFactory.build({ data: draftCancellationDataFactory.build({ cancellationReason: 'MOV' }) }),
+          sentReferral,
+          intervention,
+          serviceUser,
+          cancellationReasons
+        )
+
+        expect(presenter.cancellationReasonsFields).toEqual([
+          { value: 'MIS', text: 'Referral was made by mistake', checked: false },
+          { value: 'MOV', text: 'Service user has moved out of delivery area', checked: true },
+        ])
+      })
     })
   })
 

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
@@ -10,8 +10,6 @@ import { Draft } from '../../services/draftsService'
 
 export default class ReferralCancellationReasonPresenter {
   constructor(
-    // This property is unused right now, but we’ll shortly make use of it
-    // to replay entered data
     private readonly draftCancellation: Draft<DraftCancellationData>,
     private readonly sentReferral: SentReferral,
     private readonly intervention: Intervention,
@@ -32,7 +30,7 @@ export default class ReferralCancellationReasonPresenter {
     return this.cancellationReasons.map(cancellationReason => ({
       value: cancellationReason.code,
       text: cancellationReason.description,
-      checked: false,
+      checked: this.draftCancellation.data.cancellationReason === cancellationReason.code,
     }))
   }
 

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
@@ -34,6 +34,15 @@ export default class ReferralCancellationReasonPresenter {
     }))
   }
 
+  private readonly utils = new PresenterUtils(null)
+
+  readonly fields = {
+    cancellationComments: this.utils.stringValue(
+      this.draftCancellation.data.cancellationComments,
+      'cancellation-comments'
+    ),
+  }
+
   readonly errorMessage = PresenterUtils.errorMessage(this.error, 'cancellation-reason')
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
@@ -5,9 +5,14 @@ import SentReferral from '../../models/sentReferral'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 import Intervention from '../../models/intervention'
+import DraftCancellationData from './draftCancellationData'
+import { Draft } from '../../services/draftsService'
 
 export default class ReferralCancellationReasonPresenter {
   constructor(
+    // This property is unused right now, but we’ll shortly make use of it
+    // to replay entered data
+    private readonly draftCancellation: Draft<DraftCancellationData>,
     private readonly sentReferral: SentReferral,
     private readonly intervention: Intervention,
     private readonly serviceUser: DeliusServiceUser,
@@ -34,6 +39,4 @@ export default class ReferralCancellationReasonPresenter {
   readonly errorMessage = PresenterUtils.errorMessage(this.error, 'cancellation-reason')
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
-
-  readonly checkAnswersHref = `/probation-practitioner/referrals/${this.sentReferral.id}/cancellation/check-your-answers`
 }

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonView.ts
@@ -29,6 +29,7 @@ export default class ReferralCancellationReasonView {
       label: {
         text: this.presenter.text.additionalCommentsLabel,
       },
+      value: this.presenter.fields.cancellationComments,
     }
   }
 

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
@@ -7,7 +7,7 @@ describe(CheckAssignmentPresenter, () => {
     it('returns text to be displayed', () => {
       const user = hmppsAuthUserFactory.build()
       const intervention = interventionFactory.build({ contractType: { name: 'Social inclusion' } })
-      const presenter = new CheckAssignmentPresenter('', user, '', intervention)
+      const presenter = new CheckAssignmentPresenter('', '', user, '', intervention)
 
       expect(presenter.text).toEqual({ title: 'Confirm the Social inclusion referral assignment' })
     })
@@ -18,7 +18,7 @@ describe(CheckAssignmentPresenter, () => {
       it('returns a summary of the selected caseworker with both names', () => {
         const user = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
         const intervention = interventionFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', intervention)
+        const presenter = new CheckAssignmentPresenter('', '', user, 'john@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: ['John Smith'] },
@@ -31,7 +31,7 @@ describe(CheckAssignmentPresenter, () => {
       it('returns a summary of the selected caseworker with just the first name', () => {
         const user = hmppsAuthUserFactory.build({ firstName: 'John', lastName: '' })
         const intervention = interventionFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', intervention)
+        const presenter = new CheckAssignmentPresenter('', '', user, 'john@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: ['John '] },
@@ -44,7 +44,7 @@ describe(CheckAssignmentPresenter, () => {
       it('returns a summary of the selected caseworker with just the last name', () => {
         const user = hmppsAuthUserFactory.build({ firstName: '', lastName: 'smith' })
         const intervention = interventionFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'smith@harmonyliving.org.uk', intervention)
+        const presenter = new CheckAssignmentPresenter('', '', user, 'smith@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: [' Smith'] },
@@ -57,7 +57,7 @@ describe(CheckAssignmentPresenter, () => {
       it('returns a summary with an empty string for the caseworker name', () => {
         const user = hmppsAuthUserFactory.build({ firstName: '', lastName: '' })
         const intervention = interventionFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'unknown@harmonyliving.org.uk', intervention)
+        const presenter = new CheckAssignmentPresenter('', '', user, 'unknown@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: [''] },
@@ -67,21 +67,12 @@ describe(CheckAssignmentPresenter, () => {
     })
   })
 
-  describe('hiddenFields', () => {
-    it('returns a hidden field for the email address', () => {
-      const user = hmppsAuthUserFactory.build()
-      const intervention = interventionFactory.build()
-      const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', intervention)
-      expect(presenter.hiddenFields).toEqual({ email: 'john@harmonyliving.org.uk' })
-    })
-  })
-
   describe('formAction', () => {
     it('returns a URL for submitting the assignment', () => {
       const user = hmppsAuthUserFactory.build()
       const intervention = interventionFactory.build()
-      const presenter = new CheckAssignmentPresenter('1', user, '', intervention)
-      expect(presenter.formAction).toEqual('/service-provider/referrals/1/assignment')
+      const presenter = new CheckAssignmentPresenter('1', '2', user, '', intervention)
+      expect(presenter.formAction).toEqual('/service-provider/referrals/1/assignment/2/submit')
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
@@ -7,6 +7,7 @@ import utils from '../../utils/utils'
 export default class CheckAssignmentPresenter {
   constructor(
     private readonly referralId: string,
+    private readonly draftAssignmentId: string,
     private readonly assignee: AuthUserDetails,
     private readonly email: string,
     private readonly intervention: Intervention
@@ -21,9 +22,5 @@ export default class CheckAssignmentPresenter {
     { key: 'Email address', lines: [this.email] },
   ]
 
-  readonly hiddenFields = {
-    email: this.email,
-  }
-
-  readonly formAction = `/service-provider/referrals/${this.referralId}/assignment`
+  readonly formAction = `/service-provider/referrals/${this.referralId}/assignment/${this.draftAssignmentId}/submit`
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -54,7 +54,6 @@ import EndOfServiceReportCheckAnswersView from './endOfServiceReportCheckAnswers
 import EndOfServiceReportConfirmationPresenter from './endOfServiceReportConfirmationPresenter'
 import EndOfServiceReportConfirmationView from './endOfServiceReportConfirmationView'
 import ControllerUtils from '../../utils/controllerUtils'
-import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
 import ServiceCategory from '../../models/serviceCategory'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 import ActionPlanPresenter from '../shared/actionPlanPresenter'
@@ -66,13 +65,19 @@ import SupplierAssessmentAppointmentPresenter from '../shared/supplierAssessment
 import SupplierAssessmentAppointmentView from '../shared/supplierAssessmentAppointmentView'
 import SupplierAssessmentAppointmentConfirmationPresenter from './supplierAssessmentAppointmentConfirmationPresenter'
 import SupplierAssessmentAppointmentConfirmationView from './supplierAssessmentAppointmentConfirmationView'
+import DraftsService from '../../services/draftsService'
+
+export interface DraftAssignmentData {
+  email: string | null
+}
 
 export default class ServiceProviderReferralsController {
   constructor(
     private readonly interventionsService: InterventionsService,
     private readonly communityApiService: CommunityApiService,
     private readonly hmppsAuthService: HmppsAuthService,
-    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService
+    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService,
+    private readonly draftsService: DraftsService
   ) {}
 
   async showDashboard(req: Request, res: Response): Promise<void> {
@@ -185,9 +190,15 @@ export default class ServiceProviderReferralsController {
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async checkAssignment(req: Request, res: Response): Promise<void> {
-    const email = req.query.email as string
+  async backwardsCompatibilityStartAssignment(req: Request, res: Response): Promise<void> {
+    await this.startAssignmentWithEmail(req.query.email as string | undefined, req, res)
+  }
 
+  async startAssignment(req: Request, res: Response): Promise<void> {
+    await this.startAssignmentWithEmail(req.body.email, req, res)
+  }
+
+  async startAssignmentWithEmail(email: string | undefined, req: Request, res: Response): Promise<void> {
     if (email === undefined || email === '') {
       return res.redirect(
         `/service-provider/referrals/${req.params.id}/details?${querystring.stringify({
@@ -196,11 +207,10 @@ export default class ServiceProviderReferralsController {
       )
     }
 
-    let assignee: AuthUserDetails
     const token = await this.hmppsAuthService.getApiClientToken()
 
     try {
-      assignee = await this.hmppsAuthService.getSPUserByEmailAddress(token, email)
+      await this.hmppsAuthService.getSPUserByEmailAddress(token, email)
     } catch (e) {
       return res.redirect(
         `/service-provider/referrals/${req.params.id}/details?${querystring.stringify({
@@ -209,25 +219,57 @@ export default class ServiceProviderReferralsController {
       )
     }
 
+    const draftAssignment = this.draftsService.createDraft<DraftAssignmentData>('assignment', { email }, req)
+
+    return res.redirect(`/service-provider/referrals/${req.params.id}/assignment/${draftAssignment.id}/check`)
+  }
+
+  async checkAssignment(req: Request, res: Response): Promise<void> {
+    const draftAssignment = this.draftsService.fetchDraft<DraftAssignmentData>(req.params.draftAssignmentId, req)
+    const { email } = draftAssignment.data
+
+    if (email === null) {
+      throw new Error('Got unexpectedly null email')
+    }
+
+    const token = await this.hmppsAuthService.getApiClientToken()
+    const assignee = await this.hmppsAuthService.getSPUserByEmailAddress(token, email)
     const referral = await this.interventionsService.getSentReferral(res.locals.user.token.accessToken, req.params.id)
     const [intervention, serviceUser] = await Promise.all([
       this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn),
     ])
 
-    const presenter = new CheckAssignmentPresenter(referral.id, assignee, email, intervention)
+    const presenter = new CheckAssignmentPresenter(referral.id, draftAssignment.id, assignee, email, intervention)
     const view = new CheckAssignmentView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async assignReferral(req: Request, res: Response): Promise<void> {
+  async backwardsCompatibilitySubmitAssignment(req: Request, res: Response): Promise<void> {
     const { email } = req.body
     if (email === undefined || email === null || email === '') {
       res.sendStatus(400)
       return
     }
 
+    await this.submitAssignmentWithEmail(email, req, res)
+  }
+
+  async submitAssignment(req: Request, res: Response): Promise<void> {
+    const draftAssignment = this.draftsService.fetchDraft<DraftAssignmentData>(req.params.draftAssignmentId, req)
+
+    const { email } = draftAssignment.data
+    if (email === null) {
+      throw new Error('Got unexpectedly null email')
+    }
+
+    await this.submitAssignmentWithEmail(email, req, res)
+
+    this.draftsService.deleteDraft(draftAssignment.id, req)
+  }
+
+  async submitAssignmentWithEmail(email: string, req: Request, res: Response): Promise<void> {
     const assignee = await this.hmppsAuthService.getSPUserByEmailAddress(res.locals.user.token.accessToken, email)
 
     await this.interventionsService.assignSentReferral(res.locals.user.token.accessToken, req.params.id, {

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -45,7 +45,7 @@ describe(ShowReferralPresenter, () => {
   const riskSummary = riskSummaryFactory.build()
 
   describe('assignmentFormAction', () => {
-    it('returns the relative URL for the check assignment page', () => {
+    it('returns the relative URL for the start assignment page', () => {
       const referral = sentReferralFactory.build(referralParams)
       const presenter = new ShowReferralPresenter(
         referral,
@@ -61,7 +61,7 @@ describe(ShowReferralPresenter, () => {
         riskSummary
       )
 
-      expect(presenter.assignmentFormAction).toEqual(`/service-provider/referrals/${referral.id}/assignment/check`)
+      expect(presenter.assignmentFormAction).toEqual(`/service-provider/referrals/${referral.id}/assignment/start`)
     })
   })
 

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -47,7 +47,7 @@ export default class ShowReferralPresenter {
     this.riskPresenter = new RiskPresenter(riskSummary)
   }
 
-  readonly assignmentFormAction = `/service-provider/referrals/${this.sentReferral.id}/assignment/check`
+  readonly assignmentFormAction = `/service-provider/referrals/${this.sentReferral.id}/assignment/start`
 
   readonly text = {
     assignedTo: this.assigneeFullNameOrUnassigned,

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -13,6 +13,7 @@ import MockedHmppsAuthService from '../../services/testutils/hmppsAuthServiceSet
 import LoggedInUserFactory from '../../../testutils/factories/loggedInUser'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 import config from '../../config'
+import DraftsService from '../../services/draftsService'
 
 export enum AppSetupUserType {
   probationPractitioner = 'delius',
@@ -69,6 +70,7 @@ export default function appWithAllRoutes({
       interventionsService: {} as InterventionsService,
       hmppsAuthService: new MockedHmppsAuthService(),
       assessRisksAndNeedsService: {} as AssessRisksAndNeedsService,
+      draftsService: {} as DraftsService,
       ...overrides,
     }),
     production,

--- a/server/services/draftsService.test.ts
+++ b/server/services/draftsService.test.ts
@@ -1,0 +1,174 @@
+import { Request } from 'express'
+import { mocked } from 'ts-jest/utils'
+import uuid from 'uuid'
+import DraftsService from './draftsService'
+
+jest.mock('uuid')
+const mockedUuid = mocked(uuid)
+
+describe(DraftsService, () => {
+  function createRequestWithSession(session: unknown): Request {
+    return { session } as unknown as Request
+  }
+
+  const clock = { now: () => new Date('2021-04-01T10:25:00Z') }
+
+  describe('.createDraft', () => {
+    it('generates a random UUID and stores the data in the session under a key derived from that UUID', () => {
+      mockedUuid.v4.mockReturnValue('2dc7ef56-58dd-4339-9924-c33318738068')
+      const req = createRequestWithSession({})
+
+      const draftsService = new DraftsService(clock)
+
+      const draft = draftsService.createDraft('someExampleType', { a: 1, b: 2 }, req)
+
+      expect(draft).toEqual({
+        id: '2dc7ef56-58dd-4339-9924-c33318738068',
+        type: 'someExampleType',
+        createdAt: new Date('2021-04-01T10:25:00Z'),
+        updatedAt: new Date('2021-04-01T10:25:00Z'),
+        data: { a: 1, b: 2 },
+      })
+
+      expect(req.session['draft-2dc7ef56-58dd-4339-9924-c33318738068']).toEqual({
+        id: '2dc7ef56-58dd-4339-9924-c33318738068',
+        type: 'someExampleType',
+        createdAt: '2021-04-01T10:25:00.000Z',
+        updatedAt: '2021-04-01T10:25:00.000Z',
+        data: { a: 1, b: 2 },
+      })
+    })
+  })
+
+  describe('.fetchDraft', () => {
+    describe('when the session contains a draft for that ID', () => {
+      it('returns that draft', () => {
+        const req = createRequestWithSession({
+          'draft-2dc7ef56-58dd-4339-9924-c33318738068': {
+            id: '2dc7ef56-58dd-4339-9924-c33318738068',
+            type: 'someExampleType',
+            createdAt: '2021-04-01T10:25:00Z',
+            updatedAt: '2021-04-01T10:25:00Z',
+            data: { a: 1, b: 2 },
+          },
+        })
+
+        const draftsService = new DraftsService(clock)
+
+        const draft = draftsService.fetchDraft('2dc7ef56-58dd-4339-9924-c33318738068', req)
+
+        expect(draft).toEqual({
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: new Date('2021-04-01T10:25:00Z'),
+          updatedAt: new Date('2021-04-01T10:25:00Z'),
+          data: { a: 1, b: 2 },
+        })
+      })
+    })
+
+    describe('when the session doesn’t contain a draft for that ID', () => {
+      it('throws an error', () => {
+        const req = createRequestWithSession({
+          'draft-2dc7ef56-58dd-4339-9924-c33318738068': {
+            id: '2dc7ef56-58dd-4339-9924-c33318738068',
+            type: 'someExampleType',
+            createdAt: '2021-04-01T10:25:00Z',
+            updatedAt: '2021-04-01T10:25:00Z',
+            data: { a: 1, b: 2 },
+          },
+        })
+
+        const draftsService = new DraftsService(clock)
+
+        expect(() => draftsService.fetchDraft('def456', req)).toThrow()
+      })
+    })
+  })
+
+  describe('.updateDraft', () => {
+    describe('when the session contains a draft for that ID', () => {
+      it('updates that draft in the session and bumps the updatedAt property', () => {
+        const req = createRequestWithSession({
+          'draft-2dc7ef56-58dd-4339-9924-c33318738068': {
+            id: '2dc7ef56-58dd-4339-9924-c33318738068',
+            type: 'someExampleType',
+            createdAt: '2021-03-10T11:50:00Z',
+            updatedAt: '2021-03-10T11:50:00Z',
+            data: { a: 1, b: 2 },
+          },
+        })
+
+        const draftsService = new DraftsService(clock)
+
+        draftsService.updateDraft('2dc7ef56-58dd-4339-9924-c33318738068', { c: 3, d: 4 }, req)
+
+        expect(req.session['draft-2dc7ef56-58dd-4339-9924-c33318738068']).toEqual({
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: '2021-03-10T11:50:00.000Z',
+          updatedAt: '2021-04-01T10:25:00.000Z',
+          data: { c: 3, d: 4 },
+        })
+      })
+    })
+
+    describe('when the session doesn’t contain a draft for that ID', () => {
+      it('throws an error', () => {
+        const req = createRequestWithSession({
+          'draft-2dc7ef56-58dd-4339-9924-c33318738068': {
+            id: '2dc7ef56-58dd-4339-9924-c33318738068',
+            type: 'someExampleType',
+            createdAt: '2021-03-10T11:50:00Z',
+            updatedAt: '2021-03-10T11:50:00Z',
+            data: { a: 1, b: 2 },
+          },
+        })
+
+        const draftsService = new DraftsService(clock)
+
+        expect(() => draftsService.updateDraft('def456', { c: 3, d: 4 }, req)).toThrow()
+      })
+    })
+  })
+
+  describe('.deleteDraft', () => {
+    describe('when the session contains a draft for that ID', () => {
+      it('removes that draft from the session', () => {
+        const req = createRequestWithSession({
+          'draft-2dc7ef56-58dd-4339-9924-c33318738068': {
+            id: '2dc7ef56-58dd-4339-9924-c33318738068',
+            type: 'someExampleType',
+            createdAt: '2021-03-10T11:50:00Z',
+            updatedAt: '2021-03-10T11:50:00Z',
+            data: { a: 1, b: 2 },
+          },
+        })
+
+        const draftsService = new DraftsService(clock)
+
+        draftsService.deleteDraft('2dc7ef56-58dd-4339-9924-c33318738068', req)
+
+        expect(req.session['draft-2dc7ef56-58dd-4339-9924-c33318738068']).toBeUndefined()
+      })
+    })
+
+    describe('when the session doesn’t contain a draft for that ID', () => {
+      it('throws an error', () => {
+        const req = createRequestWithSession({
+          'draft-2dc7ef56-58dd-4339-9924-c33318738068': {
+            id: '2dc7ef56-58dd-4339-9924-c33318738068',
+            type: 'someExampleType',
+            createdAt: '2021-03-10T11:50:00Z',
+            updatedAt: '2021-03-10T11:50:00Z',
+            data: { a: 1, b: 2 },
+          },
+        })
+
+        const draftsService = new DraftsService(clock)
+
+        expect(() => draftsService.deleteDraft('def456', req)).toThrow()
+      })
+    })
+  })
+})

--- a/server/services/draftsService.ts
+++ b/server/services/draftsService.ts
@@ -1,0 +1,74 @@
+import { Request } from 'express'
+import uuid from 'uuid'
+
+export interface Draft<Data> {
+  id: string
+  type: string
+  createdAt: Date
+  updatedAt: Date
+  data: Data
+}
+
+export interface DraftDTO {
+  id: string
+  type: string
+  createdAt: string
+  updatedAt: string
+  data: unknown
+}
+
+export interface Clock {
+  now: () => Date
+}
+
+export default class DraftsService {
+  constructor(private readonly clock: Clock) {}
+
+  private sessionKey(id: string): string {
+    return `draft-${id}`
+  }
+
+  private fetchDraftDTO(id: string, req: Request): DraftDTO {
+    const dto = req.session[this.sessionKey(id)]
+
+    if (dto === undefined) {
+      throw new Error(`Draft with ID ${id} not found in session`)
+    }
+
+    return dto
+  }
+
+  private writeDraft<Data>(draft: Draft<Data>, req: Request) {
+    req.session[this.sessionKey(draft.id)] = {
+      ...draft,
+      createdAt: draft.createdAt.toISOString(),
+      updatedAt: draft.updatedAt.toISOString(),
+    }
+  }
+
+  createDraft<Data>(type: string, initialData: Data, req: Request): Draft<Data> {
+    const now = this.clock.now()
+    const draft: Draft<Data> = { id: uuid.v4(), type, data: initialData, createdAt: now, updatedAt: now }
+
+    this.writeDraft(draft, req)
+
+    return draft
+  }
+
+  fetchDraft<Data>(id: string, req: Request): Draft<Data> {
+    const dto = this.fetchDraftDTO(id, req)
+
+    return { ...dto, createdAt: new Date(dto.createdAt), updatedAt: new Date(dto.updatedAt), data: dto.data as Data }
+  }
+
+  updateDraft<Data>(id: string, newData: Data, req: Request): void {
+    const draft = this.fetchDraft(id, req)
+
+    this.writeDraft({ ...draft, data: newData, updatedAt: this.clock.now() }, req)
+  }
+
+  deleteDraft(id: string, req: Request): void {
+    this.fetchDraft(id, req)
+    delete req.session[this.sessionKey(id)]
+  }
+}

--- a/server/services/draftsService.ts
+++ b/server/services/draftsService.ts
@@ -1,5 +1,6 @@
 import { Request } from 'express'
 import uuid from 'uuid'
+import createError from 'http-errors'
 
 export interface Draft<Data> {
   id: string
@@ -32,7 +33,11 @@ export default class DraftsService {
     const dto = req.session[this.sessionKey(id)]
 
     if (dto === undefined) {
-      throw new Error(`Draft with ID ${id} not found in session`)
+      throw createError(404, new Error(`Draft with ID ${id} not found in session`), {
+        external: false,
+        userMessage:
+          'Too much time has passed since started entering your answers. Your answers have not been saved, and you will need to start again.',
+      })
     }
 
     return dto

--- a/server/views/errors/unhandledError.njk
+++ b/server/views/errors/unhandledError.njk
@@ -11,7 +11,7 @@
                 <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
                 
                 {% if userMessage %}
-                    <p class="govuk-body">{{ userMessage }}</p>
+                    <p id="user-error-message" class="govuk-body">{{ userMessage }}</p>
                 {% endif %}
 
                 <p class="govuk-body">The error has been logged.</p>

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -14,8 +14,6 @@
     </div>
     <form method="post" action="{{ presenter.confirmCancellationHref }}">
       <input type="hidden" name="_csrf" value="{{csrfToken}}">
-      <input type="hidden" name="cancellation-reason" value="{{ hiddenFields.cancellationReason }}">
-      <input type="hidden" name="cancellation-comments" value="{{ hiddenFields.cancellationComments }}">
 
       {{ govukButton({ text: "Cancel referral", preventDoubleClick: true }) }}
     </form>

--- a/server/views/probationPractitionerReferrals/referralCancellationReason.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationReason.njk
@@ -19,7 +19,7 @@
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <p class="govuk-body-m govuk-!-margin-bottom-8">{{ presenter.text.information }}</p>
     </div>
-    <form method="post" action="{{ presenter.checkAnswersHref }}">
+    <form method="post">
       <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
       {{ govukRadios(referralCancellationRadiosArgs) }}

--- a/server/views/serviceProviderReferrals/checkAssignment.njk
+++ b/server/views/serviceProviderReferrals/checkAssignment.njk
@@ -24,10 +24,6 @@
       <form method="post" action={{ presenter.formAction }}>
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
-        {% for name, value in presenter.hiddenFields %}
-          <input type="hidden" name={{ name }} value={{ value }}>
-        {% endfor %}
-
         {{ govukButton({ text: "Confirm assignment", preventDoubleClick: true }) }}
       </form>
     </div>

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -7,7 +7,7 @@
       {% if presenter.text.assignedTo == null %}
          {% if presenter.canAssignReferral %}
            <h2 class="govuk-heading-m">Who do you want to assign this referral to?</h2>
-           <form method="get" action={{ presenter.assignmentFormAction }}>
+           <form method="post" action={{ presenter.assignmentFormAction }}>
                  {{ govukInput(emailInputArgs) }}
                  {{ govukButton({ text: "Save and continue" }) }}
            </form>

--- a/testutils/factories/draft.ts
+++ b/testutils/factories/draft.ts
@@ -1,0 +1,16 @@
+import { Factory } from 'fishery'
+import { Draft } from '../../server/services/draftsService'
+
+// eslint-disable-next-line import/prefer-default-export
+export function createDraftFactory<Data>(defaultData: Data): Factory<Draft<Data>> {
+  return Factory.define<Draft<Data>>(({ sequence }) => {
+    const now = new Date()
+    return {
+      id: sequence.toString(),
+      type: 'someExampleType',
+      createdAt: now,
+      updatedAt: now,
+      data: defaultData,
+    }
+  })
+}

--- a/testutils/factories/draftCancellationData.ts
+++ b/testutils/factories/draftCancellationData.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery'
+import DraftCancellationData from '../../server/routes/probationPractitionerReferrals/draftCancellationData'
+
+class DraftCancellationDataFactory extends Factory<DraftCancellationData> {}
+
+export default DraftCancellationDataFactory.define(() => ({
+  cancellationReason: null,
+  cancellationComments: null,
+}))


### PR DESCRIPTION
## What does this pull request do?

Proposes a consistent manner for building multi-page journeys where there isn't a permanent backing data store for the data submitted on each page, and refactors the referral assignment and cancellation journeys to use it.

## What is the intent behind these changes?

To allow us to build things like the check your answers page for the scheduling journey: https://dsdmoj.atlassian.net/browse/IC-1919, and to tidy up existing journeys like the referral assignment and cancellation.

## Next steps after merge

- test on dev
- &gt; 1 week after deploy, remove the legacy routes / actions (IC-2022)