### PR TITLE
Include explicit activity numbers in URLs for adding action plan activities.

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -398,7 +398,7 @@ describe('Service provider referrals dashboard', () => {
     cy.get('#action-plan-status').contains('Not submitted')
     cy.contains('Create action plan').click()
 
-    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
+    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activity/1`)
 
     cy.contains('Add activity 1 to action plan')
     cy.contains('Referred outcomes for Alex')
@@ -422,7 +422,7 @@ describe('Service provider referrals dashboard', () => {
     cy.get('#description').type('Attend training course')
     cy.contains('Save and add activity 1').click()
 
-    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
+    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activity/2`)
 
     const draftActionPlanWithAllActivities = {
       ...draftActionPlanWithActivity,
@@ -442,7 +442,7 @@ describe('Service provider referrals dashboard', () => {
     cy.get('#description').type('Create appointment with local authority')
     cy.contains('Save and add activity 2').click()
 
-    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activities`)
+    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activity/3`)
 
     cy.contains('Continue without adding other activities').click()
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -72,10 +72,10 @@ export default function routes(router: Router, services: Services): Router {
   post('/service-provider/referrals/:id/action-plan', (req, res) =>
     serviceProviderReferralsController.createDraftActionPlan(req, res)
   )
-  get('/service-provider/action-plan/:id/add-activities', (req, res) =>
+  get('/service-provider/action-plan/:id/add-activity/:number', (req, res) =>
     serviceProviderReferralsController.showActionPlanAddActivitiesForm(req, res)
   )
-  post('/service-provider/action-plan/:id/add-activity', (req, res) =>
+  post('/service-provider/action-plan/:id/add-activity/:number', (req, res) =>
     serviceProviderReferralsController.addActivityToActionPlan(req, res)
   )
   post('/service-provider/action-plan/:id/add-activities', (req, res) =>

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.test.ts
@@ -36,7 +36,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
   describe('saveAndContinueFormAction', () => {
     it('returns a relative URL of the action plan’s add-activities page', () => {
       const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
-      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
+      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, 1)
 
       expect(presenter.saveAndContinueFormAction).toEqual(
         `/service-provider/action-plan/${actionPlan.id}/add-activities`
@@ -53,10 +53,11 @@ describe(AddActionPlanActivitiesPresenter, () => {
         const presenter = new AddActionPlanActivitiesPresenter(
           sentReferral,
           [socialInclusionServiceCategory],
-          actionPlan
+          actionPlan,
+          3
         )
 
-        expect(presenter.text.title).toEqual('Add activity 2 to action plan')
+        expect(presenter.text.title).toEqual('Add activity 3 to action plan')
       })
     })
 
@@ -64,40 +65,25 @@ describe(AddActionPlanActivitiesPresenter, () => {
       it('includes the name of the service user', () => {
         const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
 
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, 1)
 
         expect(presenter.text.referredOutcomesHeader).toEqual('Referred outcomes for Jenny')
       })
     })
   })
 
-  describe('activityNumber', () => {
-    describe('when no activities have been added', () => {
-      it('specifies the number of the activity to be added', () => {
-        const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-        const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
-        const presenter = new AddActionPlanActivitiesPresenter(
-          sentReferral,
-          [socialInclusionServiceCategory],
-          actionPlan
-        )
+  describe('addActivityAction', () => {
+    it('specifies the number of the activity to be added', () => {
+      const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+      const actionPlan = actionPlanFactory.oneActivityAdded().build()
+      const presenter = new AddActionPlanActivitiesPresenter(
+        sentReferral,
+        [socialInclusionServiceCategory],
+        actionPlan,
+        2
+      )
 
-        expect(presenter.activityNumber).toEqual(1)
-      })
-    })
-
-    describe('when 1 activity has been added', () => {
-      it('specifies the number of the activity to be added', () => {
-        const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-        const actionPlan = actionPlanFactory.oneActivityAdded().build()
-        const presenter = new AddActionPlanActivitiesPresenter(
-          sentReferral,
-          [socialInclusionServiceCategory],
-          actionPlan
-        )
-
-        expect(presenter.activityNumber).toEqual(2)
-      })
+      expect(presenter.addActivityAction).toEqual(`/service-provider/action-plan/${actionPlan.id}/add-activity/2`)
     })
   })
 
@@ -105,7 +91,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
     describe('when an no error is passed in', () => {
       it('returns null', () => {
         const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, 1)
 
         expect(presenter.errorSummary).toBeNull()
       })
@@ -124,28 +110,10 @@ describe(AddActionPlanActivitiesPresenter, () => {
           ],
         }
 
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, errors)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, 1, errors)
 
         expect(presenter.errorSummary).toEqual([{ field: 'description', message: 'Enter an activity' }])
       })
-    })
-  })
-
-  describe('desiredOutcomesByServiceCategory', () => {
-    it('returns the desired outcomes on the Service Category that match those populated on the SentReferral', () => {
-      const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build({ activities: [] })
-
-      const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
-
-      expect(presenter.desiredOutcomesByServiceCategory).toEqual([
-        {
-          serviceCategory: 'Accommodation',
-          desiredOutcomes: [
-            'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
-            'Service user makes progress in obtaining accommodation',
-          ],
-        },
-      ])
     })
   })
 
@@ -163,7 +131,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
 
     describe('when an error is passed in', () => {
       it('returns an error message', () => {
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, errors)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, 1, errors)
 
         expect(presenter.errorMessage).toEqual('Enter an activity')
       })
@@ -171,7 +139,7 @@ describe(AddActionPlanActivitiesPresenter, () => {
 
     describe('when no error is passed in', () => {
       it('returns null', () => {
-        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan)
+        const presenter = new AddActionPlanActivitiesPresenter(sentReferral, serviceCategories, actionPlan, 1)
 
         expect(presenter.errorMessage).toBeNull()
       })

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
@@ -12,6 +12,7 @@ export default class AddActionPlanActivitiesPresenter {
     private readonly sentReferral: SentReferral,
     private readonly serviceCategories: ServiceCategory[],
     private readonly actionPlan: ActionPlan,
+    readonly activityNumber: number,
     private readonly errors: FormValidationError | null = null
   ) {
     this.actionPlanPresenter = new ActionPlanPresenter(sentReferral, actionPlan, serviceCategories, 'service-provider')
@@ -19,9 +20,7 @@ export default class AddActionPlanActivitiesPresenter {
 
   readonly saveAndContinueFormAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activities`
 
-  readonly addActivityAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activity`
-
-  readonly activityNumber = this.actionPlan.activities.length + 1
+  readonly addActivityAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activity/${this.activityNumber}`
 
   readonly errorMessage = PresenterUtils.errorMessage(this.errors, 'description')
 

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
@@ -3,25 +3,25 @@ import SentReferral from '../../../../models/sentReferral'
 import ServiceCategory from '../../../../models/serviceCategory'
 import { FormValidationError } from '../../../../utils/formValidationError'
 import PresenterUtils from '../../../../utils/presenterUtils'
-import utils from '../../../../utils/utils'
+import ActionPlanPresenter from '../../../shared/action-plan/actionPlanPresenter'
 
 export default class AddActionPlanActivitiesPresenter {
+  actionPlanPresenter: ActionPlanPresenter
+
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly serviceCategories: ServiceCategory[],
     private readonly actionPlan: ActionPlan,
     private readonly errors: FormValidationError | null = null
-  ) {}
+  ) {
+    this.actionPlanPresenter = new ActionPlanPresenter(sentReferral, actionPlan, serviceCategories, 'service-provider')
+  }
 
   readonly saveAndContinueFormAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activities`
 
   readonly addActivityAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activity`
 
   readonly activityNumber = this.actionPlan.activities.length + 1
-
-  private readonly desiredOutcomesIds = this.sentReferral.referral.desiredOutcomes.flatMap(
-    desiredOutcome => desiredOutcome.desiredOutcomesIds
-  )
 
   readonly errorMessage = PresenterUtils.errorMessage(this.errors, 'description')
 
@@ -31,15 +31,4 @@ export default class AddActionPlanActivitiesPresenter {
     title: `Add activity ${this.activityNumber} to action plan`,
     referredOutcomesHeader: `Referred outcomes for ${this.sentReferral.referral.serviceUser.firstName}`,
   }
-
-  readonly desiredOutcomesByServiceCategory = this.serviceCategories.map(serviceCategory => {
-    const desiredOutcomesForServiceCategory = serviceCategory.desiredOutcomes.filter(desiredOutcome =>
-      this.desiredOutcomesIds.includes(desiredOutcome.id)
-    )
-
-    return {
-      serviceCategory: utils.convertToProperCase(serviceCategory.name),
-      desiredOutcomes: desiredOutcomesForServiceCategory.map(desiredOutcome => desiredOutcome.description),
-    }
-  })
 }

--- a/server/routes/shared/action-plan/actionPlanPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.test.ts
@@ -100,7 +100,18 @@ describe(InterventionProgressPresenter, () => {
       })
 
       const presenter = new ActionPlanPresenter(referral, actionPlan, serviceCategories, 'probation-practitioner')
-      expect(presenter.orderedActivities).toEqual(['description 2', 'description 1'])
+      expect(presenter.orderedActivities).toEqual([
+        {
+          id: '2',
+          description: 'description 2',
+          createdAt: '2021-03-15T10:00:00Z',
+        },
+        {
+          id: '1',
+          description: 'description 1',
+          createdAt: '2021-03-15T10:05:00Z',
+        },
+      ])
     })
   })
 })

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -1,4 +1,4 @@
-import ActionPlan from '../../../models/actionPlan'
+import ActionPlan, { Activity } from '../../../models/actionPlan'
 import SentReferral from '../../../models/sentReferral'
 import { FormValidationError } from '../../../utils/formValidationError'
 import PresenterUtils from '../../../utils/presenterUtils'
@@ -49,12 +49,8 @@ export default class ActionPlanPresenter {
     }
   })
 
-  get orderedActivities(): string[] {
-    return (
-      this.actionPlan?.activities
-        ?.sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1))
-        ?.map(activity => activity.description) || []
-    )
+  get orderedActivities(): Activity[] {
+    return this.actionPlan?.activities?.sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1)) || []
   }
 
   get showApprovalForm(): boolean {

--- a/server/routes/shared/action-plan/actionPlanSummaryPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanSummaryPresenter.ts
@@ -13,7 +13,12 @@ export default class ActionPlanSummaryPresenter {
 
   readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
 
-  readonly actionPlanFormUrl = `/service-provider/action-plan/${this.actionPlan?.id}/add-activities`
+  // this url is used to pick up action plan creation after it has been started.
+  // the url points to the screen for adding an additional activity
+  readonly actionPlanFormUrl =
+    this.actionPlan !== null
+      ? `/service-provider/action-plan/${this.actionPlan.id}/add-activity/${this.actionPlan.activities.length + 1}`
+      : ''
 
   readonly text = {
     actionPlanStatus: this.actionPlanStatus,

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -8,7 +8,7 @@
 
   <h2 class="govuk-heading-m">{{ presenter.text.referredOutcomesHeader }}</h2>
 
-  {% for serviceCategoryWithDesiredOutcomes in presenter.desiredOutcomesByServiceCategory %}
+  {% for serviceCategoryWithDesiredOutcomes in presenter.actionPlanPresenter.desiredOutcomesByServiceCategory %}
     <h3 class="govuk-heading-s">{{ serviceCategoryWithDesiredOutcomes.serviceCategory }}</h3>
     <ul class="govuk-list govuk-list--bullet">
       {% for desiredOutcome in serviceCategoryWithDesiredOutcomes.desiredOutcomes %}

--- a/server/views/serviceProviderReferrals/reviewActionPlan.njk
+++ b/server/views/serviceProviderReferrals/reviewActionPlan.njk
@@ -18,8 +18,8 @@
     </ul>
   {% endfor %}
 
-  {% for description in presenter.actionPlanPresenter.orderedActivities %}
-    {{ govukInsetText(insetTextArgs(loop.index, description)) }}
+  {% for activity in presenter.actionPlanPresenter.orderedActivities %}
+    {{ govukInsetText(insetTextArgs(loop.index, activity.description)) }}
   {% endfor %}
 
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -36,7 +36,7 @@
 
         <ul class="govuk-list">
         {% for activity in presenter.orderedActivities %}
-            <li>{{ govukInsetText(insetTextActivityArgs(loop.index, activity)) }}</li>
+            <li>{{ govukInsetText(insetTextActivityArgs(loop.index, activity.description)) }}</li>
         {% endfor %}
         </ul>
 


### PR DESCRIPTION
**This PR is branched from #525 so please review that one first, then ignore the overlapping commits in this PR**

## What does this pull request do?

some refactoring (see first two commits in isolation). 

adding explicit numbering to action plan activity URLs. 

![Screenshot 2021-06-30 at 23 36 42](https://user-images.githubusercontent.com/63233073/124040045-13141000-d9fc-11eb-9379-f8c266f674c7.png)

## What is the intent behind these changes?

    This commit lays the ground work for the ability to udpate an activity
    using the existing action plan form. For now we just specify the number
    in the url, and everything behaves as it did before.
