### PR TITLE
show 'in draft' status for service provider unfinished action plans

### DIFF
--- a/server/routes/shared/action-plan/actionPlanSummaryPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanSummaryPresenter.test.ts
@@ -24,9 +24,16 @@ describe(ActionPlanSummaryPresenter, () => {
     })
 
     describe('when the action plan has not been submitted', () => {
-      it('returns the correct status', () => {
+      it('returns the correct status for service providers', () => {
         const actionPlan = actionPlanFactory.notSubmitted().build({ referralId: referral.id })
         const presenter = new ActionPlanSummaryPresenter(referral, actionPlan, 'service-provider')
+
+        expect(presenter.text.actionPlanStatus).toEqual('In draft')
+      })
+
+      it('returns the correct status for probation practitioners', () => {
+        const actionPlan = actionPlanFactory.notSubmitted().build({ referralId: referral.id })
+        const presenter = new ActionPlanSummaryPresenter(referral, actionPlan, 'probation-practitioner')
 
         expect(presenter.text.actionPlanStatus).toEqual('Not submitted')
       })

--- a/server/routes/shared/action-plan/actionPlanSummaryPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanSummaryPresenter.ts
@@ -14,11 +14,8 @@ export default class ActionPlanSummaryPresenter {
   readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
 
   // this url is used to pick up action plan creation after it has been started.
-  // the url points to the screen for adding an additional activity
   readonly actionPlanFormUrl =
-    this.actionPlan !== null
-      ? `/service-provider/action-plan/${this.actionPlan.id}/add-activity/${this.actionPlan.activities.length + 1}`
-      : ''
+    this.actionPlan !== null ? `/service-provider/action-plan/${this.actionPlan.id}/add-activity/1` : ''
 
   readonly text = {
     actionPlanStatus: this.actionPlanStatus,

--- a/server/routes/shared/action-plan/actionPlanSummaryPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanSummaryPresenter.ts
@@ -33,6 +33,9 @@ export default class ActionPlanSummaryPresenter {
     if (this.actionPlanUnderReview) {
       return 'Awaiting approval'
     }
+    if (this.actionPlanCreated && this.userType === 'service-provider') {
+      return 'In draft'
+    }
     return 'Not submitted'
   }
 

--- a/server/routes/shared/action-plan/actionPlanSummaryView.ts
+++ b/server/routes/shared/action-plan/actionPlanSummaryView.ts
@@ -10,7 +10,9 @@ export default class ActionPlanSummaryView {
       case 'Approved':
         return 'govuk-tag--green'
       case 'Awaiting approval':
-        return 'govuk-tag- govuk-tag--red'
+        return 'govuk-tag--red'
+      case 'In draft':
+        return 'govuk-tag--yellow'
       default:
         return 'govuk-tag--grey'
     }
@@ -72,7 +74,7 @@ export default class ActionPlanSummaryView {
           rows.push({
             key: { text: 'Action' },
             value: {
-              html: `<a href="${this.presenter.actionPlanFormUrl}" class="govuk-link">Submit action plan</a>`,
+              html: `<a href="${this.presenter.actionPlanFormUrl}" class="govuk-link">Complete action plan</a>`,
             },
           })
         }


### PR DESCRIPTION
## What does this pull request do?

show 'in draft' status for service provider unfinished action plans

change link text from 'submit action plan' to 'complete action plan'

change link to always to go to first activity for 'in draft' action plans

<img width="862" alt="Screenshot 2021-07-13 at 12 21 50" src="https://user-images.githubusercontent.com/63233073/125443543-7d402681-8b1d-4d17-b140-ececf7e2fc36.png">

## What is the intent behind these changes?

improve overall UX for action plan creation and editing
