### PR TITLE
Ensure that the referral details page is still rendered even if getStaffDetails from communityAPI returns NOT_FOUND

### DIFF
--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -427,6 +427,17 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
         })
     })
   })
+  describe('when no staff details can be found', () => {
+    it('does not show the team details', async () => {
+      communityApiService.getStaffDetails.mockResolvedValue(null)
+      await request(app)
+        .get(`/probation-practitioner/referrals/${sentReferral.id}/details`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).not.toContain('Team contact details')
+        })
+    })
+  })
 })
 
 describe('GET /probation-practitioner/referrals/:id/action-plan', () => {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -219,6 +219,18 @@ describe('GET /service-provider/referrals/:id/details', () => {
         })
     })
   })
+
+  describe('when no staff details can be found', () => {
+    it('does not show the team details', async () => {
+      communityApiService.getStaffDetails.mockResolvedValue(null)
+      await request(app)
+        .get(`/service-provider/referrals/${sentReferral.id}/details`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).not.toContain('Team contact details')
+        })
+    })
+  })
 })
 
 describe('GET /service-provider/referrals/:id/progress', () => {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -105,7 +105,6 @@ export default class ServiceProviderReferralsController {
         this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
         this.communityApiService.getStaffDetails(sentReferral.sentBy.username),
       ])
-
     const assignee =
       sentReferral.assignedTo === null
         ? null

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -39,7 +39,7 @@ export default class ShowReferralPresenter {
     readonly canAssignReferral: boolean,
     private readonly deliusServiceUser: ExpandedDeliusServiceUser,
     private readonly riskSummary: RiskSummary | null,
-    private readonly staffDetails: DeliusStaffDetails
+    private readonly staffDetails: DeliusStaffDetails | null
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,
@@ -78,7 +78,7 @@ export default class ShowReferralPresenter {
   }
 
   private get activeTeam(): DeliusTeam | null {
-    const firstTeam = this.staffDetails.teams
+    const firstTeam = this.staffDetails?.teams
       ?.filter(team => {
         if (team.endDate === null || team.endDate === undefined) {
           return true

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -60,13 +60,22 @@ export default class CommunityApiService {
     })) as DeliusConviction
   }
 
-  async getStaffDetails(username: string): Promise<DeliusStaffDetails> {
+  async getStaffDetails(username: string): Promise<DeliusStaffDetails | null> {
     const token = await this.hmppsAuthService.getApiClientToken()
 
     logger.info({ username }, 'getting staff details for officer')
-    return (await this.restClient.get({
-      path: `/secure/staff/username/${username}`,
-      token,
-    })) as DeliusStaffDetails
+    try {
+      return (await this.restClient.get({
+        path: `/secure/staff/username/${username}`,
+        token,
+      })) as DeliusStaffDetails
+    } catch (err) {
+      if (err.status === 404) {
+        // not all users will have staff details on delius
+        return null
+      }
+
+      throw createError(err.status, err, { userMessage: 'Could retrieve staff details from nDelius.' })
+    }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Ensure that the referral details page is still rendered even if getStaffDetails from communityAPI returns NOT_FOUND

## What is the intent behind these changes?

No all users can be considered a staff so we need to simply not display the team details if this is the case.