### PR TITLE
Fix capitalisation of serviceUserCRN in contract

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2922,7 +2922,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         organisationId: 'XYZ5678',
         referringOfficerEmail: 'bernard.beaks@justice.gov.uk',
         caseworkerId: 'liane.supplier@example.com',
-        serviceUserCrn: 'X017844',
+        serviceUserCRN: 'X017844',
         dateReferralReceived: '2021-06-27T14:49:01+01:00',
         dateSaaBooked: '2021-06-27T14:49:01+01:00',
         dateSaaAttended: '2021-06-27T14:49:01+01:00',


### PR DESCRIPTION
## What does this pull request do?

This fixes an error in the capitalisation of `serviceUserCRN` in d808dec, and uses the capitalisation that George
and Ryan originally agreed upon.

## What is the intent behind these changes?

To make the contracts reflect a previous agreement between UI and API.