### PR TITLE
Ic 2130/add casework details to missed last appointment details

### DIFF
--- a/server/models/sessionFeedback.ts
+++ b/server/models/sessionFeedback.ts
@@ -1,8 +1,10 @@
 import AppointmentAttendance from './appointmentAttendance'
 import AppointmentBehaviour from './appointmentBehaviour'
+import User from './hmppsAuth/user'
 
 export default interface SessionFeedback {
   attendance: AppointmentAttendance
   behaviour: AppointmentBehaviour
   submitted: boolean
+  submittedBy: User | null
 }

--- a/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.ts
+++ b/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.ts
@@ -2,16 +2,18 @@ import { ActionPlanAppointment } from '../../../../../models/actionPlan'
 import SentReferral from '../../../../../models/sentReferral'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import ScheduleAppointmentPresenter from '../../../../serviceProviderReferrals/scheduleAppointmentPresenter'
+import AuthUserDetails from '../../../../../models/hmppsAuth/authUserDetails'
 
 export default class ScheduleActionPlanSessionPresenter extends ScheduleAppointmentPresenter {
   constructor(
     referral: SentReferral,
     currentAppointment: ActionPlanAppointment,
+    assignedCaseworker: AuthUserDetails | null = null,
     validationError: FormValidationError | null = null,
     userInputData: Record<string, unknown> | null = null,
     serverError: FormValidationError | null = null
   ) {
-    super(referral, currentAppointment, validationError, userInputData, serverError)
+    super(referral, currentAppointment, assignedCaseworker, validationError, userInputData, serverError)
     this.text.title = `Add session ${currentAppointment.sessionNumber} details`
   }
 }

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -2,6 +2,7 @@ import ScheduleAppointmentPresenter from './scheduleAppointmentPresenter'
 import appointmentFactory from '../../../testutils/factories/appointment'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import authUserDetailsFactory from '../../../testutils/factories/hmppsAuthUser'
 
 describe(ScheduleAppointmentPresenter, () => {
   const referral = sentReferralFactory.build()
@@ -42,20 +43,42 @@ describe(ScheduleAppointmentPresenter, () => {
     })
 
     describe('when the appointment has been attended', () => {
-      it('should return appointment summary', () => {
-        const presenter = new ScheduleAppointmentPresenter(
-          referral,
-          appointmentFactory.attended('no').build({
-            appointmentTime: new Date('2021-01-02T12:00:00Z').toISOString(),
-            durationInMinutes: 60,
-            appointmentDeliveryType: 'VIDEO_CALL',
-          })
-        )
-        expect(presenter.appointmentSummary).toEqual([
-          { key: 'Date', lines: ['2 January 2021'] },
-          { key: 'Time', lines: ['12:00pm to 1:00pm'] },
-          { key: 'Method', lines: ['Video call'] },
-        ])
+      describe('when an assigned caseworker is provided', () => {
+        it('should return appointment summary with caseworker details', () => {
+          const presenter = new ScheduleAppointmentPresenter(
+            referral,
+            appointmentFactory.attended('no').build({
+              appointmentTime: new Date('2021-01-02T12:00:00Z').toISOString(),
+              durationInMinutes: 60,
+              appointmentDeliveryType: 'VIDEO_CALL',
+            }),
+            authUserDetailsFactory.build({ firstName: 'firstName', lastName: 'lastName' })
+          )
+          expect(presenter.appointmentSummary).toEqual([
+            { key: 'Caseworker', lines: ['firstName lastName'] },
+            { key: 'Date', lines: ['2 January 2021'] },
+            { key: 'Time', lines: ['12:00pm to 1:00pm'] },
+            { key: 'Method', lines: ['Video call'] },
+          ])
+        })
+      })
+      describe('when no assigned caseworker is provided', () => {
+        it('should return appointment summary without caseworker details', () => {
+          const presenter = new ScheduleAppointmentPresenter(
+            referral,
+            appointmentFactory.attended('no').build({
+              appointmentTime: new Date('2021-01-02T12:00:00Z').toISOString(),
+              durationInMinutes: 60,
+              appointmentDeliveryType: 'VIDEO_CALL',
+            }),
+            null
+          )
+          expect(presenter.appointmentSummary).toEqual([
+            { key: 'Date', lines: ['2 January 2021'] },
+            { key: 'Time', lines: ['12:00pm to 1:00pm'] },
+            { key: 'Method', lines: ['Video call'] },
+          ])
+        })
       })
     })
   })
@@ -102,6 +125,7 @@ describe(ScheduleAppointmentPresenter, () => {
         const presenter = new ScheduleAppointmentPresenter(
           referral,
           appointment,
+          null,
           {
             errors: [
               {
@@ -140,6 +164,7 @@ describe(ScheduleAppointmentPresenter, () => {
         const presenter = new ScheduleAppointmentPresenter(
           referral,
           appointment,
+          null,
           {
             errors: [
               {
@@ -309,7 +334,7 @@ describe(ScheduleAppointmentPresenter, () => {
 
     describe('when overrideBackLinkHref is provided to the constructor', () => {
       it('returns the overrideBacklinkHref', () => {
-        const presenter = new ScheduleAppointmentPresenter(referral, null, null, null, null, '/example-href')
+        const presenter = new ScheduleAppointmentPresenter(referral, null, null, null, null, null, '/example-href')
 
         expect(presenter.backLinkHref).toEqual('/example-href')
       })

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -6,11 +6,13 @@ import AppointmentDecorator from '../../decorators/appointmentDecorator'
 import SentReferral from '../../models/sentReferral'
 import AppointmentSummary from '../appointments/appointmentSummary'
 import { SummaryListItem } from '../../utils/summaryList'
+import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
 
 export default class ScheduleAppointmentPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly currentAppointment: Appointment | ActionPlanAppointment | null,
+    private readonly assignedCaseworker: AuthUserDetails | null = null,
     private readonly validationError: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null,
     private readonly serverError: FormValidationError | null = null,
@@ -29,7 +31,7 @@ export default class ScheduleAppointmentPresenter {
 
   get appointmentSummary(): SummaryListItem[] {
     if (this.appointmentAlreadyAttended) {
-      return new AppointmentSummary(this.currentAppointment!, null).appointmentSummaryList
+      return new AppointmentSummary(this.currentAppointment!, this.assignedCaseworker).appointmentSummaryList
     }
     return []
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1845,6 +1845,9 @@ describe('GET /service-provider/referrals/:id/supplier-assessment/schedule', () 
         supplierAssessmentFactory.withNonAttendedAppointment.build()
       )
       interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+      hmppsAuthService.getSPUserByUsername.mockResolvedValue(
+        hmppsAuthUserFactory.build({ firstName: 'caseWorkerFirstName', lastName: 'caseWorkerLastName' })
+      )
 
       await request(app)
         .get(`/service-provider/referrals/1/supplier-assessment/schedule`)
@@ -1852,6 +1855,7 @@ describe('GET /service-provider/referrals/:id/supplier-assessment/schedule', () 
         .expect(res => {
           expect(res.text).toContain('Add appointment details')
           expect(res.text).toContain('Previous missed appointment')
+          expect(res.text).toContain('caseWorkerFirstName caseWorkerLastName')
         })
     })
   })

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2463,6 +2463,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
                 notifyProbationPractitioner: null,
               },
               submitted: false,
+              submittedBy: null,
             },
           }),
           headers: {
@@ -2517,6 +2518,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
                 notifyProbationPractitioner: false,
               },
               submitted: false,
+              submittedBy: null,
             },
           }),
           headers: {
@@ -2567,6 +2569,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
                 notifyProbationPractitioner: false,
               },
               submitted: true,
+              submittedBy: {
+                authSource: 'delius',
+                userId: '2500128586',
+                username: 'joe.smith',
+              },
             },
           }),
           headers: {
@@ -2913,6 +2920,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             notifyProbationPractitioner: null,
           },
           submitted: false,
+          submittedBy: null,
         },
       })
 
@@ -2967,6 +2975,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             notifyProbationPractitioner: false,
           },
           submitted: false,
+          submittedBy: null,
         },
       })
 
@@ -3021,6 +3030,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             notifyProbationPractitioner: false,
           },
           submitted: true,
+          submittedBy: {
+            authSource: 'auth',
+            userId: '608955ae-52ed-44cc-884c-011597a77949',
+            username: 'AUTH_USER',
+          },
         },
       })
 

--- a/testutils/factories/appointment.ts
+++ b/testutils/factories/appointment.ts
@@ -20,6 +20,11 @@ class AppointmentFactory extends Factory<Appointment> {
           notifyProbationPractitioner: false,
         },
         submitted: true,
+        submittedBy: {
+          username: 'UserABC',
+          userId: '555224b3-865c-4b56-97dd-c3e817592ba3',
+          authSource: 'auth',
+        },
       },
     })
   }
@@ -80,5 +85,6 @@ export default AppointmentFactory.define(({ sequence }) => ({
       notifyProbationPractitioner: null,
     },
     submitted: false,
+    submittedBy: null,
   },
 }))


### PR DESCRIPTION
## What does this pull request do?

Adds caseworker details to show previous missed appointment when applicable.

If the user has rescheduled a (non-attended) missed appointment they will see the previous appointment details (time, date and delivery type). 

This PR adds to this section to also include the caseworker who submitted the feedback for that appointment.


## What is the intent behind these changes?

Allows SP user to see which caseworker worked on the previous appointment

![image](https://user-images.githubusercontent.com/83066216/127851691-fcfa8989-dc33-4115-8e02-e6132484e6cf.png)

