### PR TITLE
add 'download' attribute to hrefs for structured interventions downloads

### DIFF
--- a/server/views/probationPractitionerReferrals/findStart.njk
+++ b/server/views/probationPractitionerReferrals/findStart.njk
@@ -41,10 +41,10 @@
           <rect x="0.5" y="0.5" width="76.7857" height="109" stroke="#B1B4B6"/>
         </svg>
         <span class="refer-and-monitor-download-links">
-          <p class="govuk-body-l"> <a href="{{ presenter.structuredInterventionsDownloadHrefs.xlsx }}">Structured interventions data</a></p>
+          <p class="govuk-body-l"> <a href="{{ presenter.structuredInterventionsDownloadHrefs.xlsx }}" download>Structured interventions data</a></p>
           <p class="govuk-body-m">{{ presenter.fileInformation }}</p>
           <p class="govuk-body-m">This file is available in a
-            <a href="{{ presenter.structuredInterventionsDownloadHrefs.pdf }}">pdf format</a>.
+            <a href="{{ presenter.structuredInterventionsDownloadHrefs.pdf }}" download>pdf format</a>.
           </p>
         </span>
       </div>


### PR DESCRIPTION
## What does this pull request do?

add 'download' attribute to hrefs for structured interventions downloads

## What is the intent behind these changes?

tells the browser these are files not links
