### PR TITLE
add interventions service method to update an action plan activity

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -127,6 +127,10 @@ module.exports = on => {
       return interventionsService.stubUpdateDraftActionPlan(arg.id, arg.responseJson)
     },
 
+    stubUpdateActionPlanActivity: arg => {
+      return interventionsService.stubActionPlanActivity(arg.actionPlanId, arg.activityId, arg.responseJson)
+    },
+
     stubSubmitActionPlan: arg => {
       return interventionsService.stubSubmitActionPlan(arg.id, arg.responseJson)
     },

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -70,6 +70,10 @@ Cypress.Commands.add('stubUpdateDraftActionPlan', (id, responseJson) => {
   cy.task('stubUpdateDraftActionPlan', { id, responseJson })
 })
 
+Cypress.Commands.add('stubUpdateActionPlanActivity', (actionPlanId, activityId, responseJson) => {
+  cy.task('stubUpdateActionPlanActivity', { actionPlanId, activityId, responseJson })
+})
+
 Cypress.Commands.add('stubSubmitActionPlan', (id, responseJson) => {
   cy.task('stubSubmitActionPlan', { id, responseJson })
 })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1971,6 +1971,53 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('updateActionPlanActivity', () => {
+    it('updates and returns an updated action plan activity', async () => {
+      const draftActionPlanId = '6e8dfb5c-127f-46ea-9846-f82b5fd60d27'
+      const activityId = 'fd1b6653-ea7b-4e12-9d45-72ff9b1a3ea0'
+
+      await provider.addInteraction({
+        state: `a draft action plan with ID ${draftActionPlanId} exists and it has an activity with ID ${activityId}`,
+        uponReceiving: `a PATCH request to update the activity with id ${activityId}`,
+        withRequest: {
+          method: 'PATCH',
+          path: `/action-plan/${draftActionPlanId}/activities/${activityId}`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          body: {
+            description: 'do something totally different!',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: {
+            id: draftActionPlanId,
+            activities: [
+              {
+                id: activityId,
+                description: 'do something totally different!',
+                createdAt: Matchers.like('2020-12-07T20:45:21.986389Z'),
+              },
+            ],
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const draftActionPlan = await interventionsService.updateActionPlanActivity(
+        token,
+        draftActionPlanId,
+        activityId,
+        'do something totally different!'
+      )
+
+      expect(draftActionPlan.id).toBe(draftActionPlanId)
+      expect(draftActionPlan.activities[0].id).toEqual(activityId)
+      expect(draftActionPlan.activities[0].description).toEqual('do something totally different!')
+    })
+  })
+
   describe('submitDraftActionPlan', () => {
     const submittedActionPlan = {
       id: '486ba46a-0b57-46ab-82c0-d8c5c43710c6',

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -281,6 +281,20 @@ export default class InterventionsService {
     })) as ActionPlan
   }
 
+  async updateActionPlanActivity(
+    token: string,
+    actionPlanId: string,
+    activityId: string,
+    description: string
+  ): Promise<ActionPlan> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.patch({
+      path: `/action-plan/${actionPlanId}/activities/${activityId}`,
+      headers: { Accept: 'application/json' },
+      data: { description },
+    })) as ActionPlan
+  }
+
   async submitActionPlan(token: string, id: string): Promise<ActionPlan> {
     const restClient = this.createRestClient(token)
 


### PR DESCRIPTION
**this PR is dependent on https://github.com/ministryofjustice/hmpps-interventions-service/pull/394**

## What does this pull request do?

add interventions service method to update an action plan activity

## What is the intent behind these changes?

this API endpoint already exists - and we need to use it to allow editing submitted action plans. 
