### PR TITLE
IC-2006 limit access to PP pages based on ROLE_PROBATION

### DIFF
--- a/integration_tests/integration/login.spec.js
+++ b/integration_tests/integration/login.spec.js
@@ -79,5 +79,14 @@ context('Login', () => {
       cy.get('[data-qa=logout]').click()
       AuthLoginPage.verifyOnPage()
     })
+
+    it('the user cannot access probation practitioner pages', () => {
+      cy.request({
+        url: '/probation-practitioner/dashboard',
+        failOnStatusCode: false,
+      })
+        .its('status')
+        .should('equal', 403)
+    })
   })
 })

--- a/integration_tests/integration/login.spec.js
+++ b/integration_tests/integration/login.spec.js
@@ -40,12 +40,10 @@ context('Login', () => {
     })
 
     it('the user cannot access service provider pages', () => {
-      cy.request({
-        url: '/service-provider/dashboard',
-        failOnStatusCode: false,
-      })
-        .its('status')
-        .should('equal', 403)
+      cy.request({ url: '/service-provider/dashboard', failOnStatusCode: false }).its('status').should('equal', 403)
+
+      cy.visit('/service-provider/dashboard', { failOnStatusCode: false })
+      cy.contains('you are not authorised to access this page')
     })
   })
 
@@ -81,12 +79,12 @@ context('Login', () => {
     })
 
     it('the user cannot access probation practitioner pages', () => {
-      cy.request({
-        url: '/probation-practitioner/dashboard',
-        failOnStatusCode: false,
-      })
+      cy.request({ url: '/probation-practitioner/dashboard', failOnStatusCode: false })
         .its('status')
         .should('equal', 403)
+
+      cy.visit('/probation-practitioner/dashboard', { failOnStatusCode: false })
+      cy.contains('you are not authorised to access this page')
     })
   })
 })

--- a/server/app.ts
+++ b/server/app.ts
@@ -27,6 +27,7 @@ import passportSetup from './authentication/passport'
 import AssessRisksAndNeedsService from './services/assessRisksAndNeedsService'
 import ControllerUtils from './utils/controllerUtils'
 import broadcastMessageConfig from './broadcast-message-config.json'
+import probationPractitionerRoutes, { probationPractitionerUrlPrefix } from './routes/probationPractitionerRoutes'
 
 const RedisStore = connectRedis(session)
 
@@ -205,8 +206,8 @@ export default function createApp(
   }
 
   app.use('/', indexRoutes(standardRouter(), services))
-
   app.use(serviceProviderUrlPrefix, serviceProviderRoutes(standardRouter(['ROLE_CRS_PROVIDER']), services))
+  app.use(probationPractitionerUrlPrefix, probationPractitionerRoutes(standardRouter(['ROLE_PROBATION']), services))
 
   // final regular middleware is for handling 404s
   app.use((req, res, next) => {

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -11,7 +11,7 @@ export default function createErrorHandler(production: boolean) {
 
     if (createError.isHttpError(err)) {
       // authorization errors from interventions service cause a special error page to be displayed
-      if (err.status === 403 && err.response?.body?.accessErrors) {
+      if (err.status === 403 && (!err.external || err.response?.body?.accessErrors)) {
         res.status(403)
 
         const args = {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -9,7 +9,6 @@ import CommonController from './common/commonController'
 import AssessRisksAndNeedsService from '../services/assessRisksAndNeedsService'
 import ReferralsController from './referrals/referralsController'
 import FindInterventionsController from './findInterventions/findInterventionsController'
-import ProbationPractitionerReferralsController from './probationPractitionerReferrals/probationPractitionerReferralsController'
 
 export interface Services {
   communityApiService: CommunityApiService
@@ -29,7 +28,7 @@ export default function routes(router: Router, services: Services): Router {
   const commonController = new CommonController()
 
   // fixme: we can't put these behind their own router yet because they do not share a common prefix
-  probationPractitionerRoutes(router, services)
+  probationPractitionerRoutesWithoutPrefix(router, services)
 
   get(router, '/', (req, res, next) => {
     const { authSource } = res.locals.user
@@ -59,57 +58,13 @@ export default function routes(router: Router, services: Services): Router {
   return router
 }
 
-function probationPractitionerRoutes(router: Router, services: Services): Router {
-  const probationPractitionerReferralsController = new ProbationPractitionerReferralsController(
-    services.interventionsService,
-    services.communityApiService,
-    services.hmppsAuthService,
-    services.assessRisksAndNeedsService
-  )
+function probationPractitionerRoutesWithoutPrefix(router: Router, services: Services): Router {
   const referralsController = new ReferralsController(
     services.interventionsService,
     services.communityApiService,
     services.assessRisksAndNeedsService
   )
   const findInterventionsController = new FindInterventionsController(services.interventionsService)
-
-  get(router, '/probation-practitioner/dashboard', (req, res) =>
-    probationPractitionerReferralsController.showMyCases(req, res)
-  )
-  get(router, '/probation-practitioner/find', (req, res) =>
-    probationPractitionerReferralsController.showFindStartPage(req, res)
-  )
-
-  get(router, '/probation-practitioner/referrals/:id/progress', (req, res) =>
-    probationPractitionerReferralsController.showInterventionProgress(req, res)
-  )
-  get(router, '/probation-practitioner/referrals/:id/details', (req, res) =>
-    probationPractitionerReferralsController.showReferral(req, res)
-  )
-  get(
-    router,
-    '/probation-practitioner/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback',
-    (req, res) => probationPractitionerReferralsController.viewSubmittedPostSessionFeedback(req, res)
-  )
-  get(router, '/probation-practitioner/end-of-service-report/:id', (req, res) =>
-    probationPractitionerReferralsController.viewEndOfServiceReport(req, res)
-  )
-
-  get(router, '/probation-practitioner/referrals/:id/cancellation/reason', (req, res) =>
-    probationPractitionerReferralsController.showReferralCancellationReasonPage(req, res)
-  )
-  post(router, '/probation-practitioner/referrals/:id/cancellation/check-your-answers', (req, res) =>
-    probationPractitionerReferralsController.submitFormAndShowCancellationCheckAnswersPage(req, res)
-  )
-  post(router, '/probation-practitioner/referrals/:id/cancellation/submit', (req, res) =>
-    probationPractitionerReferralsController.cancelReferral(req, res)
-  )
-  get(router, '/probation-practitioner/referrals/:id/cancellation/confirmation', (req, res) =>
-    probationPractitionerReferralsController.showCancellationConfirmationPage(req, res)
-  )
-  get(router, '/probation-practitioner/referrals/:id/supplier-assessment', (req, res) =>
-    probationPractitionerReferralsController.showSupplierAssessmentAppointment(req, res)
-  )
 
   get(router, '/intervention/:interventionId/refer', (req, res) => referralsController.startReferral(req, res))
   post(router, '/intervention/:interventionId/refer', (req, res) => referralsController.createReferral(req, res))
@@ -159,16 +114,6 @@ function probationPractitionerRoutes(router: Router, services: Services): Router
   get(router, '/find-interventions', (req, res) => findInterventionsController.search(req, res))
   get(router, '/find-interventions/intervention/:id', (req, res) =>
     findInterventionsController.viewInterventionDetails(req, res)
-  )
-
-  get(router, '/probation-practitioner/referrals/:id/action-plan', (req, res) =>
-    probationPractitionerReferralsController.viewActionPlan(req, res)
-  )
-  post(router, '/probation-practitioner/referrals/:id/action-plan/approve', (req, res) =>
-    probationPractitionerReferralsController.approveActionPlan(req, res)
-  )
-  get(router, '/probation-practitioner/referrals/:id/action-plan/approved', (req, res) =>
-    probationPractitionerReferralsController.actionPlanApproved(req, res)
   )
 
   return router

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -1,0 +1,56 @@
+import { Router } from 'express'
+import { Services, get, post } from './index'
+import ProbationPractitionerReferralsController from './probationPractitionerReferrals/probationPractitionerReferralsController'
+
+export const probationPractitionerUrlPrefix = '/probation-practitioner'
+
+export default function probationPractitionerRoutes(router: Router, services: Services): Router {
+  const probationPractitionerReferralsController = new ProbationPractitionerReferralsController(
+    services.interventionsService,
+    services.communityApiService,
+    services.hmppsAuthService,
+    services.assessRisksAndNeedsService
+  )
+
+  get(router, '/dashboard', (req, res) => probationPractitionerReferralsController.showMyCases(req, res))
+  get(router, '/find', (req, res) => probationPractitionerReferralsController.showFindStartPage(req, res))
+
+  get(router, '/referrals/:id/progress', (req, res) =>
+    probationPractitionerReferralsController.showInterventionProgress(req, res)
+  )
+  get(router, '/referrals/:id/details', (req, res) => probationPractitionerReferralsController.showReferral(req, res))
+  get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', (req, res) =>
+    probationPractitionerReferralsController.viewSubmittedPostSessionFeedback(req, res)
+  )
+  get(router, '/end-of-service-report/:id', (req, res) =>
+    probationPractitionerReferralsController.viewEndOfServiceReport(req, res)
+  )
+
+  get(router, '/referrals/:id/cancellation/reason', (req, res) =>
+    probationPractitionerReferralsController.showReferralCancellationReasonPage(req, res)
+  )
+  post(router, '/referrals/:id/cancellation/check-your-answers', (req, res) =>
+    probationPractitionerReferralsController.submitFormAndShowCancellationCheckAnswersPage(req, res)
+  )
+  post(router, '/referrals/:id/cancellation/submit', (req, res) =>
+    probationPractitionerReferralsController.cancelReferral(req, res)
+  )
+  get(router, '/referrals/:id/cancellation/confirmation', (req, res) =>
+    probationPractitionerReferralsController.showCancellationConfirmationPage(req, res)
+  )
+  get(router, '/referrals/:id/supplier-assessment', (req, res) =>
+    probationPractitionerReferralsController.showSupplierAssessmentAppointment(req, res)
+  )
+
+  get(router, '/referrals/:id/action-plan', (req, res) =>
+    probationPractitionerReferralsController.viewActionPlan(req, res)
+  )
+  post(router, '/referrals/:id/action-plan/approve', (req, res) =>
+    probationPractitionerReferralsController.approveActionPlan(req, res)
+  )
+  get(router, '/referrals/:id/action-plan/approved', (req, res) =>
+    probationPractitionerReferralsController.actionPlanApproved(req, res)
+  )
+
+  return router
+}

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -14,6 +14,7 @@ import MockedHmppsAuthService from '../../services/testutils/hmppsAuthServiceSet
 import LoggedInUserFactory from '../../../testutils/factories/loggedInUser'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 import config from '../../config'
+import probationPractitionerRoutes, { probationPractitionerUrlPrefix } from '../probationPractitionerRoutes'
 
 export enum AppSetupUserType {
   probationPractitioner = 'delius',
@@ -23,6 +24,7 @@ export enum AppSetupUserType {
 function appSetup(
   indexRouter: Router,
   serviceProviderRouter: Router,
+  probationPractitionerRouter: Router,
   production: boolean,
   userType: AppSetupUserType
 ): Express {
@@ -53,6 +55,7 @@ function appSetup(
   app.use(bodyParser.urlencoded({ extended: true }))
   app.use('/', indexRouter)
   app.use(serviceProviderUrlPrefix, serviceProviderRouter)
+  app.use(probationPractitionerUrlPrefix, probationPractitionerRouter)
   app.use(createErrorHandler(production))
 
   config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = true
@@ -81,6 +84,7 @@ export default function appWithAllRoutes({
   return appSetup(
     indexRoutes(standardRouter(), services),
     serviceProviderRoutes(standardRouter(), services),
+    probationPractitionerRoutes(standardRouter(), services),
     production,
     userType
   )

--- a/server/views/errors/authError.njk
+++ b/server/views/errors/authError.njk
@@ -8,17 +8,20 @@
     {% block content %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                <h1 class="govuk-heading-l">Sorry, you are not authorized to access this page</h1>
-                <p class="govuk-body">The following issues have been identified:</p>
-                {% if message %}
-                    <p class="govuk-body"><strong>{{ message }}</strong></p>
-                {% endif %}
-                {% if accessErrors %}
-                    <ul class="govuk-list govuk-list--bullet">
-                        {% for err in accessErrors %}
-                            <li>{{ err }}</li>
-                        {% endfor %}
-                    </ul>
+                <h1 class="govuk-heading-l">Sorry, you are not authorised to access this page</h1>
+
+                {% if message or accessErrors %}
+                    <p class="govuk-body">The following issues have been identified:</p>
+                    {% if message %}
+                        <p class="govuk-body"><strong>{{ message }}</strong></p>
+                    {% endif %}
+                    {% if accessErrors %}
+                        <ul class="govuk-list govuk-list--bullet">
+                            {% for err in accessErrors %}
+                                <li>{{ err }}</li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
## What does this pull request do?

limits access to the existing pages with prefix '/probation-practitioner', requiring ROLE_PROBATION. 

ensures when the user does _not_ have access, the generic auth error page is displayed.

not all PP facing pages are included in this change. that's because some of them do not share a common prefix, which means we can't use the ready made router middle ware to apply the auth checks. we can easily change them to use the common prefix, but we need to be careful about it because it could break bookmarks or existing sessions.

## What is the intent behind these changes?
make the service more secure by limiting what SPs and PPs can see in the UI
