### PR TITLE
IC-1745 allow editing existing action plan activities

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -76,7 +76,7 @@ export default function routes(router: Router, services: Services): Router {
     serviceProviderReferralsController.showActionPlanAddActivitiesForm(req, res)
   )
   post('/service-provider/action-plan/:id/add-activity/:number', (req, res) =>
-    serviceProviderReferralsController.addActivityToActionPlan(req, res)
+    serviceProviderReferralsController.addOrUpdateActionPlanActivity(req, res)
   )
   post('/service-provider/action-plan/:id/add-activities', (req, res) =>
     serviceProviderReferralsController.finaliseActionPlanActivities(req, res)

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesForm.test.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesForm.test.ts
@@ -3,7 +3,7 @@ import AddActionPlanActivitiesForm from './addActionPlanActivitiesForm'
 
 describe(AddActionPlanActivitiesForm, () => {
   describe('activityParamsForUpdate', () => {
-    it('returns the params to be sent to the backend, when the data in the body is valid', async () => {
+    it('returns the description, when the data in the body is valid', async () => {
       const form = await AddActionPlanActivitiesForm.createForm({
         body: {
           description: 'Attend a training course',
@@ -11,9 +11,21 @@ describe(AddActionPlanActivitiesForm, () => {
       } as Request)
 
       expect(form.activityParamsForUpdate).toEqual({
-        newActivity: {
+        description: 'Attend a training course',
+      })
+    })
+
+    it('returns the activity id, if it is present in the request', async () => {
+      const form = await AddActionPlanActivitiesForm.createForm({
+        body: {
           description: 'Attend a training course',
+          'activity-id': '20906bfd-c84d-48a5-9af2-5f3c25ab35ec',
         },
+      } as Request)
+
+      expect(form.activityParamsForUpdate).toEqual({
+        description: 'Attend a training course',
+        id: '20906bfd-c84d-48a5-9af2-5f3c25ab35ec',
       })
     })
   })
@@ -41,6 +53,29 @@ describe(AddActionPlanActivitiesForm, () => {
 
         expect(form.isValid).toEqual(false)
       })
+    })
+  })
+
+  describe('isUpdate', () => {
+    it('returns true when there is an activity id', async () => {
+      const form = await AddActionPlanActivitiesForm.createForm({
+        body: {
+          description: 'Attend a training course',
+          'activity-id': '123',
+        },
+      } as Request)
+
+      expect(form.isUpdate).toEqual(true)
+    })
+
+    it('returns false when there is no activity id', async () => {
+      const form = await AddActionPlanActivitiesForm.createForm({
+        body: {
+          description: 'Attend a training course',
+        },
+      } as Request)
+
+      expect(form.isUpdate).toEqual(false)
     })
   })
 

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesForm.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesForm.ts
@@ -1,5 +1,4 @@
 import { Request } from 'express'
-import { UpdateDraftActionPlanParams } from '../../../../services/interventionsService'
 import errorMessages from '../../../../utils/errorMessages'
 import { FormValidationError } from '../../../../utils/formValidationError'
 
@@ -10,12 +9,15 @@ export default class AddActionPlanActivitiesForm {
     return new AddActionPlanActivitiesForm(request)
   }
 
-  get activityParamsForUpdate(): Partial<UpdateDraftActionPlanParams> {
+  get activityParamsForUpdate(): Record<string, string> {
     return {
-      newActivity: {
-        description: this.request.body.description,
-      },
+      id: this.request.body['activity-id'],
+      description: this.request.body.description,
     }
+  }
+
+  get isUpdate(): boolean {
+    return this.activityParamsForUpdate.id != null
   }
 
   get isValid(): boolean {

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.test.ts
@@ -145,4 +145,19 @@ describe(AddActionPlanActivitiesPresenter, () => {
       })
     })
   })
+
+  describe('existingActivity', () => {
+    it('is populated when an activity exists for the activity number', () => {
+      const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
+      const actionPlan = actionPlanFactory.oneActivityAdded().build()
+      const presenter = new AddActionPlanActivitiesPresenter(
+        sentReferral,
+        [socialInclusionServiceCategory],
+        actionPlan,
+        1
+      )
+
+      expect(presenter.existingActivity).toEqual(actionPlan.activities[0])
+    })
+  })
 })

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
@@ -1,4 +1,4 @@
-import ActionPlan from '../../../../models/actionPlan'
+import ActionPlan, { Activity } from '../../../../models/actionPlan'
 import SentReferral from '../../../../models/sentReferral'
 import ServiceCategory from '../../../../models/serviceCategory'
 import { FormValidationError } from '../../../../utils/formValidationError'
@@ -29,5 +29,9 @@ export default class AddActionPlanActivitiesPresenter {
   readonly text = {
     title: `Add activity ${this.activityNumber} to action plan`,
     referredOutcomesHeader: `Referred outcomes for ${this.sentReferral.referral.serviceUser.firstName}`,
+  }
+
+  get existingActivity(): Activity | null {
+    return this.actionPlanPresenter.orderedActivities[this.activityNumber - 1] || null
   }
 }

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesView.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesView.ts
@@ -26,6 +26,7 @@ export default class AddActionPlanActivitiesView {
     hint: {
       text: 'Please write the details of the activity here.',
     },
+    value: this.presenter.existingActivity?.description,
     errorMessage: ViewUtils.govukErrorMessage(this.presenter.errorMessage),
   }
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -387,6 +387,33 @@ describe('GET /service-provider/action-plan/:actionPlanId/add-activity/:number',
       })
   })
 
+  it('prefills the text area for existing activities', async () => {
+    const referral = sentReferralFactory.assigned().build()
+    const draftActionPlan = actionPlanFactory.justCreated(referral.id).build({
+      activities: [
+        { id: 'bca57234-f2f3-4a25-8f25-b17008bd9052', description: 'Do a thing', createdAt: '2021-03-01T10:00:00Z' },
+        {
+          id: '084a64c2-e8f5-43de-be52-b65cf4425eb4',
+          description: 'Do another thing',
+          createdAt: '2021-03-01T11:00:00Z',
+        },
+      ],
+    })
+
+    interventionsService.getActionPlan.mockResolvedValue(draftActionPlan)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategoryFactory.build())
+
+    await request(app)
+      .get(`/service-provider/action-plan/${draftActionPlan.id}/add-activity/2`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Add activity 2 to action plan')
+        expect(res.text).toContain('Do another thing')
+        expect(res.text).toContain('084a64c2-e8f5-43de-be52-b65cf4425eb4')
+      })
+  })
+
   it('errors if the activity number is invalid', async () => {
     await request(app)
       .get(`/service-provider/action-plan/123/add-activity/invalid`)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -300,11 +300,20 @@ export default class ServiceProviderReferralsController {
     const form = await AddActionPlanActivitiesForm.createForm(req)
 
     if (form.isValid) {
-      await this.interventionsService.updateDraftActionPlan(
-        res.locals.user.token.accessToken,
-        req.params.id,
-        form.activityParamsForUpdate
-      )
+      if (form.isUpdate) {
+        // update an existing activity
+        await this.interventionsService.updateActionPlanActivity(
+          res.locals.user.token.accessToken,
+          req.params.id,
+          form.activityParamsForUpdate.id,
+          form.activityParamsForUpdate.description
+        )
+      } else {
+        // add a new activity
+        await this.interventionsService.updateDraftActionPlan(res.locals.user.token.accessToken, req.params.id, {
+          newActivity: { description: form.activityParamsForUpdate.description },
+        })
+      }
 
       const nextActivityNumber = activityNumber + 1
       res.redirect(`/service-provider/action-plan/${req.params.id}/add-activity/${nextActivityNumber}`)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -294,7 +294,7 @@ export default class ServiceProviderReferralsController {
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async addActivityToActionPlan(req: Request, res: Response): Promise<void> {
+  async addOrUpdateActionPlanActivity(req: Request, res: Response): Promise<void> {
     const activityNumber = this.parseActivityNumber(req.params.number)
 
     const form = await AddActionPlanActivitiesForm.createForm(req)

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -20,6 +20,10 @@
   <form method="post" action="{{ presenter.addActivityAction }}">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
+    {% if presenter.existingActivity %}
+      <input type="hidden" name="activity-id" value="{{ presenter.existingActivity.id }}">
+    {% endif %}
+
     {{ govukTextarea(addActivityTextareaArgs) }}
 
     {{ govukButton({ text: ('Save and add activity ' + presenter.activityNumber), classes: "govuk-button--secondary", attributes: { id: 'add-activity' }, preventDoubleClick: true }) }}


### PR DESCRIPTION
**this PR is dependent on PRs #528 and #527 so please review those first then ignore the overlapping commits**

## What does this pull request do?

allows editing existing action plan activities

## What is the intent behind these changes?

will eventually allow SPs to edit previously submitted action plans
