### PR TITLE
IC-2108 Add specific behaviour feedback presenters

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1652,7 +1652,9 @@ describe('Service provider referrals dashboard', () => {
             `/service-provider/referrals/${sentReferral.id}/supplier-assessment/post-assessment-feedback/behaviour`
           )
 
-          cy.contains("Describe Alex's behaviour in this session").type('Alex was acting very suspicious.')
+          cy.contains("Describe Alex's behaviour in the assessment appointment").type(
+            'Alex was acting very suspicious.'
+          )
           cy.contains('Yes').click()
 
           const appointmentWithBehaviourFeedback = appointmentFactory.build({
@@ -1689,7 +1691,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Yes, they were on time')
           cy.contains("Add additional information about Alex's attendance:")
           cy.contains('Alex attended the session')
-          cy.contains("Describe Alex's behaviour in this session")
+          cy.contains("Describe Alex's behaviour in the assessment appointment")
           cy.contains('Alex was acting very suspicious.')
           cy.contains('If you described poor behaviour, do you want to notify the probation practitioner?')
           cy.contains('Yes')

--- a/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.test.ts
@@ -1,0 +1,26 @@
+import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
+import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
+import ActionPlanSessionBehaviourFeedbackPresenter from './actionPlanSessionBehaviourFeedbackPresenter'
+
+describe(ActionPlanSessionBehaviourFeedbackPresenter, () => {
+  describe('text', () => {
+    it('contains the text for the title and questions to be displayed on the page', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+      const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+
+      expect(presenter.text).toMatchObject({
+        title: 'Add behaviour feedback',
+        behaviourDescription: {
+          question: `Describe Alex's behaviour in this session`,
+          hint: 'For example, consider how well-engaged they were and what their body language was like.',
+        },
+        notifyProbationPractitioner: {
+          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+          explanation: 'If you select yes, the probation practitioner will be notified by email.',
+          hint: 'Select one option',
+        },
+      })
+    })
+  })
+})

--- a/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.ts
@@ -1,0 +1,28 @@
+import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
+import { FormValidationError } from '../../../../../utils/formValidationError'
+import { AppointmentDetails } from '../../appointmentDetails'
+import BehaviourFeedbackInputsPresenter from '../../shared/behaviour/behaviourFeedbackInputsPresenter'
+
+export default class ActionPlanSessionBehaviourFeedbackPresenter {
+  constructor(
+    private readonly appointment: AppointmentDetails,
+    private readonly serviceUser: DeliusServiceUser,
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  readonly text = {
+    title: `Add behaviour feedback`,
+    behaviourDescription: {
+      question: `Describe ${this.serviceUser.firstName}'s behaviour in this session`,
+      hint: 'For example, consider how well-engaged they were and what their body language was like.',
+    },
+    notifyProbationPractitioner: {
+      question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+      explanation: 'If you select yes, the probation practitioner will be notified by email.',
+      hint: 'Select one option',
+    },
+  }
+
+  readonly inputsPresenter = new BehaviourFeedbackInputsPresenter(this.appointment, this.error, this.userInputData)
+}

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
@@ -1,14 +1,14 @@
 import { ActionPlanAppointment } from '../../../../../models/actionPlan'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import AttendanceFeedbackPresenter from '../../shared/attendance/attendanceFeedbackPresenter'
-import BehaviourFeedbackPresenter from '../../shared/behaviour/behaviourFeedbackPresenter'
 import CheckFeedbackAnswersPresenter from '../../shared/checkYourAnswers/checkFeedbackAnswersPresenter'
 import ActionPlanPostSessionAttendanceFeedbackPresenter from '../attendance/actionPlanPostSessionAttendanceFeedbackPresenter'
+import ActionPlanSessionBehaviourFeedbackPresenter from '../behaviour/actionPlanSessionBehaviourFeedbackPresenter'
 
 export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends CheckFeedbackAnswersPresenter {
   protected readonly attendancePresenter: AttendanceFeedbackPresenter
 
-  protected readonly behaviourPresenter: BehaviourFeedbackPresenter
+  protected readonly behaviourPresenter: ActionPlanSessionBehaviourFeedbackPresenter
 
   constructor(
     private readonly actionPlanAppointment: ActionPlanAppointment,
@@ -20,7 +20,10 @@ export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends 
       this.actionPlanAppointment,
       this.serviceUser
     )
-    this.behaviourPresenter = new BehaviourFeedbackPresenter(this.actionPlanAppointment, this.serviceUser)
+    this.behaviourPresenter = new ActionPlanSessionBehaviourFeedbackPresenter(
+      this.actionPlanAppointment,
+      this.serviceUser
+    )
   }
 
   readonly submitHref = `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/submit`

--- a/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.test.ts
@@ -1,0 +1,26 @@
+import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
+import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
+import InitialAssessmentBehaviourFeedbackPresenter from './initialAssessmentBehaviourFeedbackPresenter'
+
+describe(InitialAssessmentBehaviourFeedbackPresenter, () => {
+  describe('text', () => {
+    it('contains the text for the title and questions to be displayed on the page', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+      const presenter = new InitialAssessmentBehaviourFeedbackPresenter(appointment, serviceUser)
+
+      expect(presenter.text).toMatchObject({
+        title: 'Add behaviour feedback',
+        behaviourDescription: {
+          question: `Describe Alex's behaviour in the assessment appointment`,
+          hint: 'For example, consider how well-engaged they were and what their body language was like.',
+        },
+        notifyProbationPractitioner: {
+          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+          explanation: 'If you select yes, the probation practitioner will be notified by email.',
+          hint: 'Select one option',
+        },
+      })
+    })
+  })
+})

--- a/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.ts
@@ -1,0 +1,28 @@
+import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
+import { FormValidationError } from '../../../../../utils/formValidationError'
+import { AppointmentDetails } from '../../appointmentDetails'
+import BehaviourFeedbackInputsPresenter from '../../shared/behaviour/behaviourFeedbackInputsPresenter'
+
+export default class InitialAssessmentBehaviourFeedbackPresenter {
+  constructor(
+    private readonly appointment: AppointmentDetails,
+    private readonly serviceUser: DeliusServiceUser,
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  readonly text = {
+    title: `Add behaviour feedback`,
+    behaviourDescription: {
+      question: `Describe ${this.serviceUser.firstName}'s behaviour in the assessment appointment`,
+      hint: 'For example, consider how well-engaged they were and what their body language was like.',
+    },
+    notifyProbationPractitioner: {
+      question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+      explanation: 'If you select yes, the probation practitioner will be notified by email.',
+      hint: 'Select one option',
+    },
+  }
+
+  readonly inputsPresenter = new BehaviourFeedbackInputsPresenter(this.appointment, this.error, this.userInputData)
+}

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
@@ -1,14 +1,14 @@
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import CheckFeedbackAnswersPresenter from '../../shared/checkYourAnswers/checkFeedbackAnswersPresenter'
-import BehaviourFeedbackPresenter from '../../shared/behaviour/behaviourFeedbackPresenter'
 import AttendanceFeedbackPresenter from '../../shared/attendance/attendanceFeedbackPresenter'
 import InitialAssessmentAttendanceFeedbackPresenter from '../attendance/initialAssessmentAttendanceFeedbackPresenter'
 import Appointment from '../../../../../models/appointment'
+import ActionPlanSessionBehaviourFeedbackPresenter from '../../actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
 
 export default class InitialAssessmentFeedbackCheckAnswersPresenter extends CheckFeedbackAnswersPresenter {
   protected readonly attendancePresenter: AttendanceFeedbackPresenter
 
-  protected readonly behaviourPresenter: BehaviourFeedbackPresenter
+  protected readonly behaviourPresenter: ActionPlanSessionBehaviourFeedbackPresenter
 
   constructor(
     appointment: Appointment,
@@ -17,7 +17,7 @@ export default class InitialAssessmentFeedbackCheckAnswersPresenter extends Chec
   ) {
     super(appointment)
     this.attendancePresenter = new InitialAssessmentAttendanceFeedbackPresenter(appointment, this.serviceUser)
-    this.behaviourPresenter = new BehaviourFeedbackPresenter(appointment, this.serviceUser)
+    this.behaviourPresenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointment, this.serviceUser)
   }
 
   readonly submitHref = `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/submit`

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
@@ -3,12 +3,12 @@ import CheckFeedbackAnswersPresenter from '../../shared/checkYourAnswers/checkFe
 import AttendanceFeedbackPresenter from '../../shared/attendance/attendanceFeedbackPresenter'
 import InitialAssessmentAttendanceFeedbackPresenter from '../attendance/initialAssessmentAttendanceFeedbackPresenter'
 import Appointment from '../../../../../models/appointment'
-import ActionPlanSessionBehaviourFeedbackPresenter from '../../actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
+import InitialAssessmentBehaviourFeedbackPresenter from '../behaviour/initialAssessmentBehaviourFeedbackPresenter'
 
 export default class InitialAssessmentFeedbackCheckAnswersPresenter extends CheckFeedbackAnswersPresenter {
   protected readonly attendancePresenter: AttendanceFeedbackPresenter
 
-  protected readonly behaviourPresenter: ActionPlanSessionBehaviourFeedbackPresenter
+  protected readonly behaviourPresenter: InitialAssessmentBehaviourFeedbackPresenter
 
   constructor(
     appointment: Appointment,
@@ -17,7 +17,7 @@ export default class InitialAssessmentFeedbackCheckAnswersPresenter extends Chec
   ) {
     super(appointment)
     this.attendancePresenter = new InitialAssessmentAttendanceFeedbackPresenter(appointment, this.serviceUser)
-    this.behaviourPresenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointment, this.serviceUser)
+    this.behaviourPresenter = new InitialAssessmentBehaviourFeedbackPresenter(appointment, this.serviceUser)
   }
 
   readonly submitHref = `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/submit`

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.test.ts
@@ -1,59 +1,12 @@
 import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
-import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
-import BehaviourFeedbackPresenter from './behaviourFeedbackPresenter'
+import BehaviourFeedbackInputsPresenter from './behaviourFeedbackInputsPresenter'
 
-describe(BehaviourFeedbackPresenter, () => {
-  describe('text', () => {
-    it('contains the text for the title and questions to be displayed on the page', () => {
-      const appointment = actionPlanAppointmentFactory.build()
-      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-      const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser)
-
-      expect(presenter.text).toMatchObject({
-        title: 'Add behaviour feedback',
-        behaviourDescription: {
-          question: `Describe Alex's behaviour in this session`,
-          hint: 'For example, consider how well-engaged they were and what their body language was like.',
-        },
-        notifyProbationPractitioner: {
-          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-          explanation: 'If you select yes, the probation practitioner will be notified by email.',
-          hint: 'Select one option',
-        },
-      })
-    })
-
-    describe('when there are errors', () => {
-      it('populates the error messages for the fields with errors', () => {
-        const appointment = actionPlanAppointmentFactory.build()
-        const serviceUser = deliusServiceUserFactory.build()
-        const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser, {
-          errors: [
-            {
-              formFields: ['behaviour-description'],
-              errorSummaryLinkedField: 'behaviour-description',
-              message: 'behaviour msg',
-            },
-            {
-              formFields: ['notify-probation-practitioner'],
-              errorSummaryLinkedField: 'notify-probation-practitioner',
-              message: 'notify pp msg',
-            },
-          ],
-        })
-
-        expect(presenter.fields.behaviourDescription.errorMessage).toEqual('behaviour msg')
-        expect(presenter.fields.notifyProbationPractitioner.errorMessage).toEqual('notify pp msg')
-      })
-    })
-  })
-
+describe(BehaviourFeedbackInputsPresenter, () => {
   describe('errorSummary', () => {
     describe('when error is null', () => {
       it('returns null', () => {
         const appointment = actionPlanAppointmentFactory.build()
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-        const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser)
+        const presenter = new BehaviourFeedbackInputsPresenter(appointment)
 
         expect(presenter.errorSummary).toBeNull()
       })
@@ -62,8 +15,8 @@ describe(BehaviourFeedbackPresenter, () => {
     describe('when error is not null', () => {
       it('returns a summary of the errors sorted into the order their fields appear on the page', () => {
         const appointment = actionPlanAppointmentFactory.build()
-        const serviceUser = deliusServiceUserFactory.build()
-        const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser, {
+
+        const presenter = new BehaviourFeedbackInputsPresenter(appointment, {
           errors: [
             {
               formFields: ['behaviour-description'],
@@ -96,8 +49,7 @@ describe(BehaviourFeedbackPresenter, () => {
                 behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
               },
             })
-            const serviceUser = deliusServiceUserFactory.build()
-            const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser)
+            const presenter = new BehaviourFeedbackInputsPresenter(appointment)
 
             expect(presenter.fields.behaviourDescription.value).toEqual('Alex was well behaved')
           })
@@ -110,8 +62,7 @@ describe(BehaviourFeedbackPresenter, () => {
                 behaviour: { behaviourDescription: undefined },
               },
             })
-            const serviceUser = deliusServiceUserFactory.build()
-            const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser)
+            const presenter = new BehaviourFeedbackInputsPresenter(appointment)
 
             expect(presenter.fields.behaviourDescription.value).toEqual('')
           })
@@ -125,8 +76,7 @@ describe(BehaviourFeedbackPresenter, () => {
               behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
             },
           })
-          const serviceUser = deliusServiceUserFactory.build()
-          const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser, null, {
+          const presenter = new BehaviourFeedbackInputsPresenter(appointment, null, {
             'behaviour-description': 'Alex misbehaved during the session',
           })
 
@@ -145,8 +95,7 @@ describe(BehaviourFeedbackPresenter, () => {
               },
             })
 
-            const serviceUser = deliusServiceUserFactory.build()
-            const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser)
+            const presenter = new BehaviourFeedbackInputsPresenter(appointment)
 
             expect(presenter.fields.notifyProbationPractitioner.value).toEqual(false)
           })
@@ -160,8 +109,7 @@ describe(BehaviourFeedbackPresenter, () => {
               },
             })
 
-            const serviceUser = deliusServiceUserFactory.build()
-            const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser)
+            const presenter = new BehaviourFeedbackInputsPresenter(appointment)
 
             expect(presenter.fields.notifyProbationPractitioner.value).toEqual(null)
           })
@@ -175,14 +123,36 @@ describe(BehaviourFeedbackPresenter, () => {
               behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
             },
           })
-          const serviceUser = deliusServiceUserFactory.build()
-          const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser, null, {
+          const presenter = new BehaviourFeedbackInputsPresenter(appointment, null, {
             'behaviour-description': 'Alex misbehaved during the session',
             'notify-probation-practitioner': 'yes',
           })
 
           expect(presenter.fields.notifyProbationPractitioner.value).toEqual(true)
         })
+      })
+    })
+
+    describe('errors', () => {
+      it('populates the error messages for the fields with errors', () => {
+        const appointment = actionPlanAppointmentFactory.build()
+        const presenter = new BehaviourFeedbackInputsPresenter(appointment, {
+          errors: [
+            {
+              formFields: ['behaviour-description'],
+              errorSummaryLinkedField: 'behaviour-description',
+              message: 'behaviour msg',
+            },
+            {
+              formFields: ['notify-probation-practitioner'],
+              errorSummaryLinkedField: 'notify-probation-practitioner',
+              message: 'notify pp msg',
+            },
+          ],
+        })
+
+        expect(presenter.fields.behaviourDescription.errorMessage).toEqual('behaviour msg')
+        expect(presenter.fields.notifyProbationPractitioner.errorMessage).toEqual('notify pp msg')
       })
     })
   })

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.ts
@@ -1,0 +1,38 @@
+import { FormValidationError } from '../../../../../utils/formValidationError'
+import PresenterUtils from '../../../../../utils/presenterUtils'
+import { AppointmentDetails } from '../../appointmentDetails'
+
+export default class BehaviourFeedbackInputsPresenter {
+  constructor(
+    private readonly appointment: AppointmentDetails,
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  private errorMessageForField(field: string): string | null {
+    return PresenterUtils.errorMessage(this.error, field)
+  }
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error, {
+    fieldOrder: ['behaviour-description', 'notify-probation-practitioner'],
+  })
+
+  private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly fields = {
+    behaviourDescription: {
+      value: new PresenterUtils(this.userInputData).stringValue(
+        this.appointment.sessionFeedback?.behaviour?.behaviourDescription || null,
+        'behaviour-description'
+      ),
+      errorMessage: this.errorMessageForField('behaviour-description'),
+    },
+    notifyProbationPractitioner: {
+      value: this.utils.booleanValue(
+        this.appointment.sessionFeedback?.behaviour?.notifyProbationPractitioner ?? null,
+        'notify-probation-practitioner'
+      ),
+      errorMessage: this.errorMessageForField('notify-probation-practitioner'),
+    },
+  }
+}

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackPresenter.ts
@@ -1,53 +1,19 @@
-import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
-import { FormValidationError } from '../../../../../utils/formValidationError'
-import PresenterUtils from '../../../../../utils/presenterUtils'
-import { AppointmentDetails } from '../../appointmentDetails'
+import BehaviourFeedbackInputsPresenter from './behaviourFeedbackInputsPresenter'
 
-export default class BehaviourFeedbackPresenter {
-  constructor(
-    private readonly appointment: AppointmentDetails,
-    private readonly serviceUser: DeliusServiceUser,
-    private readonly error: FormValidationError | null = null,
-    private readonly userInputData: Record<string, unknown> | null = null
-  ) {}
-
-  private errorMessageForField(field: string): string | null {
-    return PresenterUtils.errorMessage(this.error, field)
+interface BehaviourText {
+  title: string
+  behaviourDescription: {
+    question: string
+    hint: string
   }
-
-  readonly errorSummary = PresenterUtils.errorSummary(this.error, {
-    fieldOrder: ['behaviour-description', 'notify-probation-practitioner'],
-  })
-
-  readonly text = {
-    title: `Add behaviour feedback`,
-    behaviourDescription: {
-      question: `Describe ${this.serviceUser.firstName}'s behaviour in this session`,
-      hint: 'For example, consider how well-engaged they were and what their body language was like.',
-    },
-    notifyProbationPractitioner: {
-      question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-      explanation: 'If you select yes, the probation practitioner will be notified by email.',
-      hint: 'Select one option',
-    },
+  notifyProbationPractitioner: {
+    question: string
+    explanation: string
+    hint: string
   }
+}
 
-  private readonly utils = new PresenterUtils(this.userInputData)
-
-  readonly fields = {
-    behaviourDescription: {
-      value: new PresenterUtils(this.userInputData).stringValue(
-        this.appointment.sessionFeedback?.behaviour?.behaviourDescription || null,
-        'behaviour-description'
-      ),
-      errorMessage: this.errorMessageForField('behaviour-description'),
-    },
-    notifyProbationPractitioner: {
-      value: this.utils.booleanValue(
-        this.appointment.sessionFeedback?.behaviour?.notifyProbationPractitioner ?? null,
-        'notify-probation-practitioner'
-      ),
-      errorMessage: this.errorMessageForField('notify-probation-practitioner'),
-    },
-  }
+export interface BehaviourFeedbackPresenter {
+  text: BehaviourText
+  inputsPresenter: BehaviourFeedbackInputsPresenter
 }

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackView.ts
@@ -1,11 +1,18 @@
-import { TextareaArgs } from '../../../../../utils/govukFrontendTypes'
+import { ErrorSummaryArgs, TextareaArgs } from '../../../../../utils/govukFrontendTypes'
 import ViewUtils from '../../../../../utils/viewUtils'
-import BehaviourFeedbackPresenter from './behaviourFeedbackPresenter'
+import BehaviourFeedbackInputsPresenter from './behaviourFeedbackInputsPresenter'
+import { BehaviourFeedbackPresenter } from './behaviourFeedbackPresenter'
 
 export default class BehaviourFeedbackView {
-  constructor(private readonly presenter: BehaviourFeedbackPresenter) {}
+  inputsPresenter: BehaviourFeedbackInputsPresenter
 
-  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+  constructor(private readonly presenter: BehaviourFeedbackPresenter) {
+    this.inputsPresenter = this.presenter.inputsPresenter
+  }
+
+  private get errorSummaryArgs(): ErrorSummaryArgs | null {
+    return ViewUtils.govukErrorSummaryArgs(this.inputsPresenter.errorSummary)
+  }
 
   private get textAreaArgs(): TextareaArgs {
     return {
@@ -19,8 +26,8 @@ export default class BehaviourFeedbackView {
       hint: {
         text: this.presenter.text.behaviourDescription.hint,
       },
-      value: this.presenter.fields.behaviourDescription.value,
-      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.behaviourDescription.errorMessage),
+      value: this.inputsPresenter.fields.behaviourDescription.value,
+      errorMessage: ViewUtils.govukErrorMessage(this.inputsPresenter.fields.behaviourDescription.errorMessage),
     }
   }
 
@@ -46,15 +53,15 @@ export default class BehaviourFeedbackView {
         {
           value: 'yes',
           text: 'Yes',
-          checked: this.presenter.fields.notifyProbationPractitioner.value === true,
+          checked: this.inputsPresenter.fields.notifyProbationPractitioner.value === true,
         },
         {
           value: 'no',
           text: 'No',
-          checked: this.presenter.fields.notifyProbationPractitioner.value === false,
+          checked: this.inputsPresenter.fields.notifyProbationPractitioner.value === false,
         },
       ],
-      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.notifyProbationPractitioner.errorMessage),
+      errorMessage: ViewUtils.govukErrorMessage(this.inputsPresenter.fields.notifyProbationPractitioner.errorMessage),
     }
   }
 

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.test.ts
@@ -5,7 +5,7 @@ import { AppointmentDetails } from '../../appointmentDetails'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import AttendanceFeedbackPresenter from '../attendance/attendanceFeedbackPresenter'
 import CheckFeedbackAnswersPresenter from './checkFeedbackAnswersPresenter'
-import BehaviourFeedbackPresenter from '../behaviour/behaviourFeedbackPresenter'
+import ActionPlanSessionBehaviourFeedbackPresenter from '../../actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
 
 describe('for a class that extends abstract class CheckFeedbackAnswersPresenter', () => {
   class ExtendedCheckFeedbackAnswersPresenter extends CheckFeedbackAnswersPresenter {
@@ -31,8 +31,8 @@ describe('for a class that extends abstract class CheckFeedbackAnswersPresenter'
       })(this.appointment)
     }
 
-    protected get behaviourPresenter(): BehaviourFeedbackPresenter {
-      return new BehaviourFeedbackPresenter(this.appointment, this.serviceUser)
+    protected get behaviourPresenter(): ActionPlanSessionBehaviourFeedbackPresenter {
+      return new ActionPlanSessionBehaviourFeedbackPresenter(this.appointment, this.serviceUser)
     }
   }
   describe('sessionDetailsSummary', () => {

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
@@ -3,9 +3,9 @@ import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { AppointmentDetails } from '../../appointmentDetails'
 import FeedbackAnswersPresenter from './feedbackAnswersPresenter'
 import AttendanceFeedbackPresenter from '../attendance/attendanceFeedbackPresenter'
-import BehaviourFeedbackPresenter from '../behaviour/behaviourFeedbackPresenter'
 import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
 import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
+import ActionPlanSessionBehaviourFeedbackPresenter from '../../actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
 
 describe(FeedbackAnswersPresenter, () => {
   class ExtendedFeedbackAnswersPresenter extends FeedbackAnswersPresenter {
@@ -29,8 +29,8 @@ describe(FeedbackAnswersPresenter, () => {
       })(this.appointment, this.serviceUser)
     }
 
-    protected get behaviourPresenter(): BehaviourFeedbackPresenter {
-      return new BehaviourFeedbackPresenter(this.appointment, this.serviceUser)
+    protected get behaviourPresenter(): ActionPlanSessionBehaviourFeedbackPresenter {
+      return new ActionPlanSessionBehaviourFeedbackPresenter(this.appointment, this.serviceUser)
     }
   }
   describe('attendedAnswers', () => {

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
@@ -1,11 +1,11 @@
 import AttendanceFeedbackPresenter from '../attendance/attendanceFeedbackPresenter'
 import { AppointmentDetails } from '../../appointmentDetails'
-import ActionPlanSessionBehaviourFeedbackPresenter from '../../actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
+import { BehaviourFeedbackPresenter } from '../behaviour/behaviourFeedbackPresenter'
 
 export default abstract class FeedbackAnswersPresenter {
   protected abstract get attendancePresenter(): AttendanceFeedbackPresenter
 
-  protected abstract get behaviourPresenter(): ActionPlanSessionBehaviourFeedbackPresenter
+  protected abstract get behaviourPresenter(): BehaviourFeedbackPresenter
 
   protected constructor(protected readonly appointment: AppointmentDetails) {}
 

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
@@ -1,11 +1,11 @@
 import AttendanceFeedbackPresenter from '../attendance/attendanceFeedbackPresenter'
-import BehaviourFeedbackPresenter from '../behaviour/behaviourFeedbackPresenter'
 import { AppointmentDetails } from '../../appointmentDetails'
+import ActionPlanSessionBehaviourFeedbackPresenter from '../../actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
 
 export default abstract class FeedbackAnswersPresenter {
   protected abstract get attendancePresenter(): AttendanceFeedbackPresenter
 
-  protected abstract get behaviourPresenter(): BehaviourFeedbackPresenter
+  protected abstract get behaviourPresenter(): ActionPlanSessionBehaviourFeedbackPresenter
 
   protected constructor(protected readonly appointment: AppointmentDetails) {}
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -2071,7 +2071,7 @@ describe('GET /service-provider/referrals/:id/supplier-assessment/post-assessmen
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Add behaviour feedback')
-        expect(res.text).toContain('Describe Alex&#39;s behaviour in this session')
+        expect(res.text).toContain('Describe Alex&#39;s behaviour in the assessment appointment')
         expect(res.text).toContain('If you described poor behaviour, do you want to notify the probation practitioner?')
       })
   })
@@ -2185,7 +2185,7 @@ describe('GET /service-provider/referrals/:id/supplier-assessment/post-assessmen
         expect(res.text).toContain('Confirm feedback')
         expect(res.text).toContain('Did Alex attend the initial assessment appointment?')
         expect(res.text).toContain('Yes, they were on time')
-        expect(res.text).toContain('Describe Alex&#39;s behaviour in this session')
+        expect(res.text).toContain('Describe Alex&#39;s behaviour in the assessment appointment')
         expect(res.text).toContain('Acceptable')
       })
   })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -68,10 +68,10 @@ import SupplierAssessmentAppointmentConfirmationView from './supplierAssessmentA
 import ActionPlanEditConfirmationPresenter from '../service-provider/action-plan/edit/actionPlanEditConfirmationPresenter'
 import ActionPlanEditConfirmationView from '../service-provider/action-plan/edit/actionPlanEditConfirmationView'
 import InitialAssessmentAttendanceFeedbackPresenter from '../appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter'
-import BehaviourFeedbackPresenter from '../appointments/feedback/shared/behaviour/behaviourFeedbackPresenter'
 import InitialAssessmentFeedbackCheckAnswersPresenter from '../appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter'
 import InitialAssessmentFeedbackConfirmationPresenter from '../appointments/feedback/initialAssessment/confirmation/initialAssessmentFeedbackConfirmationPresenter'
 import InitialAssessmentFeedbackConfirmationView from '../appointments/feedback/initialAssessment/confirmation/initialAssessmentFeedbackConfirmationView'
+import ActionPlanSessionBehaviourFeedbackPresenter from '../appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -788,7 +788,12 @@ export default class ServiceProviderReferralsController {
       }
     }
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
-    const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser, formError, userInputData)
+    const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(
+      appointment,
+      serviceUser,
+      formError,
+      userInputData
+    )
     const view = new BehaviourFeedbackView(presenter)
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
@@ -906,7 +911,12 @@ export default class ServiceProviderReferralsController {
     )
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new BehaviourFeedbackPresenter(appointment, serviceUser, formError, userInputData)
+    const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(
+      appointment,
+      serviceUser,
+      formError,
+      userInputData
+    )
     const view = new BehaviourFeedbackView(presenter)
 
     res.status(formError === null ? 200 : 400)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -72,6 +72,7 @@ import InitialAssessmentFeedbackCheckAnswersPresenter from '../appointments/feed
 import InitialAssessmentFeedbackConfirmationPresenter from '../appointments/feedback/initialAssessment/confirmation/initialAssessmentFeedbackConfirmationPresenter'
 import InitialAssessmentFeedbackConfirmationView from '../appointments/feedback/initialAssessment/confirmation/initialAssessmentFeedbackConfirmationView'
 import ActionPlanSessionBehaviourFeedbackPresenter from '../appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
+import InitialAssessmentBehaviourFeedbackPresenter from '../appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter'
 
 export default class ServiceProviderReferralsController {
   constructor(
@@ -788,7 +789,7 @@ export default class ServiceProviderReferralsController {
       }
     }
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
-    const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(
+    const presenter = new InitialAssessmentBehaviourFeedbackPresenter(
       appointment,
       serviceUser,
       formError,

--- a/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
@@ -5,15 +5,15 @@ import DateUtils from '../../../../utils/dateUtils'
 import { SummaryListItem } from '../../../../utils/summaryList'
 import FeedbackAnswersPresenter from '../../../appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter'
 import AttendanceFeedbackPresenter from '../../../appointments/feedback/shared/attendance/attendanceFeedbackPresenter'
-import BehaviourFeedbackPresenter from '../../../appointments/feedback/shared/behaviour/behaviourFeedbackPresenter'
 import ActionPlanPostSessionAttendanceFeedbackPresenter from '../../../appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter'
 import Appointment from '../../../../models/appointment'
 import InitialAssessmentAttendanceFeedbackPresenter from '../../../appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter'
+import ActionPlanSessionBehaviourFeedbackPresenter from '../../../appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
 
 export default class SubmittedFeedbackPresenter extends FeedbackAnswersPresenter {
   protected readonly attendancePresenter: AttendanceFeedbackPresenter
 
-  protected readonly behaviourPresenter: BehaviourFeedbackPresenter
+  protected readonly behaviourPresenter: ActionPlanSessionBehaviourFeedbackPresenter
 
   constructor(
     appointmentDetails: ActionPlanAppointment | Appointment,
@@ -29,7 +29,7 @@ export default class SubmittedFeedbackPresenter extends FeedbackAnswersPresenter
     } else {
       this.attendancePresenter = new InitialAssessmentAttendanceFeedbackPresenter(appointmentDetails, this.serviceUser)
     }
-    this.behaviourPresenter = new BehaviourFeedbackPresenter(appointmentDetails, this.serviceUser)
+    this.behaviourPresenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointmentDetails, this.serviceUser)
   }
 
   private isActionPlanAppointment(


### PR DESCRIPTION
## What does this pull request do?

Refactors `BehaviourFeedbackPresenter`'s shared behaviour into `BehaviourFeedbackInputsPresenter` and creates two new presenters, one for Initial Assessment and one for Action Plan Sessions to provide custom text for each page, but allowing the presenters to share common behaviour.

This is a slight departure from the previous pattern of using abstract classes to share the common behaviour, as I feel composition here is slightly more flexible than using inheritance, and allows us to extend our classes with a bit more custom functionality if the need arises in the future. See commit messge in 3dda1c9 for more information.

## What is the intent behind these changes?

To allow us to display different content on the Initial Assessment screen to the usual action plan session page.

This will also make it easier to pass in back links in future.
