### PR TITLE
IC-1118: Add UI for downloading SP performance report

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1331,4 +1331,74 @@ describe('Service provider referrals dashboard', () => {
       cy.get('#supplier-assessment-status').contains(/^\s*scheduled\s*$/)
     })
   })
+
+  describe('User downloads reporting data', () => {
+    it('allows the user to download a CSV based on the requested date range', () => {
+      const intervention = interventionFactory.build()
+
+      const sentReferrals = [
+        sentReferralFactory.build({
+          referral: {
+            interventionId: intervention.id,
+          },
+        }),
+        sentReferralFactory.build({
+          referral: {
+            interventionId: intervention.id,
+          },
+        }),
+      ]
+
+      const deliusUser = deliusUserFactory.build()
+
+      cy.stubGetIntervention(intervention.id, intervention)
+      sentReferrals.forEach(referral => cy.stubGetSentReferral(referral.id, referral))
+      cy.stubGetSentReferralsForUserToken(sentReferrals)
+      cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+      cy.stubGetServiceProviderReportingData([
+        {
+          referralLink: 'https://refer-and-monitor.example/referral/c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+          referralRef: 'SM1973AC',
+          referralId: 'c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+          contractId: 'thing',
+          organisationId: 'XYZ5678',
+          referringOfficerEmail: 'joe.probation@example.com',
+          caseworkerId: 'liane.supplier@example.com',
+          serviceUserCrn: 'X017844',
+          dateReferralReceived: '2021-06-27T14:49:01+01:00',
+          dateSaaBooked: '2021-06-27T14:49:01+01:00',
+          dateSaaAttended: '2021-06-27T14:49:01+01:00',
+          dateFirstActionPlanSubmitted: '2021-06-27T14:49:01+01:00',
+          dateOfFirstActionPlanApproval: '2021-06-27T14:49:01+01:00',
+          dateOfFirstAttendedSession: '2021-06-27T14:49:01+01:00',
+          outcomesToBeAchievedCount: 8,
+          outcomesAchieved: 5.5,
+          countOfSessionsExpected: 10,
+          countOfSessionsAttended: 6,
+          endRequestedByPPAt: '2021-06-27T14:49:01+01:00',
+          endRequestedByPPReason: 'REC',
+          dateEOSRSubmitted: '2021-06-27T14:49:01+01:00',
+          concludedAt: '2021-06-27T14:49:01+01:00',
+        },
+      ])
+
+      cy.login()
+
+      cy.contains('Reporting').click()
+      cy.contains('Reporting')
+
+      cy.get('#from-date-day').clear().type('10')
+      cy.get('#from-date-month').clear().type('6')
+      cy.get('#from-date-year').clear().type('2021')
+      cy.get('#to-date-day').clear().type('27')
+      cy.get('#to-date-month').clear().type('6')
+      cy.get('#to-date-year').clear().type('2021')
+
+      // TODO (IC-2040)
+      // Unfortunately there's currently no way to test non 'text/html' files in Cypress.
+      // https://github.com/cypress-io/cypress/issues/1551
+      // When attempting to download the generated CSV, the page hangs.
+      // I'm leaving this test here as-is, in case Cypress is updated and we can test this behaviour.
+    })
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "connect-redis": "^6.0.0",
         "cookie-session": "^1.4.0",
         "csurf": "^1.11.0",
+        "csv-stringify": "^5.6.2",
         "date-fns": "^2.16.1",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
@@ -6508,6 +6509,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/csv-stringify": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.2.tgz",
+      "integrity": "sha512-n3rIVbX6ylm1YsX2NEug9IaPV8xRnT+9/NNZbrA/bcHgOSSeqtWla6XnI/xmyu57wIw+ASCAoX1oM6EZtqJV0A=="
     },
     "node_modules/cypress": {
       "version": "7.6.0",
@@ -26715,6 +26721,11 @@
           }
         }
       }
+    },
+    "csv-stringify": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.2.tgz",
+      "integrity": "sha512-n3rIVbX6ylm1YsX2NEug9IaPV8xRnT+9/NNZbrA/bcHgOSSeqtWla6XnI/xmyu57wIw+ASCAoX1oM6EZtqJV0A=="
     },
     "cypress": {
       "version": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "connect-redis": "^6.0.0",
     "cookie-session": "^1.4.0",
     "csurf": "^1.11.0",
+    "csv-stringify": "^5.6.2",
     "date-fns": "^2.16.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -172,6 +172,8 @@ export default function routes(router: Router, services: Services): Router {
   get('/service-provider/referrals/:id/supplier-assessment/rescheduled-confirmation', (req, res) =>
     serviceProviderReferralsController.showSupplierAssessmentAppointmentConfirmation(req, res, { isReschedule: true })
   )
+  get('/service-provider/performance-report', (req, res) => serviceProviderReferralsController.viewReporting(req, res))
+  post('/service-provider/performance-report', (req, res) => serviceProviderReferralsController.createReport(req, res))
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get('/static-pages', (req, res) => {

--- a/server/routes/serviceProviderReferrals/dashboardNavPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardNavPresenter.ts
@@ -1,0 +1,19 @@
+import { PrimaryNavItem } from '../../utils/viewUtils'
+
+export default class DashboardNavPresenter {
+  constructor(private readonly active: string) {}
+
+  readonly items: PrimaryNavItem[] = [
+    {
+      text: 'All cases',
+      href: '/service-provider/dashboard',
+      active: this.active === 'All cases',
+    },
+    // TODO: do we need to restrict this to only SP managers?
+    {
+      text: 'Reporting',
+      href: '/service-provider/performance-report',
+      active: this.active === 'Reporting',
+    },
+  ]
+}

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -4,6 +4,7 @@ import CalendarDay from '../../utils/calendarDay'
 import PresenterUtils from '../../utils/presenterUtils'
 import utils from '../../utils/utils'
 import { SortableTableHeaders, SortableTableRow } from '../../utils/viewUtils'
+import DashboardNavPresenter from './dashboardNavPresenter'
 
 export default class DashboardPresenter {
   constructor(private readonly referrals: SentReferral[], private readonly interventions: Intervention[]) {}
@@ -16,6 +17,8 @@ export default class DashboardPresenter {
     { text: 'Caseworker', sort: 'none' },
     { text: 'Action', sort: 'none' },
   ]
+
+  readonly navItemsPresenter = new DashboardNavPresenter('All cases')
 
   readonly tableRows: SortableTableRow[] = this.referrals.map(referral => {
     const interventionForReferral = this.interventions.find(

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -11,6 +11,9 @@ export default class DashboardView {
   }
 
   get renderArgs(): [string, Record<string, unknown>] {
-    return ['serviceProviderReferrals/dashboard', { tableArgs: this.tableArgs }]
+    return [
+      'serviceProviderReferrals/dashboard',
+      { tableArgs: this.tableArgs, primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items) },
+    ]
   }
 }

--- a/server/routes/serviceProviderReferrals/reportingForm.test.ts
+++ b/server/routes/serviceProviderReferrals/reportingForm.test.ts
@@ -1,0 +1,176 @@
+import TestUtils from '../../../testutils/testUtils'
+import CalendarDay from '../../utils/calendarDay'
+import ReportingForm from './reportingForm'
+
+describe(ReportingForm, () => {
+  describe('data', () => {
+    describe('with valid data', () => {
+      it('returns an object with two Calendar Day values', async () => {
+        const request = TestUtils.createRequest({
+          'from-date-year': '2021',
+          'from-date-month': '06',
+          'from-date-day': '12',
+          'to-date-year': '2021',
+          'to-date-month': '06',
+          'to-date-day': '13',
+        })
+
+        const result = await new ReportingForm(request).data()
+
+        expect(result.value!.fromIncludingDate).toEqual(CalendarDay.fromComponents(12, 6, 2021))
+        expect(result.value!.toIncludingDate).toEqual(CalendarDay.fromComponents(13, 6, 2021))
+        expect(result.error).toBeNull()
+      })
+    })
+
+    describe('with invalid data', () => {
+      describe('when the "from" date is after the "to" date', () => {
+        it('returns an error object with a message', async () => {
+          const request = TestUtils.createRequest({
+            'from-date-year': '2021',
+            'from-date-month': '06',
+            'from-date-day': '12',
+            'to-date-year': '2021',
+            'to-date-month': '06',
+            'to-date-day': '11',
+          })
+
+          const result = await new ReportingForm(request).data()
+
+          expect(result.value).toBeNull()
+          expect(result.error!.errors).toEqual([
+            {
+              errorSummaryLinkedField: 'from-date-day',
+              formFields: ['from-date-day', 'from-date-month', 'from-date-year'],
+              message: 'The "from" date must be before the "to" date',
+            },
+
+            {
+              errorSummaryLinkedField: 'to-date-day',
+              formFields: ['to-date-day', 'to-date-month', 'to-date-year'],
+              message: 'The "from" date must be before the "to" date',
+            },
+          ])
+        })
+      })
+
+      describe('when the "from" date is before Day One (01/06/2021)', () => {
+        it('returns an error object with a message', async () => {
+          const request = TestUtils.createRequest({
+            'from-date-year': '2021',
+            'from-date-month': '05',
+            'from-date-day': '12',
+            'to-date-year': '2021',
+            'to-date-month': '06',
+            'to-date-day': '11',
+          })
+
+          const result = await new ReportingForm(request).data()
+
+          expect(result.value).toBeNull()
+          expect(result.error!.errors).toEqual([
+            {
+              errorSummaryLinkedField: 'from-date-day',
+              formFields: ['from-date-day', 'from-date-month', 'from-date-year'],
+              message: 'Data before 01 June 2021 is not available',
+            },
+          ])
+        })
+      })
+
+      describe('for dates in the future, for which we have no historical data', () => {
+        const today = new Date()
+        const tomorrow = new Date(today)
+        tomorrow.setDate(tomorrow.getDate() + 1)
+
+        const tomorrowDay = tomorrow.getUTCDate().toString()
+        const tomorrowYear = tomorrow.getUTCFullYear().toString()
+        const tomorrowMonth = (Number(tomorrow.getUTCMonth()) + 1).toString()
+
+        it('returns an error object with a message if the "from" date is in the future', async () => {
+          const request = TestUtils.createRequest({
+            'from-date-year': tomorrowYear,
+            'from-date-month': tomorrowMonth,
+            'from-date-day': tomorrowDay,
+            'to-date-year': tomorrowYear,
+            'to-date-month': tomorrowMonth,
+            'to-date-day': tomorrowDay,
+          })
+
+          const result = await new ReportingForm(request).data()
+
+          expect(result.value).toBeNull()
+
+          expect(result.error!.errors).toEqual([
+            {
+              errorSummaryLinkedField: 'from-date-day',
+              formFields: ['from-date-day', 'from-date-month', 'from-date-year'],
+              message: `Data after today is not available`,
+            },
+            {
+              errorSummaryLinkedField: 'to-date-day',
+              formFields: ['to-date-day', 'to-date-month', 'to-date-year'],
+              message: `Data after today is not available`,
+            },
+          ])
+        })
+
+        it('returns an error object with a message if the "to" date is in the future', async () => {
+          const request = TestUtils.createRequest({
+            'from-date-year': '2021',
+            'from-date-month': '06',
+            'from-date-day': '12',
+            'to-date-year': tomorrowYear,
+            'to-date-month': tomorrowMonth,
+            'to-date-day': tomorrowDay,
+          })
+
+          const result = await new ReportingForm(request).data()
+
+          expect(result.value).toBeNull()
+          expect(result.error!.errors).toEqual([
+            {
+              errorSummaryLinkedField: 'to-date-day',
+              formFields: ['to-date-day', 'to-date-month', 'to-date-year'],
+              message: `Data after today is not available`,
+            },
+          ])
+        })
+      })
+
+      describe('when there are multiple errors', () => {
+        it('returns an error object with multiple errors', async () => {
+          const requestForPreDayOneDataWithFromDateAfterToDate = TestUtils.createRequest({
+            'from-date-year': '2021',
+            'from-date-month': '05',
+            'from-date-day': '12',
+            'to-date-year': '2021',
+            'to-date-month': '05',
+            'to-date-day': '11',
+          })
+
+          const result = await new ReportingForm(requestForPreDayOneDataWithFromDateAfterToDate).data()
+
+          expect(result.value).toBeNull()
+          expect(result.error!.errors).toEqual([
+            {
+              errorSummaryLinkedField: 'from-date-day',
+              formFields: ['from-date-day', 'from-date-month', 'from-date-year'],
+              message: 'Data before 01 June 2021 is not available',
+            },
+            {
+              errorSummaryLinkedField: 'from-date-day',
+              formFields: ['from-date-day', 'from-date-month', 'from-date-year'],
+              message: 'The "from" date must be before the "to" date',
+            },
+            {
+              errorSummaryLinkedField: 'to-date-day',
+              formFields: ['to-date-day', 'to-date-month', 'to-date-year'],
+              message: 'The "from" date must be before the "to" date',
+            },
+          ])
+        })
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/reportingForm.ts
+++ b/server/routes/serviceProviderReferrals/reportingForm.ts
@@ -1,0 +1,66 @@
+import { Request } from 'express'
+import { CreateReportDateParams } from '../../services/interventionsService'
+import errorMessages from '../../utils/errorMessages'
+import { FormValidationResult } from '../../utils/forms/formValidationResult'
+import CalendarDayInput from '../../utils/forms/inputs/calendarDayInput'
+
+export default class ReportingForm {
+  constructor(private readonly request: Request) {}
+
+  async data(): Promise<FormValidationResult<CreateReportDateParams>> {
+    const [fromDateResult, toDateResult] = await Promise.all([
+      new CalendarDayInput(this.request, 'from-date', errorMessages.reportingDate.from).validate(),
+      new CalendarDayInput(this.request, 'to-date', errorMessages.reportingDate.to).validate(),
+    ])
+    const errors: { formFields: string[]; errorSummaryLinkedField: string; message: string }[][] = []
+
+    if (fromDateResult.error) {
+      errors.push(fromDateResult.error.errors)
+    }
+
+    if (toDateResult.error) {
+      errors.push(toDateResult.error.errors)
+    }
+
+    const dayOneDate = new Date('2021-06-01')
+    if (fromDateResult.value && new Date(fromDateResult.value.iso8601) < dayOneDate) {
+      errors.push(CalendarDayInput.createError('from-date', errorMessages.reportingDate.from.mustBeAfterDayOne).errors)
+    }
+
+    if (
+      fromDateResult.value &&
+      toDateResult.value &&
+      new Date(fromDateResult.value.iso8601) > new Date(toDateResult.value.iso8601)
+    ) {
+      errors.push(CalendarDayInput.createError('from-date', errorMessages.reportingDate.from.mustBeBeforeToDate).errors)
+      errors.push(CalendarDayInput.createError('to-date', errorMessages.reportingDate.from.mustBeBeforeToDate).errors)
+    }
+
+    const todayDate = new Date()
+
+    if (fromDateResult.value && new Date(fromDateResult.value.iso8601) > todayDate) {
+      errors.push(CalendarDayInput.createError('from-date', errorMessages.reportingDate.to.mustNotBeInFuture).errors)
+    }
+
+    if (toDateResult.value && new Date(toDateResult.value.iso8601) > todayDate) {
+      errors.push(CalendarDayInput.createError('to-date', errorMessages.reportingDate.from.mustNotBeInFuture).errors)
+    }
+
+    if (errors.length > 0 || fromDateResult.error || toDateResult.error) {
+      return {
+        error: {
+          errors: errors.flat(),
+        },
+        value: null,
+      }
+    }
+
+    return {
+      error: null,
+      value: {
+        fromIncludingDate: fromDateResult.value,
+        toIncludingDate: toDateResult.value,
+      },
+    }
+  }
+}

--- a/server/routes/serviceProviderReferrals/reportingPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/reportingPresenter.test.ts
@@ -1,0 +1,101 @@
+import ReportingPresenter from './reportingPresenter'
+
+describe(ReportingPresenter, () => {
+  describe('text', () => {
+    it('has a title and subtitle', () => {
+      const presenter = new ReportingPresenter()
+
+      expect(presenter.text).toMatchObject({
+        title: 'Reporting',
+        subtitle: 'Download service provider data as CSV documents.',
+        hint: 'For example, 11 12 2020',
+      })
+    })
+  })
+
+  describe('fields', () => {
+    describe('fromDate', () => {
+      describe('when no user information has been entered', () => {
+        it('uses an empty string value as the field value', () => {
+          const presenter = new ReportingPresenter()
+
+          expect(presenter.fields.fromDate.day.value).toEqual('')
+          expect(presenter.fields.fromDate.month.value).toEqual('')
+          expect(presenter.fields.fromDate.year.value).toEqual('')
+        })
+      })
+
+      describe('when there is user input data', () => {
+        it('uses that value as the field value', () => {
+          const presenter = new ReportingPresenter(null, {
+            'from-date-day': '01',
+            'from-date-month': '06',
+            'from-date-year': '2021',
+          })
+
+          expect(presenter.fields.fromDate.day.value).toEqual('01')
+          expect(presenter.fields.fromDate.month.value).toEqual('06')
+          expect(presenter.fields.fromDate.year.value).toEqual('2021')
+        })
+      })
+    })
+
+    describe('toDate', () => {
+      describe('when no user information has been entered', () => {
+        it('uses an empty string value as the field value', () => {
+          const presenter = new ReportingPresenter()
+
+          expect(presenter.fields.toDate.day.value).toEqual('')
+          expect(presenter.fields.toDate.month.value).toEqual('')
+          expect(presenter.fields.toDate.year.value).toEqual('')
+        })
+      })
+
+      describe('when there is user input data', () => {
+        it('uses that value as the field value', () => {
+          const presenter = new ReportingPresenter(null, {
+            'to-date-day': '01',
+            'to-date-month': '06',
+            'to-date-year': '2021',
+          })
+
+          expect(presenter.fields.toDate.day.value).toEqual('01')
+          expect(presenter.fields.toDate.month.value).toEqual('06')
+          expect(presenter.fields.toDate.year.value).toEqual('2021')
+        })
+      })
+    })
+  })
+
+  describe('error information', () => {
+    describe('when a null error is passed in', () => {
+      it('returns no errors', () => {
+        const presenter = new ReportingPresenter()
+
+        expect(presenter.errorSummary).toBeNull()
+        expect(presenter.fields.fromDate.errorMessage).toEqual(null)
+        expect(presenter.fields.toDate.errorMessage).toEqual(null)
+      })
+    })
+
+    describe('when a non-null error is passed in', () => {
+      it('returns error information', () => {
+        const presenter = new ReportingPresenter({
+          errors: [
+            {
+              errorSummaryLinkedField: 'to-date-month',
+              formFields: ['to-date-month', 'to-date-year'],
+              message: 'The "to" date must include a month',
+            },
+          ],
+        })
+
+        expect(presenter.fields.toDate.month.hasError).toEqual(true)
+        expect(presenter.fields.toDate.errorMessage).toEqual('The "to" date must include a month')
+        expect(presenter.errorSummary).toEqual([
+          { message: 'The "to" date must include a month', field: 'to-date-month' },
+        ])
+      })
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/reportingPresenter.ts
+++ b/server/routes/serviceProviderReferrals/reportingPresenter.ts
@@ -1,0 +1,24 @@
+import PresenterUtils from '../../utils/presenterUtils'
+import { FormValidationError } from '../../utils/formValidationError'
+
+export default class ReportingPresenter {
+  constructor(
+    private readonly validationError: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  readonly text = {
+    title: 'Reporting',
+    subtitle: 'Download service provider data as CSV documents.',
+    hint: 'For example, 11 12 2020',
+  }
+
+  private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.validationError)
+
+  readonly fields = {
+    fromDate: this.utils.dateValue(null, 'from-date', this.validationError),
+    toDate: this.utils.dateValue(null, 'to-date', this.validationError),
+  }
+}

--- a/server/routes/serviceProviderReferrals/reportingView.ts
+++ b/server/routes/serviceProviderReferrals/reportingView.ts
@@ -1,0 +1,91 @@
+import { DateInputArgs } from '../../utils/govukFrontendTypes'
+import ViewUtils from '../../utils/viewUtils'
+import ReportingPresenter from './reportingPresenter'
+
+export default class ReportingView {
+  constructor(private readonly presenter: ReportingPresenter) {}
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/reporting',
+      {
+        presenter: this.presenter,
+        fromDateInputArgs: this.fromDateInputArgs,
+        toDateInputArgs: this.toDateInputArgs,
+        errorSummaryArgs: this.errorSummaryArgs,
+      },
+    ]
+  }
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+
+  get fromDateInputArgs(): DateInputArgs {
+    return {
+      id: 'from-date',
+      namePrefix: 'from-date',
+      fieldset: {
+        legend: {
+          text: 'From date',
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--m',
+        },
+      },
+      hint: {
+        text: this.presenter.text.hint,
+      },
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.fromDate.errorMessage),
+      items: [
+        {
+          classes: `govuk-input--width-2${this.presenter.fields.fromDate.day.hasError ? ' govuk-input--error' : ''}`,
+          name: 'day',
+          value: this.presenter.fields.fromDate.day.value,
+        },
+        {
+          classes: `govuk-input--width-2${this.presenter.fields.fromDate.month.hasError ? ' govuk-input--error' : ''}`,
+          name: 'month',
+          value: this.presenter.fields.fromDate.month.value,
+        },
+        {
+          classes: `govuk-input--width-4${this.presenter.fields.fromDate.year.hasError ? ' govuk-input--error' : ''}`,
+          name: 'year',
+          value: this.presenter.fields.fromDate.year.value,
+        },
+      ],
+    }
+  }
+
+  get toDateInputArgs(): DateInputArgs {
+    return {
+      id: 'to-date',
+      namePrefix: 'to-date',
+      fieldset: {
+        legend: {
+          text: 'To date',
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--m',
+        },
+      },
+      hint: {
+        text: this.presenter.text.hint,
+      },
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.toDate.errorMessage),
+      items: [
+        {
+          classes: `govuk-input--width-2${this.presenter.fields.toDate.day.hasError ? ' govuk-input--error' : ''}`,
+          name: 'day',
+          value: this.presenter.fields.toDate.day.value,
+        },
+        {
+          classes: `govuk-input--width-2${this.presenter.fields.toDate.month.hasError ? ' govuk-input--error' : ''}`,
+          name: 'month',
+          value: this.presenter.fields.toDate.month.value,
+        },
+        {
+          classes: `govuk-input--width-4${this.presenter.fields.toDate.year.hasError ? ' govuk-input--error' : ''}`,
+          name: 'year',
+          value: this.presenter.fields.toDate.year.value,
+        },
+      ],
+    }
+  }
+}

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -31,6 +31,7 @@ import { ExpandedDeliusServiceUser } from '../../models/delius/deliusServiceUser
 import { SupplementaryRiskInformation } from '../../models/assessRisksAndNeeds/supplementaryRiskInformation'
 import { DeliusStaffDetails } from '../../models/delius/deliusStaffDetails'
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
+import CalendarDay from '../../utils/calendarDay'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -1866,5 +1867,76 @@ describe('GET /service-provider/referrals/:id/supplier-assessment', () => {
         expect(res.text).toContain('24 March 2021')
         expect(res.text).toContain('9:02am to 10:17am')
       })
+  })
+})
+
+describe('GET /service-provider/reporting', () => {
+  it('displays a page to allow the Service Provider to download a report of referral data', async () => {
+    await request(app)
+      .get('/service-provider/performance-report')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Reporting')
+      })
+  })
+})
+
+describe('POST /service-provider/reporting', () => {
+  it('makes a request to the interventions service for referral data and generates a CSV', async () => {
+    const reportingResponse = [
+      {
+        referralLink: 'https://refer-and-monitor.com/referral/c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+        referralRef: 'SM1973AC',
+        referralId: 'c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+        contractId: 'thing',
+        organisationId: 'XYZ5678',
+        referringOfficerEmail: 'joe.probation@example.com',
+        caseworkerId: 'liane.supplier@example.com',
+        serviceUserCRN: 'X017844',
+        dateReferralReceived: '2021-06-27T14:49:01+01:00',
+        dateSAABooked: '2021-06-27T14:49:01+01:00',
+        dateSAAAttended: '2021-06-27T14:49:01+01:00',
+        dateFirstActionPlanSubmitted: '2021-06-27T14:49:01+01:00',
+        dateOfFirstActionPlanApproval: '2021-06-27T14:49:01+01:00',
+        dateOfFirstAttendedSession: '2021-06-27T14:49:01+01:00',
+        outcomesToBeAchievedCount: 8,
+        outcomesAchieved: 5.5,
+        countOfSessionsExpected: 10,
+        countOfSessionsAttended: 6,
+        endRequestedByPPAt: '2021-06-27T14:49:01+01:00',
+        endRequestedByPPReason: 'REC',
+        dateEOSRSubmitted: '2021-06-27T14:49:01+01:00',
+        concludedAt: '2021-06-27T14:49:01+01:00',
+      },
+    ]
+
+    interventionsService.getServiceProviderReportingData.mockResolvedValue(reportingResponse)
+
+    await request(app)
+      .post('/service-provider/performance-report')
+      .type('form')
+      .send({
+        'from-date-day': '20',
+        'from-date-month': '06',
+        'from-date-year': '2021',
+        'to-date-day': '25',
+        'to-date-month': '06',
+        'to-date-year': '2021',
+      })
+      .expect(200)
+      .expect('Content-Disposition', /attachment; filename=refer-monitor-intervention_report_\d{8}\.csv/)
+      .expect(res => {
+        expect(res.text).toContain(
+          'referral_link,referral_ref,referral_id,contract_id,organisation_id,referring_officer_email,caseworker_id,service_user_crn,date_referral_received,date_saa_booked,date_saa_attended,date_first_action_plan_submitted,date_of_first_action_plan_approval,date_of_first_attended_session,outcomes_to_be_achieved_count,outcomes_achieved,count_of_sessions_expected,count_of_sessions_attended,end_requested_by_pp_at,end_requested_by_pp_reason,date_eosr_submitted,concluded_at'
+        )
+        expect(res.text).toContain(
+          'https://refer-and-monitor.com/referral/c9f9e22f-ddd9-422a-a9af-76fc02b18b38,SM1973AC,c9f9e22f-ddd9-422a-a9af-76fc02b18b38,thing,XYZ5678,joe.probation@example.com,liane.supplier@example.com,X017844,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00,8,5.5,10,6,2021-06-27T14:49:01+01:00,REC,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00'
+        )
+      })
+
+    expect(interventionsService.getServiceProviderReportingData).toHaveBeenCalledWith('token', {
+      fromIncludingDate: CalendarDay.fromComponents(20, 6, 2021),
+      toIncludingDate: CalendarDay.fromComponents(25, 6, 2021),
+    })
   })
 })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -15,6 +15,7 @@ import sentReferralFactory from '../../testutils/factories/sentReferral'
 import appointmentFactory from '../../testutils/factories/appointment'
 import supplierAssessmentFactory from '../../testutils/factories/supplierAssessment'
 import CalendarDay from '../utils/calendarDay'
+import serviceProviderReportReferralFactory from '../../testutils/factories/serviceProviderReportReferral'
 
 jest.mock('../services/hmppsAuthService')
 
@@ -2914,7 +2915,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
   describe('getServiceProviderReportingData', () => {
     const reportingResponse = [
-      {
+      serviceProviderReportReferralFactory.build({
         referralLink: 'https://refer-and-monitor.example/referral/c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
         referralRef: 'SM1973AC',
         referralId: 'c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
@@ -2937,7 +2938,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         endRequestedByPPReason: 'REC',
         dateEOSRSubmitted: '2021-06-27T14:49:01+01:00',
         concludedAt: '2021-06-27T14:49:01+01:00',
-      },
+      }),
     ]
 
     it('returns a list of referrals for with data for reporting', async () => {

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -19,6 +19,24 @@ export default {
     invalidDate: 'The date by which the service needs to be completed must be a real date',
     mustBeInFuture: 'The date by which the service needs to be completed must be in the future',
   },
+  reportingDate: {
+    from: {
+      dayEmpty: 'The "from" date must include a day',
+      monthEmpty: 'The "from" date must include a month',
+      yearEmpty: 'The "from" date must include a year',
+      invalidDate: 'The "from" date must be a real date',
+      mustBeAfterDayOne: 'Data before 01 June 2021 is not available',
+      mustBeBeforeToDate: 'The "from" date must be before the "to" date',
+      mustNotBeInFuture: `Data after today is not available`,
+    },
+    to: {
+      dayEmpty: 'The "to" date must include a day',
+      monthEmpty: 'The "to" date must include a month',
+      yearEmpty: 'The "to" date must include a year',
+      invalidDate: 'The "to" date must be a real date',
+      mustNotBeInFuture: `Data after today is not available`,
+    },
+  },
   serviceCategories: {
     empty: 'At least one service category must be selected',
   },

--- a/server/utils/forms/inputs/calendarDayInput.test.ts
+++ b/server/utils/forms/inputs/calendarDayInput.test.ts
@@ -145,4 +145,18 @@ describe(CalendarDayInput, () => {
       })
     })
   })
+
+  describe('.createErrors', () => {
+    it('creates a formError object from the key and message passed in', () => {
+      expect(CalendarDayInput.createError('deadline', 'The deadline must be a real date')).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'deadline-day',
+            formFields: ['deadline-day', 'deadline-month', 'deadline-year'],
+            message: 'The deadline must be a real date',
+          },
+        ],
+      })
+    })
+  })
 })

--- a/server/utils/forms/inputs/calendarDayInput.ts
+++ b/server/utils/forms/inputs/calendarDayInput.ts
@@ -19,8 +19,12 @@ export default class CalendarDayInput {
     private readonly errorMessages: CalendarDayErrorMessages
   ) {}
 
+  private static keys(key: string) {
+    return { day: `${key}-day`, month: `${key}-month`, year: `${key}-year` }
+  }
+
   private get keys() {
-    return { day: `${this.key}-day`, month: `${this.key}-month`, year: `${this.key}-year` }
+    return CalendarDayInput.keys(this.key)
   }
 
   async validate(): Promise<FormValidationResult<CalendarDay>> {
@@ -37,6 +41,20 @@ export default class CalendarDayInput {
     }
   }
 
+  static createError(key: string, message: string): FormValidationError {
+    const keys = this.keys(key)
+
+    return {
+      errors: [
+        {
+          errorSummaryLinkedField: keys.day,
+          formFields: [keys.day, keys.month, keys.year],
+          message,
+        },
+      ],
+    }
+  }
+
   private error(result: ExpressValidator.Result): FormValidationError | null {
     const error = FormUtils.validationErrorFromResult(result)
     if (error !== null) {
@@ -44,15 +62,7 @@ export default class CalendarDayInput {
     }
 
     if (this.calendarDay === null) {
-      return {
-        errors: [
-          {
-            errorSummaryLinkedField: this.keys.day,
-            formFields: [this.keys.day, this.keys.month, this.keys.year],
-            message: this.errorMessages.invalidDate,
-          },
-        ],
-      }
+      return CalendarDayInput.createError(this.key, this.errorMessages.invalidDate)
     }
 
     return null

--- a/server/utils/serviceProviderCSVGenerator.test.ts
+++ b/server/utils/serviceProviderCSVGenerator.test.ts
@@ -1,0 +1,107 @@
+import serviceProviderReportReferralFactory from '../../testutils/factories/serviceProviderReportReferral'
+import ServiceProviderCSVGenerator from './serviceProviderCSVGenerator'
+
+describe(ServiceProviderCSVGenerator, () => {
+  describe('.generate', () => {
+    describe('with valid ServiceProviderReportReferrals', () => {
+      it('returns a CSV-formatted string', async () => {
+        const reportReferral = serviceProviderReportReferralFactory.build({
+          referralLink: 'https://refer-and-monitor.com/referral/c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+          referralRef: 'SM1973AC',
+          referralId: 'c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+          contractId: 'thing',
+          organisationId: 'XYZ5678',
+          referringOfficerEmail: 'bernard.beaks@example.com',
+          caseworkerId: 'liane.supplier@example.com',
+          serviceUserCRN: 'X017844',
+          dateReferralReceived: '2021-06-27T14:49:01+01:00',
+          dateSAABooked: '2021-06-27T14:49:01+01:00',
+          dateSAAAttended: '2021-06-27T14:49:01+01:00',
+          dateFirstActionPlanSubmitted: '2021-06-27T14:49:01+01:00',
+          dateOfFirstActionPlanApproval: '2021-06-27T14:49:01+01:00',
+          dateOfFirstAttendedSession: '2021-06-27T14:49:01+01:00',
+          outcomesToBeAchievedCount: 8,
+          outcomesAchieved: 5.5,
+          countOfSessionsExpected: 10,
+          countOfSessionsAttended: 6,
+          endRequestedByPPAt: '2021-06-27T14:49:01+01:00',
+          endRequestedByPPReason: 'REC',
+          dateEOSRSubmitted: '2021-06-27T14:49:01+01:00',
+          concludedAt: '2021-06-27T14:49:01+01:00',
+        })
+
+        const reportingResponse = [
+          reportReferral,
+          serviceProviderReportReferralFactory.build({ referralId: '2144ed62-aa16-468c-ae8d-41588606750e' }),
+          serviceProviderReportReferralFactory.build({ referralId: 'd8cc2ad2-a29f-4168-ab84-6d3e130e234b' }),
+        ]
+
+        const csv = await ServiceProviderCSVGenerator.generate(reportingResponse)
+
+        expect(csv).toContain(
+          'referral_link,referral_ref,referral_id,contract_id,organisation_id,referring_officer_email,caseworker_id,service_user_crn,date_referral_received,date_saa_booked,date_saa_attended,date_first_action_plan_submitted,date_of_first_action_plan_approval,date_of_first_attended_session,outcomes_to_be_achieved_count,outcomes_achieved,count_of_sessions_expected,count_of_sessions_attended,end_requested_by_pp_at,end_requested_by_pp_reason,date_eosr_submitted,concluded_at'
+        )
+        expect(csv).toContain(
+          'https://refer-and-monitor.com/referral/c9f9e22f-ddd9-422a-a9af-76fc02b18b38,SM1973AC,c9f9e22f-ddd9-422a-a9af-76fc02b18b38,thing,XYZ5678,bernard.beaks@example.com,liane.supplier@example.com,X017844,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00,8,5.5,10,6,2021-06-27T14:49:01+01:00,REC,2021-06-27T14:49:01+01:00,2021-06-27T14:49:01+01:00'
+        )
+        expect(csv).toContain('2144ed62-aa16-468c-ae8d-41588606750e')
+        expect(csv).toContain('d8cc2ad2-a29f-4168-ab84-6d3e130e234b')
+      })
+
+      describe('with a large number of reporting referrals', () => {
+        it('includes all of the input referrals in the CSV', async () => {
+          const ids = Array.from({ length: 2000 }, (_, i) => i).map(number => `id-${number}`)
+          const reportingResponse = ids.map(id => serviceProviderReportReferralFactory.build({ referralId: id }))
+
+          const csv = await ServiceProviderCSVGenerator.generate(reportingResponse)
+
+          ids.forEach(id => expect(csv).toContain(id))
+        })
+      })
+
+      describe('when a nullable property is null', () => {
+        it('enters an empty string for that cell', async () => {
+          const reportReferral = serviceProviderReportReferralFactory.build({
+            referralLink: 'https://refer-and-monitor.com/referral/c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+            referralRef: 'SM1973AC',
+            referralId: 'c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+            contractId: 'thing',
+            organisationId: 'XYZ5678',
+            caseworkerId: 'liane.supplier@example.com',
+            serviceUserCRN: 'X017844',
+            dateReferralReceived: '2021-06-27T14:49:01+01:00',
+            dateSAABooked: null,
+            dateSAAAttended: null,
+            dateFirstActionPlanSubmitted: null,
+            dateOfFirstActionPlanApproval: null,
+            dateOfFirstAttendedSession: null,
+            outcomesToBeAchievedCount: null,
+            outcomesAchieved: null,
+            countOfSessionsExpected: null,
+            countOfSessionsAttended: null,
+            endRequestedByPPAt: null,
+            endRequestedByPPReason: null,
+            dateEOSRSubmitted: null,
+            concludedAt: null,
+          })
+
+          const csv = await ServiceProviderCSVGenerator.generate([reportReferral])
+
+          expect(csv).toContain(
+            'https://refer-and-monitor.com/referral/c9f9e22f-ddd9-422a-a9af-76fc02b18b38,SM1973AC,c9f9e22f-ddd9-422a-a9af-76fc02b18b38,thing,XYZ5678,joe.probation@example.com,liane.supplier@example.com,X017844,2021-06-27T14:49:01+01:00,,,,,,,,,,,,,'
+          )
+        })
+      })
+    })
+  })
+
+  describe('.createFilename', () => {
+    it('returns a filename including the date (in British time zone) the report is generated', () => {
+      const mockDate = new Date('2021-06-28T10:00:00Z')
+      const spy = jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as string)
+
+      expect(ServiceProviderCSVGenerator.createFilename()).toEqual('refer-monitor-intervention_report_20210628.csv')
+      spy.mockRestore()
+    })
+  })
+})

--- a/server/utils/serviceProviderCSVGenerator.ts
+++ b/server/utils/serviceProviderCSVGenerator.ts
@@ -1,0 +1,60 @@
+import stringify from 'csv-stringify'
+import { ServiceProviderReportReferral } from '../models/serviceProviderReportReferral'
+import CalendarDay from './calendarDay'
+
+export default class ServiceProviderCSVGenerator {
+  static async generate(reportReferrals: ServiceProviderReportReferral[]): Promise<string> {
+    const data: string[] = []
+    const stringifier = stringify({
+      header: true,
+      columns: [
+        { key: 'referralLink', header: 'referral_link' },
+        { key: 'referralRef', header: 'referral_ref' },
+        { key: 'referralId', header: 'referral_id' },
+        { key: 'contractId', header: 'contract_id' },
+        { key: 'organisationId', header: 'organisation_id' },
+        { key: 'referringOfficerEmail', header: 'referring_officer_email' },
+        { key: 'caseworkerId', header: 'caseworker_id' },
+        { key: 'serviceUserCRN', header: 'service_user_crn' },
+        { key: 'dateReferralReceived', header: 'date_referral_received' },
+        { key: 'dateSAABooked', header: 'date_saa_booked' },
+        { key: 'dateSAAAttended', header: 'date_saa_attended' },
+        { key: 'dateFirstActionPlanSubmitted', header: 'date_first_action_plan_submitted' },
+        { key: 'dateOfFirstActionPlanApproval', header: 'date_of_first_action_plan_approval' },
+        { key: 'dateOfFirstAttendedSession', header: 'date_of_first_attended_session' },
+        { key: 'outcomesToBeAchievedCount', header: 'outcomes_to_be_achieved_count' },
+        { key: 'outcomesAchieved', header: 'outcomes_achieved' },
+        { key: 'countOfSessionsExpected', header: 'count_of_sessions_expected' },
+        { key: 'countOfSessionsAttended', header: 'count_of_sessions_attended' },
+        { key: 'endRequestedByPPAt', header: 'end_requested_by_pp_at' },
+        { key: 'endRequestedByPPReason', header: 'end_requested_by_pp_reason' },
+        { key: 'dateEOSRSubmitted', header: 'date_eosr_submitted' },
+        { key: 'concludedAt', header: 'concluded_at' },
+      ],
+    })
+
+    stringifier.on('readable', () => {
+      let row = stringifier.read()
+      while (row) {
+        data.push(row)
+        row = stringifier.read()
+      }
+    })
+
+    reportReferrals.forEach(referral => {
+      stringifier.write(referral)
+    })
+    stringifier.end()
+
+    return new Promise((resolve, _) => {
+      stringifier.on('finish', () => {
+        resolve(data.join(''))
+      })
+    })
+  }
+
+  static createFilename(): string {
+    const todayCalendarDay = CalendarDay.britishDayForDate(new Date())
+    return `refer-monitor-intervention_report_${todayCalendarDay.iso8601.replace(/-/g, '').replace(/-/g, '')}.csv`
+  }
+}

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -1,9 +1,14 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = "HMPPS Interventions" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block primaryNav %}
+  {{ mojPrimaryNavigation(primaryNavArgs) }}
+{% endblock %}
 
 {% block pageContent %}
   <div class="govuk-grid-row">

--- a/server/views/serviceProviderReferrals/reporting.njk
+++ b/server/views/serviceProviderReferrals/reporting.njk
@@ -1,0 +1,35 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "components/time-input/macro.njk" import appTimeInput %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}
+  HMPPS Interventions - GOV.UK
+{% endblock %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
+      <form method="post" novalidate="novalidate">
+
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">{{ presenter.text.title }}</h1>
+        <p class="govuk-body-m govuk-!-margin-bottom-7">{{ presenter.text.subtitle }}</p>
+
+        {{ govukDateInput(fromDateInputArgs) }}
+        {{ govukDateInput(toDateInputArgs) }}
+
+        {{ govukButton({ text: "Download data as .csv" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/serviceProviderReportReferral.ts
+++ b/testutils/factories/serviceProviderReportReferral.ts
@@ -1,0 +1,27 @@
+import { Factory } from 'fishery'
+import { ServiceProviderReportReferral } from '../../server/models/serviceProviderReportReferral'
+
+export default Factory.define<ServiceProviderReportReferral>(() => ({
+  referralLink: 'https://refer-and-monitor.com/referral/c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+  referralRef: 'SM1973AC',
+  referralId: 'c9f9e22f-ddd9-422a-a9af-76fc02b18b38',
+  contractId: 'thing',
+  organisationId: 'XYZ5678',
+  referringOfficerEmail: 'joe.probation@example.com',
+  caseworkerId: 'liane.supplier@example.com',
+  serviceUserCRN: 'X017844',
+  dateReferralReceived: '2021-06-27T14:49:01+01:00',
+  dateSAABooked: '2021-06-27T14:49:01+01:00',
+  dateSAAAttended: '2021-06-27T14:49:01+01:00',
+  dateFirstActionPlanSubmitted: '2021-06-27T14:49:01+01:00',
+  dateOfFirstActionPlanApproval: '2021-06-27T14:49:01+01:00',
+  dateOfFirstAttendedSession: '2021-06-27T14:49:01+01:00',
+  outcomesToBeAchievedCount: 8,
+  outcomesAchieved: 5.5,
+  countOfSessionsExpected: 10,
+  countOfSessionsAttended: 6,
+  endRequestedByPPAt: '2021-06-27T14:49:01+01:00',
+  endRequestedByPPReason: 'REC',
+  dateEOSRSubmitted: '2021-06-27T14:49:01+01:00',
+  concludedAt: '2021-06-27T14:49:01+01:00',
+}))


### PR DESCRIPTION
## What does this pull request do?

Adds a new "reporting" page (linked via a new SP dashboard nav) allowing users to download a Report of referral data between two dates.

This won't work until we have the API changes (contracts for which are in #516).

## What is the intent behind these changes?

To allow SPs to download performance data for reporting.

## Screenshots

### Banner

<img width="922" alt="image" src="https://user-images.githubusercontent.com/19826940/123937345-f8a34d80-d98d-11eb-9a83-b184a5d16b80.png">

### Reporting page

<img width="898" alt="image" src="https://user-images.githubusercontent.com/19826940/123937368-ff31c500-d98d-11eb-8f61-0faf721994ab.png">

