### PR TITLE
Ic 1525/reschedule initial appointment when did not attend

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1588,10 +1588,10 @@ describe('Service provider referrals dashboard', () => {
             .next()
             .within(() => {
               cy.contains('Appointment status').next().contains('did not attend')
-              cy.contains('To do').next().contains('View feedback').click()
+              cy.contains('To do').next().contains('Reschedule').click()
               cy.location('pathname').should(
                 'equal',
-                `/service-provider/referrals/${sentReferral.id}/supplier-assessment/post-assessment-feedback`
+                `/service-provider/referrals/${sentReferral.id}/supplier-assessment/schedule`
               )
             })
         })

--- a/server/decorators/appointmentDecorator.ts
+++ b/server/decorators/appointmentDecorator.ts
@@ -45,4 +45,12 @@ export default class AppointmentDecorator {
     }
     return duration
   }
+
+  isInitialAssessmentAppointment(appointmentDetails: Appointment | ActionPlanAppointment): boolean {
+    return (<ActionPlanAppointment>appointmentDetails).sessionNumber === undefined
+  }
+
+  appointmentIsInThePast(appointment: Appointment | ActionPlanAppointment): boolean {
+    return new Date(appointment.appointmentTime!) < new Date()
+  }
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -646,7 +646,7 @@ describe(InterventionProgressPresenter, () => {
     })
 
     describe('when the supplier assessment appointment was not attended', () => {
-      it('returns a link to a page to view feedback for the appointment', () => {
+      it('returns a link to a page to schedule a new appointment', () => {
         const referral = sentReferralFactory.build()
 
         const presenter = new InterventionProgressPresenter(
@@ -659,8 +659,8 @@ describe(InterventionProgressPresenter, () => {
 
         expect(presenter.supplierAssessmentLink).toEqual([
           {
-            text: 'View feedback',
-            href: `/service-provider/referrals/${referral.id}/supplier-assessment/post-assessment-feedback`,
+            text: 'Reschedule',
+            href: `/service-provider/referrals/${referral.id}/supplier-assessment/schedule`,
           },
         ])
       })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -216,8 +216,14 @@ export default class InterventionProgressPresenter {
             href: `/service-provider/referrals/${this.referral.id}/supplier-assessment/post-assessment-feedback/attendance`,
           },
         ]
-      case SessionStatus.completed:
       case SessionStatus.didNotAttend:
+        return [
+          {
+            text: 'Reschedule',
+            href: `/service-provider/referrals/${this.referral.id}/supplier-assessment/schedule`,
+          },
+        ]
+      case SessionStatus.completed:
         return [
           {
             text: 'View feedback',

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -1,5 +1,6 @@
 import ScheduleAppointmentPresenter from './scheduleAppointmentPresenter'
 import appointmentFactory from '../../../testutils/factories/appointment'
+import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
 
 describe(ScheduleAppointmentPresenter, () => {
@@ -20,6 +21,75 @@ describe(ScheduleAppointmentPresenter, () => {
           const presenter = new ScheduleAppointmentPresenter(referral, appointmentFactory.build())
 
           expect(presenter.text).toEqual({ title: 'Change appointment details' })
+        })
+      })
+
+      describe('when the session has already been attended', () => {
+        it('returns an appropriate title', () => {
+          const presenter = new ScheduleAppointmentPresenter(referral, appointmentFactory.attended('no').build())
+          expect(presenter.text).toEqual({ title: 'Add appointment details' })
+        })
+      })
+    })
+  })
+
+  describe('appointmentSummary', () => {
+    describe('when the appointment has not yet been scheduled', () => {
+      it('should return an empty summary', () => {
+        const presenter = new ScheduleAppointmentPresenter(referral, null)
+        expect(presenter.appointmentSummary).toEqual([])
+      })
+    })
+
+    describe('when the appointment has been scheduled', () => {
+      it('should return appointment summary', () => {
+        const presenter = new ScheduleAppointmentPresenter(
+          referral,
+          appointmentFactory.build({
+            appointmentTime: new Date('2021-01-02T12:00:00Z').toISOString(),
+            durationInMinutes: 60,
+            appointmentDeliveryType: 'VIDEO_CALL',
+          })
+        )
+        expect(presenter.appointmentSummary).toEqual([
+          { key: 'Date', lines: ['2 January 2021'] },
+          { key: 'Time', lines: ['12:00pm to 1:00pm'] },
+          { key: 'Method', lines: ['Video call'] },
+        ])
+      })
+    })
+  })
+
+  describe('appointmentAlreadyAttended', () => {
+    describe('when the appointment has not yet been scheduled', () => {
+      it('should return false', () => {
+        const presenter = new ScheduleAppointmentPresenter(referral, null)
+        expect(presenter.appointmentAlreadyAttended).toBe(false)
+      })
+    })
+
+    describe('when the appointment has been scheduled but not yet attended', () => {
+      it('should return false', () => {
+        const presenter = new ScheduleAppointmentPresenter(referral, appointmentFactory.build())
+        expect(presenter.appointmentAlreadyAttended).toBe(false)
+      })
+    })
+
+    describe('when the appointment has been scheduled and attended', () => {
+      describe('and the appointment is an initial assessment', () => {
+        it('should return true', () => {
+          const presenter = new ScheduleAppointmentPresenter(referral, appointmentFactory.attended('no').build())
+          expect(presenter.appointmentAlreadyAttended).toBe(true)
+        })
+      })
+
+      describe('and the appointment is part of an action plan', () => {
+        it('should return false', () => {
+          const presenter = new ScheduleAppointmentPresenter(
+            referral,
+            actionPlanAppointmentFactory.attended('no').build()
+          )
+          expect(presenter.appointmentAlreadyAttended).toBe(false)
         })
       })
     })

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -41,11 +41,11 @@ describe(ScheduleAppointmentPresenter, () => {
       })
     })
 
-    describe('when the appointment has been scheduled', () => {
+    describe('when the appointment has been attended', () => {
       it('should return appointment summary', () => {
         const presenter = new ScheduleAppointmentPresenter(
           referral,
-          appointmentFactory.build({
+          appointmentFactory.attended('no').build({
             appointmentTime: new Date('2021-01-02T12:00:00Z').toISOString(),
             durationInMinutes: 60,
             appointmentDeliveryType: 'VIDEO_CALL',
@@ -205,7 +205,44 @@ describe(ScheduleAppointmentPresenter, () => {
       })
     })
 
-    describe('with a populated appointment', () => {
+    describe('when the appointment has already been attended', () => {
+      it('should return empty fields', () => {
+        const presenter = new ScheduleAppointmentPresenter(referral, appointmentFactory.attended('no').build())
+
+        expect(presenter.fields).toEqual({
+          date: {
+            errorMessage: null,
+            day: { value: '', hasError: false },
+            month: { value: '', hasError: false },
+            year: { value: '', hasError: false },
+          },
+          time: {
+            errorMessage: null,
+            hour: { value: '', hasError: false },
+            minute: { value: '', hasError: false },
+            partOfDay: {
+              value: null,
+              hasError: false,
+            },
+          },
+          duration: {
+            errorMessage: null,
+            hours: { value: '', hasError: false },
+            minutes: { value: '', hasError: false },
+          },
+          meetingMethod: { value: null, errorMessage: null },
+          address: {
+            value: null,
+            errors: {
+              firstAddressLine: null,
+              postcode: null,
+            },
+          },
+        })
+      })
+    })
+
+    describe('with a non attended appointment', () => {
       it('returns values to populate the fields with', () => {
         const appointment = appointmentFactory.build({
           appointmentTime: '2021-03-24T10:30:00Z',

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -28,8 +28,8 @@ export default class ScheduleAppointmentPresenter {
   private readonly utils = new PresenterUtils(this.userInputData)
 
   get appointmentSummary(): SummaryListItem[] {
-    if (this.currentAppointment) {
-      return new AppointmentSummary(this.currentAppointment, null).appointmentSummaryList
+    if (this.appointmentAlreadyAttended) {
+      return new AppointmentSummary(this.currentAppointment!, null).appointmentSummaryList
     }
     return []
   }
@@ -54,21 +54,37 @@ export default class ScheduleAppointmentPresenter {
     return false
   }
 
-  readonly fields = {
-    date: this.utils.dateValue(this.appointmentDecorator?.britishDay ?? null, 'date', this.validationError),
-    time: this.utils.twelveHourTimeValue(this.appointmentDecorator?.britishTime ?? null, 'time', this.validationError),
-    duration: this.utils.durationValue(this.appointmentDecorator?.duration ?? null, 'duration', this.validationError),
-    meetingMethod: this.utils.meetingMethodValue(
-      this.currentAppointment?.appointmentDeliveryType ?? null,
-      'meeting-method',
-      this.validationError
-    ),
-    address: this.utils.addressValue(
-      this.currentAppointment?.appointmentDeliveryAddress ?? null,
-      'method-other-location',
-      this.validationError
-    ),
-  }
+  readonly fields = this.appointmentAlreadyAttended
+    ? {
+        date: this.utils.dateValue(null, 'date', this.validationError),
+        time: this.utils.twelveHourTimeValue(null, 'time', this.validationError),
+        duration: this.utils.durationValue(null, 'duration', this.validationError),
+        meetingMethod: this.utils.meetingMethodValue(null, 'meeting-method', this.validationError),
+        address: this.utils.addressValue(null, 'method-other-location', this.validationError),
+      }
+    : {
+        date: this.utils.dateValue(this.appointmentDecorator?.britishDay ?? null, 'date', this.validationError),
+        time: this.utils.twelveHourTimeValue(
+          this.appointmentDecorator?.britishTime ?? null,
+          'time',
+          this.validationError
+        ),
+        duration: this.utils.durationValue(
+          this.appointmentDecorator?.duration ?? null,
+          'duration',
+          this.validationError
+        ),
+        meetingMethod: this.utils.meetingMethodValue(
+          this.currentAppointment?.appointmentDeliveryType ?? null,
+          'meeting-method',
+          this.validationError
+        ),
+        address: this.utils.addressValue(
+          this.currentAppointment?.appointmentDeliveryAddress ?? null,
+          'method-other-location',
+          this.validationError
+        ),
+      }
 
   readonly backLinkHref = this.overrideBackLinkHref ?? `/service-provider/referrals/${this.referral.id}/progress`
 }

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -4,7 +4,6 @@ import PresenterUtils from '../../utils/presenterUtils'
 import { FormValidationError } from '../../utils/formValidationError'
 import AppointmentDecorator from '../../decorators/appointmentDecorator'
 import SentReferral from '../../models/sentReferral'
-import utils from '../../utils/utils'
 import AppointmentSummary from '../appointments/appointmentSummary'
 import { SummaryListItem } from '../../utils/summaryList'
 
@@ -15,7 +14,8 @@ export default class ScheduleAppointmentPresenter {
     private readonly validationError: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null,
     private readonly serverError: FormValidationError | null = null,
-    private readonly overrideBackLinkHref?: string
+    private readonly overrideBackLinkHref?: string,
+    private readonly appointmentDecorator = currentAppointment ? new AppointmentDecorator(currentAppointment) : null
   ) {}
 
   readonly text = {
@@ -40,15 +40,11 @@ export default class ScheduleAppointmentPresenter {
 
   readonly serverErrorMessage = PresenterUtils.errorMessage(this.serverError, 'session-input')
 
-  private readonly appointmentDecorator = this.currentAppointment
-    ? new AppointmentDecorator(this.currentAppointment)
-    : null
-
   get appointmentAlreadyAttended(): boolean {
-    if (this.currentAppointment !== null) {
+    if (this.appointmentDecorator !== null) {
       // Remove this check once action plan appointments allow rescheduling
-      if (utils.isInitialAssessmentAppointment(this.currentAppointment)) {
-        return this.currentAppointment.sessionFeedback.submitted
+      if (this.appointmentDecorator.isInitialAssessmentAppointment(this.currentAppointment!)) {
+        return this.currentAppointment!.sessionFeedback.submitted
       }
     }
     return false

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
@@ -21,6 +21,7 @@ export default class ScheduleAppointmentView {
         address: this.addressFormView.inputArgs,
         meetingMethodRadioInputArgs: this.meetingMethodRadioInputArgs.bind(this),
         backLinkArgs: this.backLinkArgs,
+        appointmentSummaryListArgs: ViewUtils.summaryListArgs(this.presenter.appointmentSummary),
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -540,7 +540,7 @@ export default class ServiceProviderReferralsController {
 
     await this.scheduleAppointment(req, res, {
       getReferral: async () => referral,
-      getCurrentAppointment: async () => new SupplierAssessmentDecorator(supplierAssessment).currentAppointment,
+      getCurrentAppointment: async () => currentAppointment,
       scheduleAppointment: paramsForUpdate =>
         this.interventionsService
           .scheduleSupplierAssessmentAppointment(

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -536,7 +536,8 @@ export default class ServiceProviderReferralsController {
       referralId
     )
 
-    const hasExistingAppointment = supplierAssessment.currentAppointmentId !== null
+    const { currentAppointment } = new SupplierAssessmentDecorator(supplierAssessment)
+    const hasExistingScheduledAppointment = currentAppointment !== null && !currentAppointment.sessionFeedback.submitted
 
     await this.scheduleAppointment(req, res, {
       getReferral: async () => referral,
@@ -550,7 +551,7 @@ export default class ServiceProviderReferralsController {
           )
           .then(),
       createPresenter: (appointment, formError, userInputData, serverError) => {
-        const overrideBackLinkHref = hasExistingAppointment
+        const overrideBackLinkHref = hasExistingScheduledAppointment
           ? `/service-provider/referrals/${referralId}/supplier-assessment`
           : undefined
         return new ScheduleAppointmentPresenter(
@@ -563,7 +564,7 @@ export default class ServiceProviderReferralsController {
         )
       },
       redirectTo: `/service-provider/referrals/${referralId}/supplier-assessment/${
-        hasExistingAppointment ? 'rescheduled-confirmation' : 'scheduled-confirmation'
+        hasExistingScheduledAppointment ? 'rescheduled-confirmation' : 'scheduled-confirmation'
       }`,
     })
   }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,3 +1,6 @@
+import Appointment from '../models/appointment'
+import { ActionPlanAppointment } from '../models/actionPlan'
+
 function convertToProperCase(word: string): string {
   return word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
 }
@@ -20,7 +23,12 @@ function convertToTitleCase(sentence: string | null): string {
   return isBlank(sentence) ? '' : sentence!.split(' ').map(properCaseName).join(' ')
 }
 
+function isInitialAssessmentAppointment(appointmentDetails: Appointment | ActionPlanAppointment): boolean {
+  return (<ActionPlanAppointment>appointmentDetails).sessionNumber === undefined
+}
+
 export default {
+  isInitialAssessmentAppointment,
   convertToProperCase,
   convertToTitleCase,
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,6 +1,3 @@
-import Appointment from '../models/appointment'
-import { ActionPlanAppointment } from '../models/actionPlan'
-
 function convertToProperCase(word: string): string {
   return word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
 }
@@ -23,12 +20,7 @@ function convertToTitleCase(sentence: string | null): string {
   return isBlank(sentence) ? '' : sentence!.split(' ').map(properCaseName).join(' ')
 }
 
-function isInitialAssessmentAppointment(appointmentDetails: Appointment | ActionPlanAppointment): boolean {
-  return (<ActionPlanAppointment>appointmentDetails).sessionNumber === undefined
-}
-
 export default {
-  isInitialAssessmentAppointment,
   convertToProperCase,
   convertToTitleCase,
 }

--- a/server/views/serviceProviderReferrals/scheduleAppointment.njk
+++ b/server/views/serviceProviderReferrals/scheduleAppointment.njk
@@ -5,6 +5,7 @@
 {% from "components/time-input/macro.njk" import appTimeInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -26,6 +27,12 @@
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
         <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+        {% if presenter.appointmentAlreadyAttended %}
+            <h2 class="govuk-heading-l">Previous missed appointment</h2>
+            {{ govukSummaryList(appointmentSummaryListArgs) }}
+            <h2 class="govuk-heading-l">Details of the new appointment</h2>
+        {% endif %}
 
         <div id='session-input' {% if serverError != null %}class="{{serverError.classes}}"{% endif %}>
           {% if serverError !== null %}


### PR DESCRIPTION
## What does this pull request do?

Provides ability to create a new appointment if the service user did not attend the last appointment. Currently the SP user can only view the feedback.

## What is the intent behind these changes?

Allows SP user to reschedule a new appointment if the user did not attend.

## Note:

In order to reduce the length of this PR I will add the attendance notes showing in previous appointment details in a future PR.

## User Journey
### When viewing referral progress the following link is now available:
![image](https://user-images.githubusercontent.com/83066216/127509966-1b205ebc-127e-4c9e-83b6-b9f8b0b3813d.png)

### When the SP user clicks on reschedule
![image](https://user-images.githubusercontent.com/83066216/127513442-e84bb2de-4923-4123-8a5c-4a892d573e0c.png)

### When the SP user saves the new appointment
![image](https://user-images.githubusercontent.com/83066216/127512315-f0ea7c0f-7b69-416a-b7b9-5a92b26d74c4.png)

### When the user goes back to referral progress page
![image](https://user-images.githubusercontent.com/83066216/127513013-e8d9b635-9a6c-45a6-822f-527af9492246.png)
