### PR TITLE
IC-2034: Display Responsible Officer(s) on referral details pages.

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -8,6 +8,7 @@ import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
 import deliusStaffDetailsFactory from '../../testutils/factories/deliusStaffDetails'
+import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
 
 describe('Probation practitioner referrals dashboard', () => {
   beforeEach(() => {
@@ -287,6 +288,15 @@ describe('Probation practitioner referrals dashboard', () => {
       ],
     })
 
+    const responsibleOfficer = deliusOffenderManagerFactory.build({
+      staff: {
+        forenames: 'Peter',
+        surname: 'Practitioner',
+        email: 'p.practitioner@justice.gov.uk',
+        phoneNumber: '01234567890',
+      },
+    })
+
     cy.stubGetSentReferral(referral.id, referral)
     cy.stubGetIntervention(personalWellbeingIntervention.id, personalWellbeingIntervention)
     cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
@@ -295,6 +305,7 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
     cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
+    cy.stubGetResponsibleOfficersForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
 
     cy.login()
 
@@ -347,6 +358,11 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.contains('She uses a wheelchair')
     cy.contains('Spanish')
     cy.contains('She works Mondays 9am - midday')
+
+    cy.contains('Responsible officer details').next().contains('Name').next().contains('Peter Practitioner')
+    cy.contains('Responsible officer details').next().contains('Phone').next().contains('01234567890')
+    cy.contains('Responsible officer details').next().contains('Email').next().contains('p.practitioner@justice.gov.uk')
+
     cy.contains('Bernard Beaks')
     cy.contains('bernard.beaks@justice.gov.uk')
 

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -13,6 +13,7 @@ import expandedDeliusServiceUserFactory from '../../testutils/factories/expanded
 import deliusStaffDetailsFactory from '../../testutils/factories/deliusStaffDetails'
 import supplierAssessmentFactory from '../../testutils/factories/supplierAssessment'
 import appointmentFactory from '../../testutils/factories/appointment'
+import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
 
 describe('Service provider referrals dashboard', () => {
   beforeEach(() => {
@@ -167,6 +168,15 @@ describe('Service provider referrals dashboard', () => {
       ],
     })
 
+    const responsibleOfficer = deliusOffenderManagerFactory.build({
+      staff: {
+        forenames: 'Peter',
+        surname: 'Practitioner',
+        email: 'p.practitioner@justice.gov.uk',
+        phoneNumber: '01234567890',
+      },
+    })
+
     cy.stubGetIntervention(personalWellbeingIntervention.id, personalWellbeingIntervention)
     cy.stubGetIntervention(socialInclusionIntervention.id, socialInclusionIntervention)
     sentReferrals.forEach(referral => cy.stubGetSentReferral(referral.id, referral))
@@ -177,6 +187,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetConvictionById(referralToSelect.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetSupplementaryRiskInformation(referralToSelect.supplementaryRiskId, supplementaryRiskInformation)
     cy.stubGetStaffDetails(referralToSelect.sentBy.username, staffDetails)
+    cy.stubGetResponsibleOfficersForServiceUser(referralToSelect.referral.serviceUser.crn, [responsibleOfficer])
 
     cy.login()
 
@@ -252,6 +263,11 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('She uses a wheelchair')
     cy.contains('Spanish')
     cy.contains('She works Mondays 9am - midday')
+
+    cy.contains('Responsible officer details').next().contains('Name').next().contains('Peter Practitioner')
+    cy.contains('Responsible officer details').next().contains('Phone').next().contains('01234567890')
+    cy.contains('Responsible officer details').next().contains('Email').next().contains('p.practitioner@justice.gov.uk')
+
     cy.contains('Bernard Beaks')
     cy.contains('bernard.beaks@justice.gov.uk')
 
@@ -284,6 +300,7 @@ describe('Service provider referrals dashboard', () => {
       const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
       const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const staffDetails = deliusStaffDetailsFactory.build()
+      const responsibleOfficer = deliusOffenderManagerFactory.build()
 
       cy.stubGetIntervention(intervention.id, intervention)
       cy.stubGetSentReferral(referral.id, referral)
@@ -297,6 +314,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
       cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
       cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
+      cy.stubGetResponsibleOfficersForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
 
       cy.login()
 
@@ -356,6 +374,7 @@ describe('Service provider referrals dashboard', () => {
       const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({ ...deliusServiceUser })
       const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const staffDetails = deliusStaffDetailsFactory.build()
+      const responsibleOfficer = deliusOffenderManagerFactory.build()
 
       cy.stubGetIntervention(intervention.id, intervention)
       cy.stubGetSentReferral(referral.id, referral)
@@ -369,6 +388,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
       cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
       cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
+      cy.stubGetResponsibleOfficersForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
 
       cy.login()
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -59,6 +59,10 @@ module.exports = on => {
       return communityApi.stubGetStaffDetails(arg.username, arg.responseJson)
     },
 
+    stubGetResponsibleOfficersForServiceUser: arg => {
+      return communityApi.stubGetResponsibleOfficersForServiceUser(arg.crn, arg.responseJson)
+    },
+
     stubGetDraftReferral: arg => {
       return interventionsService.stubGetDraftReferral(arg.id, arg.responseJson)
     },

--- a/integration_tests/support/communityApiStubs.js
+++ b/integration_tests/support/communityApiStubs.js
@@ -21,3 +21,7 @@ Cypress.Commands.add('stubGetConvictionById', (crn, id, responseJson) => {
 Cypress.Commands.add('stubGetStaffDetails', (username, responseJson) => {
   cy.task('stubGetStaffDetails', { username, responseJson })
 })
+
+Cypress.Commands.add('stubGetResponsibleOfficersForServiceUser', (crn, responseJson) => {
+  cy.task('stubGetResponsibleOfficersForServiceUser', { crn, responseJson })
+})

--- a/mockApis/communityApi.ts
+++ b/mockApis/communityApi.ts
@@ -98,4 +98,20 @@ export default class CommunityApiMocks {
       },
     })
   }
+
+  stubGetResponsibleOfficersForServiceUser = async (crn: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/community-api/secure/offenders/crn/${crn}/allOffenderManagers`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/models/delius/deliusOffenderManager.ts
+++ b/server/models/delius/deliusOffenderManager.ts
@@ -1,0 +1,9 @@
+export interface DeliusOffenderManager {
+  isResponsibleOfficer: boolean
+  staff?: {
+    forenames?: string | null
+    surname?: string | null
+    email?: string | null
+    phoneNumber?: string | null
+  }
+}

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -134,16 +134,25 @@ export default class ProbationPractitionerReferralsController {
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
 
     const { crn } = sentReferral.referral.serviceUser
-    const [intervention, sentBy, expandedServiceUser, conviction, riskInformation, riskSummary, staffDetails] =
-      await Promise.all([
-        this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
-        this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
-        this.communityApiService.getExpandedServiceUserByCRN(crn),
-        this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
-        this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
-        this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
-        this.communityApiService.getStaffDetails(sentReferral.sentBy.username),
-      ])
+    const [
+      intervention,
+      sentBy,
+      expandedServiceUser,
+      conviction,
+      riskInformation,
+      riskSummary,
+      staffDetails,
+      responsibleOfficers,
+    ] = await Promise.all([
+      this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
+      this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
+      this.communityApiService.getExpandedServiceUserByCRN(crn),
+      this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
+      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
+      this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
+      this.communityApiService.getStaffDetails(sentReferral.sentBy.username),
+      this.communityApiService.getResponsibleOfficersForServiceUser(crn),
+    ])
 
     const assignee =
       sentReferral.assignedTo === null
@@ -165,7 +174,8 @@ export default class ProbationPractitionerReferralsController {
       false,
       expandedServiceUser,
       riskSummary,
-      staffDetails
+      staffDetails,
+      responsibleOfficers
     )
     const view = new ShowReferralView(presenter)
     ControllerUtils.renderWithLayout(res, view, expandedServiceUser)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -97,16 +97,25 @@ export default class ServiceProviderReferralsController {
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
 
     const { crn } = sentReferral.referral.serviceUser
-    const [intervention, sentBy, expandedServiceUser, conviction, riskInformation, riskSummary, staffDetails] =
-      await Promise.all([
-        this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
-        this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
-        this.communityApiService.getExpandedServiceUserByCRN(crn),
-        this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
-        this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
-        this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
-        this.communityApiService.getStaffDetails(sentReferral.sentBy.username),
-      ])
+    const [
+      intervention,
+      sentBy,
+      expandedServiceUser,
+      conviction,
+      riskInformation,
+      riskSummary,
+      staffDetails,
+      responsibleOfficers,
+    ] = await Promise.all([
+      this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
+      this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
+      this.communityApiService.getExpandedServiceUserByCRN(crn),
+      this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
+      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
+      this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
+      this.communityApiService.getStaffDetails(sentReferral.sentBy.username),
+      this.communityApiService.getResponsibleOfficersForServiceUser(crn),
+    ])
     const assignee =
       sentReferral.assignedTo === null
         ? null
@@ -140,7 +149,8 @@ export default class ServiceProviderReferralsController {
       true,
       expandedServiceUser,
       riskSummary,
-      staffDetails
+      staffDetails,
+      responsibleOfficers
     )
     const view = new ShowReferralView(presenter)
 

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -13,6 +13,7 @@ import riskSummaryFactory from '../../../testutils/factories/riskSummary'
 import deliusStaffDetailsFactory from '../../../testutils/factories/deliusStaffDetails'
 import { DeliusStaffDetails } from '../../models/delius/deliusStaffDetails'
 import deliusTeam from '../../../testutils/factories/deliusTeam'
+import deliusOffenderManagerFactory from '../../../testutils/factories/deliusOffenderManager'
 
 describe(ShowReferralPresenter, () => {
   const intervention = interventionFactory.build()
@@ -47,6 +48,7 @@ describe(ShowReferralPresenter, () => {
   const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
   const riskSummary = riskSummaryFactory.build()
   const defaultStaffDetails = deliusStaffDetailsFactory.build()
+  const responsibleOfficer = [deliusOffenderManagerFactory.build()]
 
   describe('assignmentFormAction', () => {
     it('returns the relative URL for the check assignment page', () => {
@@ -64,7 +66,8 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        defaultStaffDetails
+        defaultStaffDetails,
+        responsibleOfficer
       )
 
       expect(presenter.assignmentFormAction).toEqual(`/service-provider/referrals/${referral.id}/assignment/check`)
@@ -88,7 +91,8 @@ describe(ShowReferralPresenter, () => {
             true,
             deliusServiceUser,
             riskSummary,
-            defaultStaffDetails
+            defaultStaffDetails,
+            responsibleOfficer
           )
 
           expect(presenter.text.assignedTo).toBeNull()
@@ -110,7 +114,8 @@ describe(ShowReferralPresenter, () => {
             true,
             deliusServiceUser,
             riskSummary,
-            defaultStaffDetails
+            defaultStaffDetails,
+            responsibleOfficer
           )
 
           expect(presenter.text.assignedTo).toEqual('John Smith')
@@ -134,7 +139,8 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        defaultStaffDetails
+        defaultStaffDetails,
+        responsibleOfficer
       )
 
       expect(presenter.probationPractitionerDetails).toEqual([
@@ -158,7 +164,8 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        staffDetails
+        staffDetails,
+        responsibleOfficer
       )
     }
 
@@ -280,6 +287,151 @@ describe(ShowReferralPresenter, () => {
     })
   })
 
+  describe('responsibleOfficerDetails', () => {
+    describe('when all fields are present', () => {
+      it('returns an array of summary lists of the responsible officer(s)', () => {
+        const sentReferral = sentReferralFactory.build(referralParams)
+        const presenter = new ShowReferralPresenter(
+          sentReferral,
+          intervention,
+          deliusConviction,
+          supplementaryRiskInformation,
+          deliusUser,
+          null,
+          null,
+          'service-provider',
+          true,
+          deliusServiceUser,
+          riskSummary,
+          defaultStaffDetails,
+          [
+            deliusOffenderManagerFactory.build({
+              staff: {
+                forenames: 'Peter',
+                surname: 'Practitioner',
+                email: 'p.practitioner@example.com',
+                phoneNumber: '01234567890',
+              },
+            }),
+          ]
+        )
+
+        expect(presenter.responsibleOfficersDetails).toEqual([
+          [
+            { key: 'Name', lines: ['Peter Practitioner'] },
+            { key: 'Phone', lines: ['01234567890'] },
+            { key: 'Email address', lines: ['p.practitioner@example.com'] },
+          ],
+        ])
+      })
+    })
+
+    describe('when optional fields are missing', () => {
+      it('returns an array of summary lists of the responsible officer(s) with "not found" or empty values', () => {
+        const sentReferral = sentReferralFactory.build(referralParams)
+        const presenter = new ShowReferralPresenter(
+          sentReferral,
+          intervention,
+          deliusConviction,
+          supplementaryRiskInformation,
+          deliusUser,
+          null,
+          null,
+          'service-provider',
+          true,
+          deliusServiceUser,
+          riskSummary,
+          defaultStaffDetails,
+          [
+            {
+              isResponsibleOfficer: true,
+              staff: undefined,
+            },
+            {
+              isResponsibleOfficer: true,
+              staff: {
+                forenames: undefined,
+                surname: undefined,
+                email: undefined,
+                phoneNumber: undefined,
+              },
+            },
+            {
+              isResponsibleOfficer: true,
+              staff: {
+                forenames: undefined,
+                surname: 'Practitioner',
+                email: undefined,
+                phoneNumber: undefined,
+              },
+            },
+            {
+              isResponsibleOfficer: true,
+              staff: {
+                forenames: 'Peter',
+                surname: undefined,
+                email: undefined,
+                phoneNumber: undefined,
+              },
+            },
+          ]
+        )
+
+        expect(presenter.responsibleOfficersDetails).toEqual([
+          [
+            { key: 'Name', lines: ['Not found'] },
+            { key: 'Phone', lines: ['Not found'] },
+            { key: 'Email address', lines: ['Not found'] },
+          ],
+          [
+            { key: 'Name', lines: ['Not found'] },
+            { key: 'Phone', lines: ['Not found'] },
+            { key: 'Email address', lines: ['Not found'] },
+          ],
+          [
+            { key: 'Name', lines: ['Practitioner'] },
+            { key: 'Phone', lines: ['Not found'] },
+            { key: 'Email address', lines: ['Not found'] },
+          ],
+          [
+            { key: 'Name', lines: ['Peter'] },
+            { key: 'Phone', lines: ['Not found'] },
+            { key: 'Email address', lines: ['Not found'] },
+          ],
+        ])
+      })
+    })
+
+    describe('when no Responsible Officers are passed in', () => {
+      it('returns an empty response', () => {
+        const sentReferral = sentReferralFactory.build(referralParams)
+        const presenter = new ShowReferralPresenter(
+          sentReferral,
+          intervention,
+          deliusConviction,
+          supplementaryRiskInformation,
+          deliusUser,
+          null,
+          null,
+          'service-provider',
+          true,
+          deliusServiceUser,
+          riskSummary,
+          defaultStaffDetails,
+          []
+        )
+
+        expect(presenter.responsibleOfficersDetails).toEqual([
+          [
+            { key: 'Name', lines: ['Not found'] },
+            { key: 'Phone', lines: ['Not found'] },
+            { key: 'Email address', lines: ['Not found'] },
+          ],
+        ])
+      })
+    })
+  })
+
   describe('interventionDetails', () => {
     describe('when all possibly optional fields have been set on the referral', () => {
       const referralWithAllOptionalFields = sentReferralFactory.build({
@@ -350,7 +502,8 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails
+          defaultStaffDetails,
+          responsibleOfficer
         )
 
         expect(presenter.interventionDetails).toEqual([
@@ -440,7 +593,8 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails
+          defaultStaffDetails,
+          responsibleOfficer
         )
 
         expect(presenter.interventionDetails).toEqual([
@@ -496,7 +650,8 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        defaultStaffDetails
+        defaultStaffDetails,
+        responsibleOfficer
       )
       expect(
         presenter.serviceCategorySection(cohortServiceCategories[0], (args: TagArgs): string => {
@@ -536,7 +691,8 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        defaultStaffDetails
+        defaultStaffDetails,
+        responsibleOfficer
       )
 
       expect(presenter.serviceUserDetails).toEqual([
@@ -579,7 +735,8 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        defaultStaffDetails
+        defaultStaffDetails,
+        responsibleOfficer
       )
 
       expect(presenter.serviceUserRisks).toEqual([
@@ -646,7 +803,8 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails
+          defaultStaffDetails,
+          responsibleOfficer
         )
 
         expect(presenter.serviceUserNeeds).toEqual([
@@ -735,7 +893,8 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails
+          defaultStaffDetails,
+          responsibleOfficer
         )
 
         expect(presenter.serviceUserNeeds).toEqual([

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -21,6 +21,7 @@ import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
 import RiskPresenter from './riskPresenter'
 import { DeliusStaffDetails, DeliusTeam } from '../../models/delius/deliusStaffDetails'
 import CalendarDay from '../../utils/calendarDay'
+import { DeliusOffenderManager } from '../../models/delius/deliusOffenderManager'
 
 export default class ShowReferralPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
@@ -39,7 +40,8 @@ export default class ShowReferralPresenter {
     readonly canAssignReferral: boolean,
     private readonly deliusServiceUser: ExpandedDeliusServiceUser,
     private readonly riskSummary: RiskSummary | null,
-    private readonly staffDetails: DeliusStaffDetails | null
+    private readonly staffDetails: DeliusStaffDetails | null,
+    private readonly responsibleOfficers: DeliusOffenderManager[]
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,
@@ -73,6 +75,48 @@ export default class ShowReferralPresenter {
           { key: 'Phone', lines: [`${activeTeam.telephone}`] },
           { key: 'Email address', lines: [`${activeTeam.emailAddress}`] },
         ]
+  }
+
+  get responsibleOfficersDetails(): SummaryListItem[][] {
+    // This is a temporary step - I want to not break the page if fields are missing, most likely with dev data.
+    // It will be removed / simplified when we switch to using a dedicated Responsible Officer endpoint.
+    if (this.responsibleOfficers.length < 1) {
+      return [
+        [
+          {
+            key: 'Name',
+            lines: ['Not found'],
+          },
+          {
+            key: 'Phone',
+            lines: ['Not found'],
+          },
+          {
+            key: 'Email address',
+            lines: ['Not found'],
+          },
+        ],
+      ]
+    }
+
+    return this.responsibleOfficers.map(responsibleOfficer => {
+      const { staff } = responsibleOfficer
+
+      return [
+        {
+          key: 'Name',
+          lines: [`${staff?.forenames || ''} ${staff?.surname || ''}`.trim() || 'Not found'],
+        },
+        {
+          key: 'Phone',
+          lines: [staff?.phoneNumber || 'Not found'],
+        },
+        {
+          key: 'Email address',
+          lines: [staff?.email || 'Not found'],
+        },
+      ]
+    })
   }
 
   get referralServiceCategories(): ServiceCategory[] {

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -21,6 +21,10 @@ export default class ShowReferralView {
     this.presenter.probationPractitionerTeamDetails
   )
 
+  private readonly responsibleOfficerSummaryListsArgs = this.presenter.responsibleOfficersDetails.map(details =>
+    ViewUtils.summaryListArgs(details)
+  )
+
   private readonly interventionDetailsSummaryListArgs = ViewUtils.summaryListArgs(this.presenter.interventionDetails)
 
   private readonly serviceUserDetailsSummaryListArgs = ViewUtils.summaryListArgs(this.presenter.serviceUserDetails)
@@ -64,6 +68,7 @@ export default class ShowReferralView {
         subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         probationPractitionerSummaryListArgs: this.probationPractitionerSummaryListArgs,
         probationPractitionerTeamSummaryListArgs: this.probationPractitionerTeamSummaryListArgs,
+        responsibleOfficerSummaryListsArgs: this.responsibleOfficerSummaryListsArgs,
         interventionDetailsSummaryListArgs: this.interventionDetailsSummaryListArgs,
         serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs,
         serviceUserRisksSummaryListArgs: this.serviceUserRisksSummaryListArgs,

--- a/server/services/communityApiService.test.ts
+++ b/server/services/communityApiService.test.ts
@@ -9,6 +9,8 @@ import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusConviction from '../../testutils/factories/deliusConviction'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
 import deliusStaffDetails from '../../testutils/factories/deliusStaffDetails'
+import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
+import { DeliusOffenderManager } from '../models/delius/deliusOffenderManager'
 
 jest.mock('../data/restClient')
 
@@ -147,6 +149,71 @@ describe(CommunityApiService, () => {
         } catch (err) {
           expect(err.status).toBe(500)
           expect(err.userMessage).toBe('Could retrieve staff details from nDelius.')
+        }
+      })
+    })
+  })
+
+  describe('getResponsibleOfficer', () => {
+    const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
+    const service = new CommunityApiService(hmppsAuthClientMock, restClientMock)
+
+    describe('when at least one Responsible Officer is assigned to the service user in Delius', () => {
+      it('makes a request to the Community API, retrieves the Responsible Officers and casts them as a DeliusResponsibleOfficer', async () => {
+        const deliusOffenderManagers = [
+          deliusOffenderManagerFactory.responsibleOfficer().build({ staff: { forenames: 'Jerry' } }),
+          deliusOffenderManagerFactory.responsibleOfficer().build({ staff: { forenames: 'Linda' } }),
+          deliusOffenderManagerFactory.notResponsibleOfficer().build({ staff: { forenames: 'Roger' } }),
+        ]
+
+        restClientMock.get.mockResolvedValue(deliusOffenderManagers)
+
+        hmppsAuthClientMock.getApiClientToken.mockResolvedValue('token')
+
+        const responsibleOfficers = await service.getResponsibleOfficersForServiceUser('X123456')
+
+        expect(restClientMock.get).toHaveBeenCalledWith({
+          path: '/secure/offenders/crn/X123456/allOffenderManagers',
+          token: 'token',
+        })
+
+        const names = responsibleOfficers!.map((officer: DeliusOffenderManager) => officer.staff.forenames)
+
+        expect(names).toEqual(['Jerry', 'Linda'])
+        expect(names).not.toContainEqual('Roger')
+      })
+    })
+
+    describe('when none of the Offender Managers are Responsible Officers', () => {
+      it('throws an error with a user-facing message', async () => {
+        const deliusOffenderManagers = [
+          deliusOffenderManagerFactory.notResponsibleOfficer().build({ staff: { forenames: 'Jerry' } }),
+          deliusOffenderManagerFactory.notResponsibleOfficer().build({ staff: { forenames: 'Linda' } }),
+          deliusOffenderManagerFactory.notResponsibleOfficer().build({ staff: { forenames: 'Roger' } }),
+        ]
+
+        restClientMock.get.mockResolvedValue(deliusOffenderManagers)
+
+        hmppsAuthClientMock.getApiClientToken.mockResolvedValue('token')
+
+        try {
+          await service.getResponsibleOfficersForServiceUser('X123456')
+        } catch (err) {
+          expect(err.status).toBe(500)
+          expect(err.userMessage).toBe('No responsible officer is assigned to this service user in nDelius.')
+        }
+      })
+    })
+
+    describe('when Community API throws an error', () => {
+      it('makes a request to Community API and returns a user-facing error message', async () => {
+        restClientMock.get.mockRejectedValue(createError(500))
+
+        try {
+          await service.getResponsibleOfficersForServiceUser('X123456')
+        } catch (err) {
+          expect(err.status).toBe(500)
+          expect(err.userMessage).toBe('Could retrieve Responsible Officer from nDelius.')
         }
       })
     })

--- a/server/services/communityApiService.test.ts
+++ b/server/services/communityApiService.test.ts
@@ -177,31 +177,10 @@ describe(CommunityApiService, () => {
           token: 'token',
         })
 
-        const names = responsibleOfficers!.map((officer: DeliusOffenderManager) => officer.staff.forenames)
+        const names = responsibleOfficers!.map((officer: DeliusOffenderManager) => officer.staff!.forenames)
 
         expect(names).toEqual(['Jerry', 'Linda'])
         expect(names).not.toContainEqual('Roger')
-      })
-    })
-
-    describe('when none of the Offender Managers are Responsible Officers', () => {
-      it('throws an error with a user-facing message', async () => {
-        const deliusOffenderManagers = [
-          deliusOffenderManagerFactory.notResponsibleOfficer().build({ staff: { forenames: 'Jerry' } }),
-          deliusOffenderManagerFactory.notResponsibleOfficer().build({ staff: { forenames: 'Linda' } }),
-          deliusOffenderManagerFactory.notResponsibleOfficer().build({ staff: { forenames: 'Roger' } }),
-        ]
-
-        restClientMock.get.mockResolvedValue(deliusOffenderManagers)
-
-        hmppsAuthClientMock.getApiClientToken.mockResolvedValue('token')
-
-        try {
-          await service.getResponsibleOfficersForServiceUser('X123456')
-        } catch (err) {
-          expect(err.status).toBe(500)
-          expect(err.userMessage).toBe('No responsible officer is assigned to this service user in nDelius.')
-        }
       })
     })
 

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -6,6 +6,7 @@ import DeliusUser from '../models/delius/deliusUser'
 import DeliusServiceUser, { ExpandedDeliusServiceUser } from '../models/delius/deliusServiceUser'
 import DeliusConviction from '../models/delius/deliusConviction'
 import { DeliusStaffDetails } from '../models/delius/deliusStaffDetails'
+import { DeliusOffenderManager } from '../models/delius/deliusOffenderManager'
 
 export default class CommunityApiService {
   constructor(private readonly hmppsAuthService: HmppsAuthService, private readonly restClient: RestClient) {}
@@ -76,6 +77,30 @@ export default class CommunityApiService {
       }
 
       throw createError(err.status, err, { userMessage: 'Could retrieve staff details from nDelius.' })
+    }
+  }
+
+  async getResponsibleOfficersForServiceUser(crn: string): Promise<DeliusOffenderManager[]> {
+    const token = await this.hmppsAuthService.getApiClientToken()
+
+    logger.info({ crn }, 'getting offender managers for service user')
+    try {
+      const deliusOffenderManagers = (await this.restClient.get({
+        path: `/secure/offenders/crn/${crn}/allOffenderManagers`,
+        token,
+      })) as DeliusOffenderManager[]
+
+      const responsibleOfficer = deliusOffenderManagers.filter(offenderManager => offenderManager.isResponsibleOfficer)
+
+      if (!responsibleOfficer) {
+        throw createError(500, `No offender manager found in Delius for CRN ${crn}`, {
+          userMessage: 'No responsible officer is assigned to this service user in nDelius.',
+        })
+      }
+
+      return responsibleOfficer
+    } catch (err) {
+      throw createError(err.status, err, { userMessage: 'Could retrieve Responsible Officer from nDelius.' })
     }
   }
 }

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -90,15 +90,7 @@ export default class CommunityApiService {
         token,
       })) as DeliusOffenderManager[]
 
-      const responsibleOfficer = deliusOffenderManagers.filter(offenderManager => offenderManager.isResponsibleOfficer)
-
-      if (!responsibleOfficer) {
-        throw createError(500, `No offender manager found in Delius for CRN ${crn}`, {
-          userMessage: 'No responsible officer is assigned to this service user in nDelius.',
-        })
-      }
-
-      return responsibleOfficer
+      return deliusOffenderManagers.filter(offenderManager => offenderManager.isResponsibleOfficer)
     } catch (err) {
       throw createError(err.status, err, { userMessage: 'Could retrieve Responsible Officer from nDelius.' })
     }

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -45,6 +45,12 @@
 
       <h2 class="govuk-heading-m">Service user's needs</h2>
       {{ govukSummaryList(serviceUserNeedsSummaryListArgs) }}
+
+      <h2 class="govuk-heading-m">Responsible officer details</h2>
+      {% for summaryListArgs in responsibleOfficerSummaryListsArgs %}
+        {{ govukSummaryList(summaryListArgs) }}
+      {% endfor %}
+
       <h2 class="govuk-heading-m">Referring probation practitioner details</h2>
       {{ govukSummaryList(probationPractitionerSummaryListArgs) }}
       <h2 class="govuk-heading-m">Team contact details</h2>

--- a/testutils/factories/deliusOffenderManager.ts
+++ b/testutils/factories/deliusOffenderManager.ts
@@ -1,0 +1,22 @@
+import { Factory } from 'fishery'
+import { DeliusOffenderManager } from '../../server/models/delius/deliusOffenderManager'
+
+class DeliusOffenderManagerFactory extends Factory<DeliusOffenderManager> {
+  responsibleOfficer() {
+    return this.params({ isResponsibleOfficer: true })
+  }
+
+  notResponsibleOfficer() {
+    return this.params({ isResponsibleOfficer: false })
+  }
+}
+
+export default DeliusOffenderManagerFactory.define(() => ({
+  isResponsibleOfficer: true,
+  staff: {
+    email: 'officer@gov.uk',
+    forenames: 'Sheila Linda',
+    phoneNumber: '0123411278',
+    surname: 'Hancock',
+  },
+}))


### PR DESCRIPTION
## What does this pull request do?

Makes a request to the Community API for a service user's Responsible Officer.

Due to uncertainty about what might we get back from the API, there could be:
- Fields missing in the response
- Multiple `OffenderManager`s with `isResponsibleOfficer` set to true

Because of the above, we're planning to add a new endpoint to the Community API for just getting a Responsible Officer in future, but this should (as gracefully as possible) handle any issues until then by displaying a list of Responsible Officers where needed.

## What is the intent behind these changes?

For SPs to know who to contact.

## Screenshot

<img width="763" alt="image" src="https://user-images.githubusercontent.com/19826940/125443913-97a07def-3868-48dc-a594-8676e6a7b82d.png">


