### PR TITLE
IC-1745 sp can edit submitted action plans

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -280,5 +280,9 @@ export default function routes(router: Router, services: Services): Router {
     serviceProviderReferralsController.actionPlanEditConfirmation(req, res)
   )
 
+  post('/service-provider/referrals/:id/action-plan/edit', (req, res) =>
+    serviceProviderReferralsController.createNewDraftActionPlan(req, res)
+  )
+
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -276,5 +276,9 @@ export default function routes(router: Router, services: Services): Router {
     probationPractitionerReferralsController.actionPlanApproved(req, res)
   )
 
+  get('/service-provider/referrals/:id/action-plan/edit', (req, res) =>
+    serviceProviderReferralsController.actionPlanEditConfirmation(req, res)
+  )
+
   return router
 }

--- a/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationPresenter.ts
+++ b/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationPresenter.ts
@@ -1,0 +1,9 @@
+import SentReferral from '../../../../models/sentReferral'
+
+export default class ActionPlanEditConfirmationPresenter {
+  constructor(private readonly sentReferral: SentReferral) {}
+
+  readonly viewActionPlanUrl = `/service-provider/referrals/${this.sentReferral.id}/action-plan`
+
+  readonly editConfirmAction = `/service-provider/referrals/${this.sentReferral.id}/action-plan/edit`
+}

--- a/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationView.ts
+++ b/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationView.ts
@@ -1,0 +1,18 @@
+import ActionPlanEditConfirmationPresenter from './actionPlanEditConfirmationPresenter'
+
+export default class ActionPlanEditConfirmationView {
+  constructor(private readonly presenter: ActionPlanEditConfirmationPresenter) {}
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/actionPlan/actionPlanEditConfirmation',
+      {
+        presenter: this.presenter,
+        backLinkArgs: {
+          text: 'Back',
+          href: this.presenter.viewActionPlanUrl,
+        },
+      },
+    ]
+  }
+}

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -66,6 +66,8 @@ import SupplierAssessmentAppointmentPresenter from '../shared/supplierAssessment
 import SupplierAssessmentAppointmentView from '../shared/supplierAssessmentAppointmentView'
 import SupplierAssessmentAppointmentConfirmationPresenter from './supplierAssessmentAppointmentConfirmationPresenter'
 import SupplierAssessmentAppointmentConfirmationView from './supplierAssessmentAppointmentConfirmationView'
+import ActionPlanEditConfirmationPresenter from '../service-provider/action-plan/edit/actionPlanEditConfirmationPresenter'
+import ActionPlanEditConfirmationView from '../service-provider/action-plan/edit/actionPlanEditConfirmationView'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -1016,6 +1018,25 @@ export default class ServiceProviderReferralsController {
 
     const presenter = new ActionPlanPresenter(sentReferral, actionPlan, serviceCategories, 'service-provider')
     const view = new ActionPlanView(presenter)
+    ControllerUtils.renderWithLayout(res, view, serviceUser)
+  }
+
+  async actionPlanEditConfirmation(req: Request, res: Response): Promise<void> {
+    const sentReferral = await this.interventionsService.getSentReferral(
+      res.locals.user.token.accessToken,
+      req.params.id
+    )
+
+    if (sentReferral.actionPlanId === null) {
+      throw createError(500, `could not edit action plan for referral with id '${req.params.id}'`, {
+        userMessage: 'No action plan exists for this referral',
+      })
+    }
+
+    const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
+
+    const presenter = new ActionPlanEditConfirmationPresenter(sentReferral)
+    const view = new ActionPlanEditConfirmationView(presenter)
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 

--- a/server/routes/shared/action-plan/actionPlanPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.test.ts
@@ -156,4 +156,48 @@ describe(InterventionProgressPresenter, () => {
       expect(submittedActionPlanPresenter.probationPractitionerBlockedFromViewing).toBe(false)
     })
   })
+
+  describe('showEditButton', () => {
+    it('shows for SPs when the action plan has been submitted', () => {
+      const submittedActionPlan = actionPlanFactory.submitted().build()
+      const submittedActionPlanPresenter = new ActionPlanPresenter(
+        referral,
+        submittedActionPlan,
+        serviceCategories,
+        'service-provider'
+      )
+      expect(submittedActionPlanPresenter.showEditButton).toBe(true)
+    })
+
+    it('does not show for SPs when the action plan has been approved', () => {
+      const approvedActionPlan = actionPlanFactory.approved().build()
+      const approvedActionPlanPresenter = new ActionPlanPresenter(
+        referral,
+        approvedActionPlan,
+        serviceCategories,
+        'service-provider'
+      )
+      expect(approvedActionPlanPresenter.showEditButton).toBe(false)
+    })
+
+    it('never shows for PPs', () => {
+      const submittedActionPlan = actionPlanFactory.submitted().build()
+      const submittedActionPlanPresenter = new ActionPlanPresenter(
+        referral,
+        submittedActionPlan,
+        serviceCategories,
+        'probation-practitioner'
+      )
+      expect(submittedActionPlanPresenter.showEditButton).toBe(false)
+
+      const approvedActionPlan = actionPlanFactory.approved().build()
+      const approvedActionPlanPresenter = new ActionPlanPresenter(
+        referral,
+        approvedActionPlan,
+        serviceCategories,
+        'probation-practitioner'
+      )
+      expect(approvedActionPlanPresenter.showEditButton).toBe(false)
+    })
+  })
 })

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -28,6 +28,8 @@ export default class ActionPlanPresenter {
 
   readonly actionPlanApprovalUrl = `/probation-practitioner/referrals/${this.referral.id}/action-plan/approve`
 
+  readonly actionPlanEditConfirmationUrl = `/service-provider/referrals/${this.referral.id}/action-plan/edit`
+
   readonly errorSummary = PresenterUtils.errorSummary(this.validationError)
 
   readonly fieldErrors = {
@@ -60,5 +62,9 @@ export default class ActionPlanPresenter {
   get probationPractitionerBlockedFromViewing(): boolean {
     // probation practitioners can only view submitted action plans
     return this.userType === 'probation-practitioner' && !this.actionPlanSummaryPresenter.actionPlanSubmitted
+  }
+
+  get showEditButton(): boolean {
+    return this.userType === 'service-provider' && this.actionPlanSummaryPresenter.actionPlanUnderReview
   }
 }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1715,6 +1715,59 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(draftActionPlan.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
     })
+
+    it('returns a newly created draft action plan with number of sessions and activities', async () => {
+      const referralId = '81d754aa-d868-4347-9c0f-50690773014e'
+      await provider.addInteraction({
+        state: 'a caseworker has been assigned to a sent referral and an action plan can be created',
+        uponReceiving: 'a POST request to create a draft action plan that includes numberOfSessions and activities',
+        withRequest: {
+          method: 'POST',
+          path: '/draft-action-plan',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          body: {
+            referralId,
+            numberOfSessions: 5,
+            activities: [{ description: 'activity 1' }, { description: 'activity 2' }],
+          },
+        },
+        willRespondWith: {
+          status: 201,
+          body: Matchers.like({
+            id: 'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+            referralId: '81d754aa-d868-4347-9c0f-50690773014e',
+            numberOfSessions: 5,
+            activities: [
+              {
+                id: '5f7ce12c-0858-4188-a6af-5c8bdd697536',
+                createdAt: '2020-12-07T20:45:21.986389Z',
+                description: 'activity 1',
+              },
+              {
+                id: '5f7ce12c-0858-4188-a6af-5c8bdd697536',
+                createdAt: '2020-12-07T20:45:21.986389Z',
+                description: 'activity 2',
+              },
+            ],
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Location: Matchers.like(
+              'https://hmpps-interventions-service.com/draft-action-plan/dfb64747-f658-40e0-a827-87b4b0bdcfed'
+            ),
+          },
+        },
+      })
+
+      const draftActionPlan = await interventionsService.createDraftActionPlan(token, referralId, 5, [
+        { description: 'activity 1' },
+        { description: 'activity 2' },
+      ])
+      expect(draftActionPlan.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
+      expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
+      expect(draftActionPlan.numberOfSessions).toBe(5)
+      expect(draftActionPlan.activities.length).toBe(2)
+    })
   })
 
   describe('getActionPlan', () => {

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -34,7 +34,7 @@ export interface InterventionsFilterParams {
   maximumAge?: number
 }
 
-interface UpdateActivityParams {
+export interface UpdateActivityParams {
   description: string
 }
 
@@ -248,13 +248,22 @@ export default class InterventionsService {
     })) as PCCRegion[]
   }
 
-  async createDraftActionPlan(token: string, referralId: string): Promise<ActionPlan> {
+  async createDraftActionPlan(
+    token: string,
+    referralId: string,
+    numberOfSessions?: number,
+    activities?: UpdateActivityParams[]
+  ): Promise<ActionPlan> {
     const restClient = this.createRestClient(token)
 
     return (await restClient.post({
       path: '/draft-action-plan',
       headers: { Accept: 'application/json' },
-      data: { referralId },
+      data: {
+        referralId,
+        numberOfSessions,
+        activities,
+      },
     })) as ActionPlan
   }
 

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanEditConfirmation.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanEditConfirmation.njk
@@ -1,0 +1,22 @@
+{% extends "../../partials/layout.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}%}
+
+{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
+
+{% block pageContent %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukBackLink(backLinkArgs) }}
+
+            <h1 class="govuk-heading-l">Are you sure you want to change the action plan while it is being reviewed?</h1>
+
+            <p class="govuk-body">Note: This will withdraw the current action plan and the probation practitioner will no longer be able to view it.</p>
+
+            <form action="{{ presenter.editConfirmAction }}" method="post">
+                <input type="hidden" name="_csrf" value="{{csrfToken}}">
+                {{ govukButton({ text: "Confirm and continue", preventDoubleClick: true }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -39,6 +39,12 @@
 
             {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
 
+            {% if presenter.showEditButton %}
+                <a href="{{ presenter.actionPlanEditConfirmationUrl }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+                    Edit action plan
+                </a>
+            {% endif %}
+
             <h2 class="govuk-heading-m">Desired outcomes and activities</h2>
 
             {% for serviceCategoryWithDesiredOutcomes in presenter.desiredOutcomesByServiceCategory %}


### PR DESCRIPTION
## What does this pull request do?
b2681335f087096ceec1561998f4b6269c8c6534 adds a button to the SP action plan page to edit a submitted action plan 

![Screenshot 2021-07-02 at 12 17 59](https://user-images.githubusercontent.com/63233073/124267098-b87bd080-db2f-11eb-90e3-af99f5b95d4a.png)

350d2686e48d438dd18637285818d941cea7b994 adds a confirmation page with a button that creates a new draft action plan, rendering the existing action plan obsolete

![Screenshot 2021-07-02 at 12 18 17](https://user-images.githubusercontent.com/63233073/124267163-cd586400-db2f-11eb-902f-cd6556ac2dbc.png)

25d2b1bc9debb72394e1a0ad259ba7043207f264 creates the new action plan on the backend, copying over the number of sessions and activities from the existing action plan. it redirects the user to the start of the action plan journey but with the fields pre-filled.

![Screenshot 2021-07-02 at 12 18 25](https://user-images.githubusercontent.com/63233073/124267233-e6611500-db2f-11eb-94da-8853ed288900.png)

## What is the intent behind these changes?

allow SPs to update previously submitted action plans
