### PR TITLE
IC-1583:add behaviour feedback for initial assessment

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -203,8 +203,8 @@ module.exports = on => {
       return interventionsService.stubRecordAppointmentAttendance(arg.id, arg.responseJson)
     },
 
-    stubRecordAppointmentBehavior: arg => {
-      return interventionsService.stubRecordAppointmentBehavior(arg.id, arg.responseJson)
+    stubRecordAppointmentBehaviour: arg => {
+      return interventionsService.stubRecordAppointmentBehaviour(arg.id, arg.responseJson)
     },
 
     stubGetSupplierAssessment: arg => {

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -130,8 +130,8 @@ Cypress.Commands.add('stubRecordAppointmentAttendance', (id, responseJson) => {
   cy.task('stubRecordAppointmentAttendance', { id, responseJson })
 })
 
-Cypress.Commands.add('stubRecordAppointmentBehavior', (id, responseJson) => {
-  cy.task('stubRecordAppointmentBehavior', { id, responseJson })
+Cypress.Commands.add('stubRecordAppointmentBehaviour', (id, responseJson) => {
+  cy.task('stubRecordAppointmentBehaviour', { id, responseJson })
 })
 
 Cypress.Commands.add('stubGetSupplierAssessment', (referralId, responseJson) => {

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -519,7 +519,7 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubRecordAppointmentBehavior = async (id: string, responseJson: unknown): Promise<unknown> => {
+  stubRecordAppointmentBehaviour = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'PUT',

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -185,6 +185,10 @@ export default function routes(router: Router, services: Services): Router {
     serviceProviderReferralsController.addInitialAssessmentAttendanceFeedback(req, res)
   )
 
+  get('/service-provider/referrals/:id/supplier-assessment/post-assessment-feedback/behaviour', (req, res) =>
+    serviceProviderReferralsController.addInitialAssessmentBehaviourFeedback(req, res)
+  )
+
   get('/service-provider/referrals/:id/supplier-assessment/post-assessment-feedback/check-your-answers', (req, res) =>
     serviceProviderReferralsController.checkInitialAssessmentFeedbackAnswers(req, res)
   )

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -189,6 +189,10 @@ export default function routes(router: Router, services: Services): Router {
     serviceProviderReferralsController.addInitialAssessmentBehaviourFeedback(req, res)
   )
 
+  post('/service-provider/referrals/:id/supplier-assessment/post-assessment-feedback/behaviour', (req, res) =>
+    serviceProviderReferralsController.addInitialAssessmentBehaviourFeedback(req, res)
+  )
+
   get('/service-provider/referrals/:id/supplier-assessment/post-assessment-feedback/check-your-answers', (req, res) =>
     serviceProviderReferralsController.checkInitialAssessmentFeedbackAnswers(req, res)
   )

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -2044,6 +2044,52 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/post-assessme
   })
 })
 
+describe('GET /service-provider/referrals/:id/supplier-assessment/post-assessment-feedback/behaviour', () => {
+  it('renders a page with which the Service Provider can record the Service user‘s behaviour for their initial appointment', async () => {
+    const deliusServiceUser = deliusServiceUserFactory.build()
+    const referral = sentReferralFactory.assigned().build()
+    const appointment = appointmentFactory.build({
+      appointmentTime: '2021-02-01T13:00:00Z',
+    })
+    const supplierAssessment = supplierAssessmentFactory.build({
+      appointments: [appointment],
+      currentAppointmentId: appointment.id,
+    })
+    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessment)
+
+    await request(app)
+      .get(`/service-provider/referrals/${referral.id}/supplier-assessment/post-assessment-feedback/behaviour`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Add behaviour feedback')
+        expect(res.text).toContain('Describe Alex&#39;s behaviour in this session')
+        expect(res.text).toContain('If you described poor behaviour, do you want to notify the probation practitioner?')
+      })
+  })
+
+  it('renders an error if there is no current appointment for the supplier assessment', async () => {
+    const deliusServiceUser = deliusServiceUserFactory.build()
+    const referral = sentReferralFactory.assigned().build()
+    const supplierAssessment = supplierAssessmentFactory.build({
+      appointments: [],
+    })
+    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessment)
+
+    await request(app)
+      .get(`/service-provider/referrals/${referral.id}/supplier-assessment/post-assessment-feedback/behaviour`)
+      .expect(500)
+      .expect(res => {
+        expect(res.text).toContain(
+          'Attempting to add initial assessment behaviour feedback without a current appointment'
+        )
+      })
+  })
+})
+
 describe('GET /service-provider/referrals/:id/supplier-assessment/post-assessment-feedback/check-your-answers', () => {
   it('renders a page with which the Service Provider can view the feedback for the initial appointment', async () => {
     const deliusServiceUser = deliusServiceUserFactory.build()

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1951,8 +1951,6 @@ describe('GET /service-provider/referrals/:id/supplier-assessment/post-assessmen
 })
 
 describe('POST /service-provider/referrals/:id/supplier-assessment/post-assessment-feedback/attendance', () => {
-  // TODO: Uncomment when behaviour page has been implemented as part of IC-1583
-  /*
   describe('when the Service Provider marks the Service user as having attended the initial assessment', () => {
     it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the behaviour page', async () => {
       const referral = sentReferralFactory.assigned().build()
@@ -1988,7 +1986,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/post-assessme
         )
     })
   })
-*/
+
   describe('when the Service Provider marks the Service user as not having attended the initial assessment', () => {
     it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the check-your-answers page', async () => {
       const referral = sentReferralFactory.assigned().build()

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -763,10 +763,24 @@ export default class ServiceProviderReferralsController {
     if (appointment === null) {
       throw new Error('Attempting to add initial assessment behaviour feedback without a current appointment')
     }
+    let formError: FormValidationError | null = null
+    let userInputData: Record<string, unknown> | null = null
+    if (req.method === 'POST') {
+      const data = await new BehaviourFeedbackForm(req).data()
+      if (data.error) {
+        res.status(400)
+        formError = data.error
+        userInputData = req.body
+      } else {
+        await this.interventionsService.recordAppointmentBehaviour(accessToken, appointment.id, data.paramsForUpdate)
+        return res.redirect(
+          `/service-provider/referrals/${referralId}/supplier-assessment/post-assessment-feedback/check-your-answers`
+        )
+      }
+    }
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
-    const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser, null, null)
+    const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser, formError, userInputData)
     const view = new BehaviourFeedbackView(presenter)
-
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -723,16 +723,15 @@ export default class ServiceProviderReferralsController {
         formError = data.error
         userInputData = req.body
       } else {
-        await this.interventionsService.recordAppointmentAttendance(accessToken, appointment.id, data.paramsForUpdate)
-        // TODO: Uncomment when behaviour page has been implemented as part of IC-1583
-        /*
-
-
+        const updatedAppointment = await this.interventionsService.recordAppointmentAttendance(
+          accessToken,
+          appointment.id,
+          data.paramsForUpdate
+        )
         const redirectPath =
           updatedAppointment.sessionFeedback?.attendance?.attended === 'no' ? 'check-your-answers' : 'behaviour'
-      */
         return res.redirect(
-          `/service-provider/referrals/${referralId}/supplier-assessment/post-assessment-feedback/check-your-answers`
+          `/service-provider/referrals/${referralId}/supplier-assessment/post-assessment-feedback/${redirectPath}`
         )
       }
     }

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -515,8 +515,7 @@ export default class InterventionsService {
     })) as Appointment
   }
 
-  /*
-  async recordAppointmentBehavior(
+  async recordAppointmentBehaviour(
     token: string,
     id: string,
     appointmentBehaviourUpdate: Partial<AppointmentBehaviour>
@@ -529,7 +528,7 @@ export default class InterventionsService {
       data: appointmentBehaviourUpdate,
     })) as Appointment
   }
-*/
+
   async submitAppointmentFeedback(token: string, id: string): Promise<Appointment> {
     const restClient = this.createRestClient(token)
 


### PR DESCRIPTION
## What does this pull request do?

Adds ability to provide behaviour feedback for initial assessment.

## What is the intent behind these changes?

Allow the SP user to add behaviour feedback information of the initial assessment if they attended the appointment.