### PR TITLE
do not let PPs view action plans that have not been submitted

### DIFF
--- a/server/routes/shared/action-plan/actionPlanPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.test.ts
@@ -114,4 +114,46 @@ describe(InterventionProgressPresenter, () => {
       ])
     })
   })
+
+  describe('probationPractitionerBlockedFromViewing', () => {
+    it('should always return false for service providers', () => {
+      const newActionPlan = actionPlanFactory.justCreated(referral.id).build()
+      const newActionPlanPresenter = new ActionPlanPresenter(
+        referral,
+        newActionPlan,
+        serviceCategories,
+        'service-provider'
+      )
+      expect(newActionPlanPresenter.probationPractitionerBlockedFromViewing).toBe(false)
+
+      const submittedActionPlan = actionPlanFactory.submitted().build()
+      const submittedActionPlanPresenter = new ActionPlanPresenter(
+        referral,
+        submittedActionPlan,
+        serviceCategories,
+        'service-provider'
+      )
+      expect(submittedActionPlanPresenter.probationPractitionerBlockedFromViewing).toBe(false)
+    })
+
+    it('should return true for probation practitioners when the referral is unsubmitted', () => {
+      const newActionPlan = actionPlanFactory.justCreated(referral.id).build()
+      const newActionPlanPresenter = new ActionPlanPresenter(
+        referral,
+        newActionPlan,
+        serviceCategories,
+        'probation-practitioner'
+      )
+      expect(newActionPlanPresenter.probationPractitionerBlockedFromViewing).toBe(true)
+
+      const submittedActionPlan = actionPlanFactory.submitted().build()
+      const submittedActionPlanPresenter = new ActionPlanPresenter(
+        referral,
+        submittedActionPlan,
+        serviceCategories,
+        'probation-practitioner'
+      )
+      expect(submittedActionPlanPresenter.probationPractitionerBlockedFromViewing).toBe(false)
+    })
+  })
 })

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -56,4 +56,9 @@ export default class ActionPlanPresenter {
   get showApprovalForm(): boolean {
     return this.userType === 'probation-practitioner' && this.actionPlanSummaryPresenter.actionPlanUnderReview
   }
+
+  get probationPractitionerBlockedFromViewing(): boolean {
+    // probation practitioners can only view submitted action plans
+    return this.userType === 'probation-practitioner' && !this.actionPlanSummaryPresenter.actionPlanSubmitted
+  }
 }

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}%}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% block pageTitle %}
     HMPPS Interventions - GOV.UK
@@ -15,43 +15,60 @@
 {% block pageContent %}
     {% block content %}
     <div class="govuk-!-width-two-thirds">
-        {{ govukBackLink(backLinkArgs) }}
-        {% if errorSummaryArgs !== null %}
-            {{ govukErrorSummary(errorSummaryArgs) }}
-        {% endif %}
-        <h1 class="govuk-heading-l">View action plan</h1>
+        {% if presenter.probationPractitionerBlockedFromViewing %}
 
-        {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
+            {{ govukWarningText({
+                text: "Action plan cannot be reviewed.",
+                iconFallbackText: "Warning"
+            }) }}
 
-        <h2 class="govuk-heading-m">Desired outcomes and activities</h2>
+            <p class="govuk-body">
+                If you arrived at this page after clicking a link in an email, it is likely the service provider has withdrawn the action plan for editing.
+                You will receive another email when the action plan is resubmitted and ready for approval.
+            </p>
 
-        {% for serviceCategoryWithDesiredOutcomes in presenter.desiredOutcomesByServiceCategory %}
-            <h3 class="govuk-heading-s">{{ serviceCategoryWithDesiredOutcomes.serviceCategory }}</h3>
-            <ul class="govuk-list govuk-list--bullet">
-                {% for desiredOutcome in serviceCategoryWithDesiredOutcomes.desiredOutcomes %}
-                    <li>{{ desiredOutcome }}</li>
-                {% endfor %}
+            <p class="govuk-body"><a href="{{ presenter.interventionProgressURL }}">Return to intervention progress</a></p>
+
+        {% else %}
+
+            {{ govukBackLink(backLinkArgs) }}
+            {% if errorSummaryArgs !== null %}
+                {{ govukErrorSummary(errorSummaryArgs) }}
+            {% endif %}
+            <h1 class="govuk-heading-l">View action plan</h1>
+
+            {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
+
+            <h2 class="govuk-heading-m">Desired outcomes and activities</h2>
+
+            {% for serviceCategoryWithDesiredOutcomes in presenter.desiredOutcomesByServiceCategory %}
+                <h3 class="govuk-heading-s">{{ serviceCategoryWithDesiredOutcomes.serviceCategory }}</h3>
+                <ul class="govuk-list govuk-list--bullet">
+                    {% for desiredOutcome in serviceCategoryWithDesiredOutcomes.desiredOutcomes %}
+                        <li>{{ desiredOutcome }}</li>
+                    {% endfor %}
+                </ul>
+            {% endfor %}
+
+            <ul class="govuk-list">
+            {% for activity in presenter.orderedActivities %}
+                <li>{{ govukInsetText(insetTextActivityArgs(loop.index, activity.description)) }}</li>
+            {% endfor %}
             </ul>
-        {% endfor %}
 
-        <ul class="govuk-list">
-        {% for activity in presenter.orderedActivities %}
-            <li>{{ govukInsetText(insetTextActivityArgs(loop.index, activity.description)) }}</li>
-        {% endfor %}
-        </ul>
+            <h2 class="govuk-heading-m">Suggested number of sessions for the action plan</h2>
+            <p class="govuk-body">Suggested number of sessions: {{ presenter.text.actionPlanNumberOfSessions }}</p>
 
-        <h2 class="govuk-heading-m">Suggested number of sessions for the action plan</h2>
-        <p class="govuk-body">Suggested number of sessions: {{ presenter.text.actionPlanNumberOfSessions }}</p>
+            {% if presenter.showApprovalForm %}
+                <h2 class="govuk-heading-m">Do you want to approve this action plan?</h2>
+                <p class="govuk-body">Note: If you want to suggest any changes, contact <i>{{ presenter.text.spEmailAddress }}</i> before approving this action plan.</p>
 
-        {% if presenter.showApprovalForm %}
-            <h2 class="govuk-heading-m">Do you want to approve this action plan?</h2>
-            <p class="govuk-body">Note: If you want to suggest any changes, contact <i>{{ presenter.text.spEmailAddress }}</i> before approving this action plan.</p>
-
-            <form method="post" action="{{ presenter.actionPlanApprovalUrl }}">
-                {{ govukCheckboxes(confirmApprovalCheckboxArgs) }}
-                <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-                {{ govukButton({ text: "Approve", preventDoubleClick: true }) }}
-            </form>
+                <form method="post" action="{{ presenter.actionPlanApprovalUrl }}">
+                    {{ govukCheckboxes(confirmApprovalCheckboxArgs) }}
+                    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+                    {{ govukButton({ text: "Approve", preventDoubleClick: true }) }}
+                </form>
+            {% endif %}
         {% endif %}
     </div>
     {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

do not let PPs view action plans that have not been submitted

![Screenshot 2021-07-01 at 16 08 05](https://user-images.githubusercontent.com/63233073/124147369-89f5eb00-da86-11eb-8bde-9526650c8877.png)

## What is the intent behind these changes?

stop PPs viewing action plans that are being edited if they click the link in a email after it has been withdrawn for editing.
