### PR TITLE
Handle delius teams with missing start dates.

### DIFF
--- a/server/models/delius/deliusStaffDetails.ts
+++ b/server/models/delius/deliusStaffDetails.ts
@@ -6,6 +6,6 @@ export interface DeliusStaffDetails {
 export interface DeliusTeam {
   telephone?: string | null
   emailAddress?: string | null
-  startDate: string
+  startDate?: string | null
   endDate?: string | null
 }

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -226,11 +226,19 @@ describe(ShowReferralPresenter, () => {
           emailAddress: 'incorrect-team@justice.gov.uk',
           startDate: '2021-01-01',
         })
+        const teamWithNoStartDate = deliusTeam.build({
+          telephone: 'incorrect number - nsd',
+          emailAddress: 'incorrect-team@justice.gov.uk',
+        })
         const orderedAsc = createShowReferralPresenterWithStaffDetails(
-          deliusStaffDetailsFactory.build({ teams: [olderTeam, newerTeam] })
+          deliusStaffDetailsFactory.build({
+            teams: [teamWithNoStartDate, teamWithNoStartDate, olderTeam, newerTeam],
+          })
         )
         const orderedDesc = createShowReferralPresenterWithStaffDetails(
-          deliusStaffDetailsFactory.build({ teams: [newerTeam, olderTeam] })
+          deliusStaffDetailsFactory.build({
+            teams: [newerTeam, olderTeam, teamWithNoStartDate, teamWithNoStartDate],
+          })
         )
 
         expect(orderedAsc.probationPractitionerTeamDetails).toEqual([


### PR DESCRIPTION


## What does this pull request do?

Handle delius teams with missing start dates.

Assume that these teams are older than any team that does have a start date

## What is the intent behind these changes?

allows the referral details page to load when teams come back with no start date.
