### PR TITLE
IC-2081: Add back links to Attendance and Behaviour, CYA and viewing submitted feedback pages

### DIFF
--- a/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.test.ts
@@ -17,6 +17,7 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         additionalAttendanceInformationLabel: "Add additional information about Alex's attendance:",
       })
     })
+
     describe('when the session is a phone call', () => {
       it('contains an attendance question to indicate the meeting was a phone call', () => {
         const appointment = actionPlanAppointmentFactory.build({ appointmentDeliveryType: 'PHONE_CALL' })
@@ -25,6 +26,7 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex join this phone call?')
       })
     })
+
     describe('when the session is a video call', () => {
       it('contains an attendance question to indicate the meeting was a video call', () => {
         const appointment = actionPlanAppointmentFactory.build({ appointmentDeliveryType: 'VIDEO_CALL' })
@@ -33,6 +35,7 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex join this video call?')
       })
     })
+
     describe('when the session is an other location meeting', () => {
       it('contains an attendance question to indicate the meeting was an in-person meeting', () => {
         const appointment = actionPlanAppointmentFactory.build({ appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER' })
@@ -41,6 +44,7 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex attend this in-person meeting?')
       })
     })
+
     describe('when the session is an nps office location meeting', () => {
       it('contains an attendance question to indicate the meeting was an in-person meeting', () => {
         const appointment = actionPlanAppointmentFactory.build({
@@ -49,6 +53,32 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
         const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex attend this in-person meeting?')
+      })
+    })
+  })
+
+  describe('backLinkHref', () => {
+    describe('when a referral id is passed in', () => {
+      it('is a link back to the Intervention Progress page', () => {
+        const appointment = actionPlanAppointmentFactory.build()
+        const serviceUser = deliusServiceUserFactory.build()
+        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
+          appointment,
+          serviceUser,
+          null,
+          null,
+          'test-referral-id'
+        )
+        expect(presenter.backLinkHref).toEqual('/service-provider/referrals/test-referral-id/progress')
+      })
+    })
+
+    describe('when a referral id is not passed in', () => {
+      it('is null', () => {
+        const appointment = actionPlanAppointmentFactory.build()
+        const serviceUser = deliusServiceUserFactory.build()
+        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+        expect(presenter.backLinkHref).toEqual(null)
       })
     })
   })

--- a/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.ts
@@ -8,7 +8,8 @@ export default class ActionPlanPostSessionAttendanceFeedbackPresenter extends At
     private readonly appointment: ActionPlanAppointment,
     private readonly serviceUser: DeliusServiceUser,
     error: FormValidationError | null = null,
-    userInputData: Record<string, unknown> | null = null
+    userInputData: Record<string, unknown> | null = null,
+    private readonly referralId: string | null = null
   ) {
     super(appointment, error, userInputData)
   }
@@ -20,6 +21,8 @@ export default class ActionPlanPostSessionAttendanceFeedbackPresenter extends At
     attendanceQuestionHint: 'Select one option',
     additionalAttendanceInformationLabel: `Add additional information about ${this.serviceUser.firstName}'s attendance:`,
   }
+
+  readonly backLinkHref = this.referralId ? `/service-provider/referrals/${this.referralId}/progress` : null
 
   private get attendanceQuestion(): string {
     switch (this.appointment.appointmentDeliveryType) {

--- a/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.test.ts
@@ -7,7 +7,7 @@ describe(ActionPlanSessionBehaviourFeedbackPresenter, () => {
     it('contains the text for the title and questions to be displayed on the page', () => {
       const appointment = actionPlanAppointmentFactory.build()
       const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-      const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointment, serviceUser)
+      const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointment, serviceUser, 'action-plan-id')
 
       expect(presenter.text).toMatchObject({
         title: 'Add behaviour feedback',
@@ -21,6 +21,18 @@ describe(ActionPlanSessionBehaviourFeedbackPresenter, () => {
           hint: 'Select one option',
         },
       })
+    })
+  })
+
+  describe('backLinkHref', () => {
+    it('contains the link to the attendance page with the action plan id and session number', () => {
+      const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 2 })
+      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+      const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointment, serviceUser, 'action-plan-id')
+
+      expect(presenter.backLinkHref).toEqual(
+        '/service-provider/action-plan/action-plan-id/appointment/2/post-session-feedback/attendance'
+      )
     })
   })
 })

--- a/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.ts
@@ -1,12 +1,13 @@
+import { ActionPlanAppointment } from '../../../../../models/actionPlan'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
-import { AppointmentDetails } from '../../appointmentDetails'
 import BehaviourFeedbackInputsPresenter from '../../shared/behaviour/behaviourFeedbackInputsPresenter'
 
 export default class ActionPlanSessionBehaviourFeedbackPresenter {
   constructor(
-    private readonly appointment: AppointmentDetails,
+    private readonly appointment: ActionPlanAppointment,
     private readonly serviceUser: DeliusServiceUser,
+    private readonly actionPlanId: string | null = null,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
@@ -23,6 +24,10 @@ export default class ActionPlanSessionBehaviourFeedbackPresenter {
       hint: 'Select one option',
     },
   }
+
+  readonly backLinkHref = this.actionPlanId
+    ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.appointment.sessionNumber}/post-session-feedback/attendance`
+    : null
 
   readonly inputsPresenter = new BehaviourFeedbackInputsPresenter(this.appointment, this.error, this.userInputData)
 }

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/ActionPlanPostSessionFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/ActionPlanPostSessionFeedbackCheckAnswersPresenter.test.ts
@@ -31,6 +31,42 @@ describe(ActionPlanPostSessionFeedbackCheckAnswersPresenter, () => {
     })
   })
 
+  describe('backLinkHref', () => {
+    describe('when the appointment was attended', () => {
+      it('includes the referal id and link to the behaviour feedback page', () => {
+        const attendedAppointments = [
+          actionPlanAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'yes' } } }),
+          actionPlanAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'late' } } }),
+        ]
+
+        const serviceUser = deliusServiceUserFactory.build()
+        const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
+
+        attendedAppointments.forEach(appointment => {
+          const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, referralId)
+
+          expect(presenter.backLinkHref).toEqual(
+            '/service-provider/action-plan/77f0d8fc-9443-492c-b352-4cab66acbf3c/appointment/1/post-session-feedback/behaviour'
+          )
+        })
+      })
+    })
+
+    describe('when the appointment was not attended', () => {
+      it('includes the referal id and link to the attendance feedback page', () => {
+        const appointment = actionPlanAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'no' } } })
+        const serviceUser = deliusServiceUserFactory.build()
+        const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
+
+        const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, referralId)
+
+        expect(presenter.backLinkHref).toEqual(
+          '/service-provider/action-plan/77f0d8fc-9443-492c-b352-4cab66acbf3c/appointment/1/post-session-feedback/attendance'
+        )
+      })
+    })
+  })
+
   describe('sessionDetailsSummary', () => {
     it('extracts the date and time from the appointmentTime and puts it in a SummaryList format', () => {
       const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
@@ -28,4 +28,9 @@ export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends 
   }
 
   readonly submitHref = `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/submit`
+
+  readonly backLinkHref =
+    this.actionPlanAppointment.sessionFeedback.attendance.attended === 'no'
+      ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/attendance`
+      : `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/behaviour`
 }

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
@@ -22,7 +22,8 @@ export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends 
     )
     this.behaviourPresenter = new ActionPlanSessionBehaviourFeedbackPresenter(
       this.actionPlanAppointment,
-      this.serviceUser
+      this.serviceUser,
+      this.actionPlanId
     )
   }
 

--- a/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.test.ts
@@ -18,4 +18,32 @@ describe(InitialAssessmentAttendanceFeedbackPresenter, () => {
       })
     })
   })
+
+  describe('backLinkHref', () => {
+    describe('when a referral id is passed in', () => {
+      it('is a link back to the Intervention Progress page', () => {
+        const appointment = appointmentFactory.build()
+        const serviceUser = deliusServiceUserFactory.build()
+        const presenter = new InitialAssessmentAttendanceFeedbackPresenter(
+          appointment,
+          serviceUser,
+          null,
+          null,
+          'test-referral-id'
+        )
+
+        expect(presenter.backLinkHref).toEqual('/service-provider/referrals/test-referral-id/progress')
+      })
+    })
+
+    describe('when a referral id is not passed in', () => {
+      it('is null', () => {
+        const appointment = appointmentFactory.build()
+        const serviceUser = deliusServiceUserFactory.build()
+        const presenter = new InitialAssessmentAttendanceFeedbackPresenter(appointment, serviceUser)
+
+        expect(presenter.backLinkHref).toEqual(null)
+      })
+    })
+  })
 })

--- a/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.ts
@@ -8,10 +8,13 @@ export default class InitialAssessmentAttendanceFeedbackPresenter extends Attend
     private readonly appointment: Appointment,
     private readonly serviceUser: DeliusServiceUser,
     error: FormValidationError | null = null,
-    userInputData: Record<string, unknown> | null = null
+    userInputData: Record<string, unknown> | null = null,
+    private readonly referralId: string | null = null
   ) {
     super(appointment, error, userInputData)
   }
+
+  readonly backLinkHref = this.referralId ? `/service-provider/referrals/${this.referralId}/progress` : null
 
   readonly text = {
     title: `Add feedback`,

--- a/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.test.ts
@@ -7,7 +7,7 @@ describe(InitialAssessmentBehaviourFeedbackPresenter, () => {
     it('contains the text for the title and questions to be displayed on the page', () => {
       const appointment = actionPlanAppointmentFactory.build()
       const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-      const presenter = new InitialAssessmentBehaviourFeedbackPresenter(appointment, serviceUser)
+      const presenter = new InitialAssessmentBehaviourFeedbackPresenter(appointment, serviceUser, 'test-referral-id')
 
       expect(presenter.text).toMatchObject({
         title: 'Add behaviour feedback',
@@ -21,6 +21,18 @@ describe(InitialAssessmentBehaviourFeedbackPresenter, () => {
           hint: 'Select one option',
         },
       })
+    })
+  })
+
+  describe('backLinkHref', () => {
+    it('contains the link to the attendance page with the referral id', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+      const presenter = new InitialAssessmentBehaviourFeedbackPresenter(appointment, serviceUser, 'test-referral-id')
+
+      expect(presenter.backLinkHref).toEqual(
+        '/service-provider/referrals/test-referral-id/supplier-assessment/post-assessment-feedback/attendance'
+      )
     })
   })
 })

--- a/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.ts
@@ -7,6 +7,7 @@ export default class InitialAssessmentBehaviourFeedbackPresenter {
   constructor(
     private readonly appointment: AppointmentDetails,
     private readonly serviceUser: DeliusServiceUser,
+    private readonly referralId: string | null = null,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
@@ -23,6 +24,10 @@ export default class InitialAssessmentBehaviourFeedbackPresenter {
       hint: 'Select one option',
     },
   }
+
+  readonly backLinkHref = this.referralId
+    ? `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/attendance`
+    : null
 
   readonly inputsPresenter = new BehaviourFeedbackInputsPresenter(this.appointment, this.error, this.userInputData)
 }

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.test.ts
@@ -16,4 +16,40 @@ describe(InitialAssessmentFeedbackCheckAnswersPresenter, () => {
       )
     })
   })
+
+  describe('backLinkHref', () => {
+    describe('when the appointment was attended', () => {
+      it('includes the referal id and link to the behaviour feedback page', () => {
+        const attendedAppointments = [
+          appointmentFactory.build({ sessionFeedback: { attendance: { attended: 'yes' } } }),
+          appointmentFactory.build({ sessionFeedback: { attendance: { attended: 'late' } } }),
+        ]
+
+        const serviceUser = deliusServiceUserFactory.build()
+        const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
+
+        attendedAppointments.forEach(appointment => {
+          const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(appointment, serviceUser, referralId)
+
+          expect(presenter.backLinkHref).toEqual(
+            '/service-provider/referrals/77f0d8fc-9443-492c-b352-4cab66acbf3c/supplier-assessment/post-assessment-feedback/behaviour'
+          )
+        })
+      })
+    })
+
+    describe('when the appointment was not attended', () => {
+      it('includes the referal id and link to the attendance feedback page', () => {
+        const appointment = appointmentFactory.build({ sessionFeedback: { attendance: { attended: 'no' } } })
+        const serviceUser = deliusServiceUserFactory.build()
+        const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
+
+        const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(appointment, serviceUser, referralId)
+
+        expect(presenter.backLinkHref).toEqual(
+          '/service-provider/referrals/77f0d8fc-9443-492c-b352-4cab66acbf3c/supplier-assessment/post-assessment-feedback/attendance'
+        )
+      })
+    })
+  })
 })

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
@@ -21,4 +21,9 @@ export default class InitialAssessmentFeedbackCheckAnswersPresenter extends Chec
   }
 
   readonly submitHref = `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/submit`
+
+  readonly backLinkHref =
+    this.appointment.sessionFeedback.attendance.attended === 'no'
+      ? `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/attendance`
+      : `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/behaviour`
 }

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.test.ts
@@ -209,4 +209,14 @@ describe(AttendanceFeedbackPresenter, () => {
       })
     })
   })
+
+  describe('backLinkHref', () => {
+    it('is null', () => {
+      const appointment = appointmentFactory.build()
+
+      const presenter = new ExtendedAttendanceFeedbackPresenter(appointment)
+
+      expect(presenter.backLinkHref).toEqual(null)
+    })
+  })
 })

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
@@ -21,6 +21,8 @@ export default abstract class AttendanceFeedbackPresenter {
 
   abstract readonly text: AttendanceFeedbackFormText
 
+  readonly backLinkHref: string | null = null
+
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
   readonly sessionDetailsSummary: SummaryListItem[] = [

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackView.ts
@@ -1,4 +1,4 @@
-import { TextareaArgs } from '../../../../../utils/govukFrontendTypes'
+import { BackLinkArgs, TextareaArgs } from '../../../../../utils/govukFrontendTypes'
 import ViewUtils from '../../../../../utils/viewUtils'
 import AttendanceFeedbackPresenter from './attendanceFeedbackPresenter'
 
@@ -48,6 +48,16 @@ export default class AttendanceFeedbackView {
     }
   }
 
+  private get backLinkArgs(): BackLinkArgs | null {
+    if (!this.presenter.backLinkHref) {
+      return null
+    }
+
+    return {
+      href: this.presenter.backLinkHref,
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'appointments/feedback/shared/postSessionAttendanceFeedback',
@@ -57,6 +67,7 @@ export default class AttendanceFeedbackView {
         radioButtonArgs: this.radioButtonArgs,
         errorSummaryArgs: this.errorSummaryArgs,
         textAreaArgs: this.textAreaArgs,
+        backLinkArgs: this.backLinkArgs,
       },
     ]
   }

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackPresenter.ts
@@ -16,4 +16,5 @@ interface BehaviourText {
 export interface BehaviourFeedbackPresenter {
   text: BehaviourText
   inputsPresenter: BehaviourFeedbackInputsPresenter
+  backLinkHref: string | null
 }

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackView.ts
@@ -1,4 +1,4 @@
-import { ErrorSummaryArgs, TextareaArgs } from '../../../../../utils/govukFrontendTypes'
+import { BackLinkArgs, ErrorSummaryArgs, TextareaArgs } from '../../../../../utils/govukFrontendTypes'
 import ViewUtils from '../../../../../utils/viewUtils'
 import BehaviourFeedbackInputsPresenter from './behaviourFeedbackInputsPresenter'
 import { BehaviourFeedbackPresenter } from './behaviourFeedbackPresenter'
@@ -65,6 +65,16 @@ export default class BehaviourFeedbackView {
     }
   }
 
+  get backLinkArgs(): BackLinkArgs | null {
+    if (!this.presenter.backLinkHref) {
+      return null
+    }
+
+    return {
+      href: this.presenter.backLinkHref,
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'appointments/feedback/shared/postSessionBehaviourFeedback',
@@ -73,6 +83,7 @@ export default class BehaviourFeedbackView {
         textAreaArgs: this.textAreaArgs,
         radioButtonArgs: this.radioButtonArgs,
         errorSummaryArgs: this.errorSummaryArgs,
+        backLinkArgs: this.backLinkArgs,
       },
     ]
   }

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.test.ts
@@ -5,7 +5,8 @@ import { AppointmentDetails } from '../../appointmentDetails'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import AttendanceFeedbackPresenter from '../attendance/attendanceFeedbackPresenter'
 import CheckFeedbackAnswersPresenter from './checkFeedbackAnswersPresenter'
-import ActionPlanSessionBehaviourFeedbackPresenter from '../../actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
+import { BehaviourFeedbackPresenter } from '../behaviour/behaviourFeedbackPresenter'
+import BehaviourFeedbackInputsPresenter from '../behaviour/behaviourFeedbackInputsPresenter'
 
 describe('for a class that extends abstract class CheckFeedbackAnswersPresenter', () => {
   class ExtendedCheckFeedbackAnswersPresenter extends CheckFeedbackAnswersPresenter {
@@ -31,10 +32,26 @@ describe('for a class that extends abstract class CheckFeedbackAnswersPresenter'
       })(this.appointment)
     }
 
-    protected get behaviourPresenter(): ActionPlanSessionBehaviourFeedbackPresenter {
-      return new ActionPlanSessionBehaviourFeedbackPresenter(this.appointment, this.serviceUser)
+    protected get behaviourPresenter(): BehaviourFeedbackPresenter {
+      return {
+        backLinkHref: null,
+        inputsPresenter: new BehaviourFeedbackInputsPresenter(this.appointment),
+        text: {
+          title: `Add behaviour feedback`,
+          behaviourDescription: {
+            question: `Describe ${this.serviceUser.firstName}'s behaviour in this session`,
+            hint: 'For example, consider how well-engaged they were and what their body language was like.',
+          },
+          notifyProbationPractitioner: {
+            question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+            explanation: 'If you select yes, the probation practitioner will be notified by email.',
+            hint: 'Select one option',
+          },
+        },
+      }
     }
   }
+
   describe('sessionDetailsSummary', () => {
     it('extracts the date and time from the appointmentTime and puts it in a SummaryList format', () => {
       const serviceUser = deliusServiceUserFactory.build()

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.test.ts
@@ -10,7 +10,9 @@ import BehaviourFeedbackInputsPresenter from '../behaviour/behaviourFeedbackInpu
 
 describe('for a class that extends abstract class CheckFeedbackAnswersPresenter', () => {
   class ExtendedCheckFeedbackAnswersPresenter extends CheckFeedbackAnswersPresenter {
-    readonly submitHref: string = ''
+    readonly submitHref = ''
+
+    readonly backLinkHref = ''
 
     constructor(appointment: AppointmentDetails, private readonly serviceUser: DeliusServiceUser) {
       super(appointment)

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.ts
@@ -10,6 +10,8 @@ export default abstract class CheckFeedbackAnswersPresenter extends FeedbackAnsw
 
   abstract readonly submitHref: string
 
+  abstract readonly backLinkHref: string
+
   readonly text = {
     title: `Confirm feedback`,
   }

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersView.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersView.ts
@@ -1,3 +1,4 @@
+import { BackLinkArgs } from '../../../../../utils/govukFrontendTypes'
 import ViewUtils from '../../../../../utils/viewUtils'
 import CheckFeedbackAnswersPresenter from './checkFeedbackAnswersPresenter'
 
@@ -6,12 +7,19 @@ export default class CheckFeedbackAnswersView {
 
   private readonly summaryListArgs = ViewUtils.summaryListArgs(this.presenter.sessionDetailsSummary)
 
+  private get backLinkArgs(): BackLinkArgs {
+    return {
+      href: this.presenter.backLinkHref,
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'appointments/feedback/shared/postSessionFeedbackCheckAnswers',
       {
         presenter: this.presenter,
         summaryListArgs: this.summaryListArgs,
+        backLinkArgs: this.backLinkArgs,
       },
     ]
   }

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
@@ -5,7 +5,8 @@ import FeedbackAnswersPresenter from './feedbackAnswersPresenter'
 import AttendanceFeedbackPresenter from '../attendance/attendanceFeedbackPresenter'
 import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
 import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
-import ActionPlanSessionBehaviourFeedbackPresenter from '../../actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
+import { BehaviourFeedbackPresenter } from '../behaviour/behaviourFeedbackPresenter'
+import BehaviourFeedbackInputsPresenter from '../behaviour/behaviourFeedbackInputsPresenter'
 
 describe(FeedbackAnswersPresenter, () => {
   class ExtendedFeedbackAnswersPresenter extends FeedbackAnswersPresenter {
@@ -29,10 +30,26 @@ describe(FeedbackAnswersPresenter, () => {
       })(this.appointment, this.serviceUser)
     }
 
-    protected get behaviourPresenter(): ActionPlanSessionBehaviourFeedbackPresenter {
-      return new ActionPlanSessionBehaviourFeedbackPresenter(this.appointment, this.serviceUser)
+    protected get behaviourPresenter(): BehaviourFeedbackPresenter {
+      return {
+        backLinkHref: null,
+        inputsPresenter: new BehaviourFeedbackInputsPresenter(this.appointment),
+        text: {
+          title: `Add behaviour feedback`,
+          behaviourDescription: {
+            question: `Describe ${this.serviceUser.firstName}'s behaviour in this session`,
+            hint: 'For example, consider how well-engaged they were and what their body language was like.',
+          },
+          notifyProbationPractitioner: {
+            question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+            explanation: 'If you select yes, the probation practitioner will be notified by email.',
+            hint: 'Select one option',
+          },
+        },
+      }
     }
   }
+
   describe('attendedAnswers', () => {
     it('returns an object with the question and answer given', () => {
       const appointment = actionPlanAppointmentFactory.build({

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -201,7 +201,14 @@ export default class ProbationPractitionerReferralsController {
       throw new Error('Referral has not yet been assigned to a caseworker')
     }
 
-    const presenter = new SubmittedFeedbackPresenter(currentAppointment, serviceUser, null, referral.assignedTo)
+    const presenter = new SubmittedFeedbackPresenter(
+      currentAppointment,
+      serviceUser,
+      'probation-practitioner',
+      referral.id,
+      null,
+      referral.assignedTo
+    )
     const view = new SubmittedFeedbackView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
@@ -228,7 +235,12 @@ export default class ProbationPractitionerReferralsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new SubmittedFeedbackPresenter(currentAppointment, serviceUser)
+    const presenter = new SubmittedFeedbackPresenter(
+      currentAppointment,
+      serviceUser,
+      'probation-practitioner',
+      referralId
+    )
     const view = new SubmittedFeedbackView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -201,7 +201,7 @@ export default class ProbationPractitionerReferralsController {
       throw new Error('Referral has not yet been assigned to a caseworker')
     }
 
-    const presenter = new SubmittedFeedbackPresenter(currentAppointment, serviceUser, referral.assignedTo)
+    const presenter = new SubmittedFeedbackPresenter(currentAppointment, serviceUser, null, referral.assignedTo)
     const view = new SubmittedFeedbackView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -794,6 +794,7 @@ export default class ServiceProviderReferralsController {
     const presenter = new InitialAssessmentBehaviourFeedbackPresenter(
       appointment,
       serviceUser,
+      referralId,
       formError,
       userInputData
     )
@@ -917,6 +918,7 @@ export default class ServiceProviderReferralsController {
     const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(
       appointment,
       serviceUser,
+      actionPlanId,
       formError,
       userInputData
     )

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -870,7 +870,7 @@ export default class ServiceProviderReferralsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new SubmittedFeedbackPresenter(currentAppointment, serviceUser)
+    const presenter = new SubmittedFeedbackPresenter(currentAppointment, serviceUser, 'service-provider', referralId)
     const view = new SubmittedFeedbackView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
@@ -982,7 +982,7 @@ export default class ServiceProviderReferralsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new SubmittedFeedbackPresenter(currentAppointment, serviceUser)
+    const presenter = new SubmittedFeedbackPresenter(currentAppointment, serviceUser, 'service-provider', referral.id)
     const view = new SubmittedFeedbackView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -699,7 +699,8 @@ export default class ServiceProviderReferralsController {
       appointment,
       serviceUser,
       formError,
-      userInputData
+      userInputData,
+      referral.id
     )
     const view = new AttendanceFeedbackView(presenter)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -750,7 +750,8 @@ export default class ServiceProviderReferralsController {
       appointment,
       serviceUser,
       formError,
-      userInputData
+      userInputData,
+      referralId
     )
     const view = new AttendanceFeedbackView(presenter)
 

--- a/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.test.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.test.ts
@@ -5,16 +5,19 @@ import User from '../../../../models/hmppsAuth/user'
 import SubmittedFeedbackPresenter from './submittedFeedbackPresenter'
 
 describe(SubmittedFeedbackPresenter, () => {
+  const userType = 'service-provider'
+  const referralId = 'referral-id'
+
   describe('text', () => {
     it('includes the title of the page', () => {
       const serviceUser = deliusServiceUserFactory.build()
       const actionPlanAppointment = actionPlanAppointmentFactory.build()
-      let presenter = new SubmittedFeedbackPresenter(actionPlanAppointment, serviceUser)
+      let presenter = new SubmittedFeedbackPresenter(actionPlanAppointment, serviceUser, userType, referralId)
       expect(presenter.text).toMatchObject({
         title: 'View feedback',
       })
       const initialAssessmentAppointment = appointmentFactory.build()
-      presenter = new SubmittedFeedbackPresenter(initialAssessmentAppointment, serviceUser)
+      presenter = new SubmittedFeedbackPresenter(initialAssessmentAppointment, serviceUser, userType, referralId)
       expect(presenter.text).toMatchObject({
         title: 'View feedback',
       })
@@ -34,7 +37,14 @@ describe(SubmittedFeedbackPresenter, () => {
         const actionPlanAppointment = actionPlanAppointmentFactory.build({
           appointmentTime: '2021-02-01T13:00:00Z',
         })
-        let presenter = new SubmittedFeedbackPresenter(actionPlanAppointment, serviceUser, null, caseworker)
+        let presenter = new SubmittedFeedbackPresenter(
+          actionPlanAppointment,
+          serviceUser,
+          userType,
+          referralId,
+          null,
+          caseworker
+        )
         expect(presenter.sessionDetailsSummary).toEqual([
           {
             key: 'Caseworker',
@@ -52,7 +62,14 @@ describe(SubmittedFeedbackPresenter, () => {
         const initialAssessmentAppointment = appointmentFactory.build({
           appointmentTime: '2021-02-01T13:00:00Z',
         })
-        presenter = new SubmittedFeedbackPresenter(initialAssessmentAppointment, serviceUser, null, caseworker)
+        presenter = new SubmittedFeedbackPresenter(
+          initialAssessmentAppointment,
+          serviceUser,
+          userType,
+          referralId,
+          null,
+          caseworker
+        )
         expect(presenter.sessionDetailsSummary).toEqual([
           {
             key: 'Caseworker',
@@ -77,7 +94,7 @@ describe(SubmittedFeedbackPresenter, () => {
         const actionPlanAppointment = actionPlanAppointmentFactory.build({
           appointmentTime: '2021-02-01T13:00:00Z',
         })
-        let presenter = new SubmittedFeedbackPresenter(actionPlanAppointment, serviceUser)
+        let presenter = new SubmittedFeedbackPresenter(actionPlanAppointment, serviceUser, userType, referralId)
 
         expect(presenter.sessionDetailsSummary).toEqual([
           {
@@ -92,7 +109,7 @@ describe(SubmittedFeedbackPresenter, () => {
         const initialAssessmentAppointment = appointmentFactory.build({
           appointmentTime: '2021-02-01T13:00:00Z',
         })
-        presenter = new SubmittedFeedbackPresenter(initialAssessmentAppointment, serviceUser)
+        presenter = new SubmittedFeedbackPresenter(initialAssessmentAppointment, serviceUser, userType, referralId)
         expect(presenter.sessionDetailsSummary).toEqual([
           {
             key: 'Date',
@@ -104,6 +121,21 @@ describe(SubmittedFeedbackPresenter, () => {
           },
         ])
       })
+    })
+  })
+
+  describe('backLinkHref', () => {
+    it('contains a link back to the referral progress page, including the userType and referral id in the URL', () => {
+      const serviceUser = deliusServiceUserFactory.build()
+      const actionPlanAppointment = actionPlanAppointmentFactory.build()
+      const presenter = new SubmittedFeedbackPresenter(
+        actionPlanAppointment,
+        serviceUser,
+        'probation-practitioner',
+        'test-referral-id'
+      )
+
+      expect(presenter.backLinkHref).toEqual('/probation-practitioner/referrals/test-referral-id/progress')
     })
   })
 })

--- a/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.test.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.test.ts
@@ -34,7 +34,7 @@ describe(SubmittedFeedbackPresenter, () => {
         const actionPlanAppointment = actionPlanAppointmentFactory.build({
           appointmentTime: '2021-02-01T13:00:00Z',
         })
-        let presenter = new SubmittedFeedbackPresenter(actionPlanAppointment, serviceUser, caseworker)
+        let presenter = new SubmittedFeedbackPresenter(actionPlanAppointment, serviceUser, null, caseworker)
         expect(presenter.sessionDetailsSummary).toEqual([
           {
             key: 'Caseworker',
@@ -52,7 +52,7 @@ describe(SubmittedFeedbackPresenter, () => {
         const initialAssessmentAppointment = appointmentFactory.build({
           appointmentTime: '2021-02-01T13:00:00Z',
         })
-        presenter = new SubmittedFeedbackPresenter(initialAssessmentAppointment, serviceUser, caseworker)
+        presenter = new SubmittedFeedbackPresenter(initialAssessmentAppointment, serviceUser, null, caseworker)
         expect(presenter.sessionDetailsSummary).toEqual([
           {
             key: 'Caseworker',

--- a/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
@@ -20,10 +20,13 @@ export default class SubmittedFeedbackPresenter extends FeedbackAnswersPresenter
   constructor(
     appointmentDetails: ActionPlanAppointment | Appointment,
     private readonly serviceUser: DeliusServiceUser,
+    private readonly userType: 'probation-practitioner' | 'service-provider',
+    private readonly referralId: string,
     private readonly actionPlanId: string | null = null,
     private readonly assignedCaseworker: User | null = null
   ) {
     super(appointmentDetails)
+
     if (this.isActionPlanAppointment(appointmentDetails)) {
       this.attendancePresenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
         appointmentDetails,
@@ -39,6 +42,8 @@ export default class SubmittedFeedbackPresenter extends FeedbackAnswersPresenter
       this.behaviourPresenter = new InitialAssessmentBehaviourFeedbackPresenter(appointmentDetails, this.serviceUser)
     }
   }
+
+  readonly backLinkHref = `/${this.userType}/referrals/${this.referralId}/progress`
 
   private isActionPlanAppointment(
     appointmentDetails: Appointment | ActionPlanAppointment

--- a/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
@@ -20,6 +20,7 @@ export default class SubmittedFeedbackPresenter extends FeedbackAnswersPresenter
   constructor(
     appointmentDetails: ActionPlanAppointment | Appointment,
     private readonly serviceUser: DeliusServiceUser,
+    private readonly actionPlanId: string | null = null,
     private readonly assignedCaseworker: User | null = null
   ) {
     super(appointmentDetails)
@@ -28,11 +29,15 @@ export default class SubmittedFeedbackPresenter extends FeedbackAnswersPresenter
         appointmentDetails,
         this.serviceUser
       )
-      this.behaviourPresenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointmentDetails, this.serviceUser)
+      this.behaviourPresenter = new ActionPlanSessionBehaviourFeedbackPresenter(
+        appointmentDetails,
+        this.serviceUser,
+        this.actionPlanId
+      )
     } else {
       this.attendancePresenter = new InitialAssessmentAttendanceFeedbackPresenter(appointmentDetails, this.serviceUser)
+      this.behaviourPresenter = new InitialAssessmentBehaviourFeedbackPresenter(appointmentDetails, this.serviceUser)
     }
-    this.behaviourPresenter = new InitialAssessmentBehaviourFeedbackPresenter(appointmentDetails, this.serviceUser)
   }
 
   private isActionPlanAppointment(

--- a/server/routes/shared/appointment/feedback/submittedFeedbackView.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackView.ts
@@ -1,3 +1,4 @@
+import { BackLinkArgs } from '../../../../utils/govukFrontendTypes'
 import ViewUtils from '../../../../utils/viewUtils'
 import SubmittedFeedbackPresenter from './submittedFeedbackPresenter'
 
@@ -6,12 +7,19 @@ export default class SubmittedFeedbackView {
 
   private readonly summaryListArgs = ViewUtils.summaryListArgs(this.presenter.sessionDetailsSummary)
 
+  private get backLinkArgs(): BackLinkArgs {
+    return {
+      href: this.presenter.backLinkHref,
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'shared/viewSubmittedPostSessionFeedback',
       {
         presenter: this.presenter,
         summaryListArgs: this.summaryListArgs,
+        backLinkArgs: this.backLinkArgs,
       },
     ]
   }

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
@@ -13,11 +13,11 @@
         {{ govukErrorSummary(errorSummaryArgs) }}
       {% endif %}
 
-      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
-
       {% if backLinkArgs %}
         {{ govukBackLink(backLinkArgs) }}
       {% endif %}
+
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
 
       {% if presenter.text.subTitle %}
         <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>


### PR DESCRIPTION
## What does this pull request do?

Adds back links to the attendance & behaviour feedback pages, as well as the check your answers and viewing submitted feedback pages in the Initial Assessment and Action Plan Sessions journeys.

## What is the intent behind these changes?

To provide a link back to the previous pages.

## Screenshots

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/19826940/127502308-5c9e7a1d-a5bc-4149-bec5-6def72154adc.png">

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/19826940/127502323-25246978-546b-4985-b757-b4f98ac25b5a.png">

<img width="1135" alt="image" src="https://user-images.githubusercontent.com/19826940/127507742-dfa4da1c-e3e0-4b51-ae55-69f9519cceff.png">

<img width="1231" alt="image" src="https://user-images.githubusercontent.com/19826940/127510972-0bedb6fc-fd2d-4331-9bc4-6019447057ca.png">


