### PR TITLE
IC-2048: Add appointment meeting type to attendence question for session feedback

### DIFF
--- a/server/routes/service-provider/action-plan/appointment/post-session-feedback/attendance/postSessionAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/appointment/post-session-feedback/attendance/postSessionAttendanceFeedbackPresenter.test.ts
@@ -17,6 +17,40 @@ describe(PostSessionAttendanceFeedbackPresenter, () => {
         additionalAttendanceInformationLabel: "Add additional information about Alex's attendance:",
       })
     })
+    describe('when the session is a phone call', () => {
+      it('contains an attendance question to indicate the meeting was a phone call', () => {
+        const appointment = actionPlanAppointmentFactory.build({ appointmentDeliveryType: 'PHONE_CALL' })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+        const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+        expect(presenter.text.attendanceQuestion).toEqual('Did Alex join this phone call?')
+      })
+    })
+    describe('when the session is a video call', () => {
+      it('contains an attendance question to indicate the meeting was a video call', () => {
+        const appointment = actionPlanAppointmentFactory.build({ appointmentDeliveryType: 'VIDEO_CALL' })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+        const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+        expect(presenter.text.attendanceQuestion).toEqual('Did Alex join this video call?')
+      })
+    })
+    describe('when the session is an other location meeting', () => {
+      it('contains an attendance question to indicate the meeting was an in-person meeting', () => {
+        const appointment = actionPlanAppointmentFactory.build({ appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER' })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+        const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+        expect(presenter.text.attendanceQuestion).toEqual('Did Alex attend this in-person meeting?')
+      })
+    })
+    describe('when the session is an nps office location meeting', () => {
+      it('contains an attendance question to indicate the meeting was an in-person meeting', () => {
+        const appointment = actionPlanAppointmentFactory.build({
+          appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
+        })
+        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+        const presenter = new PostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+        expect(presenter.text.attendanceQuestion).toEqual('Did Alex attend this in-person meeting?')
+      })
+    })
   })
 
   describe('sessionDetailsSummary', () => {

--- a/server/routes/service-provider/action-plan/appointment/post-session-feedback/attendance/postSessionAttendanceFeedbackPresenter.ts
+++ b/server/routes/service-provider/action-plan/appointment/post-session-feedback/attendance/postSessionAttendanceFeedbackPresenter.ts
@@ -16,9 +16,23 @@ export default class PostSessionAttendanceFeedbackPresenter {
   readonly text = {
     title: `Add attendance feedback`,
     subTitle: 'Session details',
-    attendanceQuestion: `Did ${this.serviceUser.firstName} attend this session?`,
+    attendanceQuestion: this.attendanceQuestion,
     attendanceQuestionHint: 'Select one option',
     additionalAttendanceInformationLabel: `Add additional information about ${this.serviceUser.firstName}'s attendance:`,
+  }
+
+  get attendanceQuestion(): string {
+    switch (this.appointment.appointmentDeliveryType) {
+      case 'PHONE_CALL':
+        return `Did ${this.serviceUser.firstName} join this phone call?`
+      case 'VIDEO_CALL':
+        return `Did ${this.serviceUser.firstName} join this video call?`
+      case 'IN_PERSON_MEETING_OTHER':
+      case 'IN_PERSON_MEETING_PROBATION_OFFICE':
+        return `Did ${this.serviceUser.firstName} attend this in-person meeting?`
+      default:
+        return `Did ${this.serviceUser.firstName} attend this session?`
+    }
   }
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)


### PR DESCRIPTION
## What does this pull request do?

Adds appointment meeting type to attendance question for session feedback.


Change wording of:

"Did [firstName] attend this session?" 
to 
"Did [firstName] [join|attend] this [phone call | video call | in-person meeting] ?"


## What is the intent behind these changes?

Ensure user has some awareness of what type of meeting occurred on the session feedback form
