### PR TITLE
Switch service provider dashboard backend

### DIFF
--- a/integration_tests/integration/login.spec.js
+++ b/integration_tests/integration/login.spec.js
@@ -15,6 +15,7 @@ context('Login', () => {
     beforeEach(() => {
       cy.task('stubProbationPractitionerToken')
       cy.task('stubProbationPractitionerAuthUser')
+
       cy.stubGetSentReferralsForUserToken([])
       cy.stubGetDraftReferralsForUserToken([])
       cy.login()
@@ -52,6 +53,7 @@ context('Login', () => {
       cy.task('stubServiceProviderToken')
       cy.task('stubServiceProviderAuthUser')
       cy.stubGetSentReferralsForUserToken([])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
       cy.login()
     })
 

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -14,6 +14,7 @@ import deliusStaffDetailsFactory from '../../testutils/factories/deliusStaffDeta
 import supplierAssessmentFactory from '../../testutils/factories/supplierAssessment'
 import appointmentFactory from '../../testutils/factories/appointment'
 import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
+import serviceProviderSentReferralSummaryFactory from '../../testutils/factories/serviceProviderSentReferralSummary'
 
 describe('Service provider referrals dashboard', () => {
   beforeEach(() => {
@@ -176,11 +177,20 @@ describe('Service provider referrals dashboard', () => {
         phoneNumber: '01234567890',
       },
     })
+    const sentReferralsSummary = [
+      serviceProviderSentReferralSummaryFactory
+        .fromReferralAndIntervention(sentReferrals[0], socialInclusionIntervention)
+        .build({}),
+      serviceProviderSentReferralSummaryFactory
+        .fromReferralAndIntervention(sentReferrals[1], personalWellbeingIntervention)
+        .build({}),
+    ]
 
     cy.stubGetIntervention(personalWellbeingIntervention.id, personalWellbeingIntervention)
     cy.stubGetIntervention(socialInclusionIntervention.id, socialInclusionIntervention)
     sentReferrals.forEach(referral => cy.stubGetSentReferral(referral.id, referral))
     cy.stubGetSentReferralsForUserToken(sentReferrals)
+    cy.stubGetServiceProviderSentReferralsSummaryForUserToken(sentReferralsSummary)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetServiceUserByCRN(referralToSelect.referral.serviceUser.crn, deliusServiceUser)
     cy.stubGetExpandedServiceUserByCRN(referralToSelect.referral.serviceUser.crn, expandedDeliusServiceUser)
@@ -301,10 +311,13 @@ describe('Service provider referrals dashboard', () => {
       const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const staffDetails = deliusStaffDetailsFactory.build()
       const responsibleOfficer = deliusOffenderManagerFactory.build()
-
+      let referralSummary = serviceProviderSentReferralSummaryFactory
+        .fromReferralAndIntervention(referral, intervention)
+        .build()
       cy.stubGetIntervention(intervention.id, intervention)
       cy.stubGetSentReferral(referral.id, referral)
       cy.stubGetSentReferralsForUserToken([referral])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([referralSummary])
       cy.stubGetUserByUsername(deliusUser.username, deliusUser)
       cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetExpandedServiceUserByCRN(referral.referral.serviceUser.crn, expandedDeliusServiceUser)
@@ -334,6 +347,11 @@ describe('Service provider referrals dashboard', () => {
         .build({ ...referralParams, id: referral.id, assignedTo: { username: hmppsAuthUser.username } })
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetSentReferralsForUserToken([assignedReferral])
+      referralSummary = serviceProviderSentReferralSummaryFactory
+        .fromReferralAndIntervention(assignedReferral, intervention)
+        .withAssignedUser(hmppsAuthUser.username)
+        .build()
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([referralSummary])
 
       cy.contains('Confirm assignment').click()
 
@@ -375,10 +393,14 @@ describe('Service provider referrals dashboard', () => {
       const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const staffDetails = deliusStaffDetailsFactory.build()
       const responsibleOfficer = deliusOffenderManagerFactory.build()
-
+      let referralSummary = serviceProviderSentReferralSummaryFactory
+        .fromReferralAndIntervention(referral, intervention)
+        .withAssignedUser(currentAssignee.username)
+        .build()
       cy.stubGetIntervention(intervention.id, intervention)
       cy.stubGetSentReferral(referral.id, referral)
       cy.stubGetSentReferralsForUserToken([referral])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([referralSummary])
       cy.stubGetUserByUsername(deliusUser.username, deliusUser)
       cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetExpandedServiceUserByCRN(referral.referral.serviceUser.crn, expandedDeliusServiceUser)
@@ -416,8 +438,13 @@ describe('Service provider referrals dashboard', () => {
       const reAssignedReferral = sentReferralFactory
         .assigned()
         .build({ ...referral, assignedTo: { username: newAssignee.username } })
+      referralSummary = serviceProviderSentReferralSummaryFactory
+        .fromReferralAndIntervention(reAssignedReferral, intervention)
+        .withAssignedUser(newAssignee.username)
+        .build()
       cy.stubGetSentReferral(reAssignedReferral.id, reAssignedReferral)
       cy.stubGetSentReferralsForUserToken([reAssignedReferral])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([referralSummary])
 
       cy.contains('Confirm assignment').click()
 
@@ -477,9 +504,14 @@ describe('Service provider referrals dashboard', () => {
       actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 3 }),
       actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 4 }),
     ]
+    const referralSummary = serviceProviderSentReferralSummaryFactory
+      .fromReferralAndIntervention(assignedReferral, accommodationIntervention)
+      .withAssignedUser(hmppsAuthUser.username)
+      .build()
 
     cy.stubGetSentReferralsForUserToken([assignedReferral])
 
+    cy.stubGetServiceProviderSentReferralsSummaryForUserToken([referralSummary])
     cy.stubGetActionPlan(draftActionPlan.id, draftActionPlan)
     cy.stubCreateDraftActionPlan(draftActionPlan)
     cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
@@ -594,6 +626,7 @@ describe('Service provider referrals dashboard', () => {
 
     beforeEach(() => {
       cy.stubGetSentReferralsForUserToken([])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
       cy.stubGetIntervention(intervention.id, intervention)
       cy.stubGetActionPlanAppointment(actionPlan.id, appointment.sessionNumber, appointment)
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
@@ -741,6 +774,7 @@ describe('Service provider referrals dashboard', () => {
       })
 
       cy.stubGetSentReferralsForUserToken([assignedReferral])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
       cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
       cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
@@ -894,6 +928,7 @@ describe('Service provider referrals dashboard', () => {
       })
 
       cy.stubGetSentReferralsForUserToken([assignedReferral])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
       cy.stubGetActionPlan(actionPlan.id, actionPlan)
       cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
       cy.stubGetIntervention(intervention.id, intervention)
@@ -1045,6 +1080,7 @@ describe('Service provider referrals dashboard', () => {
         })
       cy.stubGetSentReferral(endedReferral.id, endedReferral)
       cy.stubGetSentReferralsForUserToken([endedReferral])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
       cy.login()
       cy.visit(`/service-provider/referrals/${endedReferral.id}/progress`)
       cy.contains('Intervention ended')
@@ -1062,6 +1098,7 @@ describe('Service provider referrals dashboard', () => {
       })
       cy.stubGetSentReferral(endedReferral.id, endedReferral)
       cy.stubGetSentReferralsForUserToken([endedReferral])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
       cy.login()
       cy.visit(`/service-provider/referrals/${endedReferral.id}/progress`)
       cy.contains('Please note that an end of service report must still be submitted within 10 working days.')
@@ -1074,6 +1111,7 @@ describe('Service provider referrals dashboard', () => {
       })
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetSentReferralsForUserToken([assignedReferral])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
       cy.login()
       cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
       cy.contains('Intervention cancelled').should('not.exist')
@@ -1133,6 +1171,7 @@ describe('Service provider referrals dashboard', () => {
     const draftEndOfServiceReport = endOfServiceReportFactory.justCreated().build({ referralId: referral.id })
 
     cy.stubGetSentReferralsForUserToken([referral])
+    cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
 
     cy.stubGetActionPlan(actionPlan.id, actionPlan)
     cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
@@ -1278,6 +1317,7 @@ describe('Service provider referrals dashboard', () => {
       const deliusServiceUser = deliusServiceUserFactory.build()
 
       cy.stubGetSentReferralsForUserToken([])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
       cy.stubGetIntervention(intervention.id, intervention)
       cy.stubGetSupplierAssessment(referral.id, supplierAssessment)
       cy.stubGetSentReferral(referral.id, referral)
@@ -1370,6 +1410,7 @@ describe('Service provider referrals dashboard', () => {
       const deliusServiceUser = deliusServiceUserFactory.build()
 
       cy.stubGetSentReferralsForUserToken([])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
       cy.stubGetIntervention(intervention.id, intervention)
       cy.stubGetSupplierAssessment(referral.id, supplierAssessmentWithScheduledAppointment)
       cy.stubGetSentReferral(referral.id, referral)

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -103,6 +103,10 @@ module.exports = on => {
       return interventionsService.stubGetSentReferralsForUserToken(arg.responseJson)
     },
 
+    stubGetServiceProviderSentReferralsSummaryForUserToken: arg => {
+      return interventionsService.stubGetServiceProviderSentReferralsSummaryForUserToken(arg.responseJson)
+    },
+
     stubAssignSentReferral: arg => {
       return interventionsService.stubAssignSentReferral(arg.id, arg.responseJson)
     },

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -38,6 +38,10 @@ Cypress.Commands.add('stubGetSentReferralsForUserToken', responseJson => {
   cy.task('stubGetSentReferralsForUserToken', { responseJson })
 })
 
+Cypress.Commands.add('stubGetServiceProviderSentReferralsSummaryForUserToken', responseJson => {
+  cy.task('stubGetServiceProviderSentReferralsSummaryForUserToken', { responseJson })
+})
+
 Cypress.Commands.add('stubAssignSentReferral', (id, responseJson) => {
   cy.task('stubAssignSentReferral', { id, responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -170,6 +170,22 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubGetServiceProviderSentReferralsSummaryForUserToken = async (responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPathPattern: `${this.mockPrefix}/sent-referrals/summary/service-provider`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
   stubAssignSentReferral = async (id: string, responseJson: Record<string, unknown>): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/models/serviceProviderSentReferralSummary.ts
+++ b/server/models/serviceProviderSentReferralSummary.ts
@@ -1,0 +1,9 @@
+export default interface ServiceProviderSentReferralSummary {
+  referralId: string
+  sentAt: string
+  referenceNumber: string
+  interventionTitle: string
+  assignedToUserName?: string | null
+  serviceUserFirstName: string | null
+  serviceUserLastName: string | null
+}

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -1,40 +1,31 @@
 import DashboardPresenter from './dashboardPresenter'
-import interventionFactory from '../../../testutils/factories/intervention'
-import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import ServiceProviderSentReferralSummary from '../../models/serviceProviderSentReferralSummary'
 
 describe(DashboardPresenter, () => {
   describe('tableRows', () => {
     it('returns the table’s rows', () => {
-      const interventions = [
-        interventionFactory.build({
-          id: '1',
-          title: 'Accommodation Services - West Midlands',
-        }),
-        interventionFactory.build({
-          id: '2',
-          title: "Women's Services - West Midlands",
-        }),
-      ]
-      const sentReferrals = [
-        sentReferralFactory.build({
+      const referralsSummary: ServiceProviderSentReferralSummary[] = [
+        {
+          referralId: '1',
           sentAt: '2021-01-26T13:00:00.000000Z',
           referenceNumber: 'ABCABCA1',
-          referral: {
-            interventionId: '1',
-            serviceUser: { firstName: 'George', lastName: 'Michael' },
-          },
-        }),
-        sentReferralFactory.build({
-          sentAt: '2020-09-13T13:00:00.000000Z',
+          interventionTitle: 'Accommodation Services - West Midlands',
+          assignedToUserName: null,
+          serviceUserFirstName: 'George',
+          serviceUserLastName: 'Michael',
+        },
+        {
+          referralId: '2',
+          sentAt: '2020-10-13T13:00:00.000000Z',
           referenceNumber: 'ABCABCA2',
-          referral: {
-            interventionId: '2',
-            serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
-          },
-        }),
+          interventionTitle: "Women's Services - West Midlands",
+          assignedToUserName: null,
+          serviceUserFirstName: 'Jenny',
+          serviceUserLastName: 'Jones',
+        },
       ]
 
-      const presenter = new DashboardPresenter(sentReferrals, interventions)
+      const presenter = new DashboardPresenter(referralsSummary)
 
       expect(presenter.tableRows).toEqual([
         [
@@ -43,29 +34,33 @@ describe(DashboardPresenter, () => {
           { text: 'George Michael', sortValue: 'michael, george', href: null },
           { text: 'Accommodation Services - West Midlands', sortValue: null, href: null },
           { text: '', sortValue: null, href: null },
-          { text: 'View', sortValue: null, href: `/service-provider/referrals/${sentReferrals[0].id}/details` },
+          { text: 'View', sortValue: null, href: `/service-provider/referrals/1/details` },
         ],
         [
-          { text: '13 Sep 2020', sortValue: '2020-09-13', href: null },
+          { text: '13 Oct 2020', sortValue: '2020-10-13', href: null },
           { text: 'ABCABCA2', sortValue: null, href: null },
           { text: 'Jenny Jones', sortValue: 'jones, jenny', href: null },
           { text: "Women's Services - West Midlands", sortValue: null, href: null },
           { text: '', sortValue: null, href: null },
-          { text: 'View', sortValue: null, href: `/service-provider/referrals/${sentReferrals[1].id}/details` },
+          { text: 'View', sortValue: null, href: `/service-provider/referrals/2/details` },
         ],
       ])
     })
 
     describe('when a referral has been assigned to a caseworker', () => {
       it('includes the caseworker’s username', () => {
-        const intervention = interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } })
-        const sentReferrals = [
-          sentReferralFactory
-            .assigned()
-            .build({ assignedTo: { username: 'john.smith' }, referral: { interventionId: intervention.id } }),
+        const referralsSummary: ServiceProviderSentReferralSummary[] = [
+          {
+            referralId: '1',
+            sentAt: '2021-01-26T13:00:00.000000Z',
+            referenceNumber: 'ABCABCA1',
+            interventionTitle: 'Accommodation Services - West Midlands',
+            assignedToUserName: 'john.smith',
+            serviceUserFirstName: 'George',
+            serviceUserLastName: 'Michael',
+          },
         ]
-
-        const presenter = new DashboardPresenter(sentReferrals, [intervention])
+        const presenter = new DashboardPresenter(referralsSummary)
 
         expect(presenter.tableRows[0][4]).toMatchObject({ text: 'john.smith' })
       })
@@ -74,15 +69,21 @@ describe(DashboardPresenter, () => {
     describe('the View link', () => {
       describe('when a referral has been assigned to a caseworker', () => {
         it('links to the intervention progress page', () => {
-          const intervention = interventionFactory.build({ id: '1', contractType: { name: 'accommodation' } })
-          const sentReferrals = [
-            sentReferralFactory.assigned().build({ referral: { interventionId: intervention.id } }),
+          const referralsSummary: ServiceProviderSentReferralSummary[] = [
+            {
+              referralId: '1',
+              sentAt: '2021-01-26T13:00:00.000000Z',
+              referenceNumber: 'ABCABCA1',
+              interventionTitle: 'Accommodation Services - West Midlands',
+              assignedToUserName: 'john.smith',
+              serviceUserFirstName: 'George',
+              serviceUserLastName: 'Michael',
+            },
           ]
-
-          const presenter = new DashboardPresenter(sentReferrals, [intervention])
+          const presenter = new DashboardPresenter(referralsSummary)
 
           expect(presenter.tableRows[0][5]).toMatchObject({
-            href: `/service-provider/referrals/${sentReferrals[0].id}/progress`,
+            href: `/service-provider/referrals/1/progress`,
           })
         })
       })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -33,6 +33,7 @@ import { DeliusStaffDetails } from '../../models/delius/deliusStaffDetails'
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
 import { DeliusOffenderManager } from '../../models/delius/deliusOffenderManager'
 import deliusOffenderManagerFactory from '../../../testutils/factories/deliusOffenderManager'
+import ServiceProviderSentReferralSummary from '../../models/serviceProviderSentReferralSummary'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -64,35 +65,28 @@ afterEach(() => {
 
 describe('GET /service-provider/dashboard', () => {
   it('displays a list of all sent referrals', async () => {
-    const accommodationIntervention = interventionFactory.build({
-      id: '1',
-      title: 'Accommodation Services - West Midlands',
-    })
-    const womensServicesIntervention = interventionFactory.build({
-      id: '2',
-      title: "Women's Services - West Midlands",
-    })
-
-    const sentReferrals = [
-      sentReferralFactory.build({
-        referral: {
-          interventionId: accommodationIntervention.id,
-          serviceUser: { firstName: 'George', lastName: 'Michael' },
-        },
-      }),
-      sentReferralFactory.build({
-        referral: {
-          interventionId: womensServicesIntervention.id,
-          serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
-        },
-      }),
+    const referralsSummary: ServiceProviderSentReferralSummary[] = [
+      {
+        referralId: '1',
+        sentAt: '2021-01-26T13:00:00.000000Z',
+        referenceNumber: 'ABCABCA1',
+        interventionTitle: 'Accommodation Services - West Midlands',
+        assignedToUserName: null,
+        serviceUserFirstName: 'George',
+        serviceUserLastName: 'Michael',
+      },
+      {
+        referralId: '2',
+        sentAt: '2020-10-13T13:00:00.000000Z',
+        referenceNumber: 'ABCABCA2',
+        interventionTitle: "Women's Services - West Midlands",
+        assignedToUserName: null,
+        serviceUserFirstName: 'Jenny',
+        serviceUserLastName: 'Jones',
+      },
     ]
 
-    interventionsService.getSentReferralsForUserToken.mockResolvedValue(sentReferrals)
-    interventionsService.getIntervention.mockImplementation(async (token, id) => {
-      const result = [accommodationIntervention, womensServicesIntervention].find(category => category.id === id)
-      return result!
-    })
+    interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue(referralsSummary)
 
     await request(app)
       .get('/service-provider/dashboard')

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -78,15 +78,11 @@ export default class ServiceProviderReferralsController {
   ) {}
 
   async showDashboard(req: Request, res: Response): Promise<void> {
-    const referrals = await this.interventionsService.getSentReferralsForUserToken(res.locals.user.token.accessToken)
-
-    const dedupedInterventionIds = Array.from(new Set(referrals.map(referral => referral.referral.interventionId)))
-
-    const interventions = await Promise.all(
-      dedupedInterventionIds.map(id => this.interventionsService.getIntervention(res.locals.user.token.accessToken, id))
+    const referralsSummary = await this.interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
+      res.locals.user.token.accessToken
     )
 
-    const presenter = new DashboardPresenter(referrals, interventions)
+    const presenter = new DashboardPresenter(referralsSummary)
     const view = new DashboardView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, null)

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -21,6 +21,7 @@ import ReferralDesiredOutcomes from '../models/referralDesiredOutcomes'
 import ReferralComplexityLevel from '../models/referralComplexityLevel'
 import Appointment from '../models/appointment'
 import SupplierAssessment from '../models/supplierAssessment'
+import ServiceProviderSentReferralSummary from '../models/serviceProviderSentReferralSummary'
 
 export interface InterventionsServiceValidationError {
   field: string
@@ -202,6 +203,17 @@ export default class InterventionsService {
       path: `/sent-referrals`,
       headers: { Accept: 'application/json' },
     })) as SentReferral[]
+  }
+
+  async getServiceProviderSentReferralsSummaryForUserToken(
+    token: string
+  ): Promise<ServiceProviderSentReferralSummary[]> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/sent-referrals/summary/service-provider`,
+      headers: { Accept: 'application/json' },
+    })) as ServiceProviderSentReferralSummary[]
   }
 
   async assignSentReferral(token: string, id: string, assignee: User): Promise<SentReferral> {

--- a/testutils/factories/oauth2Token.ts
+++ b/testutils/factories/oauth2Token.ts
@@ -18,6 +18,15 @@ class Oauth2TokenFactory extends Factory<string, TokenParams> {
       roles: ['ROLE_PROBATION'],
     })
   }
+
+  authToken() {
+    return this.transient({
+      authSource: 'auth',
+      userID: 'USER1',
+      username: 'jack.hack',
+      roles: ['ROLE_CRS_PROVIDER'],
+    })
+  }
 }
 
 export default Oauth2TokenFactory.define(({ transientParams }) => {

--- a/testutils/factories/serviceProviderSentReferralSummary.ts
+++ b/testutils/factories/serviceProviderSentReferralSummary.ts
@@ -1,0 +1,34 @@
+import { Factory } from 'fishery'
+import ServiceProviderSentReferralSummary from '../../server/models/serviceProviderSentReferralSummary'
+import SentReferral from '../../server/models/sentReferral'
+import Intervention from '../../server/models/intervention'
+
+class ServiceProviderSentReferralSummaryFactory extends Factory<ServiceProviderSentReferralSummary> {
+  fromReferralAndIntervention(
+    referral: SentReferral,
+    intervention: Intervention
+  ): Factory<ServiceProviderSentReferralSummary> {
+    return this.params({
+      referralId: referral.id,
+      sentAt: referral.sentAt,
+      referenceNumber: referral.referenceNumber,
+      interventionTitle: intervention.title,
+      serviceUserFirstName: referral.referral.serviceUser.firstName,
+      serviceUserLastName: referral.referral.serviceUser.lastName,
+    })
+  }
+
+  withAssignedUser(username: string) {
+    return this.params({
+      assignedToUserName: username,
+    })
+  }
+}
+export default ServiceProviderSentReferralSummaryFactory.define<ServiceProviderSentReferralSummary>(({ sequence }) => ({
+  referralId: sequence.toString(),
+  sentAt: '2021-01-26T13:00:00.000000Z',
+  referenceNumber: 'ABCABCA2',
+  interventionTitle: 'Social Inclusion - West Midlands',
+  serviceUserFirstName: 'Jenny',
+  serviceUserLastName: 'Jones',
+}))


### PR DESCRIPTION
## What does this pull request do?

Call a different endpoint to obtain referral summary for service provider dashboard.

## What is the intent behind these changes?

This is a temporary endpoint which provides a faster response until a more suitable solution is devised.
