### PR TITLE
IC-2072 add back links to action plan form

### DIFF
--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
@@ -18,6 +18,8 @@ export default class AddActionPlanActivitiesPresenter {
     this.actionPlanPresenter = new ActionPlanPresenter(sentReferral, actionPlan, serviceCategories, 'service-provider')
   }
 
+  readonly actionPlanId = this.actionPlan.id
+
   readonly saveAndContinueFormAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activities`
 
   readonly addActivityAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activity/${this.activityNumber}`

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesView.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesView.ts
@@ -1,8 +1,22 @@
 import ViewUtils from '../../../../utils/viewUtils'
 import AddActionPlanActivitiesPresenter from './addActionPlanActivitiesPresenter'
+import { BackLinkArgs } from '../../../../utils/govukFrontendTypes'
 
 export default class AddActionPlanActivitiesView {
   constructor(private readonly presenter: AddActionPlanActivitiesPresenter) {}
+
+  private get backLinkArgs(): BackLinkArgs | null {
+    if (this.presenter.activityNumber === 1) {
+      return null
+    }
+
+    return {
+      text: 'Back',
+      href: `/service-provider/action-plan/${this.presenter.actionPlanId}/add-activity/${
+        this.presenter.activityNumber - 1
+      }`,
+    }
+  }
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [
@@ -11,6 +25,7 @@ export default class AddActionPlanActivitiesView {
         presenter: this.presenter,
         addActivityTextareaArgs: this.addActivityTextareaArgs,
         errorSummaryArgs: this.errorSummaryArgs,
+        backLinkArgs: this.backLinkArgs,
       },
     ]
   }

--- a/server/routes/service-provider/action-plan/number-of-sessions/actionPlanNumberOfSessionsPresenter.ts
+++ b/server/routes/service-provider/action-plan/number-of-sessions/actionPlanNumberOfSessionsPresenter.ts
@@ -30,4 +30,8 @@ export default class ActionPlanNumberOfSessionsPresenter {
   readonly fields = {
     numberOfSessions: this.utils.stringValue(this.actionPlan.numberOfSessions, 'number-of-sessions'),
   }
+
+  readonly actionPlanId = this.actionPlan.id
+
+  readonly numberOfActivities = this.actionPlan.activities.length
 }

--- a/server/routes/service-provider/action-plan/number-of-sessions/actionPlanNumberOfSessionsView.ts
+++ b/server/routes/service-provider/action-plan/number-of-sessions/actionPlanNumberOfSessionsView.ts
@@ -5,6 +5,11 @@ import ViewUtils from '../../../../utils/viewUtils'
 export default class ActionPlanNumberOfSessionsView {
   constructor(private readonly presenter: ActionPlanNumberOfSessionsPresenter) {}
 
+  private readonly backLinkArgs = {
+    text: 'Back',
+    href: `/service-provider/action-plan/${this.presenter.actionPlanId}/add-activity/${this.presenter.numberOfActivities}`,
+  }
+
   private get numberOfSessionsInputArgs(): InputArgs {
     return {
       label: {
@@ -28,6 +33,7 @@ export default class ActionPlanNumberOfSessionsView {
         presenter: this.presenter,
         errorSummaryArgs: ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary),
         numberOfSessionsInputArgs: this.numberOfSessionsInputArgs,
+        backLinkArgs: this.backLinkArgs,
       },
     ]
   }

--- a/server/routes/service-provider/action-plan/review/reviewActionPlanPresenter.ts
+++ b/server/routes/service-provider/action-plan/review/reviewActionPlanPresenter.ts
@@ -14,6 +14,8 @@ export default class ReviewActionPlanPresenter {
     this.actionPlanPresenter = new ActionPlanPresenter(sentReferral, actionPlan, serviceCategories, 'service-provider')
   }
 
+  readonly actionPlanId = this.actionPlan.id
+
   readonly submitFormAction = `/service-provider/action-plan/${this.actionPlan.id}/submit`
 
   readonly text = {

--- a/server/routes/service-provider/action-plan/review/reviewActionPlanView.ts
+++ b/server/routes/service-provider/action-plan/review/reviewActionPlanView.ts
@@ -8,12 +8,18 @@ export default class ReviewActionPlanView {
     this.actionPlanView = new ActionPlanView(presenter.actionPlanPresenter)
   }
 
+  private readonly backLinkArgs = {
+    text: 'Back',
+    href: `/service-provider/action-plan/${this.presenter.actionPlanId}/number-of-sessions`,
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/reviewActionPlan',
       {
         presenter: this.presenter,
         insetTextArgs: this.actionPlanView.insetTextActivityArgs,
+        backLinkArgs: this.backLinkArgs,
       },
     ]
   }

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -13,6 +14,11 @@
       {% endif %}
 
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      {% if backLinkArgs %}
+        {{ govukBackLink(backLinkArgs) }}
+      {% endif %}
+
       {% if presenter.text.subTitle %}
         <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
       {% endif %}


### PR DESCRIPTION
## What does this pull request do?

adds back links to all pages of the action plan form (except for the first page) to return to the previous page

## What is the intent behind these changes?

allow SPs to navigate back in the form without using browser back button or editing the URL
