### PR TITLE
Remove messaging re email from referral confirmation page

### DIFF
--- a/server/views/referrals/confirmation.njk
+++ b/server/views/referrals/confirmation.njk
@@ -14,8 +14,6 @@
     <div class="govuk-grid-column-two-thirds">
       {{ govukPanel(panelArgs) }}
 
-      <p class="govuk-body">We have sent you a confirmation email.</p>
-
       <h2 class="govuk-heading-m">What happens next</h2>
 
       <p class="govuk-body">


### PR DESCRIPTION
## What does this pull request do?

Removes "we have sent you a confirmation email" text from PP referral sent confirmation page.

## What is the intent behind these changes?

The message is incorrect - we don't currently send an email - so stop confusing the user.