### PR TITLE
Quick fix: Stop title casing intervention titles

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -22,11 +22,11 @@ describe('Probation practitioner referrals dashboard', () => {
     const serviceCategory = serviceCategoryFactory.build()
     const accommodationIntervention = interventionFactory.build({
       contractType: { name: 'accommodation' },
-      title: 'accommodation services - west midlands',
+      title: 'Accommodation Services - West Midlands',
     })
     const womensServicesIntervention = interventionFactory.build({
       contractType: { name: "women's services" },
-      title: "women's services - west midlands",
+      title: "Women's Services - West Midlands",
     })
 
     const sentReferrals = [

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -29,13 +29,13 @@ describe('Service provider referrals dashboard', () => {
 
     const personalWellbeingIntervention = interventionFactory.build({
       contractType: { code: 'PWB', name: 'Personal wellbeing' },
-      title: 'personal wellbeing - west midlands',
+      title: 'Personal Wellbeing - West Midlands',
       serviceCategories: [accommodationServiceCategory, socialInclusionServiceCategory],
     })
 
     const socialInclusionIntervention = interventionFactory.build({
       contractType: { code: 'SOC', name: 'Social inclusion' },
-      title: 'social inclusion - west midlands',
+      title: 'Social Inclusion - West Midlands',
       serviceCategories: [socialInclusionServiceCategory],
     })
 

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.test.ts
@@ -4,8 +4,8 @@ import MyCasesPresenter from './myCasesPresenter'
 
 describe('MyCasesPresenter', () => {
   const interventions = [
-    interventionFactory.build({ id: '1', title: 'accommodation services - west midlands' }),
-    interventionFactory.build({ id: '2', title: "women's services - west midlands" }),
+    interventionFactory.build({ id: '1', title: 'Accommodation Services - West Midlands' }),
+    interventionFactory.build({ id: '2', title: "Women's Services - West Midlands" }),
   ]
   const referrals = [
     SentReferralFactory.assigned().build({

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
@@ -1,7 +1,6 @@
 import Intervention from '../../models/intervention'
 import SentReferral from '../../models/sentReferral'
 import PresenterUtils from '../../utils/presenterUtils'
-import utils from '../../utils/utils'
 import { SortableTableHeaders, SortableTableRow } from '../../utils/viewUtils'
 import DashboardNavPresenter from './dashboardNavPresenter'
 
@@ -42,7 +41,7 @@ export default class MyCasesPresenter {
         href: null,
       },
       {
-        text: utils.convertToTitleCase(interventionForReferral.title),
+        text: interventionForReferral.title,
         sortValue: null,
         href: null,
       },

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -83,7 +83,7 @@ describe('GET /probation-practitioner/find', () => {
 
 describe('GET /probation-practitioner/dashboard', () => {
   it('displays a dashboard page', async () => {
-    const intervention = interventionFactory.build({ id: '1', title: 'accommodation services - west midlands' })
+    const intervention = interventionFactory.build({ id: '1', title: 'Accommodation Services - West Midlands' })
     const referrals = [
       sentReferralFactory.assigned().build({
         referral: {

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -8,11 +8,11 @@ describe(DashboardPresenter, () => {
       const interventions = [
         interventionFactory.build({
           id: '1',
-          title: 'accommodation services - west midlands',
+          title: 'Accommodation Services - West Midlands',
         }),
         interventionFactory.build({
           id: '2',
-          title: "women's services - west midlands",
+          title: "Women's Services - West Midlands",
         }),
       ]
       const sentReferrals = [

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -2,7 +2,6 @@ import Intervention from '../../models/intervention'
 import SentReferral from '../../models/sentReferral'
 import CalendarDay from '../../utils/calendarDay'
 import PresenterUtils from '../../utils/presenterUtils'
-import utils from '../../utils/utils'
 import { SortableTableHeaders, SortableTableRow } from '../../utils/viewUtils'
 
 export default class DashboardPresenter {
@@ -41,7 +40,7 @@ export default class DashboardPresenter {
         sortValue: PresenterUtils.fullNameSortValue(serviceUser),
         href: null,
       },
-      { text: utils.convertToTitleCase(interventionForReferral.title), sortValue: null, href: null },
+      { text: interventionForReferral.title, sortValue: null, href: null },
       { text: referral.assignedTo?.username ?? '', sortValue: null, href: null },
       { text: 'View', sortValue: null, href: DashboardPresenter.hrefForViewing(referral) },
     ]

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -66,11 +66,11 @@ describe('GET /service-provider/dashboard', () => {
   it('displays a list of all sent referrals', async () => {
     const accommodationIntervention = interventionFactory.build({
       id: '1',
-      title: 'accommodation services - west midlands',
+      title: 'Accommodation Services - West Midlands',
     })
     const womensServicesIntervention = interventionFactory.build({
       id: '2',
-      title: "women's services - west midlands",
+      title: "Women's Services - West Midlands",
     })
 
     const sentReferrals = [


### PR DESCRIPTION
## What does this pull request do?

Stops converting Intervention titles to Title Case in dashboards.

## What is the intent behind these changes?

Looks like I introduced this behaviour a while ago, but it doesn't look right on the dashboards e.g:
- ETE -> Ete
- East of England -> East Of England.
- Accommodation/Good Tenant -> Accommodation/good Tenant

I think we can rely on the case on the Intervention itself, and it's what we're currently doing in the "Find" search results anyway.

## Screenshots

### Before
![Screenshot 2021-07-14 at 14-41-53 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/19826940/125634202-92786d60-7661-4810-a10e-9e966721e06b.png)

### After
![Screenshot 2021-07-14 at 14-42-47 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/19826940/125634224-83cac67f-42cc-4797-a81c-8dcec753379d.png)


