### PR TITLE
Clear inputs before typing when editing text in integration test

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1137,16 +1137,16 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('Review the end of service report')
 
     cy.get('#change-outcome-2').click()
-    cy.contains('Do you have any further comments about their progression on this outcome?').type(
-      'They have done fairly well but could make some changes'
-    )
+    cy.contains('Do you have any further comments about their progression on this outcome?')
+      .type('{selectall}{backspace}')
+      .type('I think that overall it’s gone well but they could make some changes')
 
     cy.contains('Save and continue').click()
 
     cy.contains('Would you like to give any additional information about this intervention (optional)?')
-    cy.contains(
-      'Provide any further information that you believe is important for the probation practitioner to know.'
-    ).type('You should know x and y and p and q')
+    cy.contains('Provide any further information that you believe is important for the probation practitioner to know.')
+      .type('{selectall}{backspace}')
+      .type('It’s important that you know p and q')
 
     cy.contains('Save and continue').click()
 


### PR DESCRIPTION
## What does this pull request do?

Clears the text of `<input>` elements before typing new text, when editing text in the integration tests.

## What is the intent behind these changes?

To stop a weird-looking appending from happening when we run the tests.