### PR TITLE
IC-2084: For /report-a-problem page, added a google docs link to allo…

### DIFF
--- a/integration_tests/integration/login.spec.js
+++ b/integration_tests/integration/login.spec.js
@@ -67,10 +67,7 @@ context('Login', () => {
     it('the user can report a problem', () => {
       cy.contains('Report a problem').click()
       cy.location('pathname').should('equal', `/report-a-problem`)
-      cy.contains(
-        'To report a problem with this digital service, please contact your helpdesk who will contact the digital service team if necessary.'
-      )
-      cy.contains('If your organisation does not have an IT helpdesk, please contact the helpdesk')
+      cy.contains('To report a problem with this digital service, please contact the helpdesk')
     })
 
     it('the user can log out', () => {

--- a/server/views/common/reportAProblem.njk
+++ b/server/views/common/reportAProblem.njk
@@ -5,14 +5,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Report a problem</h1>
 
-      <h2 class="govuk-heading-m">NPS staff</h2>
-
-      <p class="govuk-body">To report a problem with this digital service, please contact the helpdesk on <a href="tel:+44800 917 5148">0800 917 5148</a></p>
-
-      <h2 class="govuk-heading-m">Suppliers</h2>
-
-      <p class="govuk-body">To report a problem with this digital service, please contact your helpdesk who will contact the digital service team if necessary. </p>
-      <p class="govuk-body">If your organisation does not have an IT helpdesk, please contact the helpdesk on <a href="tel:+44800 917 5148">0800 917 5148</a></p>
+      <p class="govuk-body">To report a problem with this digital service, please contact the helpdesk on <a href="tel:+44800 917 5148">0800 917 5148</a> or complete this <a href="https://docs.google.com/forms/d/e/1FAIpQLScKz91VMetK49hYdZfkjiU2VkMUL2Bsvh-5QzyTqErJTpQKLw/viewform?usp=sf_link">support form</a></p>
 
       <h2 class="govuk-heading-m">Learning and resources for NPS staff</h2>
 


### PR DESCRIPTION
## What does this pull request do?
For /report-a-problem page, added a google docs link to allow the user to report issues they experience with the service.
This document form is to improve the feedback of the users by taking them through a questionnaire.

## What is the intent behind these changes?
Improves the quality of reported problems by forcing the user to go through a questionnaire form.

## Note
New screen looks like this:

![image](https://user-images.githubusercontent.com/83066216/125949140-5f3f8956-41e8-4683-bebd-2b4dc15c2896.png)
