### PR TITLE
IC-2073: Ensure we're selecting the current address for SUs

### DIFF
--- a/server/decorators/expandedDeliusServiceUserDecorator.test.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.test.ts
@@ -39,8 +39,8 @@ describe(ExpandedDeliusServiceUserDecorator, () => {
 
       describe('when there are multiple addresses returned from nDelius', () => {
         describe('when all addresses have a non-null "from" field', () => {
-          it('uses the address with the most recent "from" date', () => {
-            const oldAddress = {
+          it('uses the address with the most recent "from" date but no elapsed "to" date', () => {
+            const oldAddressWithNullToDate = {
               addressNumber: 'Flat 2',
               buildingName: null,
               streetName: 'Test Walk',
@@ -48,12 +48,25 @@ describe(ExpandedDeliusServiceUserDecorator, () => {
               town: 'London',
               district: 'City of London',
               county: 'Greater London',
-              from: '2019-01-01',
+              from: '2018-01-01',
               to: null,
               noFixedAbode: false,
             }
 
-            const newAddress = {
+            const mostRecentButNoLongerCurrentAddress = {
+              addressNumber: 'Flat 3',
+              buildingName: null,
+              streetName: 'Test Walk',
+              postcode: 'SW16 1AQ',
+              town: 'London',
+              district: 'City of London',
+              county: 'Greater London',
+              from: '2021-02-01',
+              to: '2019-02-03',
+              noFixedAbode: false,
+            }
+
+            const olderButCurrentAddress = {
               addressNumber: 'Flat 10',
               buildingName: null,
               streetName: 'Test Walk',
@@ -69,7 +82,7 @@ describe(ExpandedDeliusServiceUserDecorator, () => {
             const serviceUser = new ExpandedDeliusServiceUserDecorator(
               expandedDeliusServiceUserFactory.build({
                 contactDetails: {
-                  addresses: [oldAddress, newAddress],
+                  addresses: [oldAddressWithNullToDate, mostRecentButNoLongerCurrentAddress, olderButCurrentAddress],
                 },
               })
             )

--- a/server/decorators/expandedDeliusServiceUserDecorator.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.ts
@@ -1,5 +1,6 @@
 import logger from '../../log'
 import { Address, ExpandedDeliusServiceUser } from '../models/delius/deliusServiceUser'
+import CalendarDay from '../utils/calendarDay'
 
 export default class ExpandedDeliusServiceUserDecorator {
   constructor(private readonly deliusServiceUser: ExpandedDeliusServiceUser) {}
@@ -21,7 +22,20 @@ export default class ExpandedDeliusServiceUserDecorator {
       return null
     }
 
-    const mostRecentAddress = addresses.sort((a, b) => new Date(b.from!).getTime() - new Date(a.from!).getTime())[0]
+    const today = CalendarDay.britishDayForDate(new Date()).utcDate
+
+    const currentAddresses = addresses.filter(address => {
+      // If we have no "to" date, assume it's still current
+      if (!address.to) {
+        return true
+      }
+
+      return today < CalendarDay.britishDayForDate(new Date(address.to)).utcDate
+    })
+
+    const mostRecentAddress = currentAddresses.sort(
+      (a, b) => new Date(b.from!).getTime() - new Date(a.from!).getTime()
+    )[0]
 
     return this.deliusAddressToArray(mostRecentAddress)
   }


### PR DESCRIPTION
## What does this pull request do?

Ensures that we're displaying the Service User's current address, by selecting the address with the most recent` from` date that does not have lapsed `to` date.

## What is the intent behind these changes?

Our previous logic didn't take into account the possibility of one address having a more recent `from` date but an elapsed `to` date, meaning that we were displaying the incorrect address for a Service User in some cases.
