### PR TITLE
IC-1887: Add deliusOfficeLocationCode onto Appointment model

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -643,59 +643,109 @@ describe('Service provider referrals dashboard', () => {
       cy.login()
     })
     describe('with valid inputs', () => {
-      it('should present no errors and display scheduled appointment', () => {
-        cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
-        cy.get('#date-day').type('24')
-        cy.get('#date-month').type('3')
-        cy.get('#date-year').type('2021')
-        cy.get('#time-hour').type('9')
-        cy.get('#time-minute').type('02')
-        cy.get('#time-part-of-day').select('AM')
-        cy.get('#duration-hours').type('1')
-        cy.get('#duration-minutes').type('15')
-        cy.contains('In-person meeting').click()
-        cy.get('#method-other-location-address-line-1').type('Harmony Living Office, Room 4')
-        cy.get('#method-other-location-address-line-2').type('44 Bouverie Road')
-        cy.get('#method-other-location-address-town-or-city').type('Blackpool')
-        cy.get('#method-other-location-address-county').type('Lancashire')
-        cy.get('#method-other-location-address-postcode').type('SY4 0RE')
+      describe('when booking for an In-Person Meeting - Other Location', () => {
+        it('should present no errors and display scheduled appointment', () => {
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.get('#date-day').type('24')
+          cy.get('#date-month').type('3')
+          cy.get('#date-year').type('2021')
+          cy.get('#time-hour').type('9')
+          cy.get('#time-minute').type('02')
+          cy.get('#time-part-of-day').select('AM')
+          cy.get('#duration-hours').type('1')
+          cy.get('#duration-minutes').type('15')
+          cy.contains('In-person meeting - Other locations').click()
+          cy.get('#method-other-location-address-line-1').type('Harmony Living Office, Room 4')
+          cy.get('#method-other-location-address-line-2').type('44 Bouverie Road')
+          cy.get('#method-other-location-address-town-or-city').type('Blackpool')
+          cy.get('#method-other-location-address-county').type('Lancashire')
+          cy.get('#method-other-location-address-postcode').type('SY4 0RE')
 
-        const scheduledAppointment = actionPlanAppointmentFactory.build({
-          ...appointment,
-          appointmentTime: '2021-03-24T09:02:02Z',
-          durationInMinutes: 75,
-          appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
-          appointmentDeliveryAddress: {
-            firstAddressLine: 'Harmony Living Office, Room 4',
-            secondAddressLine: '44 Bouverie Road',
-            townOrCity: 'Blackpool',
-            county: 'Lancashire',
-            postCode: 'SY4 0RE',
-          },
+          const scheduledAppointment = actionPlanAppointmentFactory.build({
+            ...appointment,
+            appointmentTime: '2021-03-24T09:02:02Z',
+            durationInMinutes: 75,
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+            appointmentDeliveryAddress: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY4 0RE',
+            },
+          })
+          cy.stubGetActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
+          cy.stubUpdateActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
+
+          cy.contains('Save and continue').click()
+
+          cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
+
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+
+          cy.get('#date-day').should('have.value', '24')
+          cy.get('#date-month').should('have.value', '3')
+          cy.get('#date-year').should('have.value', '2021')
+          cy.get('#time-hour').should('have.value', '9')
+          cy.get('#time-minute').should('have.value', '02')
+          // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
+          cy.get('#time-part-of-day').find('option:selected').should('have.text', 'AM')
+          cy.get('#duration-hours').should('have.value', '1')
+          cy.get('#duration-minutes').should('have.value', '15')
+          cy.get('#method-other-location-address-line-1').should('have.value', 'Harmony Living Office, Room 4')
+          cy.get('#method-other-location-address-line-2').should('have.value', '44 Bouverie Road')
+          cy.get('#method-other-location-address-town-or-city').should('have.value', 'Blackpool')
+          cy.get('#method-other-location-address-county').should('have.value', 'Lancashire')
+          cy.get('#method-other-location-address-postcode').should('have.value', 'SY4 0RE')
         })
-        cy.stubGetActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
-        cy.stubUpdateActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
+      })
 
-        cy.contains('Save and continue').click()
+      describe('when booking for an In-Person Meeting - NPS Location', () => {
+        it('should present no errors and display scheduled appointment', () => {
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.get('#date-day').type('24')
+          cy.get('#date-month').type('3')
+          cy.get('#date-year').type('2021')
+          cy.get('#time-hour').type('9')
+          cy.get('#time-minute').type('02')
+          cy.get('#time-part-of-day').select('AM')
+          cy.get('#duration-hours').type('1')
+          cy.get('#duration-minutes').type('15')
+          cy.contains('In-person meeting - NPS offices').click()
+          cy.get('#delius-office-location-code').select('Blackpool: Blackpool Probation Office')
 
-        cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
+          const scheduledAppointment = actionPlanAppointmentFactory.build({
+            ...appointment,
+            appointmentTime: '2021-03-24T09:02:02Z',
+            durationInMinutes: 75,
+            appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
+            appointmentDeliveryAddress: null,
+            npsOfficeCode: 'CRS0105',
+          })
+          cy.stubGetActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
+          cy.stubUpdateActionPlanAppointment(actionPlan.id, appointment.sessionNumber, scheduledAppointment)
 
-        cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.contains('Save and continue').click()
 
-        cy.get('#date-day').should('have.value', '24')
-        cy.get('#date-month').should('have.value', '3')
-        cy.get('#date-year').should('have.value', '2021')
-        cy.get('#time-hour').should('have.value', '9')
-        cy.get('#time-minute').should('have.value', '02')
-        // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
-        cy.get('#time-part-of-day').find('option:selected').should('have.text', 'AM')
-        cy.get('#duration-hours').should('have.value', '1')
-        cy.get('#duration-minutes').should('have.value', '15')
-        cy.get('#method-other-location-address-line-1').should('have.value', 'Harmony Living Office, Room 4')
-        cy.get('#method-other-location-address-line-2').should('have.value', '44 Bouverie Road')
-        cy.get('#method-other-location-address-town-or-city').should('have.value', 'Blackpool')
-        cy.get('#method-other-location-address-county').should('have.value', 'Lancashire')
-        cy.get('#method-other-location-address-postcode').should('have.value', 'SY4 0RE')
+          cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
+          // TODO: Add checks for NPS Office address on this page
+
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+
+          cy.get('#date-day').should('have.value', '24')
+          cy.get('#date-month').should('have.value', '3')
+          cy.get('#date-year').should('have.value', '2021')
+          cy.get('#time-hour').should('have.value', '9')
+          cy.get('#time-minute').should('have.value', '02')
+          // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
+          cy.get('#time-part-of-day').find('option:selected').should('have.text', 'AM')
+          cy.get('#duration-hours').should('have.value', '1')
+          cy.get('#duration-minutes').should('have.value', '15')
+          cy.get('#delius-office-location-code option:selected').should(
+            'have.text',
+            'Blackpool: Blackpool Probation Office'
+          )
+        })
       })
     })
 
@@ -727,7 +777,7 @@ describe('Service provider referrals dashboard', () => {
           cy.get('#time-part-of-day').select('AM')
           cy.get('#duration-hours').type('1')
           cy.get('#duration-minutes').type('15')
-          cy.contains('In-person meeting').click()
+          cy.contains('In-person meeting - Other locations').click()
           cy.contains('Save and continue').click()
           cy.contains('There is a problem').next().contains('Enter a value for address line 1')
           cy.contains('There is a problem').next().contains('Enter a postcode')
@@ -1346,7 +1396,7 @@ describe('Service provider referrals dashboard', () => {
       cy.get('#time-part-of-day').select('AM')
       cy.get('#duration-hours').type('1')
       cy.get('#duration-minutes').type('15')
-      cy.contains('In-person meeting').click()
+      cy.contains('In-person meeting - Other locations').click()
       cy.get('#method-other-location-address-line-1').type('Harmony Living Office, Room 4')
       cy.get('#method-other-location-address-line-2').type('44 Bouverie Road')
       cy.get('#method-other-location-address-town-or-city').type('Blackpool')

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "connect-redis": "^6.0.0",
         "cookie-session": "^1.4.0",
         "csurf": "^1.11.0",
+        "csvtojson": "^2.0.10",
         "date-fns": "^2.23.0",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
@@ -6512,6 +6513,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/csvtojson": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
+      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      },
+      "bin": {
+        "csvtojson": "bin/csvtojson"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/csvtojson/node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cypress": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.0.0.tgz",
@@ -10439,6 +10467,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -26744,6 +26777,26 @@
         }
       }
     },
+    "csvtojson": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
+      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
+    },
     "cypress": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.0.0.tgz",
@@ -29775,6 +29828,11 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "connect-redis": "^6.0.0",
     "cookie-session": "^1.4.0",
     "csurf": "^1.11.0",
+    "csvtojson": "^2.0.10",
     "date-fns": "^2.23.0",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",

--- a/server/data/reference-data/probation-offices-v0.csv
+++ b/server/data/reference-data/probation-offices-v0.csv
@@ -1,0 +1,276 @@
+probation_office_id,name,address,probation_region_id,gov_uk_url,delius_crs_location_id
+1,"Derby: Derwent Centre","Derwent Centre, 1 Stuart Street, Derby, DE1 2EQ",F,"https://www.gov.uk/guidance/derby-derwent-centre",
+2,"Derbyshire: Buxton Probation Office","Probation Office, Chesterfield House, 25 Hardwick Street, Buxton, Derbyshire, SK17 6DH",F,"https://www.gov.uk/guidance/derbyshire-chesterfield-house",CRS0032
+3,"Derbyshire: Chesterfield Probation Office","Probation Office, 3 Birmington Road, Chesterfield, Derbyshire, S41 7UG",F,"https://www.gov.uk/guidance/derbyshire-chesterfield-probation-office",
+4,"Derbyshire: Ilkeston Probation Office","Probation Office, 34 South Street, Ilkeston, Derbyshire, DE7 5QJ",F,"https://www.gov.uk/guidance/derbyshire-derbyshire-probation-office",
+5,"Leicestershire: Coalville Probation Office","Probation Office, 27 London Road, Coalville, Leicestershire, LE67 3JB",F,"https://www.gov.uk/guidance/leicestershire-coalville-probation-office",CRS0086
+6,"Leicestershire: Leicester Probation Office","Probation Office, 2 Cobden Street, Leicester, LE1 2LB",F,"https://www.gov.uk/guidance/leicestershire-leicester-probation-office",CRS0088
+7,"Leicestershire: Loughborough Probation Office","Probation Office, 12 Southfield Road, Loughborough, Leicestershire, LE11 2UZ",F,"https://www.gov.uk/guidance/leicestershire-loughborough-probation-office",CRS0089
+8,"Leicester: Mansfield House","Mansfield House, Police Station, 74 Belgrave Gate, Leicester, LE1 3GQ",F,"https://www.gov.uk/guidance/leicester-mansfield-house",
+9,"Leicestershire: Melton Mowbray Probation Office","Probation Office, Burton Street, Melton Mowbray, Leicestershire, LE13 1GH",F,"https://www.gov.uk/guidance/leicestershire-melton-mowbray-probation-office",
+10,"Lincolnshire: Boston Probation Office","Probation Office, Unit 1 The Carlton Centre, Carlton Road, Boston, Lincolnshire, PE21 8LN",F,"https://www.gov.uk/guidance/lincolnshire-boston-probation-office",CRS0093
+11,"Lincolnshire: Grantham Probation Office","Probation Office, Grange House, 46 Union Street, Grantham, Lincolnshire, NG31 6NZ",F,"https://www.gov.uk/guidance/lincolnshire-grange-house",CRS0094
+12,"Lincolnshire: Lincoln Probation Office","Probation Office, 8 Corporation Street, Lincoln, Lincolnshire, LN2 1HN",F,"https://www.gov.uk/guidance/lincolnshire-lincoln-probation-office",CRS0095
+13,"Lincolnshire: Skegness Probation Office","Skegness Probation Office, The Town Hall, North Parade, Skegness, Lincolnshire, PE25 1DA",F,"https://www.gov.uk/guidance/lincolnshire-the-town-hall",
+14,"Newark: Castle House","Newark & Sherwood District Council Offices, Probation Office, Castle House, Great North Road, Newark, NG24 1BY",F,"https://www.gov.uk/guidance/newark-castle-house",
+15,"Nottinghamshire: Nottingham Probation Office","Probation Office, 9 Castle Quay, Nottingham, Nottinghamshire, NG7 1FW",F,"https://www.gov.uk/guidance/nottinghamshire-nottingham-probation-office",CRS0108
+16,"Nottinghamshire: Mansfield Probation Office","Probation Office, Arrival Square, Rosemary Street, Mansfield, Nottinghamshire, NG18 1LP",F,"https://www.gov.uk/guidance/nottinghamshire-mansfield-probation-office",CRS0110
+17,"Nottinghamshire: Worksop Probation Office","Probation Office, 11 Newcastle Street, Worksop, Nottinghamshire, S80 2AS",F,"https://www.gov.uk/guidance/nottinghamshire-worksop-probation-office",
+18,"Bedford: Bedford Probation Office","Probation Office, 41 Harpur Street, Bedford, Bedfordshire, MK40 1LY",I,"https://www.gov.uk/guidance/bedford-bedford-probation-office",CRS0002
+19,"Cambridgeshire: Cambridge Probation Office","Cambridge Probation Office, 27 Warkworth Street, Cambridge, Cambridgeshire, CB1 1EG",I,"https://www.gov.uk/guidance/cambridgeshire-cambridge-probation-office",CRS0014
+20,"Cambridgeshire: Huntingdon Probation Office","Huntingdon Probation Office, Godwin House, George Street, Huntingdon, Cambridgeshire, PE29 3BD",I,"https://www.gov.uk/guidance/cambridgeshire-godwin-house",CRS0015
+21,"Chelmsford: Chelmsford Probation Office","Probation Office, Gemini House, Lower Ground Floor, 88 London New Road, Chelmsford, CM2 0YN",I,"https://www.gov.uk/guidance/chelmsford-chelmsford-probation-office",CRS0098
+22,"Colchester: Colchester Probation Office","Colchester Probation Service, Portal House, 29 Southway, Colchester, Essex, CO2 7BA",I,"https://www.gov.uk/guidance/colchester-colchester-probation-office",CRS0099
+23,"Essex: Carraway House","Carraway House, Durham Road, Basildon, Essex, SS15 6PH",I,"https://www.gov.uk/guidance/essex-carraway-house",CRS0118
+24,"Harlow: Harlow Probation Office","Probation Office, Centenary House, 4 Mitre Buildings, Kitson Way, Harlow, Essex, CM20 1DR",I,"https://www.gov.uk/guidance/harlow-harlow-probation-office",CRS0100
+25,"Hertfordshire: East Hertfordshire Probation Centre","East Hertfordshire Probation Centre, Bishops College, Churchgate, Cheshunt, Hertfordshire, EN8 9XL",I,"https://www.gov.uk/guidance/hertfordshire-east-hertfordshire-probation-centre",CRS0078
+26,"Hertfordshire: Mid Herts Probation Centre","Mid Herts Probation Centre, 62-72 Victoria Street, St Alabns, Hertfordshire, AL1 3XH",I,"https://www.gov.uk/guidance/hertfordshire-mid-herts-probation-centre",CRS0080
+27,"Hertfordshire: North Hertfordshire Probation Centre","North Hertfordshire Probation Centre, Argyle House, Argyle Way, Stevenage, Hertfordshire, SG1 2AD",I,"https://www.gov.uk/guidance/hertfordshire-north-hertfordshire-probation-centre",CRS0081
+28,"Hertfordshire: South West Hertfordshire Probation Centre","South West Hertfordshire Probation Centre, Leet Court, 16-22 King Street, Watford, Hertfordshire, WD18 0BN",I,"https://www.gov.uk/guidance/hertfordshire-south-west-hertfordshire-probation-centre",CRS0082
+29,"Luton: Luton Probation Office","Probation Office, Clemitson House, 14 Upper George Street, Luton, LU1 2RP",I,"https://www.gov.uk/guidance/luton-frank-lord-house",
+30,"Norfolk: Centenary House","Centenary House, 19 Palace Street, Norwich, Norfolk, NR3 1RT",I,"https://www.gov.uk/guidance/norfolk-centenary-house",CRS0097
+31,"Norfolk: Purfleet Quay Probation Office","Probation Office, Purfleet Quay, Kings Lynn, Norfolk, PE30 1HP",I,"https://www.gov.uk/guidance/norfolk-purfleet-quay-probation-office",
+32,"Northamptonshire: Northamptonshire Probation Office","Northamptonshire Probation Office, 20 Oxford Street, Wellingborough, Northamptonshire, NN8 4HY",I,"https://www.gov.uk/guidance/northamptonshire-northamptonshire-probation-office",
+33,"Northamptonshire: Walter Tull House","Walter Tull House, 43-47 Bridge Street, Northampton, NN1 1NS",I,"https://www.gov.uk/guidance/northamptonshire-walter-tull-house",CRS0107
+34,"Peterborough: Peterborough Magistrates' Court","Peterborough Magistrates' Court, Bridge Street, Peterborough, PE1 1ED",I,"https://www.gov.uk/guidance/peterborough-peterborough-magistrates-court",CRS0017
+35,"Southend-on-Sea: Tylers House","Tylers House, 3rd Floor, Tylers Avenue, Southend on sea, SS1 2BB",I,"https://www.gov.uk/guidance/southend-on-sea-tylers-house",
+36,"Suffolk: Bury Saint Edmunds Probation Office","Probation Office, Millennium House, Dettingen Way, Blenheim Industrial Estate, Bury St Edmunds, Suffolk, IP33 3TU",I,"https://www.gov.uk/guidance/suffolk-bury-saint-edmunds-probation-office",CRS0127
+37,"Suffolk: Lowestoft Probation Office","Probation Office, 203 Whapload Road, Lowestoft, Suffolk, NR32 1UL",I,"https://www.gov.uk/guidance/suffolk-lowestoft-probation-office",CRS0131
+38,"Suffolk: Peninsular House","Peninsular House, 11-13 Lower Brook Street, Ipswich, Suffolk, IP4 1AQ",I,"https://www.gov.uk/guidance/suffolk-peninsular-house",CRS0128
+39,"Thurrock: The Old Courthouse","Unit A02, The Old Courthouse, Orsett Road, Essex, RM17 5DD",I,"https://www.gov.uk/guidance/thurrock-the-old-courthouse",
+40,"Bury: Bury Probation Office","Probation Office, Argyle & Balmoral House, 29 Castlecroft Road, Bury, Lancashire, BL9 0LN",L,"https://www.gov.uk/guidance/bury-bury-probation-office",
+41,"Greater Manchester: Bolton Probation Office","Probation Office, St. Helena Mill, St. Helena Road, Bolton, BL1 2JS",L,"https://www.gov.uk/guidance/greater-manchester-bolton-probation-office",
+42,"Greater Manchester: Moss Side Probation Office","Probation Office, 87 Moss Lane West, Manchester, M15 5PE",L,"https://www.gov.uk/guidance/greater-manchester-moss-side-probation-office",
+43,"Greater Manchester: Victoria Park Probation Centre","Victoria Park Probation Centre, Laindon Road, Manchester, M14 5YJ",L,"https://www.gov.uk/guidance/greater-manchester-victoria-park-probation-centre",
+44,"Oldham: Oldham Probation Office","Probation Office, 128 Rochdale Road, Oldham, OL1 2JG",L,"https://www.gov.uk/guidance/oldham-oldham-probation-office",
+45,"Rochdale: Rochdale Probation Office","Probation Office, 195 Drake Street, Rochdale, Lancashire, OL11 1EF",L,"https://www.gov.uk/guidance/rochdale-rochdale-probation-office",
+46,"Salford: Salford Probation Office","Probation Office, 2 Redwood Street, Salford, M6 6PF",L,"https://www.gov.uk/guidance/salford-salford-probation-office",
+47,"Stockport: Stockport Probation Office","Probation Office, 19 High Street, Stockport, Cheshire, SK1 1EG",L,"https://www.gov.uk/guidance/stockport-stockport-probation-office",
+48,"Tameside: Ashton Probation Office","Ashton Probation Office, Roz Hamilton House, 8 Lees Street, Ashton-Under-Lyne, OL6 8NT",L,"https://www.gov.uk/guidance/tameside-ashton-probation-office",
+49,"Wigan: Atherton Probation Office","Probation Office, 81 Gloucester Street, Atherton, Greater Manchester, M46 0JS",L,"https://www.gov.uk/guidance/wigan-atherton-probation-office",
+50,"Arun: Meadowfield House","Meadowfield House, East Street, Littlehampton, West Sussex, BN17 6AU",K,"https://www.gov.uk/guidance/arun-meadowfield-house",CRS0155
+51,"Brighton and Hove: Brighton Probation Office","Probation Office, Lancaster House, 47 Grand Parade, Brighton, East Sussex, BN2 9QA",K,"https://www.gov.uk/guidance/brighton-and-hove-brighton-probation-office",CRS0055
+52,"Canterbury: Ralphs Centre","Ralphs Centre, 24 Maynard Road, Wincheap, Canterbury, Kent, CT1 3RH",K,"https://www.gov.uk/guidance/canterbury-ralphs-centre",CRS0049
+53,"Crawley: Goff's Park House","Goff's Park House, Old Horsham road, Crawley, Sussex, RH11 8PB",K,"https://www.gov.uk/guidance/crawley-goffs-park-house",
+54,"Guildford: College House","College House, 89 Woodbridge Road, Guildford, Surrey, GU1 4RS",K,"https://www.gov.uk/guidance/guildford-college-house",CRS0132
+55,"Hastings: St. Leonards Probation Office","Probation Office, Crozier House, 1a Shepherd Street, St Leonards, East Sussex, TN38 0ET",K,"https://www.gov.uk/guidance/hastings-st-leonards-probation-office",CRS0058
+56,"Kent: Joynes House","Joynes House, New Road, Gravesend, Kent, DA11 0AT",K,"https://www.gov.uk/guidance/kent-joynes-house",
+57,"Kent: Maidstone Probation Office","Probation Office, 54-58 College Road, Maidstone, Kent, ME15 6SJ",K,"https://www.gov.uk/guidance/kent-maidstone-probation-office",CRS0151
+58,"Lewes & Eastbourne: Eastbourne Probation Office","Probation Office, 35 Old Orchard Road, Eastbourne, East Sussex, BN21 1DD",K,"https://www.gov.uk/guidance/lewes-eastbourne-eastbourne-probation-office",CRS0056
+59,"Medway: Chatham Probation Office","Chatham Probation Office, 27-35 New Road, Chatham, Kent, ME4 4QQ",K,"https://www.gov.uk/guidance/medway-chatham-probation-office",CRS0149
+60,"Reigate & Banstead: Redhill Probation Office","Probation Office, Forum House, 41-51 Brighton Road, Redhill, RH1 6YS",K,"https://www.gov.uk/guidance/reigate-banstead-redhill-probation-office",
+61,"Shepway: Folkestone Probation Office","Folkestone Probation Office, The Law Courts, Castle Hill Avenue, Folkestone, Kent, CT20 2DH",K,"https://www.gov.uk/guidance/shepway-folkestone-probation-office",
+62,"Spelthorne: Swan House","Swan House, Knowle Green, Staines, Surrey, TW18 1AJ",K,"https://www.gov.uk/guidance/spelthorne-swan-house",CRS0135
+63,"Thanet: Darlincton House","Darlincton House, 38-40 Grosvenor Place, Margate, Kent, CT9 1UW",K,"https://www.gov.uk/guidance/thanet-darlincton-house",CRS0050
+64,"Worthing: Worthing Probation Office","Probation Office, 4 Farncombe Road, Worthing, Sussex, BN11 2BE",K,"https://www.gov.uk/guidance/worthing-worthing-probation-office",CRS0156
+65,"Barnet: Hendon Probation Office","Probation Office, Denmark House, Suit B West Hendon Broadway, London, NW9 7BW",J,"https://www.gov.uk/guidance/barnet-hendon-probation-office",CRS0074
+66,"Bexley: Bexley Magistrates' Court","Bexley Magistrates' Court, Norwich Place, Bexleyheath, Kent, DA6 7ND",J,"https://www.gov.uk/guidance/bexley-bexley-magistrates-court",CRS0061
+67,"Brent: Willesden Probation Office","Probation Office, 440 High Road, Willesden, London, NW10 2DW",J,"https://www.gov.uk/guidance/brent-willesden-probation-office",CRS0011
+68,"Bromley: Orpington Probation Office","Probation Office, 6 Church Hill, Orpington, Kent, BR6 0HE",J,"https://www.gov.uk/guidance/bromley-orpington-probation-office",CRS0091
+69,"Croydon: Church House","Church House, 1A Old Palace Road, Croydon, Surrey, CR0 1AX",J,"https://www.gov.uk/guidance/croydon-church-house",CRS0023
+70,"Ealing: Acton Probation Office","Acton Probation Office, 2 & 4 Birkbeck Road, Acton, London, W3 6BE",J,"https://www.gov.uk/guidance/ealing-acton-probation-office",
+71,"Ealing: Leeland House","Leeland House, 12A Leeland Road, Ealing, London, W13 9HH",J,"https://www.gov.uk/guidance/ealing-leeland-house",CRS0042
+72,"Enfield: Old Court House","Old Court House, Windmill Hill, Enfield, Middlesex, EN2 6SA",J,"https://www.gov.uk/guidance/enfield-old-court-house",CRS0059
+73,"Hackney: Reed House","Reed House, 2-4 Rectory Road, London, N16 7QS",J,"https://www.gov.uk/guidance/hackney-reed-house",CRS0066
+74,"Hammersmith & Fulham: Shepherd's Bush Probation Office","Probation Office, 191a Askew Road, London, W12 9AX",J,"https://www.gov.uk/guidance/hammersmith-fulham-shepherds-bush-probation-office",CRS0067
+75,"Haringey: Haringey Probation Office","Probation Service, 90 Lansdowne Road, Tottenham, London, N17 9XX",J,"https://www.gov.uk/guidance/haringey-haringey-probation-office",
+76,"Havering: Pioneer House","Pioneer House, North Street, Hornchurch, Essex, RM11 1QZ",J,"https://www.gov.uk/guidance/havering-pioneer-house",CRS0001
+77,"Hillingdon: Uxbridge Magistrates' Court","Uxbridge Magistrates' Court, The Court House, Harefield Road, Uxbridge, Middlesex, UB8 1PQ",J,"https://www.gov.uk/guidance/hillingdon-uxbridge-magistrates-court",CRS0043
+78,"Hounslow: Hounslow Probation Office","Hounslow Probation Office, Banklabs House, 41a Cross Lances Road, Hounslow, London, TW3 2AD",J,"https://www.gov.uk/guidance/hounslow-hounslow-probation-office",CRS0083
+79,"Islington: 401 St Johns Street","401 St Johns Street, London, EC1V 4RW",J,"https://www.gov.uk/guidance/islington-401-st-johns-street",CRS0018
+80,"Lambeth: Stockwell Road Probation Office","Probation Office, 117-131 Stockwell Road, Ferndale, London, SW9 9TN",J,"https://www.gov.uk/guidance/lambeth-stockwell-road-probation-office",CRS0085
+81,"Lewisham: Lewisham Probation Office","Probation Office, 208 Lewisham High Street, Lewisham, London, SE13 6JP",J,"https://www.gov.uk/guidance/lewisham-lewisham-probation-office",CRS0092
+82,"Merton: Martin Harknett House","Martin Harknett House, 27 High Path, London, SW19 2JL",J,"https://www.gov.uk/guidance/merton-martin-harknett-house",CRS0139
+83,"Newham: Capital House","Capital House, 134-138 Romford Road, London, E15 4LD",J,"https://www.gov.uk/guidance/newham-capital-house",CRS0096
+84,"Redbridge: Oakland Court","Oakland Court, 277-289 High Road, Ilford, Essex, IG1 1QQ",J,"https://www.gov.uk/guidance/redbridge-oakland-court",CRS0114
+85,"Southwark: Mitre House – Great Dover Street","Mitre House, 2 Great Dover Street, London, SE1 4XW",J,"https://www.gov.uk/guidance/southwark-mitre-house",CRS0122
+86,"Tower Hamlets: 337 Cambridge Heath Road","Ground Floor, 377 Cambridge Heath Road, London, E2 9RD",J,"https://www.gov.uk/guidance/tower-hamlets-337-cambridge-heath-road",CRS0136
+87,"Tower Hamlets: Thames Magistrates' Courts","Thames Magistrates' Courts, Central Criminal Court, 50 Mornington Grove, Bow, London, E3 4NS",J,"https://www.gov.uk/guidance/tower-hamlets-thames-magistrates-courts",
+88,"Waltham Forest: Rowan House","Rowan House, 1 Cecil Road, London, E11 3HF",J,"https://www.gov.uk/guidance/waltham-forest-rowan-house",CRS0115
+89,"Wandsworth: East Hill Probation Office","Probation Office, 79 East Hill, London, SW18 2QE",J,"https://www.gov.uk/guidance/wandsworth-east-hill-probation-office",CRS0140
+90,"County Durham: Darlington Probation Office","Probation Office, 9 Corporation Road, Darlington, Co Durham, DL3 6TH",A,"https://www.gov.uk/guidance/county-durham-darlington-probation-office",
+91,"County Durham: Durham City Probation Office","Probation Office, Framwell House, Framwellgate, Durham, DH1 5SU",A,"https://www.gov.uk/guidance/county-durham-framwell-house",
+92,"County Durham: Newton Aycliffe Probation Office","Probation Office, Greenwell Road, Newton Aycliffe, County Durham, DL5 4DH",A,"https://www.gov.uk/guidance/county-durham-newton-aycliffe-probation-office",
+93,"County Durham: Peterlee Probation Office","Probation Office, Durham House, 60 Yoden Way, Peterlee, County Durham, SR8 1BS",A,"https://www.gov.uk/guidance/county-durham-durham-house",
+94,"Gateshead: Gateshead Probation Office","Probation Office, Warwick Street, Gateshead, Tyne and Wear, NE8 1PZ",A,"https://www.gov.uk/guidance/gateshead-gateshead-probation-office",
+95,"Newcastle: Newcastle Probation Office","Probation Office, 78 St James' Boulevard, Newcastle upon Tyne, NE1 4BN",A,"https://www.gov.uk/guidance/newcastle-newcastle-probation-office",
+96,"Northumberland: Ashington Probation Office","Probation Office, South View, Ashington, Northumberland, NE63 0RY",A,"https://www.gov.uk/guidance/northumberland-ashington-probation-office",
+97,"North Tyneside: Wallsend Probation Office","Probation Office, 13 Warwick Road, Wallsend, NE28 6SE",A,"https://www.gov.uk/guidance/north-tyneside-council-wallsend-probation-office",
+98,"South Tyneside: South Shields Probation Office","Probation Office, Secretan Way, South Shields, NE33 1HG",A,"https://www.gov.uk/guidance/south-tyneside-south-shields-probation-office",
+99,"Sunderland: Pennywell Probation Office","Pennywell Probation Office, Hylton Road, Sunderland, Tyne & Wear, SR4 8DS",A,"https://www.gov.uk/guidance/sunderland-pennywell-probation-office",
+100,"Tees Valley: Advance House","Ground and First Floor Advance House, St Marks Court, Thornaby, Stockton-on-Tees, TS17 6QX",A,"https://www.gov.uk/guidance/tees-valley-advance-house",
+101,"Tees Valley: Middlesbrough Probation Office","Probation Office, 156 Borough Road, Middlesbrough, TS1 2EJ",A,"https://www.gov.uk/guidance/tees-valley-middlesbrough-probation-office",
+102,"Tees Valley: South Bank Probation Office","Probation Office, Mowlam House, 1 Oxford Street, Middlesbrough, TS6 6DF",A,"https://www.gov.uk/guidance/tees-valley-south-bank-probation-office",
+103,"Alderdale: Progress House","Progress House, Regents Court, Guard Street, Workington, CA14 4EW",B,"https://www.gov.uk/guidance/alderdale-progress-house",CRS0027
+104,"Barrow: Barrow-in-Furness Probation Office","Probation Office, 77-79 Duke St & 57 St Vincent St, Barrow-in-Furness, Cumbria, LA14 1RP",B,"https://www.gov.uk/guidance/barrow-barrow-in-furness-probation-office",CRS0024
+105,"Blackburn with Darwen: 13-15 Wellington Street","13-15 Wellington Street, Blackburn, BB1 8AF",B,"https://www.gov.uk/guidance/blackburn-with-darwen-13-15-wellington-street",CRS0010
+106,"Blackburn with Darwen: 40B Preston New Road","40B Preston New Road, Blackburn, BB2 6AY",B,"https://www.gov.uk/guidance/blackburn-with-darwen-blackburn-probation-office",
+107,"Blackpool: Blackpool Probation Office","Probation Office, 384 Talbot Road, Blackpool, Lancashire, FY3 7AT",B,"https://www.gov.uk/guidance/blackpool-blackpool-probation-office",CRS0105
+108,"Carlisle: Georgian House","Georgian House, Lowther Street, Carlisle, CA3 8DR",B,"https://www.gov.uk/guidance/carlisle-georgian-house",CRS0025
+109,"Cheshire East: Cedric Fullwood House","Cedric Fullwood House, 14 Gateway, Crewe, Cheshire, CW1 6YY",B,"https://www.gov.uk/guidance/cheshire-east-cedric-fullwood-house",CRS0046
+110,"Cheshire East: Macclesfield Probation Office","Probation Office, Brunswick Street, Macclesfield, SK10 1HQ",B,"https://www.gov.uk/guidance/cheshire-east-macclesfield-probation-office",CRS0047
+111,"Cheshire West and Chester: Jupiter House","Jupiter House, Jupiter Drive, Blacon, Chester, CH1 4QS",B,"https://www.gov.uk/guidance/cheshire-west-and-chester-jupiter-house",CRS0146
+112,"Cheshire West and Chester: Northwich Police Station","Northwich Police Station, Chester Way, Northwich, CW9 5EP",B,"https://www.gov.uk/guidance/cheshire-west-and-chester-northwich-police-station",CRS0147
+113,"Eden: Penrith Probation Office","Probation Office, Clint Mill, Corn Market, Penrith, Cumbria, CA11 7HW",B,"https://www.gov.uk/guidance/eden-penrith-probation-office",
+114,"Halton: Runcorn Probation Office","Norton House, Crown Gate, Palacefields, Runcorn, Cheshire, WA7 2UR",B,"https://www.gov.uk/guidance/halton-runcorn-probation-office",CRS0141
+115,"Knowsley: Knowsley Probation Centre","Probation Office, Poplar House, Poplar Bank, Huyton, Merseyside, L36 9US",B,"https://www.gov.uk/guidance/knowsley-knowsley-probation-centre",CRS0084
+116,"Lancashire: Burnley Probation Office","Probation Office, Queens Lancashire Way, Burnley, BB11 1HA",B,"https://www.gov.uk/guidance/lancashire-burnley-probation-office",
+117,"Lancashire: Chorley Probation Office","Probation Office, 2 Bolton Street, Chorley, PR7 3BB",B,"https://www.gov.uk/guidance/lancashire-chorley-probation-office",
+118,"Lancashire: Lancaster Probation Office","Probation Office, 41 West Road, Lancaster, LA1 5NU",B,"https://www.gov.uk/guidance/lancashire-lancaster-probation-office",CRS0106
+119,"Lancashire: Preston Probation Office","Probation Office, 50 Avenham Street, Preston, PR1 3BN",B,"https://www.gov.uk/guidance/lancashire-preston-probation-office",CRS0020
+120,"Lancashire: Skelmersdale Probation Office","Probation Office, High Street, Chapel House, Skelmersdale, Lancashire, WN8 8AP",B,"https://www.gov.uk/guidance/lancashire-chapel-house",
+121,"Lancashire: St Stephen House","St Stephen House, Bethesda Street, Burnley, Lancashire, BB11 1QW",B,"https://www.gov.uk/guidance/lancashire-st-stephen-house",CRS0054
+122,"Liverpool: 6-8 Temple Court","6-8 Temple Court, Liverpool, L2 6PY",B,"https://www.gov.uk/guidance/liverpool-6-8-temple-court",
+123,"Liverpool: North Liverpool Probation Centre","North Liverpool Probation Centre, Cheadle Avenue, Green Lane, Liverpool, L13 3AE",B,"https://www.gov.uk/guidance/liverpool-north-liverpool-probation-centre",CRS0101
+124,"Liverpool: Resettle","Resettle, Unit 1, 3 De Havilland Drive, Estuary Business Park, Liverpool, L24 8RN",B,"https://www.gov.uk/guidance/liverpool-resettle",
+125,"Sefton: Bootle Probation Office","Probation Office, 4 Trinity Road, Bootle, Merseyside, L20 7BE",B,"https://www.gov.uk/guidance/sefton-bootle-probation-office",CRS0116
+126,"St Helens: St. Mary's House","St. Mary's House, 50 Church Street, St. Helens, Merseyside, WA10 1AP",B,"https://www.gov.uk/guidance/st-helens-st-marys-house",
+127,"South Lakeland: Kendal Probation Office","Probation Office, Busher Lodge, 149 Stricklandgate, Kendal, Cumbria, LA9 4RF",B,"https://www.gov.uk/guidance/south-lakeland-kendal-probation-office",CRS0026
+128,"Warrington: Warrington Probation Office","Probation Office, 10a Friars Gate, Warrington, Cheshire, WA1 2RW",B,"https://www.gov.uk/guidance/warrington-warrington-probation-office",CRS0142
+129,"Wirral: Wirral Probation Office","Probation Office, 40 Europa Boulevard, Birkenhead, Merseyside, CH41 4PE",B,"https://www.gov.uk/guidance/wirral-wirral-probation-office",CRS0157
+130,"Basingstoke and Deane: St Clements House","St. Clements House, Alencon Link, Basingstoke, Hampshire, RG21 7SB",H,"https://www.gov.uk/guidance/basingstoke-and-deane-st-clements-house",CRS0068
+131,"Bicester: Bicester Probation Office","Probation Office, 1a Kingsclere Road, Bicester, Oxfordshire, OX26 2QD",H,"https://www.gov.uk/guidance/bicester-bicester-probation-office",CRS0111
+132,"Bracknell Forest: James Glaisher House","James Glaisher House, Grenville Place, Bracknell, Berkshire, RG12 1BP",H,"https://www.gov.uk/guidance/bracknell-forest-james-glaisher-house",CRS0044
+133,"Buckinghamshire:  Wynne Jones Centre","2A Wynne Jones Centre, Walton Road, Aylesbury, Buckinghamshire, HP21 7RL",H,"https://www.gov.uk/guidance/buckinghamshire-wynne-jones-centre",
+134,"Hart: Imperial House","Imperial House, 2 Grosvenor Road, Aldershot, Hampshire, GU11 1DP",H,"https://www.gov.uk/guidance/hart-imperial-house",
+135,"Havant: Havant Probation Office","Havant Probation Office, The Court House, Elmleigh Road, Havant, PO9 2AS",H,"https://www.gov.uk/guidance/havant-havant-probation-office",CRS0069
+136,"Isle of Wight: Newport Probation Office","Newport Probation Office, 8 Sea Street, Newport, Isle of Wight, PO30 5BN",H,"https://www.gov.uk/guidance/isle-of-wight-newport-probation-office",CRS0070
+137,"New Forest: Island House","Island House, Priestlands Place, Lymington, Hampshire, SO41 9GA",H,"https://www.gov.uk/guidance/new-forest-island-house",CRS0072
+138,"Milton Keynes: Milton Keynes Magistrates' Court","Milton Keynes Magistrates' Court, 301 Silbury Boulevard, Milton Keynes, MK9 2YH",H,"https://www.gov.uk/guidance/milton-keynes-milton-keynes-magistrates-court",CRS0013
+139,"Oxfordshire: Oxford Probation Office","Probation Office, Macmillan House, 38 St Aldates, Oxford, Oxfordshire, OX1 1BN",H,"https://www.gov.uk/guidance/oxfordshire-oxford-probation-office",CRS0113
+140,"Portsmouth: Portsmouth Probation Office","Probation Office, 52 Isambard Brunel Road, Portsmouth, Hampshire, PO1 2BD",H,"https://www.gov.uk/guidance/portsmouth-portsmouth-probation-office",CRS0071
+141,"Reading: Greyfriars House","Greyfriars House, 30 Greyfriars Road, Reading, Berkshire, RG1 1PE",H,"https://www.gov.uk/guidance/reading-greyfriars-house",CRS0145
+142,"Slough: Slough Probation Office","Probation Office, Revelstoke House, Chalvey Park, Slough, Berkshire, SL1 2HF",H,"https://www.gov.uk/guidance/slough-slough-probation-office",CRS0045
+143,"Southampton: Old Bank House","Old Bank House, 66-68 London Road, Southampton, Hampshire, SO15 2AJ",H,"https://www.gov.uk/guidance/southampton-old-bank-house",
+144,"Southampton: Town Quay House","Town Quay House, 7 Town Quay, Waterside Place, Southampton, Hampshire, SO14 2ET",H,"https://www.gov.uk/guidance/southampton-town-quay-house",
+145,"Bath & North East Somerset: Bath Probation Office","Bath Probation Office, The Old Convent, 35 Pulteney Road, Bath, Avon, BA2 4JE",G,"https://www.gov.uk/guidance/avon-avon-probation-office",
+146,"Bournemouth, Christchurch & Poole: Bournemouth Probation Office","Bournemouth Probation Office, 7 Madeira Road, Bournemouth, Dorset, BH1 1QL",G,"https://www.gov.uk/guidance/bournemouth-bournemouth-probation-office",
+147,"Bournemouth, Christchurch & Poole: Poole Probation Office","Poole Probation Office, 63 Commercial Road, Poole, Dorset, BH14 0JB",G,"https://www.gov.uk/guidance/bournemouth-christchurch-and-poole-poole-probation-office",
+148,"Bristol: Bridewell Police Station","Bridewell Police Station, 1 Bridewell Street, Bristol, BS1 2AA",G,"https://www.gov.uk/guidance/bristol-bridewell-police-station",
+149,"Bristol: Bristol Probation Office","Bristol Probation Office, Court Building, Marlborough Street, Bristol, BS1 3NU",G,"https://www.gov.uk/guidance/bristol-bristol-probation-office",
+150,"Cornwall: Bodmin Reporting Centre","Probation Reporting Centre, Cornwall Hospice Care, 1-3 Normandy Way, Bodmin, PL31 1ET",G,"https://www.gov.uk/guidance/cornwall-bodmin-reporting-centre",
+151,"Cornwall: Camborne Probation Office","Camborne Probation Office, Endsleigh House, Roskear, Camborne, Cornwall, TR14 8DW",G,"https://www.gov.uk/guidance/north-devon-endsleigh-house",
+152,"Cornwall: St Austell Probation Office","St. Austell Probation Office, 3 Kings Avenue, St Austell, Cornwall, PL25 4TT",G,"https://www.gov.uk/guidance/cornwall-st-austell-probation-office",
+153,"Cornwall: Truro Probation Office","Truro Probation Office, Tremorvah Wood Land (off Mitchell Hill), Truro, Cornwall, TR1 1HZ",G,"https://www.gov.uk/guidance/cornwall-truro-probation-office",CRS0021
+154,"Devon: Barnstaple Probation Office","Barnstaple Probation Office, Kingsley House, Castle Street, Barnstaple, Devon, EX31 1DR",G,"https://www.gov.uk/guidance/north-devon-kingsley-house",
+155,"Devon: Exeter Probation Office","Probation Office, 3 Barnfield Road, Exeter, Devon, EX1 1RD",G,"https://www.gov.uk/guidance/exeter-exeter-probation-office",
+156,"Dorset: Weymouth Probation Office","Weymouth Probation Office, Entrance B, Westwey House, Westwey Road, Weymouth, Dorset, DT4 8TG",G,"https://www.gov.uk/guidance/dorset-weymouth-probation-office",
+157,"Gloucestershire: Cheltenham Probation Office","Cheltenham Probation Office, County Offices, St Georges Road, Cheltenham, Gloucestershire, GL50 1QF",G,"https://www.gov.uk/guidance/cheltenham-cheltenham-probation-office",
+158,"Gloucestershire: Coleford Probation Office","Coleford Probation Office, The Court House, Gloucester Road, Coleford, Gloucestershire, GL16 8BL",G,"https://www.gov.uk/guidance/forest-of-dean-the-court-house",
+159,"Gloucestershire: Gloucester Probation Office","Gloucester Probation Office, Twyver House, Bruton Way, Gloucester, GL1 1PB",G,"https://www.gov.uk/guidance/gloucester-twyver-house",
+160,"North Somerset: North Somerset Probation Office","North Somerset Probation Office, The North Somerset Courthouse, The Hedges, Weston-Super-Mare, BS22 7BB",G,"https://www.gov.uk/guidance/north-somerset-north-somerset-probation-office",
+161,"Plymouth: Hyde Park House","Harbour Drug and Alcohol Services, Hyde Park House, Mutley Plain, Plymouth, PL4 6LF",G,"https://www.gov.uk/guidance/plymouth-hyde-park-house",
+162,"Plymouth: Plymouth Probation Office","Plymouth Probation Office, St. Catherines House, 5 Notte Street, Plymouth, Devon, PL1 2TT",G,"https://www.gov.uk/guidance/plymouth-st-catherines-house",
+163,"Somerset: Bridgwater Probation Office","Bridgwater Probation Office, Riverside House, West Quay, Bridgwater, Somerset, TA6 3HW",G,"https://www.gov.uk/guidance/somerset-riverside-house",CRS0117
+164,"Somerset: Taunton Probation Office","Taunton Probation Office, Probation Service, Deane House, Belvedere Road, Taunton, Somerset, TA1 1HE",G,"https://www.gov.uk/guidance/somerset-west-and-taunton-taunton-probation-office",
+165,"Somerset: Yeovil Probation Office","Yeovil Probation Office, 22 Hendford, Yeovil, Somerset, BA20 2QD",G,"https://www.gov.uk/guidance/south-somerset-yeovil-probation-office",
+166,"Swindon: Swindon Probation Office","Swindon Probation Office, North Block, Centenary House, 150 Victoria Road, Swindon, Wiltshire, SN1 3UZ",G,"https://www.gov.uk/guidance/swindon-centenary-house",
+167,"Torbay: Torquay Probation Office","Torquay Probation Office, Thurlow House, 35 Thurlow Road, Torquay, Devon, TQ1 3EQ",G,"https://www.gov.uk/guidance/torbay-thurlow-house",
+168,"Wiltshire: Chippenham Probation Office","Chippenham Probation Office, 34 Marshfield Road, Chippenham, SN15 1JT",G,"https://www.gov.uk/guidance/wiltshire-chippenham-probation-office",
+169,"Wiltshire: Salisbury Probation Office","Salisbury Probation Office, The Boulter Centre, Avon Approach, Salisbury, Wiltshire, SP1 3SL",G,"https://www.gov.uk/guidance/salisbury-the-boulter-centre",
+170,"Blaenau Gwent: 50 Bethcar Street","50 Bethcar Street, Ebbw Vale, Gwent, NP23 6HG",D,"https://www.gov.uk/guidance/blaenau-gwent-50-bethcar-street",CRS0063
+171,"Bridgend: Bridgend Probation Office","Probation Office, Tremains Business Park, Tremains Road, Bridgend, Mid Glamorgan, CF31 1TZ",D,"https://www.gov.uk/guidance/bridgend-bridgend-probation-office",
+172,"Bridgend: Hartshorn House","Hartshorn House, Neath Road, Maesteg, Bridgend, CF34 9EE",D,"https://www.gov.uk/guidance/bridgend-hartshorn-house",
+173,"Cardiff: 33-35 Westgate street","33-35 Westgate Street, Cardiff, CF10 1JE",D,"https://www.gov.uk/guidance/cardiff-33-35-westgate-street",CRS0019
+174,"Cardiff: Cardiff Crown Court","Crown Court, Cardiff, CF10 3PG",D,"https://www.gov.uk/guidance/cardiff-cardiff-crown-court",
+175,"Cardiff: Cardiff Magistrates' Court","Cardiff Magistrates' Court, Fitzalan Place, Cardiff, CF24 0RZ",D,"https://www.gov.uk/guidance/cardiff-cardiff-magistrates-court",
+176,"Cardiff: Llanrumney Hub","Llanrumney Hub, Countisbury Avenue, Cardiff, CF3 5NQ",D,"https://www.gov.uk/guidance/cardiff-llanrumney-hub",
+177,"Cardiff: Star Hub","Star Hub, Muriton Road, Cardiff, CF24 2SJ",D,"https://www.gov.uk/guidance/cardiff-star-hub",
+178,"Caerphilly: Centenary House","Centenary House, Unit 1 De Clare Court, Caerphilly, CF83 2WA",D,"https://www.gov.uk/guidance/caerphilly-centenary-house",CRS0062
+179,"Carmarthenshire: 7a-7b Water Street","7a-7b Water Street, Carmarthen, Carmarthenshire, SA31 1PY",D,"https://www.gov.uk/guidance/carmarthenshire-7a-7b-water-street",CRS0037
+180,"Carmarthenshire: Llanelli Probation Office","Probation Office, Lloyd Street, Llanelli, Carmarthenshire, SA15 2PU",D,"https://www.gov.uk/guidance/carmarthenshire-llanelli-probation-office",CRS0040
+181,"Ceredigion: Aberystwyth Probation Office","Aberystwyth Probation Office, 23 Grays Inn Road, Aberystwyth, Ceredigion, SY23 1QE",D,"https://www.gov.uk/guidance/ceredigion-aberystwyth-probation-office",CRS0035
+182,"Ceredigion: Straight Lines House","Straight Lines House, New Road, Newtown, Powys, SY16 1BD",D,"https://www.gov.uk/guidance/ceredigion-straight-lines-house",CRS0041
+183,"Conwy: 25 Conway Road","25 Conway Road, Colwyn Bay, Conwy, LL29 7AA",D,"https://www.gov.uk/guidance/conwy-25-conway-road",CRS0102
+184,"Conwy: Llandudno Magistrates' Court","Llandudno Magistrates' Court, Conway Road, Llandudno, LL30 1GA",D,"https://www.gov.uk/guidance/conwy-llandudno-magistrates-court",
+185,"Flintshire: Unit 6, Acorn Business Park","Unit 6, Acorn Business Park, Flint, Flintshire, CH6 5YN",D,"https://www.gov.uk/guidance/flintshire-unit-6-acorn-business-park",CRS0103
+186,"Gwynedd: Unit 10 Ash Court","Unit 10 Ash Court, Parc Menai, Business Park, Bangor, LL57 4DF",D,"https://www.gov.uk/guidance/gwynedd-unit-10-ash-court",
+187,"Gwynedd: Victoria Chambers","Ground Floor, Victoria Chambers, 5 Crown Street, Caernarfon, LL55 1SY",D,"https://www.gov.uk/guidance/gwynedd-victoria-chambers",
+188,"Merthyr Tydfil: Oldway House","Oldway House, Castle Street, Merthyr Tydfil, Mid Glamorgan, CF47 8UX",D,"https://www.gov.uk/guidance/merthyr-tydfil-oldway-house",CRS0029
+189,"Newport: USK House","USK House, Lower Dock Street, Newport Gwent, NP20 2GD",D,"https://www.gov.uk/guidance/newport-usk-house",CRS0064
+190,"Pembrokeshire: 14 High Street, Haverfordwest","14 High Street, Haverfordwest, Pembrokeshire, SA61 2DA",D,"https://www.gov.uk/guidance/pembrokeshire-14-high-street-haverfordwest",CRS0038
+191,"Powys: The Limes/Temple Street","The Limes/Temple Street, Llandrindod Wells, Powys, LD1 5DP",D,"https://www.gov.uk/guidance/powys-the-limestemple-street",CRS0039
+192,"Powys: Powys Probation Office","Probation Office, Plas Y Ffynnon, Cambrian Way, Brecon, Powys, LD3 7HP",D,"https://www.gov.uk/guidance/powys-powys-probation-office",CRS0036
+193,"Rhondda Cynon Taff: Pontypridd Probation Office","Probation Office, Former Post Office, Broadway, Pontypridd, CF37 1BA",D,"https://www.gov.uk/guidance/rhondda-cynon-taff-pontypridd-probation-office",CRS0030
+194,"Swansea: 12 Orchard Street","12 Orchard Street, West Glamorgan House, Swansea, SA1 5AD",D,"https://www.gov.uk/guidance/swansea-12-orchard-street",
+195,"Swansea: Swansea Crown Court","Swansea Crown Court, St Helen's Road, Swansea, SA1 4PF",D,"https://www.gov.uk/guidance/swansea-swansea-crown-court",
+196,"Swansea: Swansea Magistrates' Court","Swansea Magistrates' Court, Grove Place, Swansea, SA1 5DL",D,"https://www.gov.uk/guidance/swansea-swansea-magistrates-court",
+197,"Torfaen: Torfaen House","Torfaen House, Station Road, Sebastopol, Pontypool, NP4 5ES",D,"https://www.gov.uk/guidance/torfaen-torfaen-house",CRS0065
+198,"Vale of Glamorgan: Barry Police Station","Barry Police Station, Gladstone Road, Barry, CF63 1TD",D,"https://www.gov.uk/guidance/vale-of-glamorgan-barry-police-station",
+199,"Wrexham: Wrexham Probation Office","Probation Office, Wrexham Technology Park, Ellice Way, Wrexham, LL13 7YX",D,"https://www.gov.uk/guidance/wrexham-wrexham-probation-office",CRS0104
+200,"Birmingham: 11-15 Lower Essex Street","11-15 Lower Essex Street, Birmingham, West Midlands, B5 6SN",E,"https://www.gov.uk/guidance/birmingham-11-15-lower-essex-street",CRS0008
+201,"Birmingham: Centenary House","Centenary House, Mackadown Lane, Kitts Green, Birmingham, West Midlands, B33 0LQ",E,"https://www.gov.uk/guidance/birmingham-centenary-house",CRS0007
+202,"Birmingham: Perry Barr Probation Office","76 Walsall Road, Birmingham, West Midlands, B42 1SF",E,"https://www.gov.uk/guidance/birmingham-perry-barr-probation-office",CRS0006
+203,"Birmingham: Selly Oak Probation Office","Selly Oak Probation Office, 826 Bristol Rd, Selly Oak, Birmingham, B29 6NA",E,"https://www.gov.uk/guidance/birmingham-selly-oak-probation-office",CRS0009
+204,"Coventry: Coventry Magistrates' Court","Coventry Magistrates' Court, 60 Little Park Street, Coventry, West Midlands, CV1 2SQ",E,"https://www.gov.uk/guidance/coventry-coventry-magistrates-court",
+205,"Coventry: Coventry Probation Office","Probation Office, Sheriff's Court, 12 Greyfriars Road, Coventry, CV1 3RY",E,"https://www.gov.uk/guidance/coventry-coventry-probation-office",CRS0022
+206,"Dudley: Hope House","Hope House, Castle Gate Business Park, Dudley, West Midlands, DY1 4TA",E,"https://www.gov.uk/guidance/dudley-hope-house",CRS0033
+207,"Herefordshire: Hereford Probation Office","Gaol Street, Hereford, HR1 2HU",E,"https://www.gov.uk/guidance/hertfordshire-hereford-probation-office",CRS0075
+208,"Redditch: Redditch Probation Office","Probation Office, 1-4 Windsor Court, Clive Road, Redditch, Worcestershire, B97 4BT",E,"https://www.gov.uk/guidance/redditch-redditch-probation-office",CRS0159
+209,"Sandwell: Unity House","Unity House, 14-16 New Street, West Bromwich, B70 7PQ",E,"https://www.gov.uk/guidance/sandwell-unity-house",CRS0034
+210,"Shropshire: Shrewsbury Probation Office","Probation Office, 135 Abbey Foregate, Shrewsbury, Shropshire, SY2 6AS",E,"https://www.gov.uk/guidance/shropshire-shrewsbury-probation-office",CRS0076
+211,"Staffordshire: 200a Wolverhampton Road","200a Wolverhampton Road, Cannock, Staffordshire, WS11 1AT",E,"https://www.gov.uk/guidance/staffordshire-200a-wolverhampton-road",CRS0124
+212,"Staffordshire: Burton Probation office","Probation Office, Horninglow Street, Burton-on-trent, Staffordshire, DE14 1PH",E,"https://www.gov.uk/guidance/staffordshire-burton-probation-office",CRS0123
+213,"Staffordshire: Stafford Police Station","Eastgate Street, Stafford, Staffordshire, ST16 2DQ",E,"https://www.gov.uk/guidance/staffordshire-stafford-police-station",
+214,"Staffordshire: Tamworth Probation Centre","19 Moor Street, Tamworth, Staffordshire, B79 7QZ",E,"https://www.gov.uk/guidance/staffordshire-tamworth-probation-centre",CRS0126
+215,"Stoke on Trent: Longton Police Station","Longton Police Station, Sutherland Road, Longton, Stoke on Trent, ST3 1HH",E,"https://www.gov.uk/guidance/stoke-on-trent-longton-police-station",
+216,"Stoke on Trent: Melbourne House","Melbourne House, Etruria Office Village, Forge Lane, Stoke on Trent, Staffordshire, ST1 5RQ",E,"https://www.gov.uk/guidance/stoke-on-trent-melbourne-house",CRS0125
+217,"Telford and Wrekin: Telford Probation Service","Telford Probation Service, Malinsgate Telford Square, Telford, Shropshire, TF3 4HX",E,"https://www.gov.uk/guidance/telford-and-wrekin-telford-probation-service",CRS0077
+218,"Walsall: Walsall Probation Complex","Walsall Probation Complex, Midland Road, Walsall, West Midlands, WS1 3QE",E,"https://www.gov.uk/guidance/walsall-walsall-probation-complex",CRS0137
+219,"Warwickshire: Warwickshire Criminal Justice Centre","Warwickshire Criminal Justice Centre, Vicarage Street, Nuneaton, CV11 4JU",E,"https://www.gov.uk/guidance/warwickshire-warwickshire-criminal-justice-centre",CRS0144
+220,"Warwickshire: Warwickshire Southern Justice Centre","Warwickshire Southern Justice Centre, Newbold Terrace, Leamington Spa, Warwickshire, CV32 4EL",E,"https://www.gov.uk/guidance/warwickshire-warwickshire-southern-justice-centre",CRS0143
+221,"Wolverhampton: Prue Earl House","Prue Earl House, Union Street, Wolverhampton, West Midlands, WV1 3JS",E,"https://www.gov.uk/guidance/wolverhampton-prue-earl-house",CRS0138
+222,"Worcestershire: Worcester Police Station","Castle Street, Worcester, WR1 3QX",E,"https://www.gov.uk/guidance/worcestershire-worcester-police-station",
+223,"Wyre Forest: Stourbank House","Stourbank House, 90 Mill Street, Kidderminster, Worcestershire, DY11 6XA",E,"https://www.gov.uk/guidance/wyre-forest-stourbank-house",CRS0158
+224,"Barnsley: Acorn House","Acorn House, Oakwell View, Barnsley, S71 1HP",C,"https://www.gov.uk/guidance/barnsley-acorn-house",
+225,"Bradford: Bradford Probation Office","Probation Office, City Courts, The Tyrls, PO Box 6, Bradford, West Yorkshire, BD1 1LA",C,"https://www.gov.uk/guidance/bradford-bradford-probation-office",
+226,"Calderdale: 173a Springhall Lane","173a Springhall Lane, Halifax, West Yorkshire, HX1 4JG",C,"https://www.gov.uk/guidance/calderdale-173a-springhall-lane",
+227,"Craven: Skipton Probation Office","Probation Office, Courthouse/Bunkers Hill, Skipton, BD23 1HU",C,"https://www.gov.uk/guidance/craven-skipton-probation-office",
+228,"Doncaster: 34 Bennetthorpe","34 Bennetthorpe, Doncaster, South Yorkshire, DN2 6AD",C,"https://www.gov.uk/guidance/doncaster-34-bennetthorpe",
+229,"East Riding of Yorkshire: 1 Airmyn Road","1 Airmyn Road, Goole, East Riding of Yorkshire, DN14 6XA",C,"https://www.gov.uk/guidance/east-riding-of-yorkshire-1-airmyn-road",
+230,"East Riding of Yorkshire: 8 Lord Roberts Road","8 Lord Roberts Road, Beverley, Yorkshire, HU17 9BE",C,"https://www.gov.uk/guidance/east-riding-of-yorkshire-8-lord-roberts-road",
+231,"East Riding of Yorkshire: Bridlington Probation Office","Probation Office, 4a St. Johns Avenue, Bridlington, North Humberside, YO16 4NG",C,"https://www.gov.uk/guidance/east-riding-of-yorkshire-bridlington-probation-office",
+232,"Hambleton: Essex Lodge","Essex Lodge, 16 South Parade, Northallerton, North Yorkshire, DL7 8SG",C,"https://www.gov.uk/guidance/hambleton-essex-lodge",
+233,"Harrogate: 5-7 Haywra Crescent","5-7 Haywra Crescent, Harrogate, North Yorkshire, HG1 5BG",C,"https://www.gov.uk/guidance/harrogate-5-7-haywra-crescent",
+234,"Hull: Barclays House","Barclays House, 10 Market Place, Hull, Humberside, HU1 1RS",C,"https://www.gov.uk/guidance/hull-barclays-house",
+235,"Kirklees: Dewsbury Probation Office","Probation Office, 5 Albion Street, Dewsbury, Yorkshire, WF13 2AJ",C,"https://www.gov.uk/guidance/kirklees-kirklees-probation-centre",
+236,"Kirklees: Huddersfield Probation Office","Huddersfield Probation Office, 21 St. Johns Road, Huddersfield, West Yorkshire, HD1 5BW",C,"https://www.gov.uk/guidance/kirklees-huddersfield-probation-office",
+237,"Leeds: Waterloo House","Waterloo House, 58 wellington Street, Leeds, West Yorkshire, LS1 2EE",C,"https://www.gov.uk/guidance/leeds-waterloo-house",
+238,"North East Lincolnshire: Grimsby Probation Office","Probation Office, Queen Street, Grimsby, North East Lincolnshire, DN31 1QG",C,"https://www.gov.uk/guidance/north-east-lincolnshire-grimsby-probation-office",
+239,"North Lincolnshire: Scunthorpe Probation Office","Scunthorpe Probation Office, 1 Park Square, Laneham Street, Scunthorpe, North Lincolnshire, DN15 6JH",C,"https://www.gov.uk/guidance/north-lincolnshire-scunthorpe-probation-office",
+240,"Rotherham: Unit 2, Ashley Business Court","Unit 2, Ashley Business Court, Rawmarsh Road, Rotherham, South Yorkshire, S60 1RU",C,"https://www.gov.uk/guidance/rotherham-unit-2-ashley-business-court",
+241,"Scarborough: 9-25 Northway","First Floor Offices, 9-25 Northway, Scarborough, Yorkshire, YO11 1JL",C,"https://www.gov.uk/guidance/scarborough-9-25-northway",
+242,"Sheffield: Sheffield Probation Office","45 Division Street, Sheffield, South Yorkshire, S1 4GE",C,"https://www.gov.uk/guidance/sheffield-sheffield-probation-office",
+243,"York: York Probation Office","Probation Office, 108 Lowther Street, York, North Yorkshire, YO31 7WD",C,"https://www.gov.uk/guidance/york-york-probation-office",
+244,"Wakefield: Wakefield Probation Office","Probation Office, 1 Burgage Square, Merchant Gate, Wakefield, WF1 2TS",C,"https://www.gov.uk/guidance/wakefield-wakefield-probation-office",
+245,"Bedford: Suite G1A, G1B And The Basement","Suite G1A, G1B And The Basement, Bromham Road, Bedford, MK40 2FG",I,,CRS0003
+246,"Luton: Clemitson House","Clemitson House, Gordon Street, Luton, LU1 2QP",I,,CRS0004
+247,"Luton: Sceptre House (First Fl)","Sceptre House (First Fl), Castle Street, Luton, LU1 3AJ",I,,CRS0005
+248,"High Wycombe: Easton Court","Easton Court, Easton Street, High Wycombe, HP11 1NT",H,,CRS0012
+249,"Peterborough: 12-13 Adam Court","12-13 Adam Court, Newark Road, Peterborough, PE1 5PP",I,,CRS0016
+250,"Bridgend: Level 3 Brackla House","Level 3 Brackla House, Brackla Street, Bridgend, CF31 1BZ",D,,CRS0028
+251,"Derby: Ground, First And Second Floors Burdett House","Ground, First And Second Floors Burdett House, Becket Street, Derby, DE1 1JP",F,,CRS0031
+252,"Ashford: Templar House","Templar House, Tannery Lane, Ashford, TN23 1PL",K,,CRS0048
+253,"Ramsgate: Queens House","Queens House, Queens Street, Ramsgate, CT11 9DH",K,,CRS0051
+254,"Sittingbourne: Bell House","Bell House, Bell Road, Sittingbourne, ME10 4DH",K,,CRS0052
+255,"Accrington: The Globe Centre","The Globe Centre, Accrington, BB5 0RE",B,,CRS0053
+256,"Hollingbury: Sussex House","Sussex House, Crowhurst Road, Hollingbury, BN1 8AF",K,,CRS0057
+257,"London: 71 Lordship Lane","71 Lordship Lane, Tottenham, London, London, N17 6RS",J,,CRS0060
+258,"Southampton: The Glenmore Centre","The Glenmore Centre, The Glenmore Centre, Southampton, SO14 5EA",H,,CRS0073
+259,"Hemel Hampstead: Waterhouse Street","Waterhouse Street, Waterhouse Street, Hemel Hampstead, HP1 1ES",I,,CRS0079
+260,"Leicester: 38 Friar Lane","38 Friar Lane, Friar Lane, Leicester, LE1 5RA",F,,CRS0087
+261,"London: Huntingdon House","Huntingdon House, Masons Hill, London, BR2 9EY",J,,CRS0090
+262,"Nottingham: Unit C, Nottingham One","Unit C, Nottingham One, Canal Street, Nottingham, NG1 7HG",F,,CRS0109
+263,"Bicester: Unit 10","Unit 10, Talisman Road, Bicester, OX26 6HR",H,,CRS0112
+264,"Basildon: The Basildon Centre","The Basildon Centre, St Martin'S Square, Basildon, SS14 1DL",I,,CRS0119
+265,"Grays: Part Second Floor, Civic Office Complex","Part Second Floor, Civic Office Complex, New Road, Grays, RM17 6SL",I,,CRS0120
+266,"Southend-On-Sea: Civic 2, Victoria Avenue","Civic 2, Victoria Avenue, Southend-On-Sea, SS2 6ER",I,,CRS0121
+267,"Ipswich: Suite 1, 3rd Floor, Hubbard House","Suite 1, 3rd Floor, Hubbard House, Civic Drive, Ipswich, IP1 2QA",I,,CRS0129
+268,"Ipswich: Suite 2, 3rd Floor, Hubbard House","Suite 2, 3rd Floor, Hubbard House, Civic Drive, Ipswich, IP1 2QA",I,,CRS0130
+269,"Guildford: First House","First House, Park Street, Guildford, GU1 4XB",K,,CRS0133
+270,"Redhill: Tower House","Tower House, Cromwell Road, Redhill, RH1 1RT",K,,CRS0134
+271,"Winsford: Business Park","Business Park, Barlow Drive, Winsford, CW7 2GN",B,,CRS0148
+272,"Maidstone: Galleon House","Galleon House, King Street, Maidstone, ME14 1BG",K,,CRS0150
+273,"Tunbridge Wells: 17 Garden Road","17 Garden Road, Garden Road, Tunbridge Wells, TN1 2XP",K,,CRS0152
+274,"Crawley: Midtown House","Midtown House, The High Street, Crawley, RH10 1BW",K,,CRS0153
+275,"Littlehampton: Arun Civic Centre","Arun Civic Centre, Maltravers Road, Littlehampton, BN17 5LF",K,,CRS0154

--- a/server/models/appointment.ts
+++ b/server/models/appointment.ts
@@ -19,4 +19,5 @@ export interface AppointmentSchedulingDetails {
   durationInMinutes: number | null
   appointmentDeliveryType: AppointmentDeliveryType | null
   appointmentDeliveryAddress: Address | null
+  npsOfficeCode: string | null
 }

--- a/server/models/deliusOfficeLocation.ts
+++ b/server/models/deliusOfficeLocation.ts
@@ -1,0 +1,8 @@
+export default interface DeliusOfficeLocation {
+  probationOfficeId: number
+  name: string
+  address: string
+  probationRegionId: string
+  govUkURL: string
+  deliusCRSLocationId: string
+}

--- a/server/models/pccRegion.ts
+++ b/server/models/pccRegion.ts
@@ -1,4 +1,7 @@
+import NPSRegion from './npsRegion'
+
 export default interface PCCRegion {
   id: string
   name: string
+  npsRegion: NPSRegion
 }

--- a/server/routes/findInterventions/findInterventionsController.test.ts
+++ b/server/routes/findInterventions/findInterventionsController.test.ts
@@ -58,7 +58,10 @@ describe(FindInterventionsController, () => {
 
     it('accepts filter params and makes a filtered request to the API', async () => {
       interventionsService.getInterventions.mockResolvedValue([])
-      const pccRegions = [pccRegionFactory.build({ name: 'Cheshire' }), pccRegionFactory.build({ name: 'Cumbria' })]
+      const pccRegions = [
+        pccRegionFactory.build({ id: '1', name: 'Cheshire' }),
+        pccRegionFactory.build({ id: '2', name: 'Cumbria' }),
+      ]
       interventionsService.getPccRegions.mockResolvedValue(pccRegions)
 
       await request(app)

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -7,6 +7,7 @@ import Intervention from '../../models/intervention'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
 import TestUtils from '../../../testutils/testUtils'
 import { ListStyle, SummaryListItem } from '../../utils/summaryList'
+import pccRegion from '../../../testutils/factories/pccRegion'
 
 describe(InterventionDetailsPresenter, () => {
   describe('title', () => {
@@ -160,10 +161,7 @@ three lines.`,
       it('is a comma-separated list of PCC regions', () => {
         expect(
           linesForKey('Location', {
-            pccRegions: [
-              { id: '1', name: 'Region 1' },
-              { id: '2', name: 'Region 2' },
-            ],
+            pccRegions: [pccRegion.build({ name: 'Region 1' }), pccRegion.build({ name: 'Region 2' })],
           })
         ).toEqual(['Region 1, Region 2'])
       })

--- a/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.test.ts
@@ -10,7 +10,7 @@ describe(ScheduleActionPlanSessionPresenter, () => {
   describe('text.title', () => {
     it('contains the appointment number', () => {
       const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 1 })
-      const presenter = new ScheduleActionPlanSessionPresenter(referral, appointment)
+      const presenter = new ScheduleActionPlanSessionPresenter(referral, appointment, [])
 
       expect(presenter.text).toEqual({ title: 'Add session 1 details' })
     })

--- a/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.ts
+++ b/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.ts
@@ -3,17 +3,27 @@ import SentReferral from '../../../../../models/sentReferral'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import ScheduleAppointmentPresenter from '../../../../serviceProviderReferrals/scheduleAppointmentPresenter'
 import AuthUserDetails from '../../../../../models/hmppsAuth/authUserDetails'
+import DeliusOfficeLocation from '../../../../../models/deliusOfficeLocation'
 
 export default class ScheduleActionPlanSessionPresenter extends ScheduleAppointmentPresenter {
   constructor(
     referral: SentReferral,
     currentAppointment: ActionPlanAppointment,
+    deliusOfficeLocations: DeliusOfficeLocation[],
     assignedCaseworker: AuthUserDetails | null = null,
     validationError: FormValidationError | null = null,
     userInputData: Record<string, unknown> | null = null,
     serverError: FormValidationError | null = null
   ) {
-    super(referral, currentAppointment, assignedCaseworker, validationError, userInputData, serverError)
+    super(
+      referral,
+      currentAppointment,
+      deliusOfficeLocations,
+      assignedCaseworker,
+      validationError,
+      userInputData,
+      serverError
+    )
     this.text.title = `Add session ${currentAppointment.sessionNumber} details`
   }
 }

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
@@ -8,9 +8,11 @@ import AddressInput from '../../utils/forms/inputs/addressInput'
 import { FormValidationResult } from '../../utils/forms/formValidationResult'
 import Address from '../../models/address'
 import { AppointmentSchedulingDetails } from '../../models/appointment'
+import DeliusOfficeLocationInput from '../../utils/forms/inputs/deliusOfficeLocationInput'
+import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
 
 export default class ScheduleAppointmentForm {
-  constructor(private readonly request: Request) {}
+  constructor(private readonly request: Request, private readonly deliusOfficeLocations: DeliusOfficeLocation[]) {}
 
   async data(): Promise<FormData<AppointmentSchedulingDetails>> {
     const [dateResult, durationResult, appointmentDeliveryType] = await Promise.all([
@@ -35,8 +37,23 @@ export default class ScheduleAppointmentForm {
         errorMessages.scheduleAppointment.address
       ).validate()
     }
+    let deliusOfficeLocation: FormValidationResult<string | null> = { value: null, error: null }
+    if (appointmentDeliveryType.value === 'IN_PERSON_MEETING_PROBATION_OFFICE') {
+      deliusOfficeLocation = await new DeliusOfficeLocationInput(
+        this.request,
+        'delius-office-location-code',
+        this.deliusOfficeLocations,
+        errorMessages.scheduleAppointment.deliusOfficeLocation
+      ).validate()
+    }
 
-    if (dateResult.error || durationResult.error || appointmentDeliveryType.error || appointmentDeliveryAddress.error) {
+    if (
+      dateResult.error ||
+      durationResult.error ||
+      appointmentDeliveryType.error ||
+      appointmentDeliveryAddress.error ||
+      deliusOfficeLocation.error
+    ) {
       return {
         paramsForUpdate: null,
         error: {
@@ -45,6 +62,7 @@ export default class ScheduleAppointmentForm {
             ...(durationResult.error?.errors ?? []),
             ...(appointmentDeliveryType.error?.errors ?? []),
             ...(appointmentDeliveryAddress.error?.errors ?? []),
+            ...(deliusOfficeLocation.error?.errors ?? []),
           ],
         },
       }
@@ -57,6 +75,7 @@ export default class ScheduleAppointmentForm {
         durationInMinutes: durationResult.value.minutes!,
         appointmentDeliveryType: appointmentDeliveryType.value!,
         appointmentDeliveryAddress: appointmentDeliveryAddress.value,
+        npsOfficeCode: deliusOfficeLocation.value,
       },
     }
   }

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -11,7 +11,7 @@ describe(ScheduleAppointmentPresenter, () => {
     describe('title', () => {
       describe('when the session has not yet been scheduled', () => {
         it('returns an appropriate title', () => {
-          const presenter = new ScheduleAppointmentPresenter(referral, null)
+          const presenter = new ScheduleAppointmentPresenter(referral, null, [])
 
           expect(presenter.text).toEqual({ title: 'Add appointment details' })
         })
@@ -19,7 +19,7 @@ describe(ScheduleAppointmentPresenter, () => {
 
       describe('when the session has already been scheduled', () => {
         it('returns an appropriate title', () => {
-          const presenter = new ScheduleAppointmentPresenter(referral, initialAssessmentAppointmentFactory.build())
+          const presenter = new ScheduleAppointmentPresenter(referral, initialAssessmentAppointmentFactory.build(), [])
 
           expect(presenter.text).toEqual({ title: 'Change appointment details' })
         })
@@ -29,7 +29,8 @@ describe(ScheduleAppointmentPresenter, () => {
         it('returns an appropriate title', () => {
           const presenter = new ScheduleAppointmentPresenter(
             referral,
-            initialAssessmentAppointmentFactory.attended('no').build()
+            initialAssessmentAppointmentFactory.attended('no').build(),
+            []
           )
           expect(presenter.text).toEqual({ title: 'Add appointment details' })
         })
@@ -40,7 +41,7 @@ describe(ScheduleAppointmentPresenter, () => {
   describe('appointmentSummary', () => {
     describe('when the appointment has not yet been scheduled', () => {
       it('should return an empty summary', () => {
-        const presenter = new ScheduleAppointmentPresenter(referral, null)
+        const presenter = new ScheduleAppointmentPresenter(referral, null, [])
         expect(presenter.appointmentSummary).toEqual([])
       })
     })
@@ -55,6 +56,7 @@ describe(ScheduleAppointmentPresenter, () => {
               durationInMinutes: 60,
               appointmentDeliveryType: 'VIDEO_CALL',
             }),
+            [],
             authUserDetailsFactory.build({ firstName: 'firstName', lastName: 'lastName' })
           )
           expect(presenter.appointmentSummary).toEqual([
@@ -74,6 +76,7 @@ describe(ScheduleAppointmentPresenter, () => {
               durationInMinutes: 60,
               appointmentDeliveryType: 'VIDEO_CALL',
             }),
+            [],
             null
           )
           expect(presenter.appointmentSummary).toEqual([
@@ -89,14 +92,14 @@ describe(ScheduleAppointmentPresenter, () => {
   describe('appointmentAlreadyAttended', () => {
     describe('when the appointment has not yet been scheduled', () => {
       it('should return false', () => {
-        const presenter = new ScheduleAppointmentPresenter(referral, null)
+        const presenter = new ScheduleAppointmentPresenter(referral, null, [])
         expect(presenter.appointmentAlreadyAttended).toBe(false)
       })
     })
 
     describe('when the appointment has been scheduled but not yet attended', () => {
       it('should return false', () => {
-        const presenter = new ScheduleAppointmentPresenter(referral, initialAssessmentAppointmentFactory.build())
+        const presenter = new ScheduleAppointmentPresenter(referral, initialAssessmentAppointmentFactory.build(), [])
         expect(presenter.appointmentAlreadyAttended).toBe(false)
       })
     })
@@ -106,7 +109,8 @@ describe(ScheduleAppointmentPresenter, () => {
         it('should return true', () => {
           const presenter = new ScheduleAppointmentPresenter(
             referral,
-            initialAssessmentAppointmentFactory.attended('no').build()
+            initialAssessmentAppointmentFactory.attended('no').build(),
+            []
           )
           expect(presenter.appointmentAlreadyAttended).toBe(true)
         })
@@ -116,7 +120,8 @@ describe(ScheduleAppointmentPresenter, () => {
         it('should return false', () => {
           const presenter = new ScheduleAppointmentPresenter(
             referral,
-            actionPlanAppointmentFactory.attended('no').build()
+            actionPlanAppointmentFactory.attended('no').build(),
+            []
           )
           expect(presenter.appointmentAlreadyAttended).toBe(false)
         })
@@ -131,6 +136,7 @@ describe(ScheduleAppointmentPresenter, () => {
         const presenter = new ScheduleAppointmentPresenter(
           referral,
           appointment,
+          [],
           null,
           {
             errors: [
@@ -170,6 +176,7 @@ describe(ScheduleAppointmentPresenter, () => {
         const presenter = new ScheduleAppointmentPresenter(
           referral,
           appointment,
+          [],
           null,
           {
             errors: [
@@ -191,7 +198,7 @@ describe(ScheduleAppointmentPresenter, () => {
     describe('when no error is passed in', () => {
       it('returns null', () => {
         const appointment = initialAssessmentAppointmentFactory.build()
-        const presenter = new ScheduleAppointmentPresenter(referral, appointment)
+        const presenter = new ScheduleAppointmentPresenter(referral, appointment, [])
 
         expect(presenter.errorSummary).toEqual(null)
       })
@@ -201,7 +208,7 @@ describe(ScheduleAppointmentPresenter, () => {
   describe('fields', () => {
     describe('with a null appointment', () => {
       it('returns empty fields', () => {
-        const presenter = new ScheduleAppointmentPresenter(referral, null)
+        const presenter = new ScheduleAppointmentPresenter(referral, null, [])
 
         expect(presenter.fields).toEqual({
           date: {
@@ -232,6 +239,10 @@ describe(ScheduleAppointmentPresenter, () => {
               postcode: null,
             },
           },
+          deliusOfficeLocation: {
+            value: null,
+            errorMessage: null,
+          },
         })
       })
     })
@@ -240,7 +251,8 @@ describe(ScheduleAppointmentPresenter, () => {
       it('should return empty fields', () => {
         const presenter = new ScheduleAppointmentPresenter(
           referral,
-          initialAssessmentAppointmentFactory.attended('no').build()
+          initialAssessmentAppointmentFactory.attended('no').build(),
+          []
         )
 
         expect(presenter.fields).toEqual({
@@ -272,6 +284,10 @@ describe(ScheduleAppointmentPresenter, () => {
               postcode: null,
             },
           },
+          deliusOfficeLocation: {
+            value: null,
+            errorMessage: null,
+          },
         })
       })
     })
@@ -290,7 +306,7 @@ describe(ScheduleAppointmentPresenter, () => {
             postCode: 'SY4 0RE',
           },
         })
-        const presenter = new ScheduleAppointmentPresenter(referral, appointment)
+        const presenter = new ScheduleAppointmentPresenter(referral, appointment, [])
 
         expect(presenter.fields).toEqual({
           date: {
@@ -327,6 +343,57 @@ describe(ScheduleAppointmentPresenter, () => {
               postcode: null,
             },
           },
+          deliusOfficeLocation: {
+            value: null,
+            errorMessage: null,
+          },
+        })
+      })
+    })
+
+    describe('with a delius office location selection', () => {
+      it('returns values to populate the fields with', () => {
+        const appointment = initialAssessmentAppointmentFactory.build({
+          appointmentTime: '2021-03-24T10:30:00Z',
+          durationInMinutes: 75,
+          appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
+          npsOfficeCode: 'CRS00001',
+        })
+        const presenter = new ScheduleAppointmentPresenter(referral, appointment, [])
+
+        expect(presenter.fields).toEqual({
+          date: {
+            errorMessage: null,
+            day: { value: '24', hasError: false },
+            month: { value: '3', hasError: false },
+            year: { value: '2021', hasError: false },
+          },
+          time: {
+            errorMessage: null,
+            hour: { value: '10', hasError: false },
+            minute: { value: '30', hasError: false },
+            partOfDay: {
+              value: 'am',
+              hasError: false,
+            },
+          },
+          duration: {
+            errorMessage: null,
+            hours: { value: '1', hasError: false },
+            minutes: { value: '15', hasError: false },
+          },
+          meetingMethod: { value: 'IN_PERSON_MEETING_PROBATION_OFFICE', errorMessage: null },
+          address: {
+            value: null,
+            errors: {
+              firstAddressLine: null,
+              postcode: null,
+            },
+          },
+          deliusOfficeLocation: {
+            value: 'CRS00001',
+            errorMessage: null,
+          },
         })
       })
     })
@@ -335,7 +402,7 @@ describe(ScheduleAppointmentPresenter, () => {
   describe('backLinkHref', () => {
     describe('when overrideBackLinkHref is not provided to the constructor', () => {
       it('returns the URL of the intervention progress page', () => {
-        const presenter = new ScheduleAppointmentPresenter(referral, null)
+        const presenter = new ScheduleAppointmentPresenter(referral, null, [])
 
         expect(presenter.backLinkHref).toEqual(`/service-provider/referrals/${referral.id}/progress`)
       })
@@ -343,7 +410,7 @@ describe(ScheduleAppointmentPresenter, () => {
 
     describe('when overrideBackLinkHref is provided to the constructor', () => {
       it('returns the overrideBacklinkHref', () => {
-        const presenter = new ScheduleAppointmentPresenter(referral, null, null, null, null, null, '/example-href')
+        const presenter = new ScheduleAppointmentPresenter(referral, null, [], null, null, null, null, '/example-href')
 
         expect(presenter.backLinkHref).toEqual('/example-href')
       })

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -3,6 +3,7 @@ import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../model
 import { FormValidationError } from '../../utils/formValidationError'
 import AppointmentDecorator from '../../decorators/appointmentDecorator'
 import SentReferral from '../../models/sentReferral'
+import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
 import AppointmentSummary from '../appointments/appointmentSummary'
 import { SummaryListItem } from '../../utils/summaryList'
 import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
@@ -11,6 +12,7 @@ export default class ScheduleAppointmentPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly currentAppointment: InitialAssessmentAppointment | ActionPlanAppointment | null,
+    private readonly deliusOfficeLocations: DeliusOfficeLocation[],
     private readonly assignedCaseworker: AuthUserDetails | null = null,
     private readonly validationError: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null,
@@ -51,6 +53,16 @@ export default class ScheduleAppointmentPresenter {
     return false
   }
 
+  get deliusOfficeLocationsDetails(): { value: string; text: string; selected: boolean }[] {
+    return this.deliusOfficeLocations.map(officeLocation => {
+      return {
+        value: officeLocation.deliusCRSLocationId,
+        text: officeLocation.name,
+        selected: this.fields.deliusOfficeLocation.value === officeLocation.deliusCRSLocationId,
+      }
+    })
+  }
+
   readonly fields = this.appointmentAlreadyAttended
     ? {
         date: this.utils.dateValue(null, 'date', this.validationError),
@@ -58,6 +70,7 @@ export default class ScheduleAppointmentPresenter {
         duration: this.utils.durationValue(null, 'duration', this.validationError),
         meetingMethod: this.utils.meetingMethodValue(null, 'meeting-method', this.validationError),
         address: this.utils.addressValue(null, 'method-other-location', this.validationError),
+        deliusOfficeLocation: this.utils.selectionValue(null, 'delius-office-location-code', this.validationError),
       }
     : {
         date: this.utils.dateValue(this.appointmentDecorator?.britishDay ?? null, 'date', this.validationError),
@@ -79,6 +92,11 @@ export default class ScheduleAppointmentPresenter {
         address: this.utils.addressValue(
           this.currentAppointment?.appointmentDeliveryAddress ?? null,
           'method-other-location',
+          this.validationError
+        ),
+        deliusOfficeLocation: this.utils.selectionValue(
+          this.currentAppointment?.npsOfficeCode ?? null,
+          'delius-office-location-code',
           this.validationError
         ),
       }

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
@@ -1,4 +1,11 @@
-import { BackLinkArgs, DateInputArgs, RadiosArgs, TimeInputArgs } from '../../utils/govukFrontendTypes'
+import {
+  BackLinkArgs,
+  DateInputArgs,
+  RadiosArgs,
+  SelectArgs,
+  SelectArgsItem,
+  TimeInputArgs,
+} from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
 import ScheduleAppointmentPresenter from './scheduleAppointmentPresenter'
 import AddressFormComponent from '../shared/addressFormComponent'
@@ -16,6 +23,7 @@ export default class ScheduleAppointmentView {
         dateInputArgs: this.dateInputArgs,
         timeInputArgs: this.timeInputArgs,
         durationDateInputArgs: this.durationDateInputArgs,
+        deliusOfficeLocationSelectArgs: this.deliusOfficeLocationSelectArgs,
         errorSummaryArgs: this.errorSummaryArgs,
         serverError: this.serverError,
         address: this.addressFormView.inputArgs,
@@ -142,7 +150,22 @@ export default class ScheduleAppointmentView {
     }
   }
 
-  private meetingMethodRadioInputArgs(otherLocationHTML: string): RadiosArgs {
+  private get deliusOfficeLocationSelectArgs(): SelectArgs {
+    const items: SelectArgsItem[] = [
+      {
+        text: '-- Select a Probation Delivery Unit --',
+        disabled: true,
+      },
+    ]
+    items.push(...this.presenter.deliusOfficeLocationsDetails)
+    return {
+      id: 'delius-office-location-code',
+      name: 'delius-office-location-code',
+      items,
+    }
+  }
+
+  private meetingMethodRadioInputArgs(deliusOfficeLocationHTML: string, otherLocationHTML: string): RadiosArgs {
     return {
       idPrefix: 'meeting-method',
       name: 'meeting-method',
@@ -169,8 +192,16 @@ export default class ScheduleAppointmentView {
           checked: this.presenter.fields.meetingMethod.value === 'VIDEO_CALL',
         },
         {
+          value: 'IN_PERSON_MEETING_PROBATION_OFFICE',
+          text: 'In-person meeting - NPS offices',
+          checked: this.presenter.fields.meetingMethod.value === 'IN_PERSON_MEETING_PROBATION_OFFICE',
+          conditional: {
+            html: deliusOfficeLocationHTML,
+          },
+        },
+        {
           value: 'IN_PERSON_MEETING_OTHER',
-          text: 'In-person meeting',
+          text: 'In-person meeting - Other locations',
           checked: this.presenter.fields.meetingMethod.value === 'IN_PERSON_MEETING_OTHER',
           conditional: {
             html: otherLocationHTML,

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -896,6 +896,7 @@ describe('GET /service-provider/action-plan/:id/sessions/:sessionNumber/edit', (
     interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
     interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
     interventionsService.getActionPlan.mockResolvedValue(actionPlanFactory.build())
+    interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
     await request(app)
       .get(`/service-provider/action-plan/1/sessions/1/edit`)
@@ -919,6 +920,8 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
 
       interventionsService.getActionPlan.mockResolvedValue(actionPlan)
       interventionsService.updateActionPlanAppointment.mockResolvedValue(updatedAppointment)
+      interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
       await request(app)
         .post(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
@@ -942,6 +945,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
         durationInMinutes: 75,
         appointmentDeliveryType: 'PHONE_CALL',
         appointmentDeliveryAddress: null,
+        npsOfficeCode: null,
       })
     })
 
@@ -950,6 +954,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
         interventionsService.getActionPlanAppointment.mockResolvedValue(actionPlanAppointmentFactory.build())
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
         interventionsService.getActionPlan.mockResolvedValue(actionPlanFactory.build())
+        interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
         const error = { status: 409 }
         interventionsService.updateActionPlanAppointment.mockRejectedValue(error)
@@ -977,6 +982,8 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
     describe('when the interventions service responds with an error that isn’t a 409 status code', () => {
       it('renders an error message', async () => {
         interventionsService.getActionPlan.mockResolvedValue(actionPlanFactory.build())
+        interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+        interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
         const error = new Error('Failed to update appointment')
         interventionsService.updateActionPlanAppointment.mockRejectedValue(error)
@@ -1010,6 +1017,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
       interventionsService.getActionPlan.mockResolvedValue(actionPlan)
       interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
       interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
       await request(app)
         .post(`/service-provider/action-plan/1/sessions/1/edit`)
@@ -1811,6 +1819,7 @@ describe('GET /service-provider/referrals/:id/supplier-assessment/schedule', () 
     it('renders an empty form', async () => {
       interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessmentFactory.build())
       interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
       await request(app)
         .get(`/service-provider/referrals/1/supplier-assessment/schedule`)
@@ -1828,6 +1837,7 @@ describe('GET /service-provider/referrals/:id/supplier-assessment/schedule', () 
         supplierAssessmentFactory.withSingleAppointment.build()
       )
       interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
       await request(app)
         .get(`/service-provider/referrals/1/supplier-assessment/schedule`)
@@ -1845,6 +1855,7 @@ describe('GET /service-provider/referrals/:id/supplier-assessment/schedule', () 
         supplierAssessmentFactory.withNonAttendedAppointment.build()
       )
       interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
       hmppsAuthService.getSPUserByUsername.mockResolvedValue(
         hmppsAuthUserFactory.build({ firstName: 'caseWorkerFirstName', lastName: 'caseWorkerLastName' })
       )
@@ -1878,6 +1889,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
         interventionsService.getSentReferral.mockResolvedValue(referral)
         interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessment)
         interventionsService.scheduleSupplierAssessmentAppointment.mockResolvedValue(scheduledAppointment)
+        interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
         await request(app)
           .post(`/service-provider/referrals/${referral.id}/supplier-assessment/schedule`)
@@ -1904,6 +1916,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             appointmentDeliveryAddress: null,
+            npsOfficeCode: null,
           }
         )
       })
@@ -1924,6 +1937,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
         interventionsService.getSentReferral.mockResolvedValue(referral)
         interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessment)
         interventionsService.scheduleSupplierAssessmentAppointment.mockResolvedValue(scheduledAppointment)
+        interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
         await request(app)
           .post(`/service-provider/referrals/${referral.id}/supplier-assessment/schedule`)
@@ -1950,6 +1964,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             appointmentDeliveryAddress: null,
+            npsOfficeCode: null,
           }
         )
       })
@@ -1959,6 +1974,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
       it('renders a specific error message', async () => {
         interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessmentFactory.build())
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+        interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
         const error = { status: 409 }
         interventionsService.scheduleSupplierAssessmentAppointment.mockRejectedValue(error)
@@ -1987,6 +2003,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
       it('renders an error message', async () => {
         interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessmentFactory.build())
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+        interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
         const error = new Error('Failed to update appointment')
         interventionsService.scheduleSupplierAssessmentAppointment.mockRejectedValue(error)
@@ -2016,6 +2033,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
     it('does not try to schedule an appointment on the interventions service, and renders an error message', async () => {
       interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessmentFactory.build())
       interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
       await request(app)
         .post(`/service-provider/referrals/1/supplier-assessment/schedule`)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -75,6 +75,8 @@ import InitialAssessmentBehaviourFeedbackPresenter from '../appointments/feedbac
 import DraftsService from '../../services/draftsService'
 import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
 import { ActionPlanAppointment, AppointmentSchedulingDetails } from '../../models/appointment'
+import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
+import DeliusOfficeLocationFilter from '../../services/deliusOfficeLocationFilter'
 
 export interface DraftAssignmentData {
   email: string | null
@@ -86,7 +88,8 @@ export default class ServiceProviderReferralsController {
     private readonly communityApiService: CommunityApiService,
     private readonly hmppsAuthService: HmppsAuthService,
     private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService,
-    private readonly draftsService: DraftsService
+    private readonly draftsService: DraftsService,
+    private readonly deliusOfficeLocationFilter: DeliusOfficeLocationFilter
   ) {}
 
   async showDashboard(req: Request, res: Response): Promise<void> {
@@ -553,27 +556,46 @@ export default class ServiceProviderReferralsController {
   async editActionPlanSession(req: Request, res: Response): Promise<void> {
     const sessionNumber = Number(req.params.sessionNumber)
     const actionPlan = await this.interventionsService.getActionPlan(res.locals.user.token.accessToken, req.params.id)
-    const referral = await this.interventionsService.getSentReferral(
-      res.locals.user.token.accessToken,
-      actionPlan.referralId
-    )
+    const { accessToken } = res.locals.user.token
+    const referral = await this.interventionsService.getSentReferral(accessToken, actionPlan.referralId)
+    const intervention = await this.interventionsService.getIntervention(accessToken, referral.referral.interventionId)
+    const deliusOfficeLocations: DeliusOfficeLocation[] =
+      await this.deliusOfficeLocationFilter.findOfficesByIntervention(intervention)
 
-    await this.scheduleAppointment(req, res, {
-      getReferral: async () => referral,
-      getCurrentAppointment: () =>
-        this.interventionsService.getActionPlanAppointment(
-          res.locals.user.token.accessToken,
-          req.params.id,
-          sessionNumber
-        ),
-      scheduleAppointment: paramsForUpdate =>
-        this.interventionsService
-          .updateActionPlanAppointment(res.locals.user.token.accessToken, req.params.id, sessionNumber, paramsForUpdate)
-          .then(),
-      createPresenter: (appointment, formError, userInputData, serverError) =>
-        new ScheduleActionPlanSessionPresenter(referral, appointment, null, formError, userInputData, serverError),
-      redirectTo: `/service-provider/referrals/${actionPlan.referralId}/progress`,
-    })
+    await this.scheduleAppointment(
+      req,
+      res,
+      {
+        getReferral: async () => referral,
+        getCurrentAppointment: () =>
+          this.interventionsService.getActionPlanAppointment(
+            res.locals.user.token.accessToken,
+            req.params.id,
+            sessionNumber
+          ),
+        scheduleAppointment: paramsForUpdate =>
+          this.interventionsService
+            .updateActionPlanAppointment(
+              res.locals.user.token.accessToken,
+              req.params.id,
+              sessionNumber,
+              paramsForUpdate
+            )
+            .then(),
+        createPresenter: (appointment, formError, userInputData, serverError) =>
+          new ScheduleActionPlanSessionPresenter(
+            referral,
+            appointment,
+            deliusOfficeLocations,
+            null,
+            formError,
+            userInputData,
+            serverError
+          ),
+        redirectTo: `/service-provider/referrals/${actionPlan.referralId}/progress`,
+      },
+      deliusOfficeLocations
+    )
   }
 
   async showSupplierAssessmentAppointmentConfirmation(
@@ -594,15 +616,15 @@ export default class ServiceProviderReferralsController {
 
   async scheduleSupplierAssessmentAppointment(req: Request, res: Response): Promise<void> {
     const referralId = req.params.id
-    const referral = await this.interventionsService.getSentReferral(res.locals.user.token.accessToken, referralId)
-
-    const supplierAssessment = await this.interventionsService.getSupplierAssessment(
-      res.locals.user.token.accessToken,
-      referralId
-    )
+    const { accessToken } = res.locals.user.token
+    const referral = await this.interventionsService.getSentReferral(accessToken, referralId)
+    const supplierAssessment = await this.interventionsService.getSupplierAssessment(accessToken, referralId)
+    const intervention = await this.interventionsService.getIntervention(accessToken, referral.referral.interventionId)
 
     const { currentAppointment } = new SupplierAssessmentDecorator(supplierAssessment)
     const hasExistingScheduledAppointment = currentAppointment !== null && !currentAppointment.sessionFeedback.submitted
+    const deliusOfficeLocations: DeliusOfficeLocation[] =
+      await this.deliusOfficeLocationFilter.findOfficesByIntervention(intervention)
     let assignedCaseworker: AuthUserDetails | null = null
     if (currentAppointment?.sessionFeedback?.submitted) {
       assignedCaseworker = await this.hmppsAuthService.getSPUserByUsername(
@@ -611,35 +633,41 @@ export default class ServiceProviderReferralsController {
       )
     }
 
-    await this.scheduleAppointment(req, res, {
-      getReferral: async () => referral,
-      getCurrentAppointment: async () => currentAppointment,
-      scheduleAppointment: paramsForUpdate =>
-        this.interventionsService
-          .scheduleSupplierAssessmentAppointment(
-            res.locals.user.token.accessToken,
-            supplierAssessment.id,
-            paramsForUpdate
+    await this.scheduleAppointment(
+      req,
+      res,
+      {
+        getReferral: async () => referral,
+        getCurrentAppointment: async () => currentAppointment,
+        scheduleAppointment: paramsForUpdate =>
+          this.interventionsService
+            .scheduleSupplierAssessmentAppointment(
+              res.locals.user.token.accessToken,
+              supplierAssessment.id,
+              paramsForUpdate
+            )
+            .then(),
+        createPresenter: (appointment, formError, userInputData, serverError) => {
+          const overrideBackLinkHref = hasExistingScheduledAppointment
+            ? `/service-provider/referrals/${referralId}/supplier-assessment`
+            : undefined
+          return new ScheduleAppointmentPresenter(
+            referral,
+            appointment,
+            deliusOfficeLocations,
+            assignedCaseworker,
+            formError,
+            userInputData,
+            serverError,
+            overrideBackLinkHref
           )
-          .then(),
-      createPresenter: (appointment, formError, userInputData, serverError) => {
-        const overrideBackLinkHref = hasExistingScheduledAppointment
-          ? `/service-provider/referrals/${referralId}/supplier-assessment`
-          : undefined
-        return new ScheduleAppointmentPresenter(
-          referral,
-          appointment,
-          assignedCaseworker,
-          formError,
-          userInputData,
-          serverError,
-          overrideBackLinkHref
-        )
+        },
+        redirectTo: `/service-provider/referrals/${referralId}/supplier-assessment/${
+          hasExistingScheduledAppointment ? 'rescheduled-confirmation' : 'scheduled-confirmation'
+        }`,
       },
-      redirectTo: `/service-provider/referrals/${referralId}/supplier-assessment/${
-        hasExistingScheduledAppointment ? 'rescheduled-confirmation' : 'scheduled-confirmation'
-      }`,
-    })
+      deliusOfficeLocations
+    )
   }
 
   async showSupplierAssessmentAppointment(req: Request, res: Response): Promise<void> {
@@ -680,14 +708,15 @@ export default class ServiceProviderReferralsController {
         serverError: FormValidationError | null
       ) => ScheduleAppointmentPresenter
       redirectTo: string
-    }
+    },
+    deliusOfficeLocations: DeliusOfficeLocation[]
   ): Promise<void> {
     let userInputData: Record<string, unknown> | null = null
     let formError: FormValidationError | null = null
     let serverError: FormValidationError | null = null
 
     if (req.method === 'POST') {
-      const data = await new ScheduleAppointmentForm(req).data()
+      const data = await new ScheduleAppointmentForm(req, deliusOfficeLocations).data()
 
       if (data.error) {
         res.status(400)

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -1,16 +1,20 @@
 import { Router } from 'express'
 import { Services, get, post } from './index'
 import ServiceProviderReferralsController from './serviceProviderReferrals/serviceProviderReferralsController'
+import DeliusOfficeLocationFilter from '../services/deliusOfficeLocationFilter'
+import ReferenceDataService from '../services/referenceDataService'
 
 export const serviceProviderUrlPrefix = '/service-provider'
 
 export default function serviceProviderRoutes(router: Router, services: Services): Router {
+  const deliusOfficeLocationFilter = new DeliusOfficeLocationFilter(new ReferenceDataService())
   const serviceProviderReferralsController = new ServiceProviderReferralsController(
     services.interventionsService,
     services.communityApiService,
     services.hmppsAuthService,
     services.assessRisksAndNeedsService,
-    services.draftsService
+    services.draftsService,
+    deliusOfficeLocationFilter
   )
 
   get(router, '/dashboard', (req, res) => serviceProviderReferralsController.showDashboard(req, res))

--- a/server/routes/testutils/mocks/mockDeliusOfficeLocationFilter.ts
+++ b/server/routes/testutils/mocks/mockDeliusOfficeLocationFilter.ts
@@ -1,0 +1,8 @@
+import DeliusOfficeLocationFilter from '../../../services/deliusOfficeLocationFilter'
+import MockReferenceDataService from './mockReferenceDataService'
+
+export default class MockDeliusOfficeLocationFilter extends DeliusOfficeLocationFilter {
+  constructor() {
+    super(new MockReferenceDataService())
+  }
+}

--- a/server/routes/testutils/mocks/mockReferenceDataService.ts
+++ b/server/routes/testutils/mocks/mockReferenceDataService.ts
@@ -1,0 +1,7 @@
+import ReferenceDataService from '../../../services/referenceDataService'
+
+export default class MockReferenceDataService extends ReferenceDataService {
+  constructor() {
+    super()
+  }
+}

--- a/server/services/deliusOfficeLocationFilter.test.ts
+++ b/server/services/deliusOfficeLocationFilter.test.ts
@@ -1,0 +1,89 @@
+import ReferenceDataService from './referenceDataService'
+import DeliusOfficeLocationFilter from './deliusOfficeLocationFilter'
+import MockReferenceDataService from '../routes/testutils/mocks/mockReferenceDataService'
+import interventionFactory from '../../testutils/factories/intervention'
+import deliusOfficeLocationFactory from '../../testutils/factories/deliusOfficeLocation'
+
+jest.mock('./interventionsService')
+jest.mock('./referenceDataService')
+
+describe(DeliusOfficeLocationFilter, () => {
+  const referenceDataService = new MockReferenceDataService() as jest.Mocked<ReferenceDataService>
+  const deliusOfficeLocationProvider = new DeliusOfficeLocationFilter(referenceDataService)
+  describe('with an intervention having an nps region', () => {
+    it('should return an office within the same nps region', async () => {
+      const intervention = interventionFactory.build({
+        npsRegion: { id: 'B', name: 'North West' },
+        pccRegions: [],
+      })
+      const deliusOfficeLocation = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
+      referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
+      const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
+      expect(offices.length).toEqual(1)
+      expect(offices[0].probationRegionId).toEqual('B')
+    })
+    it('should filter out offices with empty crs location ids', async () => {
+      const intervention = interventionFactory.build({
+        npsRegion: { id: 'B', name: 'North West' },
+        pccRegions: [],
+      })
+      const emptyOfficeLocation = deliusOfficeLocationFactory.build({
+        deliusCRSLocationId: '',
+      })
+      referenceDataService.getProbationOffices.mockResolvedValue([emptyOfficeLocation])
+      const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
+      expect(offices.length).toEqual(0)
+    })
+  })
+  describe('with an intervention having a pcc region', () => {
+    it('should return an office within the same nps region', async () => {
+      const intervention = interventionFactory.build({
+        npsRegion: null,
+        pccRegions: [{ id: 'cheshire', name: 'Cheshire', npsRegion: { id: 'B', name: 'North West' } }],
+      })
+      const deliusOfficeLocation = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
+      referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
+      const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
+      expect(offices.length).toEqual(1)
+      expect(offices[0].probationRegionId).toEqual('B')
+    })
+  })
+
+  describe('with an intervention containing multiple regions', () => {
+    it('should return an an office for each region', async () => {
+      const intervention = interventionFactory.build({
+        npsRegion: { id: 'A', name: 'North West' },
+        pccRegions: [
+          { id: 'cheshire', name: 'Cheshire', npsRegion: { id: 'B', name: 'North West' } },
+          { id: 'cheshire', name: 'Cheshire', npsRegion: { id: 'C', name: 'North West' } },
+        ],
+      })
+      const deliusOfficeLocationA = deliusOfficeLocationFactory.build({ probationRegionId: 'A' })
+      const deliusOfficeLocationB = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
+      const deliusOfficeLocationC = deliusOfficeLocationFactory.build({ probationRegionId: 'C' })
+      referenceDataService.getProbationOffices.mockResolvedValue([
+        deliusOfficeLocationA,
+        deliusOfficeLocationB,
+        deliusOfficeLocationC,
+      ])
+      const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
+      expect(offices.length).toEqual(3)
+      expect(offices[0].probationRegionId).toEqual('A')
+      expect(offices[1].probationRegionId).toEqual('B')
+      expect(offices[2].probationRegionId).toEqual('C')
+    })
+  })
+
+  describe('with an intervention having no valid regions', () => {
+    it('should return an empty list of offices', async () => {
+      const intervention = interventionFactory.build({
+        npsRegion: { id: 'UNKNOWN', name: 'Unknown' },
+        pccRegions: [{ id: 'unknown', name: 'Unknown', npsRegion: { id: 'UNKNOWN', name: 'Unknown' } }],
+      })
+      const deliusOfficeLocation = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
+      referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
+      const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
+      expect(offices.length).toEqual(0)
+    })
+  })
+})

--- a/server/services/deliusOfficeLocationFilter.ts
+++ b/server/services/deliusOfficeLocationFilter.ts
@@ -1,0 +1,24 @@
+import ReferenceDataService from './referenceDataService'
+import DeliusOfficeLocation from '../models/deliusOfficeLocation'
+import Intervention from '../models/intervention'
+
+export default class DeliusOfficeLocationFilter {
+  constructor(private referenceDataService: ReferenceDataService) {}
+
+  async findOfficesByIntervention(intervention: Intervention): Promise<DeliusOfficeLocation[]> {
+    const npsRegionIds: string[] = []
+    if (intervention.npsRegion !== undefined && intervention.npsRegion !== null) {
+      npsRegionIds.push(intervention.npsRegion.id)
+    }
+    intervention.pccRegions.map(pccRegion => npsRegionIds.push(pccRegion.npsRegion?.id))
+    return this.findOfficesByNpsRegionIds(npsRegionIds)
+  }
+
+  private async findOfficesByNpsRegionIds(npsRegionIds: string[]): Promise<DeliusOfficeLocation[]> {
+    const deliusOfficeLocations = await this.referenceDataService.getProbationOffices()
+    const filteredOfficeLocations = deliusOfficeLocations
+      .filter(deliusOfficeLocation => deliusOfficeLocation.deliusCRSLocationId !== '')
+      .filter(deliusOfficeLocation => npsRegionIds.includes(deliusOfficeLocation.probationRegionId))
+    return filteredOfficeLocations
+  }
+}

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2392,6 +2392,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
                 county: 'Lancashire',
                 postCode: 'SY40RE',
               },
+              npsOfficeCode: null,
             },
             headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
           },
@@ -2417,6 +2418,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
               county: 'Lancashire',
               postCode: 'SY40RE',
             },
+            npsOfficeCode: null,
           })
         ).toMatchObject(actionPlanAppointment)
       })

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -1,0 +1,19 @@
+import ReferenceDataService from './referenceDataService'
+
+describe(ReferenceDataService, () => {
+  describe('with valid csv', () => {
+    it('should return correct reference data office locations', async () => {
+      const referenceDataService = new ReferenceDataService()
+      const data = await referenceDataService.getProbationOffices()
+      const buxtonOffice = data[1]
+      expect(buxtonOffice.probationOfficeId).toEqual(2)
+      expect(buxtonOffice.name).toEqual('Derbyshire: Buxton Probation Office')
+      expect(buxtonOffice.address).toEqual(
+        'Probation Office, Chesterfield House, 25 Hardwick Street, Buxton, Derbyshire, SK17 6DH'
+      )
+      expect(buxtonOffice.probationRegionId).toEqual('F')
+      expect(buxtonOffice.govUkURL).toEqual('https://www.gov.uk/guidance/derbyshire-chesterfield-house')
+      expect(buxtonOffice.deliusCRSLocationId).toEqual('CRS0032')
+    })
+  })
+})

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -1,0 +1,21 @@
+import csv from 'csvtojson'
+import DeliusOfficeLocation from '../models/deliusOfficeLocation'
+
+export default class ReferenceDataService {
+  async getProbationOffices(): Promise<DeliusOfficeLocation[]> {
+    return csv()
+      .fromFile('server/data/reference-data/probation-offices-v0.csv')
+      .then(json => {
+        return json.map(jsonFile => {
+          return {
+            probationOfficeId: Number(jsonFile.probation_office_id),
+            name: jsonFile.name,
+            address: jsonFile.address,
+            probationRegionId: jsonFile.probation_region_id,
+            govUkURL: jsonFile.gov_uk_url,
+            deliusCRSLocationId: jsonFile.delius_crs_location_id,
+          }
+        })
+      })
+  }
+}

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -104,6 +104,10 @@ export default {
       postCodeEmpty: 'Enter a postcode',
       postCodeInvalid: 'Enter a valid postcode',
     },
+    deliusOfficeLocation: {
+      empty: 'Select an office',
+      invalidOfficeSelection: 'Select an office from the list',
+    },
   },
   endOfServiceReportOutcome: {
     achievementLevel: {

--- a/server/utils/forms/inputs/deliusOfficeLocationInput.test.ts
+++ b/server/utils/forms/inputs/deliusOfficeLocationInput.test.ts
@@ -1,0 +1,81 @@
+import TestUtils from '../../../../testutils/testUtils'
+import DeliusOfficeLocationInput, { DeliusOfficeLocationErrorMessages } from './deliusOfficeLocationInput'
+import DeliusOfficeLocation from '../../../models/deliusOfficeLocation'
+
+describe(DeliusOfficeLocationInput, () => {
+  const errorMessage: DeliusOfficeLocationErrorMessages = {
+    empty: 'Select an office',
+    invalidOfficeSelection: 'Invalid office selection',
+  }
+  const deliusOfficeLocations: DeliusOfficeLocation[] = [
+    {
+      probationOfficeId: 76,
+      name: 'Havering: Pioneer House',
+      address: 'Pioneer House, North Street, Hornchurch, Essex, RM11 1QZ',
+      probationRegionId: 'J',
+      govUkURL: 'https://www.gov.uk/guidance/havering-pioneer-house',
+      deliusCRSLocationId: 'CRS0001',
+    },
+  ]
+  describe('validate', () => {
+    describe('with valid data', () => {
+      it('returns an office location code', async () => {
+        const request = TestUtils.createRequest({
+          'delius-office-location-code': 'CRS0001',
+        })
+        const result = await new DeliusOfficeLocationInput(
+          request,
+          'delius-office-location-code',
+          deliusOfficeLocations,
+          errorMessage
+        ).validate()
+        expect(result.value).toEqual('CRS0001')
+      })
+    })
+    describe('with invalid data', () => {
+      describe('with empty selection', () => {
+        it('should present an error', async () => {
+          const request = TestUtils.createRequest({})
+          const result = await new DeliusOfficeLocationInput(
+            request,
+            'delius-office-location-code',
+            deliusOfficeLocations,
+            errorMessage
+          ).validate()
+          expect(result.error).toEqual({
+            errors: [
+              {
+                errorSummaryLinkedField: 'delius-office-location-code',
+                formFields: ['delius-office-location-code'],
+                message: 'Select an office',
+              },
+            ],
+          })
+        })
+      })
+
+      describe('with an invalid selection', () => {
+        it('should present an error', async () => {
+          const request = TestUtils.createRequest({
+            'delius-office-location-code': 'CRS0002',
+          })
+          const result = await new DeliusOfficeLocationInput(
+            request,
+            'delius-office-location-code',
+            deliusOfficeLocations,
+            errorMessage
+          ).validate()
+          expect(result.error).toEqual({
+            errors: [
+              {
+                errorSummaryLinkedField: 'delius-office-location-code',
+                formFields: ['delius-office-location-code'],
+                message: 'Invalid office selection',
+              },
+            ],
+          })
+        })
+      })
+    })
+  })
+})

--- a/server/utils/forms/inputs/deliusOfficeLocationInput.ts
+++ b/server/utils/forms/inputs/deliusOfficeLocationInput.ts
@@ -1,0 +1,59 @@
+import { Request } from 'express'
+import * as ExpressValidator from 'express-validator'
+import { Result, ValidationError } from 'express-validator'
+import { FormValidationResult } from '../formValidationResult'
+import FormUtils from '../../formUtils'
+import PresenterUtils from '../../presenterUtils'
+import DeliusOfficeLocation from '../../../models/deliusOfficeLocation'
+
+export interface DeliusOfficeLocationErrorMessages {
+  empty: string
+  invalidOfficeSelection: string
+}
+
+export default class DeliusOfficeLocationInput {
+  constructor(
+    private readonly request: Request,
+    private readonly key: string,
+    private readonly deliusOfficeLocations: DeliusOfficeLocation[],
+    private readonly errorMessages: DeliusOfficeLocationErrorMessages
+  ) {}
+
+  private readonly utils = new PresenterUtils(this.request.body)
+
+  async validate(): Promise<FormValidationResult<string>> {
+    const validationResult = await this.runValidations()
+    const error = FormUtils.validationErrorFromResult(validationResult)
+    if (error) {
+      return { value: null, error }
+    }
+
+    return {
+      value: this.selection!,
+      error: null,
+    }
+  }
+
+  private async runValidations(): Promise<Result<ValidationError>> {
+    const validation: Result<ValidationError> = await FormUtils.runValidations({
+      request: this.request,
+      validations: this.validations,
+    })
+    return validation
+  }
+
+  private get validations(): ExpressValidator.ValidationChain[] {
+    return [
+      ExpressValidator.body(this.key)
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(this.errorMessages.empty)
+        .bail()
+        .isIn(this.deliusOfficeLocations.map(office => office.deliusCRSLocationId))
+        .withMessage(this.errorMessages.invalidOfficeSelection),
+    ]
+  }
+
+  private get selection(): string | null {
+    return this.utils.selectionValue(null, this.key, null).value ?? null
+  }
+}

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -597,6 +597,49 @@ describe(PresenterUtils, () => {
     })
   })
 
+  describe('selectionValue', () => {
+    describe('when there is no user input data', () => {
+      describe('and the model has a null value', () => {
+        it('returns a null value', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.selectionValue(null, 'delius-office-location-code', null)
+          expect(value).toMatchObject({ errorMessage: null, value: null })
+        })
+      })
+      describe('and the model has a value', () => {
+        it('returns the model value', () => {
+          const utils = new PresenterUtils(null)
+          const value = utils.selectionValue('CRS0001', 'delius-office-location-code', null)
+          expect(value).toMatchObject({ errorMessage: null, value: 'CRS0001' })
+        })
+      })
+    })
+    describe('when there is user input data', () => {
+      describe('and the data is valid', () => {
+        it('returns a meeting method', () => {
+          const utils = new PresenterUtils({ 'delius-office-location-code': 'CRS0001' })
+          const value = utils.selectionValue(null, 'delius-office-location-code', null)
+          expect(value).toMatchObject({ errorMessage: null, value: 'CRS0001' })
+        })
+      })
+      describe('and the selection is invalid', () => {
+        it('returns an error message', () => {
+          const utils = new PresenterUtils({ 'delius-office-location-code': 'INVALID' })
+          const formValidationError: FormValidationError = {
+            errors: [
+              {
+                formFields: ['delius-office-location-code'],
+                errorSummaryLinkedField: 'delius-office-location-code0',
+                message: 'errorMessage',
+              },
+            ],
+          }
+          const value = utils.meetingMethodValue(null, 'delius-office-location-code', formValidationError)
+          expect(value).toMatchObject({ errorMessage: 'errorMessage', value: null })
+        })
+      })
+    })
+  })
   describe('address', () => {
     describe('when there are errors', () => {
       it('they should be linked to the correct field', () => {

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -40,6 +40,11 @@ interface TwelveHourTimeInputPresenter {
   partOfDay: PartOfDayInputPresenter
 }
 
+interface SelectionInputPresenter {
+  errorMessage: string | null
+  value: string | null
+}
+
 interface MeetingMethodInputPresenter {
   errorMessage: string | null
   value: AppointmentDeliveryType | null
@@ -156,6 +161,23 @@ export default class PresenterUtils {
     }
   }
 
+  selectionValue(
+    modelValue: string | null,
+    userInputKey: string,
+    error: FormValidationError | null
+  ): SelectionInputPresenter {
+    let selection: string | null
+    if (this.userInputData === null) {
+      selection = modelValue
+    } else {
+      selection = (this.userInputData[userInputKey] as string) ?? null
+    }
+    return {
+      errorMessage: PresenterUtils.errorMessage(error, userInputKey),
+      value: selection,
+    }
+  }
+
   meetingMethodValue(
     modelValue: AppointmentDeliveryType | null,
     userInputKey: string,
@@ -167,7 +189,11 @@ export default class PresenterUtils {
       appointmentDeliveryType = modelValue
     } else {
       const radioButtonValue = this.userInputData['meeting-method']
-      if (['PHONE_CALL', 'VIDEO_CALL', 'IN_PERSON_MEETING_OTHER'].includes(radioButtonValue as string)) {
+      if (
+        ['PHONE_CALL', 'VIDEO_CALL', 'IN_PERSON_MEETING_OTHER', 'IN_PERSON_MEETING_PROBATION_OFFICE'].includes(
+          radioButtonValue as string
+        )
+      ) {
         appointmentDeliveryType = radioButtonValue as AppointmentDeliveryType
       }
     }

--- a/server/views/serviceProviderReferrals/scheduleAppointment.njk
+++ b/server/views/serviceProviderReferrals/scheduleAppointment.njk
@@ -5,6 +5,7 @@
 {% from "components/time-input/macro.njk" import appTimeInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% extends "../partials/layout.njk" %}
@@ -45,6 +46,9 @@
           {{ govukDateInput(dateInputArgs) }}
           {{ appTimeInput(timeInputArgs) }}
           {{ govukDateInput(durationDateInputArgs) }}
+          {% set deliusOfficeLocationHtml %}
+            {{ govukSelect(deliusOfficeLocationSelectArgs) }}
+          {% endset -%}
           {% set otherLocationHtml %}
               {{ govukInput(address.firstAddressLineInputArgs) }}
               {{ govukInput(address.secondAddressLineInputArgs) }}
@@ -52,7 +56,7 @@
               {{ govukInput(address.countyInputArgs) }}
               {{ govukInput(address.postCodeInputArgs) }}
           {% endset -%}
-          {{ govukRadios(meetingMethodRadioInputArgs(otherLocationHtml)) }}
+          {{ govukRadios(meetingMethodRadioInputArgs(deliusOfficeLocationHtml, otherLocationHtml)) }}
         </div>
         {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
       </form>

--- a/testutils/factories/actionPlanAppointment.ts
+++ b/testutils/factories/actionPlanAppointment.ts
@@ -28,4 +28,5 @@ export default ActionPlanAppointmentFactory.define(() => ({
   appointmentDeliveryType: null,
   appointmentDeliveryAddress: null,
   sessionFeedback: initialAssessmentAppointmentFactory.newlyBooked().build().sessionFeedback,
+  npsOfficeCode: null,
 }))

--- a/testutils/factories/deliusOfficeLocation.ts
+++ b/testutils/factories/deliusOfficeLocation.ts
@@ -1,0 +1,11 @@
+import { Factory } from 'fishery'
+import DeliusOfficeLocation from '../../server/models/deliusOfficeLocation'
+
+export default Factory.define<DeliusOfficeLocation>(() => ({
+  probationOfficeId: 127,
+  name: 'South Lakeland: Kendal Probation Office',
+  address: 'Probation Office, Busher Lodge, 149 Stricklandgate, Kendal, Cumbria, LA9 4RF',
+  probationRegionId: 'B',
+  govUkURL: 'https://www.gov.uk/guidance/south-lakeland-kendal-probation-office',
+  deliusCRSLocationId: 'CRS0026',
+}))

--- a/testutils/factories/initialAssessmentAppointment.ts
+++ b/testutils/factories/initialAssessmentAppointment.ts
@@ -37,6 +37,13 @@ class InitialAssessmentAppointmentFactory extends Factory<InitialAssessmentAppoi
     return this.params({ appointmentDeliveryType: 'VIDEO_CALL', appointmentDeliveryAddress: null })
   }
 
+  inPersonDeliusOfficeLocation(npsOfficeCode: string): InitialAssessmentAppointmentFactory {
+    return this.params({
+      appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
+      npsOfficeCode,
+    })
+  }
+
   get inPersonOtherWithFullAddress(): InitialAssessmentAppointmentFactory {
     return this.params({
       appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -75,6 +82,7 @@ export default InitialAssessmentAppointmentFactory.define(({ sequence }) => ({
   // For some reason the compiler complains if I write 'VIDEO_CALL' inline
   appointmentDeliveryType: defaultAppointmentDeliveryType,
   appointmentDeliveryAddress: null,
+  npsOfficeCode: null,
   sessionFeedback: {
     attendance: {
       attended: null,

--- a/testutils/factories/intervention.ts
+++ b/testutils/factories/intervention.ts
@@ -3,6 +3,7 @@ import Intervention from '../../server/models/intervention'
 import serviceCategoryFactory from './serviceCategory'
 import serviceProviderFactory from './serviceProvider'
 import eligibilityFactory from './eligibility'
+import pccRegionFactory from './pccRegion'
 
 export default Factory.define<Intervention>(({ sequence }) => {
   const serviceCategory = serviceCategoryFactory.build()
@@ -21,10 +22,10 @@ The service will use the following methods:
 • Hypnotherapy`,
     npsRegion: { id: 'B', name: 'North West' },
     pccRegions: [
-      { id: 'cheshire', name: 'Cheshire' },
-      { id: 'cumbria', name: 'Cumbria' },
-      { id: 'lancashire', name: 'Lancashire' },
-      { id: 'merseyside', name: 'Merseyside' },
+      pccRegionFactory.build({ id: 'cheshire', name: 'Cheshire', npsRegion: { id: 'B', name: 'North West' } }),
+      pccRegionFactory.build({ id: 'cumbria', name: 'Cumbria', npsRegion: { id: 'B', name: 'North West' } }),
+      pccRegionFactory.build({ id: 'lancashire', name: 'Lancashire', npsRegion: { id: 'B', name: 'North West' } }),
+      pccRegionFactory.build({ id: 'merseyside', name: 'Merseyside', npsRegion: { id: 'B', name: 'North West' } }),
     ],
     serviceCategories: [serviceCategory],
     serviceProvider: serviceProviderFactory.build(),

--- a/testutils/factories/pccRegion.ts
+++ b/testutils/factories/pccRegion.ts
@@ -4,4 +4,5 @@ import PCCRegion from '../../server/models/pccRegion'
 export default Factory.define<PCCRegion>(({ sequence }) => ({
   id: sequence.toString(),
   name: 'Cheshire',
+  npsRegion: { id: 'B', name: 'North West' },
 }))


### PR DESCRIPTION
## What does this pull request do?

Provides a drop down selection for NPS office

## What is the intent behind these changes?

Ensure user can select NPS office. 

This change adds in an NPS office csv from reference-data. It is committed directly into interventions-ui as MVP since there is a bit of uncertainty regarding the solution of how to integrate with reference-data.

![image](https://user-images.githubusercontent.com/83066216/124574087-094a3c80-de42-11eb-8a38-acca2d51e125.png)


I've created this as a feature branch because still need to do the following before merging into main:

1. Disable updating NPS office location for an appointment
2. Add pacts tests
3. Finish the progress screen for NPS office
4. Ensure that intervention-service returns npsRegionId for PccRegion