### PR TITLE
IC-1116: Add GetServiceProviderReportingData function and contracts

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -218,5 +218,9 @@ module.exports = on => {
     stubSubmitAppointmentFeedback: arg => {
       return interventionsService.stubSubmitAppointmentFeedback(arg.id, arg.responseJson)
     },
+
+    stubGetServiceProviderReportingData: arg => {
+      return interventionsService.stubGetServiceProviderReportingData(arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -145,3 +145,7 @@ Cypress.Commands.add('stubScheduleSupplierAssessmentAppointment', (supplierAsses
 Cypress.Commands.add('stubSubmitAppointmentFeedback', (id, responseJson) => {
   cy.task('stubSubmitAppointmentFeedback', { id, responseJson })
 })
+
+Cypress.Commands.add('stubGetServiceProviderReportingData', responseJson => {
+  cy.task('stubGetServiceProviderReportingData', { responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -585,4 +585,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubGetServiceProviderReportingData = async (responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `${this.mockPrefix}/performance-report`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -12,6 +12,10 @@ interface GetRequest {
   responseType?: string
   raw?: boolean
   token?: string | null
+  timeout?: {
+    response: number
+    deadline: number
+  }
 }
 
 interface PostRequest {
@@ -52,6 +56,7 @@ export default class RestClient {
     responseType = '',
     raw = false,
     token = this.token,
+    timeout = this.timeoutConfig(),
   }: GetRequest): Promise<unknown> {
     this.logger.info(
       {
@@ -79,7 +84,7 @@ export default class RestClient {
         .query(query)
         .set(headers)
         .responseType(responseType)
-        .timeout(this.timeoutConfig())
+        .timeout(timeout)
 
       const result =
         token === null ? await unauthenticatedRequest : await unauthenticatedRequest.auth(token, { type: 'bearer' })

--- a/server/models/serviceProviderReportReferral.ts
+++ b/server/models/serviceProviderReportReferral.ts
@@ -1,0 +1,24 @@
+export interface ServiceProviderReportReferral {
+  referralLink: string
+  referralRef: string
+  referralId: string
+  contractId: string
+  organisationId: string
+  referringOfficerEmail: string
+  caseworkerId: string
+  serviceUserCRN: string
+  dateReferralReceived: string
+  dateSAABooked: string | null
+  dateSAAAttended: string | null
+  dateFirstActionPlanSubmitted: string | null
+  dateOfFirstActionPlanApproval: string | null
+  dateOfFirstAttendedSession: string | null
+  outcomesToBeAchievedCount: number | null
+  outcomesAchieved: number | null
+  countOfSessionsExpected: number | null
+  countOfSessionsAttended: number | null
+  endRequestedByPPAt: string | null
+  endRequestedByPPReason: string | null
+  dateEOSRSubmitted: string | null
+  concludedAt: string | null
+}

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -14,6 +14,7 @@ import endOfServiceReportFactory from '../../testutils/factories/endOfServiceRep
 import sentReferralFactory from '../../testutils/factories/sentReferral'
 import appointmentFactory from '../../testutils/factories/appointment'
 import supplierAssessmentFactory from '../../testutils/factories/supplierAssessment'
+import CalendarDay from '../utils/calendarDay'
 
 jest.mock('../services/hmppsAuthService')
 
@@ -2910,6 +2911,60 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
   */
+
+  describe('getServiceProviderReportingData', () => {
+    const reportingResponse = [
+      {
+        referralLink: 'https://refer-and-monitor.example/referral/c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+        referralRef: 'SM1973AC',
+        referralId: 'c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+        contractId: 'some-contract-id',
+        organisationId: 'XYZ5678',
+        referringOfficerEmail: 'bernard.beaks@justice.gov.uk',
+        caseworkerId: 'liane.supplier@example.com',
+        serviceUserCrn: 'X017844',
+        dateReferralReceived: '2021-06-27T14:49:01+01:00',
+        dateSaaBooked: '2021-06-27T14:49:01+01:00',
+        dateSaaAttended: '2021-06-27T14:49:01+01:00',
+        dateFirstActionPlanSubmitted: '2021-06-27T14:49:01+01:00',
+        dateOfFirstActionPlanApproval: '2021-06-27T14:49:01+01:00',
+        dateOfFirstAttendedSession: '2021-06-27T14:49:01+01:00',
+        outcomesToBeAchievedCount: 8,
+        outcomesAchieved: 5.5,
+        countOfSessionsExpected: 10,
+        countOfSessionsAttended: 6,
+        endRequestedByPPAt: '2021-06-27T14:49:01+01:00',
+        endRequestedByPPReason: 'REC',
+        dateEOSRSubmitted: '2021-06-27T14:49:01+01:00',
+        concludedAt: '2021-06-27T14:49:01+01:00',
+      },
+    ]
+
+    it('returns a list of referrals for with data for reporting', async () => {
+      await provider.addInteraction({
+        state: 'nothing',
+        uponReceiving: 'a GET request for referral reporting data',
+        withRequest: {
+          method: 'GET',
+          path: '/performance-report',
+          query: { fromIncludingDate: '2021-06-01', toIncludingDate: '2021-06-10' },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(reportingResponse),
+          headers: { 'Content-Type': 'application/json' },
+        },
+      })
+
+      expect(
+        await interventionsService.getServiceProviderReportingData(token, {
+          fromIncludingDate: CalendarDay.fromComponents(1, 6, 2021)!,
+          toIncludingDate: CalendarDay.fromComponents(10, 6, 2021)!,
+        })
+      ).toMatchObject(reportingResponse)
+    })
+  })
 })
 
 describe('serializeDeliusServiceUser', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -550,6 +550,11 @@ export default class InterventionsService {
         toIncludingDate: reportDates.toIncludingDate.iso8601,
       },
       headers: { Accept: 'application/json' },
+      // this will likely be a very large request, so we're overriding the timeout to play it safe
+      timeout: {
+        deadline: 120000,
+        response: 120000,
+      },
     })) as ServiceProviderReportReferral[]
   }
 }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -21,6 +21,7 @@ import ReferralDesiredOutcomes from '../models/referralDesiredOutcomes'
 import ReferralComplexityLevel from '../models/referralComplexityLevel'
 import Appointment from '../models/appointment'
 import SupplierAssessment from '../models/supplierAssessment'
+import { ServiceProviderReportReferral } from '../models/serviceProviderReportReferral'
 
 export interface InterventionsServiceValidationError {
   field: string
@@ -60,6 +61,11 @@ export interface CreateEndOfServiceReportOutcome {
 export interface UpdateDraftEndOfServiceReportParams {
   furtherInformation: string | null
   outcome: CreateEndOfServiceReportOutcome | null
+}
+
+export interface CreateReportDateParams {
+  fromIncludingDate: CalendarDay
+  toIncludingDate: CalendarDay
 }
 
 export default class InterventionsService {
@@ -530,4 +536,20 @@ export default class InterventionsService {
     })) as Appointment
   }
  */
+
+  async getServiceProviderReportingData(
+    token: string,
+    reportDates: CreateReportDateParams
+  ): Promise<ServiceProviderReportReferral[]> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: '/performance-report',
+      query: {
+        fromIncludingDate: reportDates.fromIncludingDate.iso8601,
+        toIncludingDate: reportDates.toIncludingDate.iso8601,
+      },
+      headers: { Accept: 'application/json' },
+    })) as ServiceProviderReportReferral[]
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds a function (with contract tests & mocks) to fetch full referral reporting data for a Service Provider organisation.

## What is the intent behind these changes?

The data returned from this will be used to generate a CSV for the Service Provider to download data on all of their referrals.

