### PR TITLE
Add desired outcomes to action plan views & remove repeated code

### DIFF
--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -443,12 +443,14 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
 describe('GET /probation-practitioner/referrals/:id/action-plan', () => {
   it('displays information about the action plan and service user', async () => {
     const sentReferral = sentReferralFactory.assigned().build()
+    const serviceCategory = serviceCategoryFactory.build()
     const deliusServiceUser = deliusServiceUserFactory.build()
     const actionPlan = actionPlanFactory.submitted().build({ referralId: sentReferral.id })
     sentReferral.actionPlanId = actionPlan.id
 
     interventionsService.getActionPlan.mockResolvedValue(actionPlan)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
 
     await request(app)
@@ -478,12 +480,14 @@ describe('POST /probation-practitioner/referrals/:id/action-plan/approve', () =>
   })
   it("redirects back to action-plan if approval hasn't been confirmed", async () => {
     const sentReferral = sentReferralFactory.assigned().build()
+    const serviceCategory = serviceCategoryFactory.build()
     const deliusServiceUser = deliusServiceUserFactory.build()
     const actionPlan = actionPlanFactory.submitted().build({ referralId: sentReferral.id })
     sentReferral.actionPlanId = actionPlan.id
 
     interventionsService.getActionPlan.mockResolvedValue(actionPlan)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
 
     await request(app)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -319,12 +319,23 @@ export default class ProbationPractitionerReferralsController {
       })
     }
 
-    const [actionPlan, serviceUser] = await Promise.all([
+    const [serviceCategories, actionPlan, serviceUser] = await Promise.all([
+      Promise.all(
+        sentReferral.referral.serviceCategoryIds.map(id =>
+          this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
+        )
+      ),
       this.interventionsService.getActionPlan(accessToken, sentReferral.actionPlanId),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
 
-    const presenter = new ActionPlanPresenter(sentReferral, actionPlan, 'probation-practitioner', formValidationError)
+    const presenter = new ActionPlanPresenter(
+      sentReferral,
+      actionPlan,
+      serviceCategories,
+      'probation-practitioner',
+      formValidationError
+    )
     const view = new ActionPlanView(presenter)
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }

--- a/server/routes/service-provider/action-plan/review/reviewActionPlanPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/review/reviewActionPlanPresenter.test.ts
@@ -52,55 +52,5 @@ describe(ReviewActionPlanPresenter, () => {
         expect(presenter.text.title).toEqual('Confirm action plan')
       })
     })
-
-    describe('numberOfSessions', () => {
-      it('returns the suggested number of sessions in the action plan', () => {
-        const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build({ numberOfSessions: 10 })
-
-        const presenter = new ReviewActionPlanPresenter(sentReferral, serviceCategories, actionPlan)
-
-        expect(presenter.text.numberOfSessions).toEqual('10')
-      })
-    })
-  })
-
-  describe('desiredOutcomesByServiceCategory', () => {
-    it('returns the desired outcomes on the Service Category that match those populated on the SentReferral', () => {
-      const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build({ activities: [] })
-
-      const presenter = new ReviewActionPlanPresenter(sentReferral, serviceCategories, actionPlan)
-
-      expect(presenter.desiredOutcomesByServiceCategory).toEqual([
-        {
-          serviceCategory: 'Accommodation',
-          desiredOutcomes: [
-            'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
-            'Service user makes progress in obtaining accommodation',
-          ],
-        },
-      ])
-    })
-  })
-
-  describe('orderedActivities', () => {
-    it('returns the activities specified on the draft action plan in date created order', () => {
-      const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build({
-        activities: [
-          {
-            id: '1',
-            description: 'description 1',
-            createdAt: '2021-03-15T10:05:00Z',
-          },
-          {
-            id: '2',
-            description: 'description 2',
-            createdAt: '2021-03-15T10:00:00Z',
-          },
-        ],
-      })
-
-      const presenter = new ReviewActionPlanPresenter(sentReferral, serviceCategories, actionPlan)
-      expect(presenter.orderedActivities).toEqual(['description 2', 'description 1'])
-    })
   })
 })

--- a/server/routes/service-provider/action-plan/review/reviewActionPlanPresenter.ts
+++ b/server/routes/service-provider/action-plan/review/reviewActionPlanPresenter.ts
@@ -1,38 +1,23 @@
 import ActionPlan from '../../../../models/actionPlan'
 import SentReferral from '../../../../models/sentReferral'
 import ServiceCategory from '../../../../models/serviceCategory'
-import utils from '../../../../utils/utils'
+import ActionPlanPresenter from '../../../shared/action-plan/actionPlanPresenter'
 
 export default class ReviewActionPlanPresenter {
+  actionPlanPresenter: ActionPlanPresenter
+
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly serviceCategories: ServiceCategory[],
     private readonly actionPlan: ActionPlan
-  ) {}
+  ) {
+    this.actionPlanPresenter = new ActionPlanPresenter(sentReferral, actionPlan, serviceCategories, 'service-provider')
+  }
 
   readonly submitFormAction = `/service-provider/action-plan/${this.actionPlan.id}/submit`
-
-  private readonly desiredOutcomesIds = this.sentReferral.referral.desiredOutcomes.flatMap(
-    desiredOutcome => desiredOutcome.desiredOutcomesIds
-  )
 
   readonly text = {
     title: 'Confirm action plan',
     numberOfSessions: this.actionPlan.numberOfSessions?.toString() ?? '',
   }
-
-  readonly desiredOutcomesByServiceCategory = this.serviceCategories.map(serviceCategory => {
-    const desiredOutcomesForServiceCategory = serviceCategory.desiredOutcomes.filter(desiredOutcome =>
-      this.desiredOutcomesIds.includes(desiredOutcome.id)
-    )
-
-    return {
-      serviceCategory: utils.convertToProperCase(serviceCategory.name),
-      desiredOutcomes: desiredOutcomesForServiceCategory.map(desiredOutcome => desiredOutcome.description),
-    }
-  })
-
-  readonly orderedActivities = this.actionPlan.activities
-    .sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1))
-    .map(activity => activity.description)
 }

--- a/server/routes/service-provider/action-plan/review/reviewActionPlanView.ts
+++ b/server/routes/service-provider/action-plan/review/reviewActionPlanView.ts
@@ -1,23 +1,20 @@
-import { InsetTextArgs } from '../../../../utils/govukFrontendTypes'
 import ReviewActionPlanPresenter from './reviewActionPlanPresenter'
+import ActionPlanView from '../../../shared/action-plan/actionPlanView'
 
 export default class ReviewActionPlanView {
-  constructor(private readonly presenter: ReviewActionPlanPresenter) {}
+  actionPlanView: ActionPlanView
+
+  constructor(private readonly presenter: ReviewActionPlanPresenter) {
+    this.actionPlanView = new ActionPlanView(presenter.actionPlanPresenter)
+  }
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/reviewActionPlan',
       {
         presenter: this.presenter,
-        insetTextArgs: this.insetTextArgs,
+        insetTextArgs: this.actionPlanView.insetTextActivityArgs,
       },
     ]
-  }
-
-  insetTextArgs(index: number, description: string): InsetTextArgs {
-    return {
-      html: `<h3 class="govuk-heading-m govuk-!-font-weight-bold">Activity ${index}</h3><p class="govuk-body">${description}</p>`,
-      classes: 'app-inset-text--grey',
-    }
   }
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -977,12 +977,17 @@ export default class ServiceProviderReferralsController {
       })
     }
 
-    const [actionPlan, serviceUser] = await Promise.all([
+    const [serviceCategories, actionPlan, serviceUser] = await Promise.all([
+      Promise.all(
+        sentReferral.referral.serviceCategoryIds.map(id =>
+          this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
+        )
+      ),
       this.interventionsService.getActionPlan(accessToken, sentReferral.actionPlanId),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
     ])
 
-    const presenter = new ActionPlanPresenter(sentReferral, actionPlan, 'service-provider')
+    const presenter = new ActionPlanPresenter(sentReferral, actionPlan, serviceCategories, 'service-provider')
     const view = new ActionPlanView(presenter)
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }

--- a/server/routes/shared/action-plan/actionPlanPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.test.ts
@@ -29,4 +29,26 @@ describe(InterventionProgressPresenter, () => {
       })
     })
   })
+
+  describe('orderedActivities', () => {
+    it('returns the activities specified on the draft action plan in date created order', () => {
+      const actionPlan = actionPlanFactory.justCreated(referral.id).build({
+        activities: [
+          {
+            id: '1',
+            description: 'description 1',
+            createdAt: '2021-03-15T10:05:00Z',
+          },
+          {
+            id: '2',
+            description: 'description 2',
+            createdAt: '2021-03-15T10:00:00Z',
+          },
+        ],
+      })
+
+      const presenter = new ActionPlanPresenter(referral, actionPlan, 'probation-practitioner')
+      expect(presenter.orderedActivities).toEqual(['description 2', 'description 1'])
+    })
+  })
 })

--- a/server/routes/shared/action-plan/actionPlanPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.test.ts
@@ -2,9 +2,37 @@ import actionPlanFactory from '../../../../testutils/factories/actionPlan'
 import referralFactory from '../../../../testutils/factories/sentReferral'
 import ActionPlanPresenter from './actionPlanPresenter'
 import InterventionProgressPresenter from '../../serviceProviderReferrals/interventionProgressPresenter'
+import serviceCategoryFactory from '../../../../testutils/factories/serviceCategory'
 
 describe(InterventionProgressPresenter, () => {
-  const referral = referralFactory.build()
+  const desiredOutcomes = [
+    {
+      id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+      description:
+        'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+    },
+    {
+      id: '65924ac6-9724-455b-ad30-906936291421',
+      description: 'Service user makes progress in obtaining accommodation',
+    },
+    {
+      id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
+      description: 'Service user is helped to secure social or supported housing',
+    },
+    {
+      id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
+      description: 'Service user is helped to secure a tenancy in the private rented sector (PRS)',
+    },
+  ]
+  const serviceCategories = [serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })]
+  const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
+  const referral = referralFactory.assigned().build({
+    referral: {
+      serviceCategoryIds: [serviceCategories[0].id],
+      serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+      desiredOutcomes: [{ serviceCategoryId: serviceCategories[0].id, desiredOutcomesIds: selectedDesiredOutcomesIds }],
+    },
+  })
 
   describe('errorSummary', () => {
     describe('when a validation error is passed in', () => {
@@ -19,7 +47,13 @@ describe(InterventionProgressPresenter, () => {
             },
           ],
         }
-        const presenter = new ActionPlanPresenter(referral, actionPlan, 'service-provider', validationError)
+        const presenter = new ActionPlanPresenter(
+          referral,
+          actionPlan,
+          serviceCategories,
+          'service-provider',
+          validationError
+        )
         expect(presenter.errorSummary).toEqual([
           { field: 'confirm-approval', message: 'Select the checkbox to confirm before you approve the action plan' },
         ])
@@ -27,6 +61,24 @@ describe(InterventionProgressPresenter, () => {
           'Select the checkbox to confirm before you approve the action plan'
         )
       })
+    })
+  })
+
+  describe('desiredOutcomesByServiceCategory', () => {
+    it('returns the desired outcomes on the Service Category that match those populated on the SentReferral', () => {
+      const actionPlan = actionPlanFactory.justCreated(referral.id).build({ activities: [] })
+
+      const presenter = new ActionPlanPresenter(referral, actionPlan, serviceCategories, 'service-provider')
+
+      expect(presenter.desiredOutcomesByServiceCategory).toEqual([
+        {
+          serviceCategory: 'Accommodation',
+          desiredOutcomes: [
+            'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+            'Service user makes progress in obtaining accommodation',
+          ],
+        },
+      ])
     })
   })
 
@@ -47,7 +99,7 @@ describe(InterventionProgressPresenter, () => {
         ],
       })
 
-      const presenter = new ActionPlanPresenter(referral, actionPlan, 'probation-practitioner')
+      const presenter = new ActionPlanPresenter(referral, actionPlan, serviceCategories, 'probation-practitioner')
       expect(presenter.orderedActivities).toEqual(['description 2', 'description 1'])
     })
   })

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -31,11 +31,11 @@ export default class ActionPlanPresenter {
     confirmApproval: PresenterUtils.errorMessage(this.validationError, 'confirm-approval'),
   }
 
-  get activities(): string[] {
+  get orderedActivities(): string[] {
     return (
-      this.actionPlan?.activities?.map(it => {
-        return it.description
-      }) || []
+      this.actionPlan?.activities
+        ?.sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1))
+        ?.map(activity => activity.description) || []
     )
   }
 

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -3,6 +3,8 @@ import SentReferral from '../../../models/sentReferral'
 import { FormValidationError } from '../../../utils/formValidationError'
 import PresenterUtils from '../../../utils/presenterUtils'
 import ActionPlanSummaryPresenter from './actionPlanSummaryPresenter'
+import utils from '../../../utils/utils'
+import ServiceCategory from '../../../models/serviceCategory'
 
 export default class ActionPlanPresenter {
   actionPlanSummaryPresenter: ActionPlanSummaryPresenter
@@ -10,6 +12,7 @@ export default class ActionPlanPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly actionPlan: ActionPlan,
+    private readonly serviceCategories: ServiceCategory[],
     readonly userType: 'service-provider' | 'probation-practitioner',
     private readonly validationError: FormValidationError | null = null
   ) {
@@ -30,6 +33,21 @@ export default class ActionPlanPresenter {
   readonly fieldErrors = {
     confirmApproval: PresenterUtils.errorMessage(this.validationError, 'confirm-approval'),
   }
+
+  private readonly desiredOutcomesIds = this.referral.referral.desiredOutcomes.flatMap(
+    desiredOutcome => desiredOutcome.desiredOutcomesIds
+  )
+
+  readonly desiredOutcomesByServiceCategory = this.serviceCategories.map(serviceCategory => {
+    const desiredOutcomesForServiceCategory = serviceCategory.desiredOutcomes.filter(desiredOutcome =>
+      this.desiredOutcomesIds.includes(desiredOutcome.id)
+    )
+
+    return {
+      serviceCategory: utils.convertToProperCase(serviceCategory.name),
+      desiredOutcomes: desiredOutcomesForServiceCategory.map(desiredOutcome => desiredOutcome.description),
+    }
+  })
 
   get orderedActivities(): string[] {
     return (

--- a/server/views/serviceProviderReferrals/reviewActionPlan.njk
+++ b/server/views/serviceProviderReferrals/reviewActionPlan.njk
@@ -9,7 +9,7 @@
     Desired outcomes and activities
   </h2>
 
-  {% for serviceCategoryWithDesiredOutcomes in presenter.desiredOutcomesByServiceCategory %}
+  {% for serviceCategoryWithDesiredOutcomes in presenter.actionPlanPresenter.desiredOutcomesByServiceCategory %}
     <h3 class="govuk-heading-m">{{ serviceCategoryWithDesiredOutcomes.serviceCategory }}</h3>
     <ul class="govuk-list govuk-list--bullet">
       {% for desiredOutcome in serviceCategoryWithDesiredOutcomes.desiredOutcomes %}
@@ -18,7 +18,7 @@
     </ul>
   {% endfor %}
 
-  {% for description in presenter.orderedActivities %}
+  {% for description in presenter.actionPlanPresenter.orderedActivities %}
     {{ govukInsetText(insetTextArgs(loop.index, description)) }}
   {% endfor %}
 
@@ -29,7 +29,7 @@
   </h2>
 
   <p class="govuk-body">
-    Suggested number of sessions: {{ presenter.text.numberOfSessions }}
+    Suggested number of sessions: {{ presenter.actionPlanPresenter.text.actionPlanNumberOfSessions }}
   </p>
 
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -25,6 +25,15 @@
 
         <h2 class="govuk-heading-m">Desired outcomes and activities</h2>
 
+        {% for serviceCategoryWithDesiredOutcomes in presenter.desiredOutcomesByServiceCategory %}
+            <h3 class="govuk-heading-s">{{ serviceCategoryWithDesiredOutcomes.serviceCategory }}</h3>
+            <ul class="govuk-list govuk-list--bullet">
+                {% for desiredOutcome in serviceCategoryWithDesiredOutcomes.desiredOutcomes %}
+                    <li>{{ desiredOutcome }}</li>
+                {% endfor %}
+            </ul>
+        {% endfor %}
+
         <ul class="govuk-list">
         {% for activity in presenter.orderedActivities %}
             <li>{{ govukInsetText(insetTextActivityArgs(loop.index, activity)) }}</li>

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -26,7 +26,7 @@
         <h2 class="govuk-heading-m">Desired outcomes and activities</h2>
 
         <ul class="govuk-list">
-        {% for activity in presenter.activities %}
+        {% for activity in presenter.orderedActivities %}
             <li>{{ govukInsetText(insetTextActivityArgs(loop.index, activity)) }}</li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
## What does this pull request do?

**this PR depends on #519 so please review that one first and then ignore the first commit on this PR**

- takes code from 'review action plan' view and presenter and ensures it is contained in the shared action plan view and presenter classes
- removes that common code from 'review action plan' view and presenter.

a side effect of this is that the desired outcomes are now displayed on the SP and PP action plan view pages (this was a known omission).

![Screenshot 2021-06-30 at 17 07 09](https://user-images.githubusercontent.com/63233073/124024505-32ed0900-d9e7-11eb-9843-aeb7596b8874.png)

## What is the intent behind these changes?

tidy up shared code and include the required information on the action plan pages.
