### PR TITLE
IC-2080: Add AWAITING FEEDBACK appointment status

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -211,33 +211,64 @@ describe('Probation practitioner referrals dashboard', () => {
         cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
       })
       describe('when the referral has been assigned and the appointment scheduled', () => {
-        it('should show the initial appointment as scheduled and a link to view appointment details', () => {
-          const appointmentWithNoFeedback = appointmentFactory.build({
-            appointmentTime: '2021-03-24T09:02:02Z',
-            durationInMinutes: 75,
-            appointmentDeliveryType: 'PHONE_CALL',
-          })
-          const supplierAssessment = supplierAssessmentFactory.build({
-            appointments: [appointmentWithNoFeedback],
-            currentAppointmentId: appointmentWithNoFeedback.id,
-          })
-          cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessment)
-          cy.login()
-          cy.visit(`/probation-practitioner/referrals/${assignedReferral.id}/progress`)
-
-          cy.contains('Initial assessment appointment')
-            .next()
-            .contains('The appointment has been scheduled by the supplier')
-            .next()
-            .within(() => {
-              cy.contains('Caseworker').next().contains('John Smith')
-              cy.contains('Appointment status').next().contains('scheduled')
-              cy.contains('To do').next().contains('View appointment details').click()
-              cy.location('pathname').should(
-                'equal',
-                `/probation-practitioner/referrals/${assignedReferral.id}/supplier-assessment`
-              )
+        describe('and the appointment is in the past', () => {
+          it('should show the initial appointment as awaiting feedback and a link to view appointment details', () => {
+            const appointmentWithNoFeedback = appointmentFactory.inThePast.build({
+              durationInMinutes: 75,
+              appointmentDeliveryType: 'PHONE_CALL',
             })
+            const supplierAssessment = supplierAssessmentFactory.build({
+              appointments: [appointmentWithNoFeedback],
+              currentAppointmentId: appointmentWithNoFeedback.id,
+            })
+            cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessment)
+            cy.login()
+            cy.visit(`/probation-practitioner/referrals/${assignedReferral.id}/progress`)
+
+            cy.contains('Initial assessment appointment')
+              .next()
+              .contains('The appointment has been scheduled by the supplier')
+              .next()
+              .within(() => {
+                cy.contains('Caseworker').next().contains('John Smith')
+                cy.contains('Appointment status').next().contains('awaiting feedback')
+                cy.contains('To do').next().contains('View appointment details').click()
+                cy.location('pathname').should(
+                  'equal',
+                  `/probation-practitioner/referrals/${assignedReferral.id}/supplier-assessment`
+                )
+              })
+          })
+        })
+
+        describe('and the appointment is in the future', () => {
+          it('should show the initial appointment as scheduled and a link to view appointment details', () => {
+            const appointmentWithNoFeedback = appointmentFactory.inTheFuture.build({
+              durationInMinutes: 75,
+              appointmentDeliveryType: 'PHONE_CALL',
+            })
+            const supplierAssessment = supplierAssessmentFactory.build({
+              appointments: [appointmentWithNoFeedback],
+              currentAppointmentId: appointmentWithNoFeedback.id,
+            })
+            cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessment)
+            cy.login()
+            cy.visit(`/probation-practitioner/referrals/${assignedReferral.id}/progress`)
+
+            cy.contains('Initial assessment appointment')
+              .next()
+              .contains('The appointment has been scheduled by the supplier')
+              .next()
+              .within(() => {
+                cy.contains('Caseworker').next().contains('John Smith')
+                cy.contains('Appointment status').next().contains('scheduled')
+                cy.contains('To do').next().contains('View appointment details').click()
+                cy.location('pathname').should(
+                  'equal',
+                  `/probation-practitioner/referrals/${assignedReferral.id}/supplier-assessment`
+                )
+              })
+          })
         })
       })
       describe('when the referral has been assigned and the appointment delivered and attended', () => {

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1209,7 +1209,7 @@ describe('Service provider referrals dashboard', () => {
       cy.get('#method-other-location-address-postcode').type('SY4 0RE')
 
       const scheduledAppointment = appointmentFactory.build({
-        appointmentTime: '2021-03-24T09:02:02Z',
+        appointmentTime: '3021-03-24T09:02:02Z',
         durationInMinutes: 75,
         appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
         appointmentDeliveryAddress: {
@@ -1244,7 +1244,7 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('View appointment details').click()
       cy.get('h1').contains('View appointment details')
 
-      cy.contains('24 March 2021')
+      cy.contains('24 March 3021')
       cy.contains('9:02am to 10:17am')
       cy.contains('In-person meeting')
       cy.contains('Harmony Living Office, Room 4')
@@ -1261,7 +1261,7 @@ describe('Service provider referrals dashboard', () => {
         referral: { serviceCategoryIds: [serviceCategory.id], interventionId: intervention.id },
       })
       const scheduledAppointment = appointmentFactory.build({
-        appointmentTime: '2021-03-24T09:02:00Z',
+        appointmentTime: '3021-03-24T09:02:00Z',
         durationInMinutes: 75,
       })
       const supplierAssessmentWithScheduledAppointment = supplierAssessmentFactory.justCreated.build({
@@ -1289,7 +1289,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.get('#date-day').should('have.value', '24')
       cy.get('#date-month').should('have.value', '3')
-      cy.get('#date-year').should('have.value', '2021')
+      cy.get('#date-year').should('have.value', '3021')
       cy.get('#time-hour').should('have.value', '9')
       cy.get('#time-minute').should('have.value', '02')
       // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
@@ -1307,7 +1307,7 @@ describe('Service provider referrals dashboard', () => {
       cy.get('#duration-minutes').clear().type('45')
 
       const rescheduledAppointment = appointmentFactory.build({
-        appointmentTime: '2021-04-10T16:15:00Z',
+        appointmentTime: '3021-04-10T16:15:00Z',
         durationInMinutes: 45,
       })
       const supplierAssessmentWithRescheduledAppointment = supplierAssessmentFactory.build({
@@ -1356,8 +1356,7 @@ describe('Service provider referrals dashboard', () => {
 
       describe('when user records the attendance', () => {
         it('should allow user to add attendance, check their answers and submit the referral', () => {
-          const appointmentWithNoFeedback = appointmentFactory.build({
-            appointmentTime: '2021-03-24T09:02:02Z',
+          const appointmentWithNoFeedback = appointmentFactory.inThePast.build({
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
           })
@@ -1376,7 +1375,7 @@ describe('Service provider referrals dashboard', () => {
             .contains('Feedback needs to be added on the same day the assessment is delivered.')
             .next()
             .within(() => {
-              cy.contains('Appointment status').next().contains('scheduled')
+              cy.contains('Appointment status').next().contains('awaiting feedback')
               cy.contains('To do').next().contains('Add feedback').click()
               cy.location('pathname').should(
                 'equal',

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -124,6 +124,7 @@ export default class InterventionProgressPresenter {
             href: `/probation-practitioner/action-plan/${this.referral.actionPlanId}/appointment/${appointment.sessionNumber}/post-session-feedback`,
           },
         }
+      case SessionStatus.awaitingFeedback:
       case SessionStatus.scheduled:
         return {
           text: presenter.text,
@@ -176,6 +177,7 @@ export default class InterventionProgressPresenter {
   private get supplierAssessmentStatus(): SupplierAssessmentStatus {
     switch (this.supplierAssessmentSessionStatus) {
       case SessionStatus.scheduled:
+      case SessionStatus.awaitingFeedback:
         return SupplierAssessmentStatus.scheduled
       case SessionStatus.didNotAttend:
       case SessionStatus.completed:
@@ -213,6 +215,7 @@ export default class InterventionProgressPresenter {
   get supplierAssessmentLink(): { text: string; href: string } | null {
     switch (this.supplierAssessmentSessionStatus) {
       case SessionStatus.scheduled:
+      case SessionStatus.awaitingFeedback:
         return {
           text: 'View appointment details',
           href: `/probation-practitioner/referrals/${this.referral.id}/supplier-assessment`,

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -5,6 +5,7 @@ import actionPlanFactory from '../../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 import endOfServiceReportFactory from '../../../testutils/factories/endOfServiceReport'
 import supplierAssessmentFactory from '../../../testutils/factories/supplierAssessment'
+import appointmentFactory from '../../../testutils/factories/appointment'
 import SessionStatusPresenter from '../shared/sessionStatusPresenter'
 import { SessionStatus } from '../../utils/sessionStatus'
 
@@ -580,27 +581,46 @@ describe(InterventionProgressPresenter, () => {
     })
 
     describe('when there is a supplier assessment scheduled', () => {
-      it('returns links to a page to view appointment details and add feedback for the appointment', () => {
-        const referral = sentReferralFactory.build()
+      describe('when the appointment is in the past', () => {
+        it('returns links to a page to add feedback for the appointment', () => {
+          const referral = sentReferralFactory.build()
 
-        const presenter = new InterventionProgressPresenter(
-          referral,
-          interventionFactory.build(),
-          null,
-          [],
-          supplierAssessmentFactory.withSingleAppointment.build()
-        )
+          const presenter = new InterventionProgressPresenter(
+            referral,
+            interventionFactory.build(),
+            null,
+            [],
+            supplierAssessmentFactory.withAnAppointment(appointmentFactory.inThePast.build()).build()
+          )
 
-        expect(presenter.supplierAssessmentLink).toEqual([
-          {
-            text: 'View appointment details',
-            href: `/service-provider/referrals/${referral.id}/supplier-assessment`,
-          },
-          {
-            text: 'Add feedback',
-            href: `/service-provider/referrals/${referral.id}/supplier-assessment/post-assessment-feedback/attendance`,
-          },
-        ])
+          expect(presenter.supplierAssessmentLink).toEqual([
+            {
+              text: 'Add feedback',
+              href: `/service-provider/referrals/${referral.id}/supplier-assessment/post-assessment-feedback/attendance`,
+            },
+          ])
+        })
+      })
+
+      describe('when the appointment is in the future', () => {
+        it('returns links to a page to view appointment details for the appointment', () => {
+          const referral = sentReferralFactory.build()
+
+          const presenter = new InterventionProgressPresenter(
+            referral,
+            interventionFactory.build(),
+            null,
+            [],
+            supplierAssessmentFactory.withAnAppointment(appointmentFactory.inTheFuture.build()).build()
+          )
+
+          expect(presenter.supplierAssessmentLink).toEqual([
+            {
+              text: 'View appointment details',
+              href: `/service-provider/referrals/${referral.id}/supplier-assessment`,
+            },
+          ])
+        })
       })
     })
 
@@ -667,20 +687,40 @@ describe(InterventionProgressPresenter, () => {
     })
 
     describe('when there is a supplier assessment scheduled', () => {
-      it('provides text relating to the status of the appointment', () => {
-        const referral = sentReferralFactory.build()
+      describe('and the appointment is in the past', () => {
+        it('provides text relating to the status of the appointment', () => {
+          const referral = sentReferralFactory.build()
 
-        const presenter = new InterventionProgressPresenter(
-          referral,
-          interventionFactory.build(),
-          null,
-          [],
-          supplierAssessmentFactory.withSingleAppointment.build()
-        )
+          const presenter = new InterventionProgressPresenter(
+            referral,
+            interventionFactory.build(),
+            null,
+            [],
+            supplierAssessmentFactory.withAnAppointment(appointmentFactory.inThePast.build()).build()
+          )
 
-        expect(presenter.supplierAssessmentMessage).toEqual(
-          'Feedback needs to be added on the same day the assessment is delivered.'
-        )
+          expect(presenter.supplierAssessmentMessage).toEqual(
+            'Feedback needs to be added on the same day the assessment is delivered.'
+          )
+        })
+      })
+
+      describe('and the appointment is in the future', () => {
+        it('provides text relating to the status of the appointment', () => {
+          const referral = sentReferralFactory.build()
+
+          const presenter = new InterventionProgressPresenter(
+            referral,
+            interventionFactory.build(),
+            null,
+            [],
+            supplierAssessmentFactory.withAnAppointment(appointmentFactory.inTheFuture.build()).build()
+          )
+
+          expect(presenter.supplierAssessmentMessage).toEqual(
+            'Feedback needs to be added on the same day the assessment is delivered.'
+          )
+        })
       })
     })
 

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -121,6 +121,7 @@ export default class InterventionProgressPresenter {
           },
         ]
         break
+      case SessionStatus.awaitingFeedback:
       case SessionStatus.scheduled:
         links = [
           {
@@ -180,6 +181,7 @@ export default class InterventionProgressPresenter {
     switch (this.supplierAssessmentStatus) {
       case SessionStatus.notScheduled:
         return 'Complete the initial assessment within 10 working days from receiving a new referral. Once you enter the appointment details, you will be able to change them.'
+      case SessionStatus.awaitingFeedback:
       case SessionStatus.scheduled:
         return 'Feedback needs to be added on the same day the assessment is delivered.'
       case SessionStatus.completed:
@@ -206,6 +208,9 @@ export default class InterventionProgressPresenter {
             text: 'View appointment details',
             href: `/service-provider/referrals/${this.referral.id}/supplier-assessment`,
           },
+        ]
+      case SessionStatus.awaitingFeedback:
+        return [
           {
             text: 'Add feedback',
             href: `/service-provider/referrals/${this.referral.id}/supplier-assessment/post-assessment-feedback/attendance`,

--- a/server/routes/shared/sessionStatusPresenter.test.ts
+++ b/server/routes/shared/sessionStatusPresenter.test.ts
@@ -15,6 +15,11 @@ describe(SessionStatusPresenter, () => {
         tagClass: 'govuk-tag--blue',
       },
       {
+        status: SessionStatus.awaitingFeedback,
+        text: 'awaiting feedback',
+        tagClass: 'govuk-tag--red',
+      },
+      {
         status: SessionStatus.completed,
         text: 'completed',
         tagClass: 'govuk-tag--green',

--- a/server/routes/shared/sessionStatusPresenter.ts
+++ b/server/routes/shared/sessionStatusPresenter.ts
@@ -9,6 +9,8 @@ export default class SessionStatusPresenter {
         return 'did not attend'
       case SessionStatus.scheduled:
         return 'scheduled'
+      case SessionStatus.awaitingFeedback:
+        return 'awaiting feedback'
       case SessionStatus.completed:
         return 'completed'
       default:
@@ -22,6 +24,8 @@ export default class SessionStatusPresenter {
         return 'govuk-tag--purple'
       case SessionStatus.scheduled:
         return 'govuk-tag--blue'
+      case SessionStatus.awaitingFeedback:
+        return 'govuk-tag--red'
       case SessionStatus.completed:
         return 'govuk-tag--green'
       default:

--- a/server/utils/sessionStatus.test.ts
+++ b/server/utils/sessionStatus.test.ts
@@ -44,22 +44,35 @@ describe(sessionStatus.forAppointment, () => {
   })
 
   describe('when the appointment does not have feedback, but has an appointment time set', () => {
-    const scheduledAppointment = appointmentFactory.build({
-      sessionFeedback: {
-        submitted: false,
-        attendance: {
-          attended: null,
-          additionalAttendanceInformation: null,
-        },
-        behaviour: {
-          behaviourDescription: null,
-          notifyProbationPractitioner: null,
-        },
-      },
+    describe('and when the appointment time is in the past', () => {
+      const pastDate = new Date(Date.now() - 1000000).toISOString()
+      describe('and when the appointment is an action plan appointment', () => {
+        const pastAppointment = actionPlanAppointmentFactory.scheduled().build({
+          appointmentTime: pastDate,
+        })
+        it('returns "scheduled" status', () => {
+          expect(sessionStatus.forAppointment(pastAppointment)).toEqual(SessionStatus.scheduled)
+        })
+      })
+
+      describe('and when the appointment is an initial assessment appointment', () => {
+        it('returns "awaiting feedback" status', () => {
+          const pastAppointment = appointmentFactory.build({
+            appointmentTime: pastDate,
+          })
+          expect(sessionStatus.forAppointment(pastAppointment)).toEqual(SessionStatus.awaitingFeedback)
+        })
+      })
     })
 
-    it('returns "scheduled" status', () => {
-      expect(sessionStatus.forAppointment(scheduledAppointment)).toEqual(SessionStatus.scheduled)
+    describe('when the appointment time is in the future', () => {
+      const futureDate = new Date(Date.now() + 1000000).toISOString()
+      it('returns "scheduled" status', () => {
+        const futureAppointment = appointmentFactory.build({
+          appointmentTime: futureDate,
+        })
+        expect(sessionStatus.forAppointment(futureAppointment)).toEqual(SessionStatus.scheduled)
+      })
     })
   })
 

--- a/server/utils/sessionStatus.ts
+++ b/server/utils/sessionStatus.ts
@@ -4,6 +4,7 @@ import Appointment from '../models/appointment'
 export enum SessionStatus {
   notScheduled,
   scheduled,
+  awaitingFeedback,
   completed,
   didNotAttend,
 }

--- a/server/utils/sessionStatus.ts
+++ b/server/utils/sessionStatus.ts
@@ -8,7 +8,12 @@ export enum SessionStatus {
   completed,
   didNotAttend,
 }
-
+function appointmentIsInThePast(appointment: Appointment | ActionPlanAppointment): boolean {
+  return new Date(appointment.appointmentTime!) < new Date()
+}
+function appointmentIsInitialAssessment(appointment: Appointment | ActionPlanAppointment): appointment is Appointment {
+  return (<ActionPlanAppointment>appointment).sessionNumber === undefined
+}
 export default {
   forAppointment: (appointment: Appointment | ActionPlanAppointment | null): SessionStatus => {
     if (appointment === null) {
@@ -27,6 +32,9 @@ export default {
     }
 
     if (appointment.appointmentTime) {
+      if (appointmentIsInitialAssessment(appointment) && appointmentIsInThePast(appointment)) {
+        return SessionStatus.awaitingFeedback
+      }
       return SessionStatus.scheduled
     }
 

--- a/testutils/factories/appointment.ts
+++ b/testutils/factories/appointment.ts
@@ -44,13 +44,28 @@ class AppointmentFactory extends Factory<Appointment> {
       },
     })
   }
+
+  get inThePast(): AppointmentFactory {
+    return this.params({
+      // one day in the past
+      appointmentTime: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    })
+  }
+
+  get inTheFuture(): AppointmentFactory {
+    return this.params({
+      // one day in the future
+      appointmentTime: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).toISOString(),
+    })
+  }
 }
 
 const defaultAppointmentDeliveryType: AppointmentDeliveryType = 'VIDEO_CALL'
 
 export default AppointmentFactory.define(({ sequence }) => ({
   id: sequence.toString(),
-  appointmentTime: new Date().toISOString(),
+  // one day in the future
+  appointmentTime: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).toISOString(),
   durationInMinutes: 60,
   // For some reason the compiler complains if I write 'VIDEO_CALL' inline
   appointmentDeliveryType: defaultAppointmentDeliveryType,

--- a/testutils/factories/supplierAssessment.ts
+++ b/testutils/factories/supplierAssessment.ts
@@ -1,6 +1,7 @@
 import { Factory } from 'fishery'
 import SupplierAssessment from '../../server/models/supplierAssessment'
 import appointmentFactory from './appointment'
+import Appointment from '../../server/models/appointment'
 
 class SupplierAssessmentFactory extends Factory<SupplierAssessment> {
   get justCreated() {
@@ -9,6 +10,10 @@ class SupplierAssessmentFactory extends Factory<SupplierAssessment> {
 
   get withSingleAppointment() {
     const appointment = appointmentFactory.build()
+    return this.params({ appointments: [appointment], currentAppointmentId: appointment.id })
+  }
+
+  withAnAppointment(appointment: Appointment) {
     return this.params({ appointments: [appointment], currentAppointmentId: appointment.id })
   }
 


### PR DESCRIPTION
## What does this pull request do?

Adds a new appointment status titled `AWAITING FEEDBACK` for initial assessment appointments.
This is shown on the `/progress` page for both service-provider and probation-practitioner.

An appointment is considered 'AWAITING FEEDBACK' if:
- the start time of the appointment is in the past
- feedback has not been submitted 

For service-provider:
The `SCHEDULED` status has a link to view appointment details, whilst the `AWAITING FEEDBACK` status has a link to the add feedback page. Previously both links were shown at the same time for a 'SCHEDULED' appointment.

For probation-practitioner:
Both 'SCHEDULED' and 'AWAITING FEEDBACK' will have a link to view appointment details.

For action plan sessions there will still be two links to both view appointment details and add feedback with 'SCHEDULED' status if the appointment is in the past.

## What is the intent behind these changes?

To provide the users a better understanding on the status of the appointment and prevent feedback until the appointment has started.


#### Screenshots

#### service provider view

![image](https://user-images.githubusercontent.com/83066216/125608620-8e3fb5de-8d21-4387-b015-db7196cfb61a.png)

#### probation provider view
![image](https://user-images.githubusercontent.com/83066216/125608709-99e07181-a06f-4693-b822-73345516aac5.png)
