### PR TITLE
modsec ruleset: increase blocking threshold to 6 (up from 5)

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6,setvar:tx.outbound_anomaly_score_threshold=4"
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
     {{- else }}


### PR DESCRIPTION
## What does this pull request do?

Lets more genuine requests through until we can have a more sophisticated ruleset.

## What is the intent behind these changes?

Some users are getting blocked, with one who is trying to do urgent work.

## Statistics

Score distributions in the past two days:

- score 5: 234
- score 10: 21
- score 15: 7

Most of the problems seem to happen with

- `/referrals/:uuid/risk-information` (173 total, 5 with score 10)
- `/referrals/:uuid/further-information` (60 total, 14 with score 10, 7 with score 15)
- `/referrals/:uuid/needs-and-requirements` (25 total, 2 with score 10)
- `/` (3 total)
- `/login/callback` (1 total)