### PR TITLE
Update reporting contract test

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -39,11 +39,13 @@ jest.setTimeout(30000)
 pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, provider => {
   let interventionsService: InterventionsService
   let probationPractitionerToken: string
+  let serviceProviderToken: string
 
   beforeEach(() => {
     const testConfig = { ...config.apis.interventionsService, url: provider.mockService.baseUrl }
     interventionsService = new InterventionsService(testConfig)
     probationPractitionerToken = oauth2TokenFactory.probationPractitionerToken().build()
+    serviceProviderToken = oauth2TokenFactory.serviceProviderToken().build()
   })
 
   describe('getDraftReferral', () => {
@@ -3129,7 +3131,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     it('returns a list of referrals for with data for reporting', async () => {
       await provider.addInteraction({
         state: 'nothing',
-        uponReceiving: 'a GET request for referral reporting data',
+        uponReceiving: 'a service provider user’s GET request for referral reporting data',
         withRequest: {
           method: 'GET',
           path: '/performance-report',
@@ -3144,7 +3146,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       expect(
-        await interventionsService.getServiceProviderReportingData(probationPractitionerToken, {
+        await interventionsService.getServiceProviderReportingData(serviceProviderToken, {
           fromIncludingDate: CalendarDay.fromComponents(1, 6, 2021)!,
           toIncludingDate: CalendarDay.fromComponents(10, 6, 2021)!,
         })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -43,7 +43,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   beforeEach(() => {
     const testConfig = { ...config.apis.interventionsService, url: provider.mockService.baseUrl }
     interventionsService = new InterventionsService(testConfig)
-    token = oauth2TokenFactory.deliusToken().build()
+    token = oauth2TokenFactory.probationPractitionerToken().build()
   })
 
   describe('getDraftReferral', () => {
@@ -1166,7 +1166,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
   describe('getDraftReferralsForUserToken', () => {
     it('returns a list of draft referrals for a given userID', async () => {
-      const userToken = oauth2TokenFactory.deliusToken().build('', { transient: { userID: '8751622134' } })
+      const userToken = oauth2TokenFactory
+        .probationPractitionerToken()
+        .build('', { transient: { userID: '8751622134' } })
 
       await provider.addInteraction({
         state: 'a single referral for user with ID 8751622134 exists',
@@ -1199,7 +1201,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
 
     it('returns an empty list for an unknown user ID', async () => {
-      const unknownUserToken = oauth2TokenFactory.deliusToken().build('', { transient: { userID: '123344556' } })
+      const unknownUserToken = oauth2TokenFactory
+        .probationPractitionerToken()
+        .build('', { transient: { userID: '123344556' } })
 
       await provider.addInteraction({
         state: 'a referral does not exist for user with ID 123344556',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -38,12 +38,12 @@ jest.setTimeout(30000)
 
 pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, provider => {
   let interventionsService: InterventionsService
-  let token: string
+  let probationPractitionerToken: string
 
   beforeEach(() => {
     const testConfig = { ...config.apis.interventionsService, url: provider.mockService.baseUrl }
     interventionsService = new InterventionsService(testConfig)
-    token = oauth2TokenFactory.probationPractitionerToken().build()
+    probationPractitionerToken = oauth2TokenFactory.probationPractitionerToken().build()
   })
 
   describe('getDraftReferral', () => {
@@ -54,7 +54,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/draft-referral/ac386c25-52c8-41fa-9213-fcf42e24b0b5',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -66,7 +66,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.getDraftReferral(token, 'ac386c25-52c8-41fa-9213-fcf42e24b0b5')
+      const referral = await interventionsService.getDraftReferral(
+        probationPractitionerToken,
+        'ac386c25-52c8-41fa-9213-fcf42e24b0b5'
+      )
       expect(referral.id).toBe('ac386c25-52c8-41fa-9213-fcf42e24b0b5')
     })
 
@@ -79,7 +82,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: '/draft-referral/d496e4a7-7cc1-44ea-ba67-c295084f1962',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -94,7 +97,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       it('returns a referral for the given ID, with the service category id field populated', async () => {
-        const referral = await interventionsService.getDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962')
+        const referral = await interventionsService.getDraftReferral(
+          probationPractitionerToken,
+          'd496e4a7-7cc1-44ea-ba67-c295084f1962'
+        )
 
         expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
         expect(referral.serviceCategoryIds![0]).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
@@ -110,7 +116,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: '/draft-referral/d496e4a7-7cc1-44ea-ba67-c295084f1962',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -126,7 +132,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       it('returns a referral for the given ID, with the serviceProviderId field populated', async () => {
-        const referral = await interventionsService.getDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962')
+        const referral = await interventionsService.getDraftReferral(
+          probationPractitionerToken,
+          'd496e4a7-7cc1-44ea-ba67-c295084f1962'
+        )
 
         expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
         expect(referral.serviceProvider!.name).toEqual('Harmony Living')
@@ -142,7 +151,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: '/draft-referral/037cc90b-beaa-4a32-9ab7-7f79136e1d27',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -162,7 +171,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       it('returns a referral for the given ID, with the desired outcomes selected', async () => {
-        const referral = await interventionsService.getDraftReferral(token, '037cc90b-beaa-4a32-9ab7-7f79136e1d27')
+        const referral = await interventionsService.getDraftReferral(
+          probationPractitionerToken,
+          '037cc90b-beaa-4a32-9ab7-7f79136e1d27'
+        )
 
         expect(referral.id).toBe('037cc90b-beaa-4a32-9ab7-7f79136e1d27')
         expect(referral.desiredOutcomes![0].desiredOutcomesIds).toEqual([
@@ -180,7 +192,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: '/draft-referral/06716f8e-f507-42d4-bdcc-44c90e18dbd7',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -201,7 +213,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         })
 
-        const referral = await interventionsService.getDraftReferral(token, '06716f8e-f507-42d4-bdcc-44c90e18dbd7')
+        const referral = await interventionsService.getDraftReferral(
+          probationPractitionerToken,
+          '06716f8e-f507-42d4-bdcc-44c90e18dbd7'
+        )
 
         expect(referral.id).toBe('06716f8e-f507-42d4-bdcc-44c90e18dbd7')
         expect(referral.desiredOutcomes![0].serviceCategoryId).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
@@ -226,7 +241,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: '/draft-referral/037cc90b-beaa-4a32-9ab7-7f79136e1d27',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -245,7 +260,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       it('returns a referral for the given ID, with the desired outcomes selected', async () => {
-        const referral = await interventionsService.getDraftReferral(token, '037cc90b-beaa-4a32-9ab7-7f79136e1d27')
+        const referral = await interventionsService.getDraftReferral(
+          probationPractitionerToken,
+          '037cc90b-beaa-4a32-9ab7-7f79136e1d27'
+        )
 
         expect(referral.id).toBe('037cc90b-beaa-4a32-9ab7-7f79136e1d27')
         expect(referral.complexityLevels![0].complexityLevelId).toEqual('d0db50b0-4a50-4fc7-a006-9c97530e38b2')
@@ -260,7 +278,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: '/draft-referral/06716f8e-f507-42d4-bdcc-44c90e18dbd7',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -281,7 +299,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         })
 
-        const referral = await interventionsService.getDraftReferral(token, '06716f8e-f507-42d4-bdcc-44c90e18dbd7')
+        const referral = await interventionsService.getDraftReferral(
+          probationPractitionerToken,
+          '06716f8e-f507-42d4-bdcc-44c90e18dbd7'
+        )
 
         expect(referral.id).toBe('06716f8e-f507-42d4-bdcc-44c90e18dbd7')
         expect(referral.complexityLevels![0].serviceCategoryId).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
@@ -301,7 +322,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: '/draft-referral/1219a064-709b-4b6c-a11e-10b8cb3966f6',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -326,7 +347,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       it('returns a referral for the given ID, with the service user details', async () => {
-        const referral = await interventionsService.getDraftReferral(token, '1219a064-709b-4b6c-a11e-10b8cb3966f6')
+        const referral = await interventionsService.getDraftReferral(
+          probationPractitionerToken,
+          '1219a064-709b-4b6c-a11e-10b8cb3966f6'
+        )
 
         expect(referral.id).toBe('1219a064-709b-4b6c-a11e-10b8cb3966f6')
         expect(referral.serviceUser.crn).toEqual('X862134')
@@ -354,7 +378,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: '/draft-referral',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           body: {
             serviceUserCrn,
             interventionId,
@@ -377,7 +401,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.createDraftReferral(token, serviceUserCrn, interventionId)
+      const referral = await interventionsService.createDraftReferral(
+        probationPractitionerToken,
+        serviceUserCrn,
+        interventionId
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.serviceUser.crn).toBe(serviceUserCrn)
       expect(referral.interventionId).toBe(interventionId)
@@ -395,7 +423,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: { completionDeadline: '2020-04-01' },
         },
@@ -418,7 +446,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       await expect(
-        interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
+        interventionsService.patchDraftReferral(probationPractitionerToken, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
           completionDeadline: '2020-04-01',
         })
       ).rejects.toMatchObject({
@@ -449,7 +477,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: {
             serviceUser,
@@ -468,9 +496,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
-        serviceUser,
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        {
+          serviceUser,
+        }
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.serviceUser).toEqual(serviceUser)
     })
@@ -485,7 +517,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: { completionDeadline: '2045-04-01' },
         },
@@ -502,9 +534,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
-        completionDeadline: '2045-04-01',
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        {
+          completionDeadline: '2045-04-01',
+        }
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.completionDeadline).toBe('2045-04-01')
     })
@@ -520,7 +556,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: {
             serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
@@ -545,7 +581,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const referral = await interventionsService.setComplexityLevelForServiceCategory(
-        token,
+        probationPractitionerToken,
         'd496e4a7-7cc1-44ea-ba67-c295084f1962',
         {
           serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
@@ -566,7 +602,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: { furtherInformation: 'Some information about the service user' },
         },
@@ -582,9 +618,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
-        furtherInformation: 'Some information about the service user',
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        {
+          furtherInformation: 'Some information about the service user',
+        }
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.furtherInformation).toBe('Some information about the service user')
     })
@@ -599,7 +639,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: {
             relevantSentenceId: 2600295124,
@@ -617,9 +657,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962', {
-        relevantSentenceId: 2600295124,
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'd496e4a7-7cc1-44ea-ba67-c295084f1962',
+        {
+          relevantSentenceId: 2600295124,
+        }
+      )
       expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
       expect(referral.relevantSentenceId).toEqual(2600295124)
     })
@@ -635,7 +679,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: {
             serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
@@ -660,7 +704,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const referral = await interventionsService.setDesiredOutcomesForServiceCategory(
-        token,
+        probationPractitionerToken,
         'd496e4a7-7cc1-44ea-ba67-c295084f1962',
         {
           serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
@@ -684,7 +728,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: {
             accessibilityNeeds: 'She uses a wheelchair',
@@ -704,10 +748,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
-        accessibilityNeeds: 'She uses a wheelchair',
-        additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        {
+          accessibilityNeeds: 'She uses a wheelchair',
+          additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
+        }
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.accessibilityNeeds).toBe('She uses a wheelchair')
       expect(referral.additionalNeedsInformation).toBe('Alex is currently sleeping on her aunt’s sofa')
@@ -723,7 +771,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: { needsInterpreter: true, interpreterLanguage: 'Spanish' },
         },
@@ -740,10 +788,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
-        needsInterpreter: true,
-        interpreterLanguage: 'Spanish',
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        {
+          needsInterpreter: true,
+          interpreterLanguage: 'Spanish',
+        }
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.needsInterpreter).toBe(true)
       expect(referral.interpreterLanguage).toEqual('Spanish')
@@ -759,7 +811,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: { needsInterpreter: false, interpreterLanguage: null },
         },
@@ -776,10 +828,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
-        needsInterpreter: false,
-        interpreterLanguage: null,
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        {
+          needsInterpreter: false,
+          interpreterLanguage: null,
+        }
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.needsInterpreter).toBe(false)
       expect(referral.interpreterLanguage).toBeNull()
@@ -795,7 +851,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: { hasAdditionalResponsibilities: true, whenUnavailable: 'She works Mondays 9am - midday' },
         },
@@ -812,10 +868,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
-        hasAdditionalResponsibilities: true,
-        whenUnavailable: 'She works Mondays 9am - midday',
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        {
+          hasAdditionalResponsibilities: true,
+          whenUnavailable: 'She works Mondays 9am - midday',
+        }
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.hasAdditionalResponsibilities).toBe(true)
       expect(referral.whenUnavailable).toEqual('She works Mondays 9am - midday')
@@ -831,7 +891,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: { hasAdditionalResponsibilities: false, whenUnavailable: null },
         },
@@ -848,10 +908,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
-        hasAdditionalResponsibilities: false,
-        whenUnavailable: null,
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        {
+          hasAdditionalResponsibilities: false,
+          whenUnavailable: null,
+        }
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.hasAdditionalResponsibilities).toBe(false)
       expect(referral.whenUnavailable).toBeNull()
@@ -867,7 +931,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: { additionalRiskInformation: 'A danger to the elderly' },
         },
@@ -883,9 +947,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
-        additionalRiskInformation: 'A danger to the elderly',
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        {
+          additionalRiskInformation: 'A danger to the elderly',
+        }
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.additionalRiskInformation).toEqual('A danger to the elderly')
     })
@@ -900,7 +968,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: { maximumEnforceableDays: 4 },
         },
@@ -916,9 +984,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'dfb64747-f658-40e0-a827-87b4b0bdcfed', {
-        maximumEnforceableDays: 4,
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'dfb64747-f658-40e0-a827-87b4b0bdcfed',
+        {
+          maximumEnforceableDays: 4,
+        }
+      )
       expect(referral.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(referral.maximumEnforceableDays).toEqual(4)
     })
@@ -934,7 +1006,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: {
             serviceCategoryIds: ['ca374ac3-84eb-4b91-bea7-9005398f426f', '428ee70f-3001-4399-95a6-ad25eaaede16'],
@@ -952,9 +1024,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const referral = await interventionsService.patchDraftReferral(token, 'd496e4a7-7cc1-44ea-ba67-c295084f1962', {
-        serviceCategoryIds: ['ca374ac3-84eb-4b91-bea7-9005398f426f', '428ee70f-3001-4399-95a6-ad25eaaede16'],
-      })
+      const referral = await interventionsService.patchDraftReferral(
+        probationPractitionerToken,
+        'd496e4a7-7cc1-44ea-ba67-c295084f1962',
+        {
+          serviceCategoryIds: ['ca374ac3-84eb-4b91-bea7-9005398f426f', '428ee70f-3001-4399-95a6-ad25eaaede16'],
+        }
+      )
       expect(referral.id).toBe('d496e4a7-7cc1-44ea-ba67-c295084f1962')
       expect(referral.serviceCategoryIds).toEqual([
         'ca374ac3-84eb-4b91-bea7-9005398f426f',
@@ -974,7 +1050,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: {
             serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
@@ -999,7 +1075,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const referral = await interventionsService.setDesiredOutcomesForServiceCategory(
-        token,
+        probationPractitionerToken,
         '06716f8e-f507-42d4-bdcc-44c90e18dbd7',
         {
           serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
@@ -1027,7 +1103,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
           body: {
             serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
@@ -1052,7 +1128,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const referral = await interventionsService.setComplexityLevelForServiceCategory(
-        token,
+        probationPractitionerToken,
         '06716f8e-f507-42d4-bdcc-44c90e18dbd7',
         {
           serviceCategoryId: '428ee70f-3001-4399-95a6-ad25eaaede16',
@@ -1133,7 +1209,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           path: '/service-category/428ee70f-3001-4399-95a6-ad25eaaede16',
           headers: {
             Accept: 'application/json',
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${probationPractitionerToken}`,
           },
         },
         willRespondWith: {
@@ -1153,7 +1229,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
     it('returns a service category', async () => {
       const serviceCategory = await interventionsService.getServiceCategory(
-        token,
+        probationPractitionerToken,
         '428ee70f-3001-4399-95a6-ad25eaaede16'
       )
 
@@ -1301,7 +1377,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: '/draft-referral/2a67075a-9c77-4103-9de0-63c4cfe3e8d6/send',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 201,
@@ -1317,9 +1393,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
 
     it('returns a sent referral', async () => {
-      expect(await interventionsService.sendDraftReferral(token, '2a67075a-9c77-4103-9de0-63c4cfe3e8d6')).toEqual(
-        sentReferral
-      )
+      expect(
+        await interventionsService.sendDraftReferral(probationPractitionerToken, '2a67075a-9c77-4103-9de0-63c4cfe3e8d6')
+      ).toEqual(sentReferral)
     })
   })
 
@@ -1331,7 +1407,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/sent-referral/81d754aa-d868-4347-9c0f-50690773014e',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -1340,9 +1416,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      expect(await interventionsService.getSentReferral(token, '81d754aa-d868-4347-9c0f-50690773014e')).toEqual(
-        sentReferral
-      )
+      expect(
+        await interventionsService.getSentReferral(probationPractitionerToken, '81d754aa-d868-4347-9c0f-50690773014e')
+      ).toEqual(sentReferral)
     })
 
     describe('for a referral that has had a caseworker assigned', () => {
@@ -1354,7 +1430,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: '/sent-referral/2f4e91bf-5f73-4ca8-ad84-afee3f12ed8e',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -1365,11 +1441,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         })
 
-        expect(await interventionsService.getSentReferral(token, '2f4e91bf-5f73-4ca8-ad84-afee3f12ed8e')).toMatchObject(
-          {
-            assignedTo: { username: 'UserABC', userId: '555224b3-865c-4b56-97dd-c3e817592ba3', authSource: 'auth' },
-          }
-        )
+        expect(
+          await interventionsService.getSentReferral(probationPractitionerToken, '2f4e91bf-5f73-4ca8-ad84-afee3f12ed8e')
+        ).toMatchObject({
+          assignedTo: { username: 'UserABC', userId: '555224b3-865c-4b56-97dd-c3e817592ba3', authSource: 'auth' },
+        })
       })
     })
 
@@ -1382,7 +1458,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: '/sent-referral/8b423e17-9b60-4cc2-a927-8941ac76fdf9',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -1393,11 +1469,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         })
 
-        expect(await interventionsService.getSentReferral(token, '8b423e17-9b60-4cc2-a927-8941ac76fdf9')).toMatchObject(
-          {
-            actionPlanId: '8b423e17-9b60-4cc2-a927-8941ac76fdf9',
-          }
-        )
+        expect(
+          await interventionsService.getSentReferral(probationPractitionerToken, '8b423e17-9b60-4cc2-a927-8941ac76fdf9')
+        ).toMatchObject({
+          actionPlanId: '8b423e17-9b60-4cc2-a927-8941ac76fdf9',
+        })
       })
     })
 
@@ -1412,7 +1488,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: `/sent-referral/${id}`,
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -1423,7 +1499,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         })
 
-        expect(await interventionsService.getSentReferral(token, id)).toMatchObject({
+        expect(await interventionsService.getSentReferral(probationPractitionerToken, id)).toMatchObject({
           endOfServiceReport,
         })
       })
@@ -1439,7 +1515,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           withRequest: {
             method: 'GET',
             path: '/sent-referral/c5554f8f-aac6-4eaf-ba70-63281de35685',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -1448,7 +1524,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         })
 
-        const referral = await interventionsService.getSentReferral(token, 'c5554f8f-aac6-4eaf-ba70-63281de35685')
+        const referral = await interventionsService.getSentReferral(
+          probationPractitionerToken,
+          'c5554f8f-aac6-4eaf-ba70-63281de35685'
+        )
         expect(referral.endRequestedAt).not.toBeNull()
         expect(referral.endRequestedReason).not.toBeNull()
         expect(referral.endRequestedComments).not.toBeNull()
@@ -1464,7 +1543,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/sent-referrals',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -1473,7 +1552,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      expect(await interventionsService.getSentReferralsForUserToken(token)).toEqual([sentReferral, sentReferral])
+      expect(await interventionsService.getSentReferralsForUserToken(probationPractitionerToken)).toEqual([
+        sentReferral,
+        sentReferral,
+      ])
     })
   })
 
@@ -1490,7 +1572,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           body: {
             assignedTo: { username: 'UserABC', userId: '555224b3-865c-4b56-97dd-c3e817592ba3', authSource: 'auth' },
           },
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -1502,11 +1584,15 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       expect(
-        await interventionsService.assignSentReferral(token, '400be4c6-1aa4-4f52-ae86-cbd5d23309bf', {
-          username: 'UserABC',
-          userId: '555224b3-865c-4b56-97dd-c3e817592ba3',
-          authSource: 'auth',
-        })
+        await interventionsService.assignSentReferral(
+          probationPractitionerToken,
+          '400be4c6-1aa4-4f52-ae86-cbd5d23309bf',
+          {
+            username: 'UserABC',
+            userId: '555224b3-865c-4b56-97dd-c3e817592ba3',
+            authSource: 'auth',
+          }
+        )
       ).toMatchObject({
         assignedTo: { username: 'UserABC', userId: '555224b3-865c-4b56-97dd-c3e817592ba3', authSource: 'auth' },
       })
@@ -1523,7 +1609,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/interventions',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -1532,7 +1618,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      expect(await interventionsService.getInterventions(token, {})).toEqual(interventions)
+      expect(await interventionsService.getInterventions(probationPractitionerToken, {})).toEqual(interventions)
     })
 
     describe('allowsMale filter', () => {
@@ -1546,7 +1632,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             method: 'GET',
             path: '/interventions',
             query: { allowsMale: value ? 'true' : 'false' },
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -1555,7 +1641,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         })
 
-        expect(await interventionsService.getInterventions(token, { allowsMale: value })).toEqual(interventions)
+        expect(await interventionsService.getInterventions(probationPractitionerToken, { allowsMale: value })).toEqual(
+          interventions
+        )
       })
     })
 
@@ -1570,7 +1658,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             method: 'GET',
             path: '/interventions',
             query: { allowsFemale: value ? 'true' : 'false' },
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -1579,7 +1667,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         })
 
-        expect(await interventionsService.getInterventions(token, { allowsFemale: value })).toEqual(interventions)
+        expect(
+          await interventionsService.getInterventions(probationPractitionerToken, { allowsFemale: value })
+        ).toEqual(interventions)
       })
     })
 
@@ -1594,7 +1684,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             method: 'GET',
             path: '/interventions',
             query: { pccRegionIds: 'cheshire,cumbria,merseyside' },
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -1604,7 +1694,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         })
 
         expect(
-          await interventionsService.getInterventions(token, { pccRegionIds: ['cheshire', 'cumbria', 'merseyside'] })
+          await interventionsService.getInterventions(probationPractitionerToken, {
+            pccRegionIds: ['cheshire', 'cumbria', 'merseyside'],
+          })
         ).toEqual([intervention, intervention])
       })
     })
@@ -1620,7 +1712,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             method: 'GET',
             path: '/interventions',
             query: { maximumAge: '25' },
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -1629,7 +1721,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           },
         })
 
-        expect(await interventionsService.getInterventions(token, { maximumAge: 25 })).toEqual(interventions)
+        expect(await interventionsService.getInterventions(probationPractitionerToken, { maximumAge: 25 })).toEqual(
+          interventions
+        )
       })
     })
   })
@@ -1645,7 +1739,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: `/intervention/${interventionId}`,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -1654,7 +1748,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      expect(await interventionsService.getIntervention(token, interventionId)).toEqual(intervention)
+      expect(await interventionsService.getIntervention(probationPractitionerToken, interventionId)).toEqual(
+        intervention
+      )
     })
   })
 
@@ -1673,7 +1769,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: `/pcc-regions`,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -1682,7 +1778,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      expect(await interventionsService.getPccRegions(token)).toEqual(pccRegions)
+      expect(await interventionsService.getPccRegions(probationPractitionerToken)).toEqual(pccRegions)
     })
   })
 
@@ -1695,7 +1791,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: '/draft-action-plan',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           body: {
             referralId,
           },
@@ -1717,7 +1813,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const draftActionPlan = await interventionsService.createDraftActionPlan(token, referralId)
+      const draftActionPlan = await interventionsService.createDraftActionPlan(probationPractitionerToken, referralId)
       expect(draftActionPlan.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
     })
@@ -1730,7 +1826,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: '/draft-action-plan',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           body: {
             referralId,
             numberOfSessions: 5,
@@ -1765,10 +1861,12 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const draftActionPlan = await interventionsService.createDraftActionPlan(token, referralId, 5, [
-        { description: 'activity 1' },
-        { description: 'activity 2' },
-      ])
+      const draftActionPlan = await interventionsService.createDraftActionPlan(
+        probationPractitionerToken,
+        referralId,
+        5,
+        [{ description: 'activity 1' }, { description: 'activity 2' }]
+      )
       expect(draftActionPlan.id).toBe('dfb64747-f658-40e0-a827-87b4b0bdcfed')
       expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
       expect(draftActionPlan.numberOfSessions).toBe(5)
@@ -1787,7 +1885,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: `/action-plan/${actionPlanId}`,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -1807,7 +1905,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const actionPlan = await interventionsService.getActionPlan(token, actionPlanId)
+      const actionPlan = await interventionsService.getActionPlan(probationPractitionerToken, actionPlanId)
       expect(actionPlan).toMatchObject({
         id: actionPlanId,
         referralId,
@@ -1842,7 +1940,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: `/action-plan/${actionPlanId}`,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -1861,7 +1959,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const actionPlan = await interventionsService.getActionPlan(token, actionPlanId)
+      const actionPlan = await interventionsService.getActionPlan(probationPractitionerToken, actionPlanId)
       expect(actionPlan).toMatchObject({
         id: actionPlanId,
         referralId,
@@ -1895,7 +1993,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: `/action-plan/${actionPlanId}`,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -1914,7 +2012,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const actionPlan = await interventionsService.getActionPlan(token, actionPlanId)
+      const actionPlan = await interventionsService.getActionPlan(probationPractitionerToken, actionPlanId)
       expect(actionPlan).toMatchObject({
         id: actionPlanId,
         referralId,
@@ -1937,7 +2035,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'PATCH',
           path: `/draft-action-plan/${draftActionPlanId}`,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           body: {
             newActivity: {
               description: 'Attend training course',
@@ -1964,11 +2062,15 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const draftActionPlan = await interventionsService.updateDraftActionPlan(token, draftActionPlanId, {
-        newActivity: {
-          description: 'Attend training course',
-        },
-      })
+      const draftActionPlan = await interventionsService.updateDraftActionPlan(
+        probationPractitionerToken,
+        draftActionPlanId,
+        {
+          newActivity: {
+            description: 'Attend training course',
+          },
+        }
+      )
 
       expect(draftActionPlan.id).toBe(draftActionPlanId)
       expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
@@ -1987,7 +2089,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'PATCH',
           path: `/draft-action-plan/${draftActionPlanId}`,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           body: {
             numberOfSessions: 4,
           },
@@ -2018,9 +2120,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const draftActionPlan = await interventionsService.updateDraftActionPlan(token, draftActionPlanId, {
-        numberOfSessions: 4,
-      })
+      const draftActionPlan = await interventionsService.updateDraftActionPlan(
+        probationPractitionerToken,
+        draftActionPlanId,
+        {
+          numberOfSessions: 4,
+        }
+      )
       expect(draftActionPlan.id).toBe(draftActionPlanId)
       expect(draftActionPlan.referralId).toBe('81d754aa-d868-4347-9c0f-50690773014e')
       expect(draftActionPlan.numberOfSessions).toBe(4)
@@ -2041,7 +2147,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'PATCH',
           path: `/action-plan/${draftActionPlanId}/activities/${activityId}`,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           body: {
             description: 'do something totally different!',
           },
@@ -2065,7 +2171,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const draftActionPlan = await interventionsService.updateActionPlanActivity(
-        token,
+        probationPractitionerToken,
         draftActionPlanId,
         activityId,
         'do something totally different!'
@@ -2111,7 +2217,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: '/draft-action-plan/6e8dfb5c-127f-46ea-9846-f82b5fd60d27/submit',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 201,
@@ -2127,9 +2233,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
 
     it('returns a submitted action plan', async () => {
-      expect(await interventionsService.submitActionPlan(token, '6e8dfb5c-127f-46ea-9846-f82b5fd60d27')).toMatchObject(
-        submittedActionPlan
-      )
+      expect(
+        await interventionsService.submitActionPlan(probationPractitionerToken, '6e8dfb5c-127f-46ea-9846-f82b5fd60d27')
+      ).toMatchObject(submittedActionPlan)
     })
   })
 
@@ -2141,7 +2247,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: '/action-plan/7a165933-d851-48c1-9ab0-ff5b8da12695/approve',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2149,7 +2255,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
     })
     it('returns successfully', async () => {
-      await interventionsService.approveActionPlan(token, '7a165933-d851-48c1-9ab0-ff5b8da12695')
+      await interventionsService.approveActionPlan(probationPractitionerToken, '7a165933-d851-48c1-9ab0-ff5b8da12695')
     })
   })
 
@@ -2182,7 +2288,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/action-plan/e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d/appointments',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2196,7 +2302,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
     it('returns action plan appointments', async () => {
       expect(
-        await interventionsService.getActionPlanAppointments(token, 'e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d')
+        await interventionsService.getActionPlanAppointments(
+          probationPractitionerToken,
+          'e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d'
+        )
       ).toMatchObject(actionPlanAppointments)
     })
   })
@@ -2218,7 +2327,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/action-plan/e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d/appointments/1',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2232,7 +2341,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
     it('returns the requested action plan appointment', async () => {
       const appointment = await interventionsService.getActionPlanAppointment(
-        token,
+        probationPractitionerToken,
         'e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d',
         1
       )
@@ -2250,9 +2359,17 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
       it('fetches the subsequent action plan appointment', async () => {
         interventionsService.getActionPlanAppointment = jest.fn()
-        await interventionsService.getSubsequentActionPlanAppointment(token, actionPlan, appointment)
+        await interventionsService.getSubsequentActionPlanAppointment(
+          probationPractitionerToken,
+          actionPlan,
+          appointment
+        )
 
-        expect(interventionsService.getActionPlanAppointment).toHaveBeenCalledWith(token, actionPlan.id, 2)
+        expect(interventionsService.getActionPlanAppointment).toHaveBeenCalledWith(
+          probationPractitionerToken,
+          actionPlan.id,
+          2
+        )
       })
     })
 
@@ -2264,7 +2381,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         interventionsService.getActionPlanAppointment = jest.fn()
 
         const subsequentAppointment = await interventionsService.getSubsequentActionPlanAppointment(
-          token,
+          probationPractitionerToken,
           actionPlan,
           appointment
         )
@@ -2316,7 +2433,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
                 postCode: 'SY40RE',
               },
             },
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           // note - this is an exact match
           willRespondWith: {
@@ -2329,18 +2446,23 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         })
 
         expect(
-          await interventionsService.updateActionPlanAppointment(token, '345059d4-1697-467b-8914-fedec9957279', 2, {
-            appointmentTime: '2021-05-13T12:30:00Z',
-            durationInMinutes: 60,
-            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
-            appointmentDeliveryAddress: {
-              firstAddressLine: 'Harmony Living Office, Room 4',
-              secondAddressLine: '44 Bouverie Road',
-              townOrCity: 'Blackpool',
-              county: 'Lancashire',
-              postCode: 'SY40RE',
-            },
-          })
+          await interventionsService.updateActionPlanAppointment(
+            probationPractitionerToken,
+            '345059d4-1697-467b-8914-fedec9957279',
+            2,
+            {
+              appointmentTime: '2021-05-13T12:30:00Z',
+              durationInMinutes: 60,
+              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+              appointmentDeliveryAddress: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '44 Bouverie Road',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY40RE',
+              },
+            }
+          )
         ).toMatchObject(actionPlanAppointment)
       })
     })
@@ -2360,7 +2482,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             attended: 'late',
             additionalAttendanceInformation: 'Alex missed the bus',
           },
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2395,7 +2517,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const appointment = await interventionsService.recordActionPlanAppointmentAttendance(
-        token,
+        probationPractitionerToken,
         '345059d4-1697-467b-8914-fedec9957279',
         2,
         {
@@ -2422,7 +2544,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             behaviourDescription: 'Alex was well behaved',
             notifyProbationPractitioner: false,
           },
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2449,7 +2571,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const appointment = await interventionsService.recordActionPlanAppointmentBehavior(
-        token,
+        probationPractitionerToken,
         '81987e8b-aeb9-4fbf-8ecb-1a054ad74b2d',
         1,
         {
@@ -2472,7 +2594,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: '/action-plan/0f5afe04-e323-4699-9423-fb6122580638/appointment/1/submit',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2499,7 +2621,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const appointment = await interventionsService.submitActionPlanSessionFeedback(
-        token,
+        probationPractitionerToken,
         '0f5afe04-e323-4699-9423-fb6122580638',
         1
       )
@@ -2519,7 +2641,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           method: 'POST',
           path: '/draft-end-of-service-report',
           body: { referralId },
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 201,
@@ -2530,7 +2652,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const result = await interventionsService.createDraftEndOfServiceReport(token, referralId)
+      const result = await interventionsService.createDraftEndOfServiceReport(probationPractitionerToken, referralId)
       expect(result).toEqual(endOfServiceReport)
     })
   })
@@ -2546,7 +2668,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: `/end-of-service-report/${id}`,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2557,7 +2679,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const result = await interventionsService.getEndOfServiceReport(token, id)
+      const result = await interventionsService.getEndOfServiceReport(probationPractitionerToken, id)
       expect(result).toEqual(endOfServiceReport)
     })
   })
@@ -2597,7 +2719,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           method: 'PATCH',
           path: `/draft-end-of-service-report/${id}`,
           body: patch,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2608,7 +2730,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const result = await interventionsService.updateDraftEndOfServiceReport(token, id, patch)
+      const result = await interventionsService.updateDraftEndOfServiceReport(probationPractitionerToken, id, patch)
       expect(result).toEqual(updatedEndOfServiceReport)
     })
   })
@@ -2624,7 +2746,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'POST',
           path: `/draft-end-of-service-report/${id}/submit`,
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2635,7 +2757,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const result = await interventionsService.submitEndOfServiceReport(token, id)
+      const result = await interventionsService.submitEndOfServiceReport(probationPractitionerToken, id)
       expect(result).toEqual(submittedEndOfServiceReport)
     })
   })
@@ -2656,7 +2778,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             reasonCode: 'REC',
             comments: 'Alex was arrested for driving without insurance and immediately recalled.',
           },
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2669,7 +2791,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     it('returns an ended referral', async () => {
       expect(
         await interventionsService.endReferral(
-          token,
+          probationPractitionerToken,
           '5f71c68f-3e43-46b6-8f25-027a88637ee1',
           'REC',
           'Alex was arrested for driving without insurance and immediately recalled.'
@@ -2691,7 +2813,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/referral-cancellation-reasons',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2702,7 +2824,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
 
     it('returns cancellation reasons', async () => {
-      expect(await interventionsService.getReferralCancellationReasons(token)).toMatchObject(reasons)
+      expect(await interventionsService.getReferralCancellationReasons(probationPractitionerToken)).toMatchObject(
+        reasons
+      )
     })
   })
 
@@ -2720,7 +2844,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/sent-referral/cbf2f82b-4581-4fe1-9de1-1b52465f1afa/supplier-assessment',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2732,7 +2856,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const fetchedSupplierAssessment = await interventionsService.getSupplierAssessment(
-        token,
+        probationPractitionerToken,
         'cbf2f82b-4581-4fe1-9de1-1b52465f1afa'
       )
       expect(fetchedSupplierAssessment).toEqual(supplierAssessment)
@@ -2753,7 +2877,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         withRequest: {
           method: 'GET',
           path: '/sent-referral/a38d9184-5498-4049-af16-3d8eb2547962/supplier-assessment',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -2765,7 +2889,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       const fetchedSupplierAssessment = await interventionsService.getSupplierAssessment(
-        token,
+        probationPractitionerToken,
         'a38d9184-5498-4049-af16-3d8eb2547962'
       )
       expect(fetchedSupplierAssessment).toEqual(supplierAssessment)
@@ -2803,7 +2927,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             method: 'PUT',
             path: `/supplier-assessment/${supplierAssessmentId}/schedule-appointment`,
             body: appointment,
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
           },
           willRespondWith: {
             status: 200,
@@ -2815,7 +2939,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         })
 
         expect(
-          await interventionsService.scheduleSupplierAssessmentAppointment(token, supplierAssessmentId, appointment)
+          await interventionsService.scheduleSupplierAssessmentAppointment(
+            probationPractitionerToken,
+            supplierAssessmentId,
+            appointment
+          )
         ).toMatchObject(appointment)
       })
     })
@@ -3006,7 +3134,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           method: 'GET',
           path: '/performance-report',
           query: { fromIncludingDate: '2021-06-01', toIncludingDate: '2021-06-10' },
-          headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
         willRespondWith: {
           status: 200,
@@ -3016,7 +3144,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
 
       expect(
-        await interventionsService.getServiceProviderReportingData(token, {
+        await interventionsService.getServiceProviderReportingData(probationPractitionerToken, {
           fromIncludingDate: CalendarDay.fromComponents(1, 6, 2021)!,
           toIncludingDate: CalendarDay.fromComponents(10, 6, 2021)!,
         })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -3130,7 +3130,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
     it('returns a list of referrals for with data for reporting', async () => {
       await provider.addInteraction({
-        state: 'nothing',
+        state: 'there are referrals available for the reporting period of 1 June 2021 to 10 June 2021',
         uponReceiving: 'a service provider user’s GET request for referral reporting data',
         withRequest: {
           method: 'GET',

--- a/testutils/factories/oauth2Token.ts
+++ b/testutils/factories/oauth2Token.ts
@@ -18,6 +18,15 @@ class Oauth2TokenFactory extends Factory<string, TokenParams> {
       roles: ['ROLE_PROBATION'],
     })
   }
+
+  serviceProviderToken() {
+    return this.transient({
+      authSource: 'auth',
+      userID: '6c4036b7-e87d-44fb-864f-5a06c1c492f3',
+      username: 'TEST_INTERVENTIONS_SP_1',
+      roles: ['ROLE_CRS_PROVIDER'],
+    })
+  }
 }
 
 export default Oauth2TokenFactory.define(({ transientParams }) => {

--- a/testutils/factories/oauth2Token.ts
+++ b/testutils/factories/oauth2Token.ts
@@ -10,7 +10,7 @@ interface TokenParams {
 }
 
 class Oauth2TokenFactory extends Factory<string, TokenParams> {
-  deliusToken() {
+  probationPractitionerToken() {
     return this.transient({
       authSource: 'delius',
       userID: '2500128586',


### PR DESCRIPTION
## What does this pull request do?

A couple of changes to the contract test for the reporting endpoint:

- call the endpoint with a service provider token
- be explicit about the state required to ensure results are returned

## What is the intent behind these changes?

To help @rgforsyth make the tests pass on the interventions service.