### PR TITLE
Fix for Desired Outcome not found

### DIFF
--- a/server/routes/service-provider/end-of-service-report/check-answers/endOfServiceReportCheckAnswersPresenter.test.ts
+++ b/server/routes/service-provider/end-of-service-report/check-answers/endOfServiceReportCheckAnswersPresenter.test.ts
@@ -38,11 +38,9 @@ describe(EndOfServiceReportCheckAnswersPresenter, () => {
 
   describe('text', () => {
     it('returns text to be displayed', () => {
-      const presenter = new EndOfServiceReportCheckAnswersPresenter(
-        referral,
-        buildEndOfServiceReport(),
-        serviceCategory
-      )
+      const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, buildEndOfServiceReport(), [
+        serviceCategory,
+      ])
 
       expect(presenter.text).toEqual({
         subTitle: 'Review the end of service report',
@@ -52,11 +50,9 @@ describe(EndOfServiceReportCheckAnswersPresenter, () => {
 
   describe('answersPresenter', () => {
     it('returns a presenter', () => {
-      const presenter = new EndOfServiceReportCheckAnswersPresenter(
-        referral,
-        buildEndOfServiceReport(),
-        serviceCategory
-      )
+      const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, buildEndOfServiceReport(), [
+        serviceCategory,
+      ])
 
       expect(presenter.answersPresenter).toBeDefined()
     })

--- a/server/routes/service-provider/end-of-service-report/check-answers/endOfServiceReportCheckAnswersPresenter.ts
+++ b/server/routes/service-provider/end-of-service-report/check-answers/endOfServiceReportCheckAnswersPresenter.ts
@@ -8,7 +8,7 @@ export default class EndOfServiceReportCheckAnswersPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategory: ServiceCategory
+    private readonly serviceCategories: ServiceCategory[]
   ) {}
 
   readonly formAction = `/service-provider/end-of-service-report/${this.endOfServiceReport.id}/submit`
@@ -17,12 +17,13 @@ export default class EndOfServiceReportCheckAnswersPresenter {
     subTitle: 'Review the end of service report',
   }
 
-  readonly formPagePresenter = new EndOfServiceReportFormPresenter(this.serviceCategory, this.referral).checkAnswersPage
+  readonly formPagePresenter = new EndOfServiceReportFormPresenter(this.serviceCategories[0], this.referral)
+    .checkAnswersPage
 
   readonly answersPresenter = new EndOfServiceReportAnswersPresenter(
     this.referral,
     this.endOfServiceReport,
-    [this.serviceCategory],
+    this.serviceCategories,
     true
   )
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -973,7 +973,7 @@ export default class ServiceProviderReferralsController {
     )
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, endOfServiceReport, serviceCategories[0])
+    const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, endOfServiceReport, serviceCategories)
     const view = new EndOfServiceReportCheckAnswersView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)


### PR DESCRIPTION
EOSR Check Answers Presenter now accepts service categories list rather than single service category. This was causing a problem with EOSR answers presenter for cohort referrals since only the first service category was being passed causing a not found exception when searching for desired outcomes within the service categories list


## Note:

The End of Service report pages still need to be cohortized; however the important thing is that it doesn't break any longer. The only issue is that now the title of the page will show `service category name` rather than `intervention name` for check answers and further information pages.

More specific description of the problem:

The problem is that there is a shared class (`EndOfServiceReportFormPresenter`) for: 
- check Your Answers page
- outcomes page
- further information page

This shared class produces a title which is used as the title for all three pages above.

The title is computed as:
`${utils.convertToProperCase(this.serviceCategory.name)}: End of service report`

This is only correct for the outcome pages since they are specific to a chosen service category.

The checkAnswers and further information pages should have the title using the form:

`${utils.convertToProperCase(this.intervention.contractType.name)}: End of service report`

