### PR TITLE
Prevent double-click of non-idempotent buttons

### DIFF
--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -114,7 +114,7 @@ export default class InterventionProgressView {
         value: {
           html: `<form method="post" action="${ViewUtils.escape(this.presenter.createEndOfServiceReportFormAction)}">
                    <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken)}">
-                   <button>
+                   <button data-module="govuk-button" data-prevent-double-click="true">
                      ${this.presenter.endOfServiceReportButtonActionText} end of service report
                    </button>
                  </form>`,

--- a/server/routes/shared/actionPlanView.ts
+++ b/server/routes/shared/actionPlanView.ts
@@ -82,7 +82,9 @@ export default class ActionPlanView {
             value: {
               html: `<form method="post" action="${ViewUtils.escape(this.presenter.createActionPlanFormAction)}">
                      <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken!)}">
-                     <button>Create action plan</button>
+                     <button data-module="govuk-button" data-prevent-double-click="true">
+                       Create action plan
+                     </button>
                      </form>`,
             },
           })

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -17,7 +17,7 @@
       <input type="hidden" name="cancellation-reason" value="{{ hiddenFields.cancellationReason }}">
       <input type="hidden" name="cancellation-comments" value="{{ hiddenFields.cancellationComments }}">
 
-      {{ govukButton({ text: "Cancel referral" }) }}
+      {{ govukButton({ text: "Cancel referral", preventDoubleClick: true }) }}
     </form>
   </div>
 {% endblock %}

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -56,7 +56,7 @@
 
       <form method="post" action="send">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
-        {{ govukButton({ text: "Submit referral" }) }}
+        {{ govukButton({ text: "Submit referral", preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/server/views/referrals/start.njk
+++ b/server/views/referrals/start.njk
@@ -25,7 +25,7 @@
 
         <p>The service user's details will be imported</p>
 
-        <button role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+        <button role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button" data-prevent-double-click="true">
           Continue
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -22,7 +22,7 @@
 
     {{ govukTextarea(addActivityTextareaArgs) }}
 
-    {{ govukButton({ text: ('Save and add activity ' + presenter.activityNumber), classes: "govuk-button--secondary", attributes: { id: 'add-activity' } }) }}
+    {{ govukButton({ text: ('Save and add activity ' + presenter.activityNumber), classes: "govuk-button--secondary", attributes: { id: 'add-activity' }, preventDoubleClick: true }) }}
   </form>
 
   <form method="post" action="{{ presenter.saveAndContinueFormAction }}">

--- a/server/views/serviceProviderReferrals/checkAssignment.njk
+++ b/server/views/serviceProviderReferrals/checkAssignment.njk
@@ -28,7 +28,7 @@
           <input type="hidden" name={{ name }} value={{ value }}>
         {% endfor %}
 
-        {{ govukButton({ text: "Confirm assignment" }) }}
+        {{ govukButton({ text: "Confirm assignment", preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/server/views/serviceProviderReferrals/endOfServiceReport/checkAnswers.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/checkAnswers.njk
@@ -9,6 +9,6 @@
 
   <form method="post" action="{{ presenter.formAction }}">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    {{ govukButton({ text: "Submit the report" }) }}
+    {{ govukButton({ text: "Submit the report", preventDoubleClick: true }) }}
   </form>
 {% endblock %}

--- a/server/views/serviceProviderReferrals/postSessionFeedbackCheckAnswers.njk
+++ b/server/views/serviceProviderReferrals/postSessionFeedbackCheckAnswers.njk
@@ -12,6 +12,6 @@
 
   <form method="post" action="{{ presenter.submitHref }}">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukButton({ text: "Confirm" }) }}
+    {{ govukButton({ text: "Confirm", preventDoubleClick: true }) }}
   </form>
 {% endblock %}

--- a/server/views/serviceProviderReferrals/scheduleAppointment.njk
+++ b/server/views/serviceProviderReferrals/scheduleAppointment.njk
@@ -47,7 +47,7 @@
           {% endset -%}
           {{ govukRadios(meetingMethodRadioInputArgs(otherLocationHtml)) }}
         </div>
-        {{ govukButton({ text: "Save and continue" }) }}
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -41,7 +41,7 @@
             <form method="post" action="{{ presenter.actionPlanApprovalUrl }}">
                 {{ govukCheckboxes(confirmApprovalCheckboxArgs) }}
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-                {{ govukButton({ text: "Approve" }) }}
+                {{ govukButton({ text: "Approve", preventDoubleClick: true }) }}
             </form>
         {% endif %}
     </div>


### PR DESCRIPTION
## What does this pull request do?

Prevents the user from clicking twice on form buttons that are only meant to be clicked once. Namely, buttons where attempting to repeat an action will unintentionally attempt to create a second resource. See commit message for more details.

## What is the intent behind these changes?

To avoid errors that we've been seeing on production from trying to repeat actions that shouldn't be repeated.