### PR TITLE
IC-2094: Completely remove retries to services

### DIFF
--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -65,17 +65,7 @@ export default class RestClient {
       const unauthenticatedRequest = superagent
         .get(`${this.apiUrl()}${path}`)
         .agent(this.agent)
-        .retry(2, (err, res) => {
-          if (err)
-            this.logger.info(
-              {
-                code: err.code,
-                message: err.message,
-              },
-              'retry handler found API error'
-            )
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
+        .retry(0)
         .query(query)
         .set(headers)
         .responseType(responseType)
@@ -137,10 +127,7 @@ export default class RestClient {
         .patch(`${this.apiUrl()}${path}`)
         .send(data)
         .agent(this.agent)
-        .retry(2, (err, res) => {
-          if (err) this.logger.info({ code: err.code, message: err.message }, 'retry handler found API error')
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
+        .retry(0)
         .set(headers)
         .responseType(responseType)
         .timeout(this.timeoutConfig())
@@ -171,10 +158,7 @@ export default class RestClient {
         .put(`${this.apiUrl()}${path}`)
         .send(data)
         .agent(this.agent)
-        .retry(2, (err, res) => {
-          if (err) this.logger.info({ code: err.code, message: err.message }, 'retry handler found API error')
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
+        .retry(0)
         .set(headers)
         .responseType(responseType)
         .timeout(this.timeoutConfig())


### PR DESCRIPTION
## What does this pull request do?

Complete remove retries to our and 3rd party services

## What is the intent behind these changes?

Currently, we're facing some load-related problems. If there's a problem, a retry creates _more_ load, which we don't need right now.

There's benefit to retries, but only if we can determine that it's not making things worse... I think that requires guarantees that the service wouldn't accept connections it cannot handle.