### PR TITLE
Present empty team details rather than hide them

### DIFF
--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -415,29 +415,6 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
         })
     })
   })
-  describe('when no team details can be found', () => {
-    it('does not show the team details', async () => {
-      staffDetails = deliusStaffDetailsFactory.build({ teams: [] })
-      communityApiService.getStaffDetails.mockResolvedValue(staffDetails)
-      await request(app)
-        .get(`/probation-practitioner/referrals/${sentReferral.id}/details`)
-        .expect(200)
-        .expect(res => {
-          expect(res.text).not.toContain('Team contact details')
-        })
-    })
-  })
-  describe('when no staff details can be found', () => {
-    it('does not show the team details', async () => {
-      communityApiService.getStaffDetails.mockResolvedValue(null)
-      await request(app)
-        .get(`/probation-practitioner/referrals/${sentReferral.id}/details`)
-        .expect(200)
-        .expect(res => {
-          expect(res.text).not.toContain('Team contact details')
-        })
-    })
-  })
 })
 
 describe('GET /probation-practitioner/referrals/:id/action-plan', () => {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -206,31 +206,6 @@ describe('GET /service-provider/referrals/:id/details', () => {
         })
     })
   })
-
-  describe('when no team details can be found', () => {
-    it('does not show the team details', async () => {
-      staffDetails = deliusStaffDetailsFactory.build({ teams: [] })
-      communityApiService.getStaffDetails.mockResolvedValue(staffDetails)
-      await request(app)
-        .get(`/service-provider/referrals/${sentReferral.id}/details`)
-        .expect(200)
-        .expect(res => {
-          expect(res.text).not.toContain('Team contact details')
-        })
-    })
-  })
-
-  describe('when no staff details can be found', () => {
-    it('does not show the team details', async () => {
-      communityApiService.getStaffDetails.mockResolvedValue(null)
-      await request(app)
-        .get(`/service-provider/referrals/${sentReferral.id}/details`)
-        .expect(200)
-        .expect(res => {
-          expect(res.text).not.toContain('Team contact details')
-        })
-    })
-  })
 })
 
 describe('GET /service-provider/referrals/:id/progress', () => {

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -170,6 +170,23 @@ describe(ShowReferralPresenter, () => {
           { key: 'Email address', lines: ['probation-team4692@justice.gov.uk'] },
         ])
       })
+      describe('when start date is empty', () => {
+        it('should display the team details', () => {
+          const staffDetails = deliusStaffDetailsFactory.build({
+            teams: [
+              {
+                telephone: '07890 123456',
+                emailAddress: 'probation-team4692@justice.gov.uk',
+              },
+            ],
+          })
+          const presenter = createShowReferralPresenterWithStaffDetails(staffDetails)
+          expect(presenter.probationPractitionerTeamDetails).toEqual([
+            { key: 'Phone', lines: ['07890 123456'] },
+            { key: 'Email address', lines: ['probation-team4692@justice.gov.uk'] },
+          ])
+        })
+      })
       describe('when ended date is null', () => {
         it('should display the team details', () => {
           const staffDetails = deliusStaffDetailsFactory.build({
@@ -188,9 +205,15 @@ describe(ShowReferralPresenter, () => {
         const presenterWithEmptyListTeams = createShowReferralPresenterWithStaffDetails(
           deliusStaffDetailsFactory.build({ teams: [] })
         )
-        expect(presenterWithEmptyListTeams.probationPractitionerTeamDetails).toEqual([])
+        expect(presenterWithEmptyListTeams.probationPractitionerTeamDetails).toEqual([
+          { key: 'Phone', lines: [] },
+          { key: 'Email address', lines: [] },
+        ])
         const presenterWithUndefinedTeams = createShowReferralPresenterWithStaffDetails({ username: 'username' })
-        expect(presenterWithUndefinedTeams.probationPractitionerTeamDetails).toEqual([])
+        expect(presenterWithUndefinedTeams.probationPractitionerTeamDetails).toEqual([
+          { key: 'Phone', lines: [] },
+          { key: 'Email address', lines: [] },
+        ])
       })
     })
     describe('when all teams are ended in the past', () => {
@@ -199,9 +222,13 @@ describe(ShowReferralPresenter, () => {
           teams: [deliusTeam.build({ endDate: '2021-01-01' })],
         })
         const presenter = createShowReferralPresenterWithStaffDetails(staffDetails)
-        expect(presenter.probationPractitionerTeamDetails).toEqual([])
+        expect(presenter.probationPractitionerTeamDetails).toEqual([
+          { key: 'Phone', lines: [] },
+          { key: 'Email address', lines: [] },
+        ])
       })
     })
+
     describe('when a team is ended in the future', () => {
       it('should show the team details', () => {
         const staffDetails = deliusStaffDetailsFactory.build({

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -65,7 +65,10 @@ export default class ShowReferralPresenter {
   get probationPractitionerTeamDetails(): SummaryListItem[] {
     const { activeTeam } = this
     return activeTeam == null
-      ? []
+      ? [
+          { key: 'Phone', lines: [] },
+          { key: 'Email address', lines: [] },
+        ]
       : [
           { key: 'Phone', lines: [`${activeTeam.telephone}`] },
           { key: 'Email address', lines: [`${activeTeam.emailAddress}`] },

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -47,10 +47,7 @@
       {{ govukSummaryList(serviceUserNeedsSummaryListArgs) }}
       <h2 class="govuk-heading-m">Referring probation practitioner details</h2>
       {{ govukSummaryList(probationPractitionerSummaryListArgs) }}
-      {% if probationPractitionerTeamSummaryListArgs.rows|length %}
-          <h2 class="govuk-heading-m">Team contact details</h2>
-          {{ govukSummaryList(probationPractitionerTeamSummaryListArgs) }}
-      {% endif %}
-
+      <h2 class="govuk-heading-m">Team contact details</h2>
+      {{ govukSummaryList(probationPractitionerTeamSummaryListArgs) }}
 
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Team details simply displays as blank rather than hiding the section

## What is the intent behind these changes?

Keep in line with existing pattern for empty details.


![image](https://user-images.githubusercontent.com/83066216/124096185-42ee0280-da52-11eb-9445-53fd5367f6b1.png)