### PR TITLE
IC-2084: Replaced the /report-a-problem link on the footer

### DIFF
--- a/integration_tests/integration/login.spec.js
+++ b/integration_tests/integration/login.spec.js
@@ -29,9 +29,11 @@ context('Login', () => {
     })
 
     it('the user can report a problem', () => {
-      cy.contains('Report a problem').click()
-      cy.location('pathname').should('equal', `/report-a-problem`)
-      cy.contains('To report a problem with this digital service, please contact the helpdesk')
+      cy.contains('Report a problem').should(
+        'have.attr',
+        'href',
+        'https://docs.google.com/forms/d/e/1FAIpQLScKz91VMetK49hYdZfkjiU2VkMUL2Bsvh-5QzyTqErJTpQKLw/viewform?usp=sf_link'
+      )
     })
 
     it('the user can log out', () => {
@@ -58,12 +60,11 @@ context('Login', () => {
     })
 
     it('the user can report a problem', () => {
-      cy.contains('Report a problem').click()
-      cy.location('pathname').should('equal', `/report-a-problem`)
-      cy.contains(
-        'To report a problem with this digital service, please contact your helpdesk who will contact the digital service team if necessary.'
+      cy.contains('Report a problem').should(
+        'have.attr',
+        'href',
+        'https://docs.google.com/forms/d/e/1FAIpQLScKz91VMetK49hYdZfkjiU2VkMUL2Bsvh-5QzyTqErJTpQKLw/viewform?usp=sf_link'
       )
-      cy.contains('If your organisation does not have an IT helpdesk, please contact the helpdesk')
     })
 
     it('the user can log out', () => {

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -69,7 +69,7 @@
                      meta: {
                        items: [
                          {
-                           href: "/report-a-problem",
+                           href: "https://docs.google.com/forms/d/e/1FAIpQLScKz91VMetK49hYdZfkjiU2VkMUL2Bsvh-5QzyTqErJTpQKLw/viewform?usp=sf_link",
                            text: "Report a problem"
                          }
                        ]


### PR DESCRIPTION
## What does this pull request do?

Replaced the /report-a-problem link on the footer of all pages to point directly to a google docs link rather than our report-a-problem page.

## What is the intent behind these changes?

Improves the quality of reported problems by forcing the user to go through a questionnaire form.

![image](https://user-images.githubusercontent.com/83066216/125792443-097ac2cc-5749-43fe-8b2f-edb9db3222bc.png)
