### PR TITLE
Fix undefined exception for delius addresses

### DIFF
--- a/server/decorators/expandedDeliusServiceUserDecorator.test.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.test.ts
@@ -223,79 +223,17 @@ describe(ExpandedDeliusServiceUserDecorator, () => {
         })
       })
 
-      describe('null  values checks', () => {
-        describe('when there is no address returned from nDelius', () => {
-          it('returns null', () => {
-            const serviceUser = new ExpandedDeliusServiceUserDecorator(
-              expandedDeliusServiceUserFactory.build({
-                contactDetails: {
-                  addresses: [],
-                },
-              })
-            )
+      describe('when there is no address returned from nDelius', () => {
+        it('returns null', () => {
+          const serviceUser = new ExpandedDeliusServiceUserDecorator(
+            expandedDeliusServiceUserFactory.build({
+              contactDetails: {
+                addresses: [],
+              },
+            })
+          )
 
-            expect(serviceUser.address).toBeNull()
-          })
-        })
-        describe('when the addresses contains a single undefined address', () => {
-          it('should return null', () => {
-            const serviceUser = new ExpandedDeliusServiceUserDecorator(
-              expandedDeliusServiceUserFactory.build({
-                contactDetails: {
-                  addresses: [undefined],
-                },
-              })
-            )
-
-            expect(serviceUser.address).toBeNull()
-          })
-        })
-        describe('when the addresses contains a single null address', () => {
-          it('should return null', () => {
-            const serviceUser = new ExpandedDeliusServiceUserDecorator(
-              expandedDeliusServiceUserFactory.build({
-                contactDetails: {
-                  addresses: [null],
-                },
-              })
-            )
-            expect(serviceUser.address).toBeNull()
-          })
-        })
-
-        describe('when there is only one address mixed in with undefined and null', () => {
-          it('should return the single address', () => {
-            const serviceUser = new ExpandedDeliusServiceUserDecorator(
-              expandedDeliusServiceUserFactory.build({
-                contactDetails: {
-                  addresses: [
-                    null,
-                    undefined,
-                    {
-                      addressNumber: 'Flat 2',
-                      buildingName: null,
-                      streetName: 'Test Walk',
-                      postcode: 'SW16 1AQ',
-                      town: 'London',
-                      district: 'City of London',
-                      county: 'Greater London',
-                      from: '2019-01-01',
-                      to: null,
-                      noFixedAbode: false,
-                    },
-                  ],
-                },
-              })
-            )
-
-            expect(serviceUser.address).toEqual([
-              'Flat 2 Test Walk',
-              'London',
-              'City of London',
-              'Greater London',
-              'SW16 1AQ',
-            ])
-          })
+          expect(serviceUser.address).toBeNull()
         })
       })
     })

--- a/server/decorators/expandedDeliusServiceUserDecorator.test.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.test.ts
@@ -191,6 +191,36 @@ describe(ExpandedDeliusServiceUserDecorator, () => {
             expect(serviceUser.address).toBeNull()
           })
         })
+
+        describe('when there is no current address added for the service user', () => {
+          it('should return null', () => {
+            const serviceUser = new ExpandedDeliusServiceUserDecorator(
+              expandedDeliusServiceUserFactory.build({
+                contactDetails: {
+                  addresses: [
+                    {
+                      from: '2021-04-09',
+                      to: '2021-04-30',
+                      noFixedAbode: true,
+                      postcode: 'xxx',
+                    },
+                    {
+                      from: '2020-06-29',
+                      to: '2021-04-09',
+                      noFixedAbode: false,
+                      addressNumber: 'xxx',
+                      streetName: 'xxx',
+                      district: 'xxx',
+                      postcode: 'xxx',
+                    },
+                  ],
+                },
+              })
+            )
+
+            expect(serviceUser.address).toBeNull()
+          })
+        })
       })
 
       describe('null  values checks', () => {

--- a/server/decorators/expandedDeliusServiceUserDecorator.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.ts
@@ -39,6 +39,9 @@ export default class ExpandedDeliusServiceUserDecorator {
       return today < CalendarDay.britishDayForDate(new Date(address.to)).utcDate
     })
 
+    if (currentAddresses.length === 0) {
+      return null
+    }
     const mostRecentAddress = currentAddresses.sort(
       (a, b) => new Date(b.from!).getTime() - new Date(a.from!).getTime()
     )[0]

--- a/server/decorators/expandedDeliusServiceUserDecorator.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.ts
@@ -1,7 +1,6 @@
 import logger from '../../log'
 import { Address, ExpandedDeliusServiceUser } from '../models/delius/deliusServiceUser'
 import CalendarDay from '../utils/calendarDay'
-import PresenterUtils from '../utils/presenterUtils'
 
 export default class ExpandedDeliusServiceUserDecorator {
   constructor(private readonly deliusServiceUser: ExpandedDeliusServiceUser) {}
@@ -12,25 +11,24 @@ export default class ExpandedDeliusServiceUserDecorator {
     if (!addresses) {
       return null
     }
-    const definedAddresses: Address[] = addresses.filter(PresenterUtils.isNonNullAndDefined)
 
-    if (definedAddresses.length === 0) {
+    if (addresses.length === 0) {
       return null
     }
 
-    if (definedAddresses.length === 1) {
-      return this.deliusAddressToArray(definedAddresses[0])
+    if (addresses.length === 1) {
+      return this.deliusAddressToArray(addresses[0])
     }
 
     // If we have no "from" date, how do we know which is the most recent?
-    if (definedAddresses.every(address => address.from === null || address.from === undefined)) {
+    if (addresses.every(address => address.from === null || address.from === undefined)) {
       logger.error({ err: `No 'from' value in addresses for user ${this.deliusServiceUser.otherIds.crn}.` })
       return null
     }
 
     const today = CalendarDay.britishDayForDate(new Date()).utcDate
 
-    const currentAddresses = definedAddresses.filter(address => {
+    const currentAddresses = addresses.filter(address => {
       // If we have no "to" date, assume it's still current
       if (!address.to) {
         return true

--- a/server/models/delius/deliusServiceUser.ts
+++ b/server/models/delius/deliusServiceUser.ts
@@ -30,7 +30,7 @@ interface ContactDetails {
 }
 
 interface ExpandedContactDetails extends ContactDetails {
-  addresses: (Address | null | undefined)[] | null
+  addresses: Address[] | null
 }
 
 interface PhoneNumber {


### PR DESCRIPTION
When all addresses have a to field populated with a date, then this causes a undefined exception to be thrown as it assumes that there is at least one active address at all times

