### PR TITLE
Filter out null and undefined addresses returned by delius.

### DIFF
--- a/server/decorators/expandedDeliusServiceUserDecorator.test.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.test.ts
@@ -193,17 +193,79 @@ describe(ExpandedDeliusServiceUserDecorator, () => {
         })
       })
 
-      describe('when there is no address returned from nDelius', () => {
-        it('returns null', () => {
-          const serviceUser = new ExpandedDeliusServiceUserDecorator(
-            expandedDeliusServiceUserFactory.build({
-              contactDetails: {
-                addresses: [],
-              },
-            })
-          )
+      describe('null  values checks', () => {
+        describe('when there is no address returned from nDelius', () => {
+          it('returns null', () => {
+            const serviceUser = new ExpandedDeliusServiceUserDecorator(
+              expandedDeliusServiceUserFactory.build({
+                contactDetails: {
+                  addresses: [],
+                },
+              })
+            )
 
-          expect(serviceUser.address).toBeNull()
+            expect(serviceUser.address).toBeNull()
+          })
+        })
+        describe('when the addresses contains a single undefined address', () => {
+          it('should return null', () => {
+            const serviceUser = new ExpandedDeliusServiceUserDecorator(
+              expandedDeliusServiceUserFactory.build({
+                contactDetails: {
+                  addresses: [undefined],
+                },
+              })
+            )
+
+            expect(serviceUser.address).toBeNull()
+          })
+        })
+        describe('when the addresses contains a single null address', () => {
+          it('should return null', () => {
+            const serviceUser = new ExpandedDeliusServiceUserDecorator(
+              expandedDeliusServiceUserFactory.build({
+                contactDetails: {
+                  addresses: [null],
+                },
+              })
+            )
+            expect(serviceUser.address).toBeNull()
+          })
+        })
+
+        describe('when there is only one address mixed in with undefined and null', () => {
+          it('should return the single address', () => {
+            const serviceUser = new ExpandedDeliusServiceUserDecorator(
+              expandedDeliusServiceUserFactory.build({
+                contactDetails: {
+                  addresses: [
+                    null,
+                    undefined,
+                    {
+                      addressNumber: 'Flat 2',
+                      buildingName: null,
+                      streetName: 'Test Walk',
+                      postcode: 'SW16 1AQ',
+                      town: 'London',
+                      district: 'City of London',
+                      county: 'Greater London',
+                      from: '2019-01-01',
+                      to: null,
+                      noFixedAbode: false,
+                    },
+                  ],
+                },
+              })
+            )
+
+            expect(serviceUser.address).toEqual([
+              'Flat 2 Test Walk',
+              'London',
+              'City of London',
+              'Greater London',
+              'SW16 1AQ',
+            ])
+          })
         })
       })
     })

--- a/server/decorators/expandedDeliusServiceUserDecorator.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.ts
@@ -1,6 +1,7 @@
 import logger from '../../log'
 import { Address, ExpandedDeliusServiceUser } from '../models/delius/deliusServiceUser'
 import CalendarDay from '../utils/calendarDay'
+import PresenterUtils from '../utils/presenterUtils'
 
 export default class ExpandedDeliusServiceUserDecorator {
   constructor(private readonly deliusServiceUser: ExpandedDeliusServiceUser) {}
@@ -11,20 +12,25 @@ export default class ExpandedDeliusServiceUserDecorator {
     if (!addresses) {
       return null
     }
+    const definedAddresses: Address[] = addresses.filter(PresenterUtils.isNonNullAndDefined)
 
-    if (addresses.length === 1) {
-      return this.deliusAddressToArray(addresses[0])
+    if (definedAddresses.length === 0) {
+      return null
+    }
+
+    if (definedAddresses.length === 1) {
+      return this.deliusAddressToArray(definedAddresses[0])
     }
 
     // If we have no "from" date, how do we know which is the most recent?
-    if (addresses.every(address => address.from === null || address.from === undefined)) {
+    if (definedAddresses.every(address => address.from === null || address.from === undefined)) {
       logger.error({ err: `No 'from' value in addresses for user ${this.deliusServiceUser.otherIds.crn}.` })
       return null
     }
 
     const today = CalendarDay.britishDayForDate(new Date()).utcDate
 
-    const currentAddresses = addresses.filter(address => {
+    const currentAddresses = definedAddresses.filter(address => {
       // If we have no "to" date, assume it's still current
       if (!address.to) {
         return true

--- a/server/models/delius/deliusServiceUser.ts
+++ b/server/models/delius/deliusServiceUser.ts
@@ -30,7 +30,7 @@ interface ContactDetails {
 }
 
 interface ExpandedContactDetails extends ContactDetails {
-  addresses: Address[] | null
+  addresses: (Address | null | undefined)[] | null
 }
 
 interface PhoneNumber {

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -878,4 +878,23 @@ describe(PresenterUtils, () => {
       ).toEqual('10:30am to 3:45pm')
     })
   })
+
+  describe('type guards', () => {
+    describe('isNonNullAndDefined', () => {
+      it('should return false if undefined', () => {
+        expect(PresenterUtils.isNonNullAndDefined(undefined)).toBe(false)
+      })
+      it('should return false if null', () => {
+        expect(PresenterUtils.isNonNullAndDefined(null)).toBe(false)
+      })
+      it('should return true if non-null and defined', () => {
+        expect(PresenterUtils.isNonNullAndDefined('defined')).toBe(true)
+      })
+      it('can be used to filter types', () => {
+        const multiTypes: (string | null | undefined)[] = ['value', null, undefined]
+        const singleType: string[] = multiTypes.filter(PresenterUtils.isNonNullAndDefined)
+        expect(singleType).toEqual(['value'])
+      })
+    })
+  })
 })

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -395,4 +395,10 @@ export default class PresenterUtils {
   static formattedTimeRange(startsAt: ClockTime, endsAt: ClockTime): string {
     return `${this.formattedTime(startsAt)} to ${this.formattedTime(endsAt)}`
   }
+
+  // This is a useful type guard that can be used to filter an array to modify the types defined in the array.
+  // i.e. const filtered: T = (T | undefined | null)[].filter(isNonNullAndDefined)
+  static isNonNullAndDefined<T>(arg: T | undefined | null): arg is T {
+    return arg !== null && arg !== undefined
+  }
 }


### PR DESCRIPTION
The following exception was seen in sentry: "Cannot read property 'addressNumber' of undefined"
https://sentry.io/organizations/ministryofjustice/issues/2522368458

This implies that the data from delius is not clean. So this commit is to remove any null and undefined values before working with addresses.

## Note:
I've added a check for (address.length === 0). At first glance it would seem that would fix the problem, but the addresses.every returns true if the addresses array is empty anyway.

