### PR TITLE
IC-2032: Basic journey for service provider user to reassign a referral

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -264,70 +264,72 @@ describe('Service provider referrals dashboard', () => {
       .contains('probation-team4692@justice.gov.uk')
   })
 
-  it('User assigns a referral to a caseworker', () => {
-    const intervention = interventionFactory.build()
-    const conviction = deliusConvictionFactory.build()
+  describe('Assigning a referral to a caseworker', () => {
+    it('User assigns a referral to a caseworker', () => {
+      const intervention = interventionFactory.build()
+      const conviction = deliusConvictionFactory.build()
 
-    const referralParams = {
-      referral: {
-        interventionId: intervention.id,
-        serviceCategoryIds: [intervention.serviceCategories[0].id],
-        relevantSentenceId: conviction.convictionId,
-      },
-    }
+      const referralParams = {
+        referral: {
+          interventionId: intervention.id,
+          serviceCategoryIds: [intervention.serviceCategories[0].id],
+          relevantSentenceId: conviction.convictionId,
+        },
+      }
 
-    const referral = sentReferralFactory.build(referralParams)
-    const deliusUser = deliusUserFactory.build()
-    const deliusServiceUser = deliusServiceUserFactory.build()
-    const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({ ...deliusServiceUser })
-    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
-    const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-    const staffDetails = deliusStaffDetailsFactory.build()
+      const referral = sentReferralFactory.build(referralParams)
+      const deliusUser = deliusUserFactory.build()
+      const deliusServiceUser = deliusServiceUserFactory.build()
+      const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({ ...deliusServiceUser })
+      const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+      const staffDetails = deliusStaffDetailsFactory.build()
 
-    cy.stubGetIntervention(intervention.id, intervention)
-    cy.stubGetSentReferral(referral.id, referral)
-    cy.stubGetSentReferralsForUserToken([referral])
-    cy.stubGetUserByUsername(deliusUser.username, deliusUser)
-    cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
-    cy.stubGetExpandedServiceUserByCRN(referral.referral.serviceUser.crn, expandedDeliusServiceUser)
-    cy.stubGetAuthUserByEmailAddress([hmppsAuthUser])
-    cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
-    cy.stubAssignSentReferral(referral.id, referral)
-    cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
-    cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
-    cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
+      cy.stubGetIntervention(intervention.id, intervention)
+      cy.stubGetSentReferral(referral.id, referral)
+      cy.stubGetSentReferralsForUserToken([referral])
+      cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+      cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
+      cy.stubGetExpandedServiceUserByCRN(referral.referral.serviceUser.crn, expandedDeliusServiceUser)
+      cy.stubGetAuthUserByEmailAddress([hmppsAuthUser])
+      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubAssignSentReferral(referral.id, referral)
+      cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
+      cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
+      cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
 
-    cy.login()
+      cy.login()
 
-    cy.visit(`/service-provider/referrals/${referral.id}/details`)
+      cy.visit(`/service-provider/referrals/${referral.id}/details`)
 
-    cy.get('h2').contains('Who do you want to assign this referral to?')
+      cy.get('h2').contains('Who do you want to assign this referral to?')
 
-    cy.get('#email').type('john@harmonyliving.org.uk')
-    cy.contains('Save and continue').click()
+      cy.get('#email').type('john@harmonyliving.org.uk')
+      cy.contains('Save and continue').click()
 
-    cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/check`)
-    cy.get('h1').contains('Confirm the Accommodation referral assignment')
-    cy.contains('John Smith')
+      cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/check`)
+      cy.get('h1').contains('Confirm the Accommodation referral assignment')
+      cy.contains('John Smith')
 
-    const assignedReferral = sentReferralFactory
-      .assigned()
-      .build({ ...referralParams, id: referral.id, assignedTo: { username: hmppsAuthUser.username } })
-    cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
-    cy.stubGetSentReferralsForUserToken([assignedReferral])
+      const assignedReferral = sentReferralFactory
+        .assigned()
+        .build({ ...referralParams, id: referral.id, assignedTo: { username: hmppsAuthUser.username } })
+      cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+      cy.stubGetSentReferralsForUserToken([assignedReferral])
 
-    cy.contains('Confirm assignment').click()
+      cy.contains('Confirm assignment').click()
 
-    cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/confirmation`)
-    cy.get('h1').contains('Caseworker assigned')
+      cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/confirmation`)
+      cy.get('h1').contains('Caseworker assigned')
 
-    cy.contains('Return to dashboard').click()
+      cy.contains('Return to dashboard').click()
 
-    cy.location('pathname').should('equal', `/service-provider/dashboard`)
-    cy.contains('john.smith')
+      cy.location('pathname').should('equal', `/service-provider/dashboard`)
+      cy.contains('john.smith')
 
-    cy.visit(`/service-provider/referrals/${referral.id}/details`)
-    cy.contains('This intervention is assigned to John Smith.')
+      cy.visit(`/service-provider/referrals/${referral.id}/details`)
+      cy.contains('This intervention is assigned to John Smith.')
+    })
   })
 
   it('User creates an action plan and submits it for approval', () => {

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -330,6 +330,83 @@ describe('Service provider referrals dashboard', () => {
       cy.visit(`/service-provider/referrals/${referral.id}/details`)
       cy.contains('This intervention is assigned to John Smith.')
     })
+
+    it('User re-assigns a referral to a different caseworker', () => {
+      const intervention = interventionFactory.build()
+      const conviction = deliusConvictionFactory.build()
+
+      const referralParams = {
+        referral: {
+          interventionId: intervention.id,
+          serviceCategoryIds: [intervention.serviceCategories[0].id],
+          relevantSentenceId: conviction.convictionId,
+        },
+      }
+
+      const currentAssignee = hmppsAuthUserFactory.build({
+        firstName: 'John',
+        lastName: 'Smith',
+        username: 'john.smith',
+      })
+      const referral = sentReferralFactory
+        .assigned()
+        .build({ ...referralParams, assignedTo: { username: currentAssignee.username } })
+      const deliusUser = deliusUserFactory.build()
+      const deliusServiceUser = deliusServiceUserFactory.build()
+      const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({ ...deliusServiceUser })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+      const staffDetails = deliusStaffDetailsFactory.build()
+
+      cy.stubGetIntervention(intervention.id, intervention)
+      cy.stubGetSentReferral(referral.id, referral)
+      cy.stubGetSentReferralsForUserToken([referral])
+      cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+      cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
+      cy.stubGetExpandedServiceUserByCRN(referral.referral.serviceUser.crn, expandedDeliusServiceUser)
+      cy.stubGetAuthUserByEmailAddress([currentAssignee])
+      cy.stubGetAuthUserByUsername(currentAssignee.username, currentAssignee)
+      cy.stubAssignSentReferral(referral.id, referral)
+      cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
+      cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
+      cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
+
+      cy.login()
+
+      cy.visit(`/service-provider/referrals/${referral.id}/details`)
+
+      cy.contains('This intervention is assigned to John Smith.')
+
+      cy.get('h2').contains('Who do you want to assign this referral to?')
+
+      const newAssignee = hmppsAuthUserFactory.build({
+        firstName: 'Anna',
+        lastName: 'Dawkins',
+        username: 'anna.dawkins',
+      })
+      cy.stubGetAuthUserByEmailAddress([newAssignee])
+      cy.stubGetAuthUserByUsername(newAssignee.username, newAssignee)
+
+      cy.get('#email').type('anna@harmonyliving.org.uk')
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/check`)
+      cy.get('h1').contains('Confirm the Accommodation referral assignment')
+      cy.contains('Anna Dawkins')
+
+      const reAssignedReferral = sentReferralFactory
+        .assigned()
+        .build({ ...referral, assignedTo: { username: newAssignee.username } })
+      cy.stubGetSentReferral(reAssignedReferral.id, reAssignedReferral)
+      cy.stubGetSentReferralsForUserToken([reAssignedReferral])
+
+      cy.contains('Confirm assignment').click()
+
+      cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/confirmation`)
+      cy.get('h1').contains('Caseworker assigned')
+
+      cy.visit(`/service-provider/referrals/${referral.id}/details`)
+      cy.contains('This intervention is assigned to Anna Dawkins.')
+    })
   })
 
   it('User creates an action plan and submits it for approval', () => {

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -4,18 +4,18 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% block referralPageSection %}
-      {% if presenter.text.assignedTo == null %}
-         {% if presenter.canAssignReferral %}
-           <h2 class="govuk-heading-m">Who do you want to assign this referral to?</h2>
-           <form method="get" action={{ presenter.assignmentFormAction }}>
-                 {{ govukInput(emailInputArgs) }}
-                 {{ govukButton({ text: "Save and continue" }) }}
-           </form>
-         {% else %}
-           <p class="govuk-body">This intervention is not yet assigned to a caseworker.</p>
-         {% endif %}
-      {% else %}
+      {% if presenter.text.assignedTo != null %}
         <p class="govuk-body">This intervention is assigned to <strong>{{ presenter.text.assignedTo }}</strong>.</p>
+      {% endif %}
+
+      {% if presenter.canAssignReferral %}
+        <h2 class="govuk-heading-m">Who do you want to assign this referral to?</h2>
+        <form method="get" action={{ presenter.assignmentFormAction }}>
+              {{ govukInput(emailInputArgs) }}
+              {{ govukButton({ text: "Save and continue" }) }}
+        </form>
+      {% elif presenter.text.assignedTo == null %}
+        <p class="govuk-body">This intervention is not yet assigned to a caseworker.</p>
       {% endif %}
 
       <h2 class="govuk-heading-m">Intervention details</h2>


### PR DESCRIPTION
**DON'T MERGE UNTIL THE BACKEND HAS IMPLEMENTED AUDIT TRAIL (IC-2033)**

## What does this pull request do?

Allows a service provider user to assign a referral that is already assigned. This is the "quick and dirty" version and there will be a proper journey to follow in a later story, I believe.

## What is the intent behind these changes?

To allow the original choice of caseworker to be changed.

## Screenshot

![image](https://user-images.githubusercontent.com/53756884/124626179-59db8d00-de76-11eb-90e5-8a84676538b3.png)
