### PR TITLE
Use temporary Redis-based draft objects for multi page journeys that aren't backed by API calls

### DIFF
--- a/doc/architecture/decisions/0011-use-redis-backed-drafts.md
+++ b/doc/architecture/decisions/0011-use-redis-backed-drafts.md
@@ -1,0 +1,86 @@
+# 11. Use Redis-backed drafts
+
+Date: 2021-06-28
+
+## Status
+
+Accepted
+
+## Context
+
+### Background
+
+Our service frequently needs to take a user through a journey which involves asking them a series of questions over multiple pages, and then playing all the answers back to the user before finally submitting all the answers to the interventions service API.
+
+This means that we need somewhere to store the user’s answers as they progress through the journey. For some journeys, the interventions service provides this storage. For example, in the journey of submitting a referral, the interventions service provides endpoints for creating and updating a draft referral.
+
+However, we have other journeys where the interventions service does not provide this storage. For example, assigning a referral to a caseworker, or cancelling a referral. For these journeys, the UI application needs to provide its own storage.
+
+### Why not have the interventions service store everything?
+
+We _could_ make the interventions service provide storage for the data of every page of every journey in the UI. However, this would be very tied to the user journeys of this UI and less of a general-purpose interventions API. We should reserve interventions service storage for long journeys which the user might want to complete in multiple sittings.
+
+### The solution so far
+
+We pass data from page A to page B to page C of a journey by making sure that the HTTP request for page C includes all of the data that was submitted on pages A and B. We do this either by:
+
+- accepting the data from previous pages as data encoded in the request URL’s query, and then passing it in a GET request to subsequent pages by placing the data from previous pages into the query of the URL that’s used for navigating to the next page
+- accepting the data from previous pages as `application/x-www-form-urlencoded` form data, and then passing it in a POST request to subsequent pages by placing `<input type="hidden">` fields on each page, replaying the data from the previous pages
+
+### The problem with this solution
+
+Using a GET request limits the amount of data a user can submit on a page, since many clients and servers do not support URLs over 2000 bytes long.
+
+Using a POST request means that we cannot redirect to different pages in the journey (for example, check your answers) based on the user’s input, since a redirect response cannot instruct the browser to make a POST request.
+
+Also, the approach of embedding the data in the HTML is laborious. We have to make sure that every possible route through the pages in the journey preserves the data. This becomes particularly easy to get wrong when we have non-linear sequences of pages — for example, a link on the check your answers page that allows the user to edit a previous answer.
+
+### Other requirements for a solution
+
+The solution must also:
+
+- make sure that a user is not able to access data entered by a different user
+- not prevent the user from performing the same journey multiple times concurrently — for example, they should be able to assign two different interventions at the same time in different browser tabs
+- preserve the data that the user entered on previous pages when they use the browser’s Back button
+- give us maximum flexibility in deciding how to meet [WCAG 2.1’s Success Criterion 2.2.1 Timing Adjustable](https://www.w3.org/TR/WCAG21/#timing-adjustable) — for example, by making sure that the data is kept for at least 20 hours before it expires
+
+It would also be good if the solution could:
+
+- not introduce new dependencies to the service — for example a database
+- allow us to continue using the same kinds of coding patterns as we do when interacting with the interventions service API — creating and updating a resource
+- allow us to identify and clean up old data
+
+## Decision
+
+We’ll use the UI application’s existing Redis server as our storage. It allows us to store essentially unlimited amounts of data. The data is private to the current browsing session and is not accessible by other users.
+
+In Redis, we’ll store “draft” objects. These are containers of arbitrary JSON data, along with:
+
+- a globally unique identifier
+- the unique identifier of the user who created the draft
+- timestamps of creation and last update
+- an identifier explaining what type of data the draft represents
+
+We’ll:
+
+- provide a “CRUD” API for creating, fetching, updating and deleting these draft objects
+- include the draft’s ID in all URLs in a journey
+- allow these drafts to be created by a GET request, so that we can use `<a>` tags to link to journeys
+- prefer to use POSTs to pass data to a page instead of GET, so we don't have to worry about body size constraints
+
+The aforementioned API will:
+
+- enforce access control — making sure that a user is only allowed to access drafts that they created
+- make sure that drafts are automatically removed after they are no longer accessed for a certain amount of time (for example, 1 day), using Redis’s expiry functionality, to make sure that drafts do not consume storage in Redis indefinitely
+
+### Alternatives
+
+We might consider using the (Redis-backed) Express `session` object. However, this object expires after 2 hours of inactivity, which is insufficient for our needs. We don’t want to increase this timeout since there are security implications to increasing the amount of time that a user remains logged in to the service.
+
+## Consequences
+
+Draft data will be lost after a period of inactivity. We should inform the user when this has happened, so that they can start the journey again. If this time limit proves to be a problem then we may need to reconsider the expiry duration.
+
+The URLs for some pages in our service will become longer.
+
+The draft data will only be as secure as our Redis instance.

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -338,7 +338,10 @@ describe('Service provider referrals dashboard', () => {
       cy.get('#email').type('john@harmonyliving.org.uk')
       cy.contains('Save and continue').click()
 
-      cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/check`)
+      cy.location('pathname').should(
+        'match',
+        new RegExp(`/service-provider/referrals/${referral.id}/assignment/[a-z0-9-]+/check`)
+      )
       cy.get('h1').contains('Confirm the Accommodation referral assignment')
       cy.contains('John Smith')
 
@@ -431,7 +434,10 @@ describe('Service provider referrals dashboard', () => {
       cy.get('#email').type('anna@harmonyliving.org.uk')
       cy.contains('Save and continue').click()
 
-      cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/assignment/check`)
+      cy.location('pathname').should(
+        'match',
+        new RegExp(`/service-provider/referrals/${referral.id}/assignment/[a-z0-9-]+/check`)
+      )
       cy.get('h1').contains('Confirm the Accommodation referral assignment')
       cy.contains('Anna Dawkins')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@ministryofjustice/frontend": "0.2.5",
         "@sentry/node": "^6.10.0",
         "@types/connect-flash": "0.0.37",
+        "@types/uuid": "^8.3.0",
         "agentkeepalive": "^4.1.3",
         "applicationinsights": "^2.1.4",
         "body-parser": "^1.19.0",
@@ -40,7 +41,8 @@
         "passport-oauth2": "^1.6.0",
         "redis": "^3.1.1",
         "superagent": "^6.1.0",
-        "timezone-support": "^2.0.2"
+        "timezone-support": "^2.0.2",
+        "uuid": "^3.4.0"
       },
       "devDependencies": {
         "@pact-foundation/pact": "^9.16.0",
@@ -3983,6 +3985,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "node_modules/@types/yargs": {
       "version": "15.0.13",
@@ -24797,6 +24804,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@types/yargs": {
       "version": "15.0.13",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@ministryofjustice/frontend": "0.2.5",
     "@sentry/node": "^6.10.0",
     "@types/connect-flash": "0.0.37",
+    "@types/uuid": "^8.3.0",
     "agentkeepalive": "^4.1.3",
     "applicationinsights": "^2.1.4",
     "body-parser": "^1.19.0",
@@ -122,7 +123,8 @@
     "passport-oauth2": "^1.6.0",
     "redis": "^3.1.1",
     "superagent": "^6.1.0",
-    "timezone-support": "^2.0.2"
+    "timezone-support": "^2.0.2",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "@pact-foundation/pact": "^9.16.0",

--- a/server/app.ts
+++ b/server/app.ts
@@ -28,6 +28,7 @@ import AssessRisksAndNeedsService from './services/assessRisksAndNeedsService'
 import ControllerUtils from './utils/controllerUtils'
 import broadcastMessageConfig from './broadcast-message-config.json'
 import probationPractitionerRoutes, { probationPractitionerUrlPrefix } from './routes/probationPractitionerRoutes'
+import DraftsService from './services/draftsService'
 
 const RedisStore = connectRedis(session)
 
@@ -96,7 +97,7 @@ export default function createApp(
 
   app.use(addRequestId())
 
-  const client = redis.createClient({
+  const redisClient = redis.createClient({
     port: config.redis.port,
     password: config.redis.password,
     host: config.redis.host,
@@ -105,7 +106,7 @@ export default function createApp(
 
   app.use(
     session({
-      store: new RedisStore({ client }),
+      store: new RedisStore({ client: redisClient }),
       cookie: { secure: config.https, sameSite: 'lax', maxAge: config.session.expiryMinutes * 60 * 1000 },
       secret: config.session.secret,
       resave: false, // redis implements touch so shouldn't need this
@@ -198,11 +199,15 @@ export default function createApp(
     next()
   })
 
+  const clock = { now: () => new Date() }
+  const draftsService = new DraftsService(redisClient, config.draftsService.expiry, clock)
+
   const services = {
     communityApiService,
     interventionsService,
     hmppsAuthService,
     assessRisksAndNeedsService,
+    draftsService,
   }
 
   app.use('/', indexRoutes(standardRouter(), services))

--- a/server/config.ts
+++ b/server/config.ts
@@ -108,4 +108,7 @@ export default {
     },
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
+  draftsService: {
+    expiry: { seconds: Number(get('DRAFTS_EXPIRY_IN_SECONDS', `${24 * 60 * 60}`)) },
+  },
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -9,12 +9,14 @@ import CommonController from './common/commonController'
 import AssessRisksAndNeedsService from '../services/assessRisksAndNeedsService'
 import ReferralsController from './referrals/referralsController'
 import FindInterventionsController from './findInterventions/findInterventionsController'
+import DraftsService from '../services/draftsService'
 
 export interface Services {
   communityApiService: CommunityApiService
   interventionsService: InterventionsService
   hmppsAuthService: HmppsAuthService
   assessRisksAndNeedsService: AssessRisksAndNeedsService
+  draftsService: DraftsService
 }
 
 export const get = (router: Router, path: string, handler: RequestHandler): Router =>

--- a/server/routes/probationPractitionerReferrals/draftCancellationData.ts
+++ b/server/routes/probationPractitionerReferrals/draftCancellationData.ts
@@ -1,0 +1,4 @@
+export default interface DraftCancellationData {
+  cancellationReason: string | null
+  cancellationComments: string | null
+}

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -214,7 +214,7 @@ describe(InterventionProgressPresenter, () => {
       const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
 
       expect(presenter.referralCancellationHref).toEqual(
-        `/probation-practitioner/referrals/${referral.id}/cancellation/reason`
+        `/probation-practitioner/referrals/${referral.id}/cancellation/start`
       )
     })
   })

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -74,7 +74,7 @@ export default class InterventionProgressPresenter {
     title: `${utils.convertToTitleCase(this.intervention.contractType.name)} progress`,
   }
 
-  readonly referralCancellationHref = `/probation-practitioner/referrals/${this.referral.id}/cancellation/reason`
+  readonly referralCancellationHref = `/probation-practitioner/referrals/${this.referral.id}/cancellation/start`
 
   readonly hasSessions = this.actionPlanAppointments.length !== 0
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -35,10 +35,16 @@ import supplierAssessmentFactory from '../../../testutils/factories/supplierAsse
 import appointmentFactory from '../../../testutils/factories/appointment'
 import deliusOffenderManagerFactory from '../../../testutils/factories/deliusOffenderManager'
 import { DeliusOffenderManager } from '../../models/delius/deliusOffenderManager'
+import DraftsService from '../../services/draftsService'
+import { createDraftFactory } from '../../../testutils/factories/draft'
+import draftCancellationDataFactory from '../../../testutils/factories/draftCancellationData'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
 jest.mock('../../services/assessRisksAndNeedsService')
+jest.mock('../../services/draftsService')
+
+const draftCancellationFactory = createDraftFactory(draftCancellationDataFactory.build())
 
 const interventionsService = new InterventionsService(
   apiConfig.apis.interventionsService
@@ -49,11 +55,24 @@ const hmppsAuthService = new MockedHmppsAuthService() as jest.Mocked<HmppsAuthSe
 
 const assessRisksAndNeedsService = new MockAssessRisksAndNeedsService() as jest.Mocked<AssessRisksAndNeedsService>
 
+const draftsService = {
+  createDraft: jest.fn(),
+  fetchDraft: jest.fn(),
+  updateDraft: jest.fn(),
+  deleteDraft: jest.fn(),
+} as unknown as jest.Mocked<DraftsService>
+
 let app: Express
 
 beforeEach(() => {
   app = appWithAllRoutes({
-    overrides: { interventionsService, communityApiService, hmppsAuthService, assessRisksAndNeedsService },
+    overrides: {
+      interventionsService,
+      communityApiService,
+      hmppsAuthService,
+      assessRisksAndNeedsService,
+      draftsService,
+    },
     userType: AppSetupUserType.serviceProvider,
   })
 })
@@ -315,8 +334,53 @@ describe('GET /probation-practitioner/referrals/:id/supplier-assessment/post-ass
   })
 })
 
+describe('GET /probation-practitioner/referrals/:id/cancellation/start', () => {
+  it('creates a draft cancellation using the drafts service and redirects to the reason page', async () => {
+    const draftCancellation = draftCancellationFactory.build()
+    draftsService.createDraft.mockResolvedValue(draftCancellation)
+
+    await request(app)
+      .get(`/probation-practitioner/referrals/123/cancellation/start`)
+      .expect(302)
+      .expect('Location', `/probation-practitioner/referrals/123/cancellation/${draftCancellation.id}/reason`)
+
+    expect(draftsService.createDraft).toHaveBeenCalledWith(
+      'cancellation',
+      {
+        cancellationReason: null,
+        cancellationComments: null,
+      },
+      { userId: '123' }
+    )
+  })
+})
+
 describe('GET /probation-practitioner/referrals/:id/cancellation/reason', () => {
+  it('creates a draft cancellation using the drafts service and redirects to the reason page', async () => {
+    const draftCancellation = draftCancellationFactory.build()
+    draftsService.createDraft.mockResolvedValue(draftCancellation)
+
+    await request(app)
+      .get(`/probation-practitioner/referrals/123/cancellation/reason`)
+      .expect(302)
+      .expect('Location', `/probation-practitioner/referrals/123/cancellation/${draftCancellation.id}/reason`)
+
+    expect(draftsService.createDraft).toHaveBeenCalledWith(
+      'cancellation',
+      {
+        cancellationReason: null,
+        cancellationComments: null,
+      },
+      { userId: '123' }
+    )
+  })
+})
+
+describe('GET /probation-practitioner/referrals/:id/cancellation/:draftCancellationId/reason', () => {
   it('renders a page where the PP can add comments and cancel a referral', async () => {
+    const draftCancellation = draftCancellationFactory.build()
+    draftsService.fetchDraft.mockResolvedValue(draftCancellation)
+
     const referral = sentReferralFactory.assigned().build()
     const intervention = interventionFactory.build()
     const serviceUser = deliusServiceUserFactory.build()
@@ -330,7 +394,7 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/reason', () => 
     ])
 
     await request(app)
-      .get(`/probation-practitioner/referrals/${referral.id}/cancellation/reason`)
+      .get(`/probation-practitioner/referrals/${referral.id}/cancellation/${draftCancellation.id}/reason`)
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Referral cancellation')
@@ -340,10 +404,103 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/reason', () => 
         expect(res.text).toContain('Additional comments (optional)')
       })
   })
+
+  describe('when no draft exists with that ID', () => {
+    it('displays an error', async () => {
+      draftsService.fetchDraft.mockResolvedValue(null)
+
+      await request(app)
+        .get(`/probation-practitioner/referrals/abc/cancellation/def/reason`)
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain(
+            'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.'
+          )
+        })
+    })
+  })
 })
 
 describe('POST /probation-practitioner/referrals/:id/cancellation/check-your-answers', () => {
-  it('passes through params to a page where the PP can confirm whether or not to cancel a referral', async () => {
+  it('creates a draft cancellation using the drafts service with the submitted data, and redirects to the check your answers page', async () => {
+    const draftCancellation = draftCancellationFactory.build()
+    draftsService.createDraft.mockResolvedValue(draftCancellation)
+
+    await request(app)
+      .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/check-your-answers`)
+      .type('form')
+      .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
+      .expect(302)
+      .expect(
+        'Location',
+        `/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/${draftCancellation.id}/check-your-answers`
+      )
+
+    expect(draftsService.createDraft).toHaveBeenCalledWith(
+      'cancellation',
+      {
+        cancellationReason: 'MOV',
+        cancellationComments: 'Alex has moved out of the area',
+      },
+      { userId: '123' }
+    )
+  })
+})
+
+describe('POST /probation-practitioner/referrals/:id/cancellation/:draftCancellationId/reason', () => {
+  it('updates the draft cancellation using the drafts service and redirects to the check your answers page', async () => {
+    const draftCancellation = draftCancellationFactory.build({
+      data: { cancellationReason: null, cancellationComments: null },
+    })
+    draftsService.fetchDraft.mockResolvedValue(draftCancellation)
+
+    const referral = sentReferralFactory.assigned().build()
+
+    await request(app)
+      .post(`/probation-practitioner/referrals/${referral.id}/cancellation/${draftCancellation.id}/reason`)
+      .type('form')
+      .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
+      .expect(302)
+      .expect(
+        'Location',
+        `/probation-practitioner/referrals/${referral.id}/cancellation/${draftCancellation.id}/check-your-answers`
+      )
+
+    expect(draftsService.updateDraft).toHaveBeenCalledWith(
+      draftCancellation.id,
+      {
+        cancellationReason: 'MOV',
+        cancellationComments: 'Alex has moved out of the area',
+      },
+      { userId: '123' }
+    )
+  })
+
+  describe('when no draft exists with that ID', () => {
+    it('displays an error', async () => {
+      draftsService.fetchDraft.mockResolvedValue(null)
+
+      await request(app)
+        .post(`/probation-practitioner/referrals/abc/cancellation/def/reason`)
+        .type('form')
+        .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain(
+            'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.'
+          )
+        })
+    })
+  })
+})
+
+describe('GET /probation-practitioner/referrals/:id/cancellation/:draftCancellationId/check-your-answers', () => {
+  it('renders a page where the PP can confirm whether or not to cancel a referral', async () => {
+    const draftCancellation = draftCancellationFactory.build({
+      data: { cancellationReason: 'MOV', cancellationComments: 'Alex has moved out of the area' },
+    })
+    draftsService.fetchDraft.mockResolvedValue(draftCancellation)
+
     const referral = sentReferralFactory.assigned().build()
     const intervention = interventionFactory.build()
     const serviceUser = deliusServiceUserFactory.build()
@@ -353,16 +510,27 @@ describe('POST /probation-practitioner/referrals/:id/cancellation/check-your-ans
     interventionsService.getIntervention.mockResolvedValue(intervention)
 
     await request(app)
-      .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/check-your-answers`)
-      .type('form')
-      .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
+      .get(`/probation-practitioner/referrals/${referral.id}/cancellation/${draftCancellation.id}/check-your-answers`)
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Referral Cancellation')
         expect(res.text).toContain('Are you sure you want to cancel this referral?')
-        expect(res.text).toContain('MOV')
-        expect(res.text).toContain('Alex has moved out of the area')
       })
+  })
+
+  describe('when no draft exists with that ID', () => {
+    it('displays an error', async () => {
+      draftsService.fetchDraft.mockResolvedValue(null)
+
+      await request(app)
+        .get(`/probation-practitioner/referrals/abc/cancellation/def/check-your-answers`)
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain(
+            'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.'
+          )
+        })
+    })
   })
 })
 
@@ -384,6 +552,50 @@ describe('POST /probation-practitioner/referrals/:id/cancellation/submit', () =>
       'MOV',
       'Alex has moved out of the area'
     )
+  })
+})
+
+describe('POST /probation-practitioner/referrals/:id/cancellation/:draftCancellationId/submit', () => {
+  it('submits a request to cancel the referral on the backend and redirects to the confirmation screen', async () => {
+    const draftCancellation = draftCancellationFactory.build({
+      data: { cancellationReason: 'MOV', cancellationComments: 'Alex has moved out of the area' },
+    })
+    draftsService.fetchDraft.mockResolvedValue(draftCancellation)
+    draftsService.deleteDraft.mockResolvedValue()
+
+    await request(app)
+      .post(
+        `/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/${draftCancellation.id}/submit`
+      )
+      .expect(302)
+      .expect(
+        'Location',
+        `/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/confirmation`
+      )
+
+    expect(interventionsService.endReferral).toHaveBeenCalledWith(
+      'token',
+      '9747b7fb-51bc-40e2-bbbd-791a9be9284b',
+      'MOV',
+      'Alex has moved out of the area'
+    )
+
+    expect(draftsService.deleteDraft).toHaveBeenCalledWith(draftCancellation.id, { userId: '123' })
+  })
+
+  describe('when no draft exists with that ID', () => {
+    it('displays an error', async () => {
+      draftsService.fetchDraft.mockResolvedValue(null)
+
+      await request(app)
+        .post(`/probation-practitioner/referrals/abc/cancellation/def/submit`)
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain(
+            'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.'
+          )
+        })
+    })
   })
 })
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -34,13 +34,16 @@ import SupplierAssessmentDecorator from '../../decorators/supplierAssessmentDeco
 import SupplierAssessmentAppointmentPresenter from '../shared/supplierAssessmentAppointmentPresenter'
 import SupplierAssessmentAppointmentView from '../shared/supplierAssessmentAppointmentView'
 import FileUtils from '../../utils/fileUtils'
+import DraftsService from '../../services/draftsService'
+import DraftCancellationData from './draftCancellationData'
 
 export default class ProbationPractitionerReferralsController {
   constructor(
     private readonly interventionsService: InterventionsService,
     private readonly communityApiService: CommunityApiService,
     private readonly hmppsAuthService: HmppsAuthService,
-    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService
+    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService,
+    private readonly draftsService: DraftsService
   ) {}
 
   async showMyCases(req: Request, res: Response): Promise<void> {
@@ -246,11 +249,122 @@ export default class ProbationPractitionerReferralsController {
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async showReferralCancellationReasonPage(req: Request, res: Response): Promise<void> {
+  async startCancellation(req: Request, res: Response): Promise<void> {
+    const draftCancellation = await this.draftsService.createDraft<DraftCancellationData>(
+      'cancellation',
+      {
+        cancellationReason: null,
+        cancellationComments: null,
+      },
+      { userId: res.locals.user.userId }
+    )
+    res.redirect(`/probation-practitioner/referrals/${req.params.id}/cancellation/${draftCancellation.id}/reason`)
+  }
+
+  async backwardsCompatibilityUpdateCancellationReason(req: Request, res: Response): Promise<void> {
     const { user } = res.locals
     const { accessToken } = user.token
+    const referralId = req.params.id
 
-    const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
+    const data = await new ReferralCancellationReasonForm(req).data()
+
+    let formError: FormValidationError | null = null
+
+    if (req.method === 'POST') {
+      if (!data.error) {
+        const draftCancellation = await this.draftsService.createDraft<DraftCancellationData>(
+          'cancellation',
+          data.paramsForUpdate,
+          { userId: res.locals.user.userId }
+        )
+
+        return res.redirect(
+          `/probation-practitioner/referrals/${referralId}/cancellation/${draftCancellation.id}/check-your-answers`
+        )
+      }
+
+      res.status(400)
+      formError = data.error
+    }
+
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, referralId)
+    const intervention = await this.interventionsService.getIntervention(
+      accessToken,
+      sentReferral.referral.interventionId
+    )
+    const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
+    const cancellationReasons = await this.interventionsService.getReferralCancellationReasons(accessToken)
+
+    // We don’t use this draft, other than to pass it to the presenter for rendering
+    // (remember this controller action is only temporary)
+    const draftCancellation = await this.draftsService.createDraft<DraftCancellationData>(
+      'cancellation',
+      {
+        cancellationReason: null,
+        cancellationComments: null,
+      },
+      { userId: res.locals.user.userId }
+    )
+
+    const presenter = new ReferralCancellationReasonPresenter(
+      draftCancellation,
+      sentReferral,
+      intervention,
+      serviceUser,
+      cancellationReasons,
+      formError
+    )
+
+    await this.draftsService.deleteDraft(draftCancellation.id, { userId: res.locals.user.userId })
+
+    const view = new ReferralCancellationReasonView(presenter)
+
+    return ControllerUtils.renderWithLayout(res, view, serviceUser)
+  }
+
+  private async fetchDraftCancellationOrThrowSpecificError(req: Request, res: Response) {
+    const id = req.params.draftCancellationId
+    const draftCancellation = await this.draftsService.fetchDraft<DraftCancellationData>(id, {
+      userId: res.locals.user.userId,
+    })
+
+    if (draftCancellation === null) {
+      throw createError(500, `Draft cancellation with ID ${id} not found by drafts service`, {
+        userMessage:
+          'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.',
+      })
+    }
+
+    return draftCancellation
+  }
+
+  async editCancellationReason(req: Request, res: Response): Promise<void> {
+    const { user } = res.locals
+    const { accessToken } = user.token
+    const referralId = req.params.id
+
+    const draftCancellation = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+
+    const data = await new ReferralCancellationReasonForm(req).data()
+
+    let formError: FormValidationError | null = null
+
+    if (req.method === 'POST') {
+      if (!data.error) {
+        await this.draftsService.updateDraft<DraftCancellationData>(draftCancellation.id, data.paramsForUpdate, {
+          userId: res.locals.user.userId,
+        })
+
+        return res.redirect(
+          `/probation-practitioner/referrals/${referralId}/cancellation/${draftCancellation.id}/check-your-answers`
+        )
+      }
+
+      res.status(400)
+      formError = data.error
+    }
+
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, referralId)
     const intervention = await this.interventionsService.getIntervention(
       accessToken,
       sentReferral.referral.interventionId
@@ -259,68 +373,66 @@ export default class ProbationPractitionerReferralsController {
     const cancellationReasons = await this.interventionsService.getReferralCancellationReasons(accessToken)
 
     const presenter = new ReferralCancellationReasonPresenter(
+      draftCancellation,
       sentReferral,
       intervention,
       serviceUser,
-      cancellationReasons
+      cancellationReasons,
+      formError
     )
     const view = new ReferralCancellationReasonView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async submitFormAndShowCancellationCheckAnswersPage(req: Request, res: Response): Promise<void> {
+  async cancellationCheckAnswers(req: Request, res: Response): Promise<void> {
     const { user } = res.locals
     const { accessToken } = user.token
-    let formError: FormValidationError | null = null
+
+    const draftCancellation = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
 
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
     const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
 
-    const data = await new ReferralCancellationReasonForm(req).data()
-
-    if (data.error) {
-      res.status(400)
-      formError = data.error
-
-      const intervention = await this.interventionsService.getIntervention(
-        accessToken,
-        sentReferral.referral.interventionId
-      )
-      const cancellationReasons = await this.interventionsService.getReferralCancellationReasons(accessToken)
-
-      const presenter = new ReferralCancellationReasonPresenter(
-        sentReferral,
-        intervention,
-        serviceUser,
-        cancellationReasons,
-        formError
-      )
-      const view = new ReferralCancellationReasonView(presenter)
-
-      return ControllerUtils.renderWithLayout(res, view, serviceUser)
-    }
-
-    const { cancellationReason, cancellationComments } = data.paramsForUpdate
-
-    const presenter = new ReferralCancellationCheckAnswersPresenter(
-      req.params.id,
-      cancellationReason,
-      cancellationComments
-    )
-
+    const presenter = new ReferralCancellationCheckAnswersPresenter(req.params.id, draftCancellation.id)
     const view = new ReferralCancellationCheckAnswersView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async cancelReferral(req: Request, res: Response): Promise<void> {
+  async backwardsCompatibilitySubmitCancellation(req: Request, res: Response): Promise<void> {
+    const cancellationReason = req.body['cancellation-reason']
+    const cancellationComments = req.body['cancellation-comments']
+
+    await this.submitCancellationWithValues(cancellationReason, cancellationComments, req, res)
+  }
+
+  async submitCancellation(req: Request, res: Response): Promise<void> {
+    const draftCancellation = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+
+    const { cancellationReason, cancellationComments } = draftCancellation.data
+
+    await this.submitCancellationWithValues(cancellationReason, cancellationComments, req, res)
+
+    await this.draftsService.deleteDraft(draftCancellation.id, { userId: res.locals.user.userId })
+  }
+
+  async submitCancellationWithValues(
+    cancellationReason: string | null,
+    cancellationComments: string | null,
+    req: Request,
+    res: Response
+  ): Promise<void> {
+    if (cancellationReason === null) {
+      throw new Error('Got unexpectedly null cancellationReason')
+    }
+    if (cancellationComments === null) {
+      throw new Error('Got unexpectedly null cancellationComments')
+    }
+
     const { user } = res.locals
     const { accessToken } = user.token
     const referralId = req.params.id
-
-    const cancellationReason = req.body['cancellation-reason']
-    const cancellationComments = req.body['cancellation-comments']
 
     await this.interventionsService.endReferral(accessToken, referralId, cancellationReason, cancellationComments)
 

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.test.ts
@@ -3,7 +3,7 @@ import ReferralCancellationCheckAnswersPresenter from './referralCancellationChe
 describe(ReferralCancellationCheckAnswersPresenter, () => {
   describe('text', () => {
     it('contains a title and confirmation question', () => {
-      const presenter = new ReferralCancellationCheckAnswersPresenter('89047822-1014-4f8f-a52c-c348137c89a5')
+      const presenter = new ReferralCancellationCheckAnswersPresenter('', '')
 
       expect(presenter.text).toMatchObject({
         title: 'Referral Cancellation',
@@ -14,25 +14,13 @@ describe(ReferralCancellationCheckAnswersPresenter, () => {
 
   describe('confirmCancellationHref', () => {
     it('contains a reference to the referral cancellation endpoint', () => {
-      const presenter = new ReferralCancellationCheckAnswersPresenter('89047822-1014-4f8f-a52c-c348137c89a5')
-      expect(presenter.confirmCancellationHref).toEqual(
-        '/probation-practitioner/referrals/89047822-1014-4f8f-a52c-c348137c89a5/cancellation/submit'
-      )
-    })
-  })
-
-  describe('hiddenFields', () => {
-    it('contains the cancellation code and comments', () => {
       const presenter = new ReferralCancellationCheckAnswersPresenter(
         '89047822-1014-4f8f-a52c-c348137c89a5',
-        'MOV',
-        'Alex moved out of the area'
+        'e3eac95b-787b-4ab9-93fd-39df32aabc41'
       )
-
-      expect(presenter.hiddenFields).toMatchObject({
-        cancellationReason: 'MOV',
-        cancellationComments: 'Alex moved out of the area',
-      })
+      expect(presenter.confirmCancellationHref).toEqual(
+        '/probation-practitioner/referrals/89047822-1014-4f8f-a52c-c348137c89a5/cancellation/e3eac95b-787b-4ab9-93fd-39df32aabc41/submit'
+      )
     })
   })
 })

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersPresenter.ts
@@ -1,19 +1,10 @@
 export default class ReferralCancellationCheckAnswersPresenter {
-  constructor(
-    private readonly referralId: string,
-    private readonly cancellationReason?: string,
-    private readonly cancellationComments?: string
-  ) {}
+  constructor(private readonly referralId: string, private readonly draftCancellationId: string) {}
 
   readonly text = {
     title: 'Referral Cancellation',
     confirmationQuestion: 'Are you sure you want to cancel this referral?',
   }
 
-  readonly confirmCancellationHref = `/probation-practitioner/referrals/${this.referralId}/cancellation/submit`
-
-  readonly hiddenFields = {
-    cancellationReason: this.cancellationReason,
-    cancellationComments: this.cancellationComments,
-  }
+  readonly confirmCancellationHref = `/probation-practitioner/referrals/${this.referralId}/cancellation/${this.draftCancellationId}/submit`
 }

--- a/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationCheckAnswersView.ts
@@ -8,7 +8,6 @@ export default class ReferralCancellationCheckAnswersView {
       'probationPractitionerReferrals/referralCancellationCheckAnswers',
       {
         presenter: this.presenter,
-        hiddenFields: this.presenter.hiddenFields,
       },
     ]
   }

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonForm.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonForm.ts
@@ -8,7 +8,7 @@ import { FormValidationError } from '../../utils/formValidationError'
 export default class ReferralCancellationReasonForm {
   constructor(private readonly request: Request) {}
 
-  async data(): Promise<FormData<Partial<{ cancellationReason: string; cancellationComments: string }>>> {
+  async data(): Promise<FormData<{ cancellationReason: string; cancellationComments: string }>> {
     const validationResult = await FormUtils.runValidations({
       request: this.request,
       validations: ReferralCancellationReasonForm.validations,

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
@@ -75,6 +75,44 @@ describe(ReferralCancellationReasonPresenter, () => {
     })
   })
 
+  describe('fields', () => {
+    describe('cancellationComments', () => {
+      const sentReferral = sentReferralFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+      const intervention = interventionFactory.build()
+
+      describe('when the draft cancellation has null cancellationComments', () => {
+        it('returns an empty string', () => {
+          const presenter = new ReferralCancellationReasonPresenter(
+            draftFactory.build({ data: draftCancellationDataFactory.build({ cancellationComments: null }) }),
+            sentReferral,
+            intervention,
+            serviceUser,
+            []
+          )
+
+          expect(presenter.fields.cancellationComments).toEqual('')
+        })
+      })
+
+      describe('when the draft cancellation has a non-null cancellationComments', () => {
+        it('returns that value', () => {
+          const presenter = new ReferralCancellationReasonPresenter(
+            draftFactory.build({
+              data: draftCancellationDataFactory.build({ cancellationComments: 'David has been recalled' }),
+            }),
+            sentReferral,
+            intervention,
+            serviceUser,
+            []
+          )
+
+          expect(presenter.fields.cancellationComments).toEqual('David has been recalled')
+        })
+      })
+    })
+  })
+
   describe('errorSummary', () => {
     const sentReferral = sentReferralFactory.build()
     const serviceUser = deliusServiceUserFactory.build()

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
@@ -4,6 +4,10 @@ import interventionFactory from '../../../testutils/factories/intervention'
 import serviceProviderFactory from '../../../testutils/factories/serviceProvider'
 import CancellationReason from '../../models/cancellationReason'
 import ReferralCancellationReasonPresenter from './referralCancellationReasonPresenter'
+import { createDraftFactory } from '../../../testutils/factories/draft'
+import draftCancellationDataFactory from '../../../testutils/factories/draftCancellationData'
+
+const draftFactory = createDraftFactory(draftCancellationDataFactory.build())
 
 describe(ReferralCancellationReasonPresenter, () => {
   describe('text', () => {
@@ -15,6 +19,7 @@ describe(ReferralCancellationReasonPresenter, () => {
       const cancellationReasons: CancellationReason[] = []
 
       const presenter = new ReferralCancellationReasonPresenter(
+        draftFactory.build({ data: draftCancellationDataFactory.build() }),
         sentReferral,
         intervention,
         serviceUser,
@@ -39,6 +44,7 @@ describe(ReferralCancellationReasonPresenter, () => {
       ]
 
       const presenter = new ReferralCancellationReasonPresenter(
+        draftFactory.build({ data: draftCancellationDataFactory.build() }),
         sentReferral,
         intervention,
         serviceUser,
@@ -61,6 +67,7 @@ describe(ReferralCancellationReasonPresenter, () => {
     describe('when there is an error', () => {
       it('returns a summary of the error', () => {
         const presenter = new ReferralCancellationReasonPresenter(
+          draftFactory.build({ data: draftCancellationDataFactory.build() }),
           sentReferral,
           intervention,
           serviceUser,
@@ -85,6 +92,7 @@ describe(ReferralCancellationReasonPresenter, () => {
     describe('when there is no error', () => {
       it('returns null', () => {
         const presenter = new ReferralCancellationReasonPresenter(
+          draftFactory.build({ data: draftCancellationDataFactory.build() }),
           sentReferral,
           intervention,
           serviceUser,
@@ -105,6 +113,7 @@ describe(ReferralCancellationReasonPresenter, () => {
     describe('when there is an error', () => {
       it('returns the error message', () => {
         const presenter = new ReferralCancellationReasonPresenter(
+          draftFactory.build({ data: draftCancellationDataFactory.build() }),
           sentReferral,
           intervention,
           serviceUser,
@@ -127,6 +136,7 @@ describe(ReferralCancellationReasonPresenter, () => {
     describe('when there is no error', () => {
       it('returns null', () => {
         const presenter = new ReferralCancellationReasonPresenter(
+          draftFactory.build({ data: draftCancellationDataFactory.build() }),
           sentReferral,
           intervention,
           serviceUser,

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.test.ts
@@ -34,17 +34,17 @@ describe(ReferralCancellationReasonPresenter, () => {
   })
 
   describe('referralCancellationFields', () => {
-    it('returns an array of fields to be passed as radio button args', () => {
-      const sentReferral = sentReferralFactory.build()
-      const serviceUser = deliusServiceUserFactory.build()
-      const intervention = interventionFactory.build()
-      const cancellationReasons: CancellationReason[] = [
-        { code: 'MIS', description: 'Referral was made by mistake' },
-        { code: 'MOV', description: 'Service user has moved out of delivery area' },
-      ]
+    const sentReferral = sentReferralFactory.build()
+    const serviceUser = deliusServiceUserFactory.build()
+    const intervention = interventionFactory.build()
+    const cancellationReasons: CancellationReason[] = [
+      { code: 'MIS', description: 'Referral was made by mistake' },
+      { code: 'MOV', description: 'Service user has moved out of delivery area' },
+    ]
 
+    it('returns an array of fields to be passed as radio button args', () => {
       const presenter = new ReferralCancellationReasonPresenter(
-        draftFactory.build({ data: draftCancellationDataFactory.build() }),
+        draftFactory.build({ data: draftCancellationDataFactory.build({ cancellationReason: null }) }),
         sentReferral,
         intervention,
         serviceUser,
@@ -55,6 +55,23 @@ describe(ReferralCancellationReasonPresenter, () => {
         { value: 'MIS', text: 'Referral was made by mistake', checked: false },
         { value: 'MOV', text: 'Service user has moved out of delivery area', checked: false },
       ])
+    })
+
+    describe('when the draft cancellation has a non-null cancellationReason', () => {
+      it('sets checked to true for that reason', () => {
+        const presenter = new ReferralCancellationReasonPresenter(
+          draftFactory.build({ data: draftCancellationDataFactory.build({ cancellationReason: 'MOV' }) }),
+          sentReferral,
+          intervention,
+          serviceUser,
+          cancellationReasons
+        )
+
+        expect(presenter.cancellationReasonsFields).toEqual([
+          { value: 'MIS', text: 'Referral was made by mistake', checked: false },
+          { value: 'MOV', text: 'Service user has moved out of delivery area', checked: true },
+        ])
+      })
     })
   })
 

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
@@ -10,8 +10,6 @@ import { Draft } from '../../services/draftsService'
 
 export default class ReferralCancellationReasonPresenter {
   constructor(
-    // This property is unused right now, but we’ll shortly make use of it
-    // to replay entered data
     private readonly draftCancellation: Draft<DraftCancellationData>,
     private readonly sentReferral: SentReferral,
     private readonly intervention: Intervention,
@@ -32,7 +30,7 @@ export default class ReferralCancellationReasonPresenter {
     return this.cancellationReasons.map(cancellationReason => ({
       value: cancellationReason.code,
       text: cancellationReason.description,
-      checked: false,
+      checked: this.draftCancellation.data.cancellationReason === cancellationReason.code,
     }))
   }
 

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
@@ -34,6 +34,15 @@ export default class ReferralCancellationReasonPresenter {
     }))
   }
 
+  private readonly utils = new PresenterUtils(null)
+
+  readonly fields = {
+    cancellationComments: this.utils.stringValue(
+      this.draftCancellation.data.cancellationComments,
+      'cancellation-comments'
+    ),
+  }
+
   readonly errorMessage = PresenterUtils.errorMessage(this.error, 'cancellation-reason')
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonPresenter.ts
@@ -5,9 +5,14 @@ import SentReferral from '../../models/sentReferral'
 import { FormValidationError } from '../../utils/formValidationError'
 import PresenterUtils from '../../utils/presenterUtils'
 import Intervention from '../../models/intervention'
+import DraftCancellationData from './draftCancellationData'
+import { Draft } from '../../services/draftsService'
 
 export default class ReferralCancellationReasonPresenter {
   constructor(
+    // This property is unused right now, but we’ll shortly make use of it
+    // to replay entered data
+    private readonly draftCancellation: Draft<DraftCancellationData>,
     private readonly sentReferral: SentReferral,
     private readonly intervention: Intervention,
     private readonly serviceUser: DeliusServiceUser,
@@ -34,6 +39,4 @@ export default class ReferralCancellationReasonPresenter {
   readonly errorMessage = PresenterUtils.errorMessage(this.error, 'cancellation-reason')
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
-
-  readonly checkAnswersHref = `/probation-practitioner/referrals/${this.sentReferral.id}/cancellation/check-your-answers`
 }

--- a/server/routes/probationPractitionerReferrals/referralCancellationReasonView.ts
+++ b/server/routes/probationPractitionerReferrals/referralCancellationReasonView.ts
@@ -29,6 +29,7 @@ export default class ReferralCancellationReasonView {
       label: {
         text: this.presenter.text.additionalCommentsLabel,
       },
+      value: this.presenter.fields.cancellationComments,
     }
   }
 

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -9,7 +9,8 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     services.interventionsService,
     services.communityApiService,
     services.hmppsAuthService,
-    services.assessRisksAndNeedsService
+    services.assessRisksAndNeedsService,
+    services.draftsService
   )
 
   get(router, '/dashboard', (req, res) => probationPractitionerReferralsController.showMyCases(req, res))
@@ -27,13 +28,31 @@ export default function probationPractitionerRoutes(router: Router, services: Se
   )
 
   get(router, '/referrals/:id/cancellation/reason', (req, res) =>
-    probationPractitionerReferralsController.showReferralCancellationReasonPage(req, res)
+    // This keeps the cancel link on any pre-drafts version of the intervention progress page working
+    probationPractitionerReferralsController.startCancellation(req, res)
+  )
+  get(router, '/referrals/:id/cancellation/start', (req, res) =>
+    probationPractitionerReferralsController.startCancellation(req, res)
+  )
+  get(router, '/referrals/:id/cancellation/:draftCancellationId/reason', (req, res) =>
+    probationPractitionerReferralsController.editCancellationReason(req, res)
   )
   post(router, '/referrals/:id/cancellation/check-your-answers', (req, res) =>
-    probationPractitionerReferralsController.submitFormAndShowCancellationCheckAnswersPage(req, res)
+    // This keeps a submission of any pre-drafts version of the cancellation reason form working
+    probationPractitionerReferralsController.backwardsCompatibilityUpdateCancellationReason(req, res)
+  )
+  post(router, '/referrals/:id/cancellation/:draftCancellationId/reason', (req, res) =>
+    probationPractitionerReferralsController.editCancellationReason(req, res)
+  )
+  get(router, '/referrals/:id/cancellation/:draftCancellationId/check-your-answers', (req, res) =>
+    probationPractitionerReferralsController.cancellationCheckAnswers(req, res)
   )
   post(router, '/referrals/:id/cancellation/submit', (req, res) =>
-    probationPractitionerReferralsController.cancelReferral(req, res)
+    // This keeps a submission of any pre-drafts version of the cancellation check your answers page working
+    probationPractitionerReferralsController.backwardsCompatibilitySubmitCancellation(req, res)
+  )
+  post(router, '/referrals/:id/cancellation/:draftCancellationId/submit', (req, res) =>
+    probationPractitionerReferralsController.submitCancellation(req, res)
   )
   get(router, '/referrals/:id/cancellation/confirmation', (req, res) =>
     probationPractitionerReferralsController.showCancellationConfirmationPage(req, res)

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.test.ts
@@ -7,7 +7,7 @@ describe(CheckAssignmentPresenter, () => {
     it('returns text to be displayed', () => {
       const user = hmppsAuthUserFactory.build()
       const intervention = interventionFactory.build({ contractType: { name: 'Social inclusion' } })
-      const presenter = new CheckAssignmentPresenter('', user, '', intervention)
+      const presenter = new CheckAssignmentPresenter('', '', user, '', intervention)
 
       expect(presenter.text).toEqual({ title: 'Confirm the Social inclusion referral assignment' })
     })
@@ -18,7 +18,7 @@ describe(CheckAssignmentPresenter, () => {
       it('returns a summary of the selected caseworker with both names', () => {
         const user = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
         const intervention = interventionFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', intervention)
+        const presenter = new CheckAssignmentPresenter('', '', user, 'john@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: ['John Smith'] },
@@ -31,7 +31,7 @@ describe(CheckAssignmentPresenter, () => {
       it('returns a summary of the selected caseworker with just the first name', () => {
         const user = hmppsAuthUserFactory.build({ firstName: 'John', lastName: '' })
         const intervention = interventionFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', intervention)
+        const presenter = new CheckAssignmentPresenter('', '', user, 'john@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: ['John '] },
@@ -44,7 +44,7 @@ describe(CheckAssignmentPresenter, () => {
       it('returns a summary of the selected caseworker with just the last name', () => {
         const user = hmppsAuthUserFactory.build({ firstName: '', lastName: 'smith' })
         const intervention = interventionFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'smith@harmonyliving.org.uk', intervention)
+        const presenter = new CheckAssignmentPresenter('', '', user, 'smith@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: [' Smith'] },
@@ -57,7 +57,7 @@ describe(CheckAssignmentPresenter, () => {
       it('returns a summary with an empty string for the caseworker name', () => {
         const user = hmppsAuthUserFactory.build({ firstName: '', lastName: '' })
         const intervention = interventionFactory.build()
-        const presenter = new CheckAssignmentPresenter('', user, 'unknown@harmonyliving.org.uk', intervention)
+        const presenter = new CheckAssignmentPresenter('', '', user, 'unknown@harmonyliving.org.uk', intervention)
 
         expect(presenter.summary).toEqual([
           { key: 'Name', lines: [''] },
@@ -67,21 +67,12 @@ describe(CheckAssignmentPresenter, () => {
     })
   })
 
-  describe('hiddenFields', () => {
-    it('returns a hidden field for the email address', () => {
-      const user = hmppsAuthUserFactory.build()
-      const intervention = interventionFactory.build()
-      const presenter = new CheckAssignmentPresenter('', user, 'john@harmonyliving.org.uk', intervention)
-      expect(presenter.hiddenFields).toEqual({ email: 'john@harmonyliving.org.uk' })
-    })
-  })
-
   describe('formAction', () => {
     it('returns a URL for submitting the assignment', () => {
       const user = hmppsAuthUserFactory.build()
       const intervention = interventionFactory.build()
-      const presenter = new CheckAssignmentPresenter('1', user, '', intervention)
-      expect(presenter.formAction).toEqual('/service-provider/referrals/1/assignment')
+      const presenter = new CheckAssignmentPresenter('1', '2', user, '', intervention)
+      expect(presenter.formAction).toEqual('/service-provider/referrals/1/assignment/2/submit')
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/checkAssignmentPresenter.ts
@@ -7,6 +7,7 @@ import utils from '../../utils/utils'
 export default class CheckAssignmentPresenter {
   constructor(
     private readonly referralId: string,
+    private readonly draftAssignmentId: string,
     private readonly assignee: AuthUserDetails,
     private readonly email: string,
     private readonly intervention: Intervention
@@ -21,9 +22,5 @@ export default class CheckAssignmentPresenter {
     { key: 'Email address', lines: [this.email] },
   ]
 
-  readonly hiddenFields = {
-    email: this.email,
-  }
-
-  readonly formAction = `/service-provider/referrals/${this.referralId}/assignment`
+  readonly formAction = `/service-provider/referrals/${this.referralId}/assignment/${this.draftAssignmentId}/submit`
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -34,11 +34,17 @@ import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
 import { DeliusOffenderManager } from '../../models/delius/deliusOffenderManager'
 import deliusOffenderManagerFactory from '../../../testutils/factories/deliusOffenderManager'
 import ServiceProviderSentReferralSummary from '../../models/serviceProviderSentReferralSummary'
+import { createDraftFactory } from '../../../testutils/factories/draft'
+import { DraftAssignmentData } from './serviceProviderReferralsController'
+import DraftsService from '../../services/draftsService'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
 jest.mock('../../services/hmppsAuthService')
 jest.mock('../../services/assessRisksAndNeedsService')
+jest.mock('../../services/draftsService')
+
+const draftAssignmentFactory = createDraftFactory<DraftAssignmentData>({ email: null })
 
 const interventionsService = new InterventionsService(
   apiConfig.apis.interventionsService
@@ -50,11 +56,24 @@ const hmppsAuthService = new MockedHmppsAuthService() as jest.Mocked<HmppsAuthSe
 
 const assessRisksAndNeedsService = new MockAssessRisksAndNeedsService() as jest.Mocked<AssessRisksAndNeedsService>
 
+const draftsService = {
+  createDraft: jest.fn(),
+  fetchDraft: jest.fn(),
+  updateDraft: jest.fn(),
+  deleteDraft: jest.fn(),
+} as unknown as jest.Mocked<DraftsService>
+
 let app: Express
 
 beforeEach(() => {
   app = appWithAllRoutes({
-    overrides: { interventionsService, communityApiService, hmppsAuthService, assessRisksAndNeedsService },
+    overrides: {
+      interventionsService,
+      communityApiService,
+      hmppsAuthService,
+      assessRisksAndNeedsService,
+      draftsService,
+    },
     userType: AppSetupUserType.serviceProvider,
   })
 })
@@ -240,24 +259,21 @@ describe('GET /service-provider/referrals/:id/progress', () => {
 })
 
 describe('GET /service-provider/referrals/:id/assignment/check', () => {
-  it('displays the name of the selected caseworker', async () => {
-    const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
-    const referral = sentReferralFactory.build({ referral: { interventionId: intervention.id } })
-    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
-
-    interventionsService.getIntervention.mockResolvedValue(intervention)
-    interventionsService.getSentReferral.mockResolvedValue(referral)
-    hmppsAuthService.getSPUserByEmailAddress.mockResolvedValue(hmppsAuthUser)
+  it('creates a draft assignment using the drafts service and redirects to the check answers page', async () => {
+    const draftAssignment = draftAssignmentFactory.build({ data: { email: 'tom@tom.com' } })
+    draftsService.createDraft.mockResolvedValue(draftAssignment)
 
     await request(app)
-      .get(`/service-provider/referrals/${referral.id}/assignment/check`)
+      .get(`/service-provider/referrals/123456/assignment/check`)
       .query({ email: 'john@harmonyliving.org.uk' })
-      .expect(200)
-      .expect(res => {
-        expect(res.text).toContain('Confirm the Accommodation referral assignment')
-        expect(res.text).toContain('John Smith')
-        expect(res.text).toContain('john@harmonyliving.org.uk')
-      })
+      .expect(302)
+      .expect('Location', `/service-provider/referrals/123456/assignment/${draftAssignment.id}/check`)
+
+    expect(draftsService.createDraft).toHaveBeenCalledWith(
+      'assignment',
+      { email: 'john@harmonyliving.org.uk' },
+      { userId: '123' }
+    )
   })
   it('redirects to referral details page with an error if the assignee email address is missing from the URL', async () => {
     await request(app)
@@ -272,6 +288,130 @@ describe('GET /service-provider/referrals/:id/assignment/check', () => {
       .get(`/service-provider/referrals/123456/assignment/check?email=tom@tom.com`)
       .expect(302)
       .expect('Location', '/service-provider/referrals/123456/details?error=Email%20address%20not%20found')
+  })
+})
+
+describe('POST /service-provider/referrals/:id/assignment/start', () => {
+  it('creates a draft assignment using the drafts service and redirects to the check answers page', async () => {
+    const draftAssignment = draftAssignmentFactory.build({ data: { email: 'tom@tom.com' } })
+    draftsService.createDraft.mockResolvedValue(draftAssignment)
+
+    await request(app)
+      .post(`/service-provider/referrals/123456/assignment/start`)
+      .type('form')
+      .send({ email: 'tom@tom.com' })
+      .expect(302)
+      .expect('Location', `/service-provider/referrals/123456/assignment/${draftAssignment.id}/check`)
+
+    expect(draftsService.createDraft).toHaveBeenCalledWith('assignment', { email: 'tom@tom.com' }, { userId: '123' })
+  })
+
+  it('redirects to referral details page with an error if the assignee email address is missing from the request body', async () => {
+    await request(app)
+      .post(`/service-provider/referrals/123456/assignment/start`)
+      .expect(302)
+      .expect('Location', '/service-provider/referrals/123456/details?error=An%20email%20address%20is%20required')
+
+    expect(draftsService.createDraft).not.toHaveBeenCalled()
+  })
+
+  it('redirects to referral details page with an error if the assignee email address is not found in HMPPS Auth', async () => {
+    hmppsAuthService.getSPUserByEmailAddress.mockRejectedValue(new Error(''))
+
+    await request(app)
+      .post(`/service-provider/referrals/123456/assignment/start`)
+      .type('form')
+      .send({ email: 'tom@tom.com' })
+      .expect(302)
+      .expect('Location', '/service-provider/referrals/123456/details?error=Email%20address%20not%20found')
+
+    expect(draftsService.createDraft).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /service-provider/referrals/:id/assignment/:draftAssignmentId/check', () => {
+  it('displays the name of the selected caseworker', async () => {
+    const draftAssignment = draftAssignmentFactory.build({ data: { email: 'john@harmonyliving.org.uk' } })
+    draftsService.fetchDraft.mockResolvedValue(draftAssignment)
+
+    const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
+    const referral = sentReferralFactory.build({ referral: { interventionId: intervention.id } })
+    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith' })
+
+    interventionsService.getIntervention.mockResolvedValue(intervention)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    hmppsAuthService.getSPUserByEmailAddress.mockResolvedValue(hmppsAuthUser)
+
+    await request(app)
+      .get(`/service-provider/referrals/${referral.id}/assignment/${draftAssignment.id}/check`)
+      .query({ email: 'john@harmonyliving.org.uk' })
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Confirm the Accommodation referral assignment')
+        expect(res.text).toContain('John Smith')
+        expect(res.text).toContain('john@harmonyliving.org.uk')
+      })
+  })
+
+  describe('when no draft exists with that ID', () => {
+    it('displays an error', async () => {
+      draftsService.fetchDraft.mockResolvedValue(null)
+
+      await request(app)
+        .get(`/service-provider/referrals/abc/assignment/def/check`)
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain(
+            'Too much time has passed since you started assigning this intervention to a caseworker. The referral has not been assigned, and you will need to start again.'
+          )
+        })
+    })
+  })
+})
+
+describe('POST /service-provider/referrals/:id/:draftAssignmentId/submit', () => {
+  it('assigns the referral to the selected caseworker', async () => {
+    const draftAssignment = draftAssignmentFactory.build({ data: { email: 'john@harmonyliving.org.uk' } })
+    draftsService.fetchDraft.mockResolvedValue(draftAssignment)
+    draftsService.deleteDraft.mockResolvedValue()
+
+    const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
+    const referral = sentReferralFactory.build({
+      referral: { interventionId: intervention.id, serviceUser: { firstName: 'Alex', lastName: 'River' } },
+    })
+    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
+
+    interventionsService.getIntervention.mockResolvedValue(intervention)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    hmppsAuthService.getSPUserByEmailAddress.mockResolvedValue(hmppsAuthUser)
+    interventionsService.assignSentReferral.mockResolvedValue(referral)
+
+    await request(app)
+      .post(`/service-provider/referrals/${referral.id}/assignment/${draftAssignment.id}/submit`)
+      .expect(302)
+      .expect('Location', `/service-provider/referrals/${referral.id}/assignment/confirmation`)
+
+    expect(interventionsService.assignSentReferral.mock.calls[0][2]).toEqual({
+      username: 'john.smith',
+      userId: hmppsAuthUser.userId,
+      authSource: 'auth',
+    })
+    expect(draftsService.deleteDraft).toHaveBeenCalledWith(draftAssignment.id, { userId: '123' })
+  })
+
+  describe('when no draft exists with that ID', () => {
+    it('displays an error', async () => {
+      draftsService.fetchDraft.mockResolvedValue(null)
+
+      await request(app)
+        .post(`/service-provider/referrals/abc/assignment/def/submit`)
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain(
+            'Too much time has passed since you started assigning this intervention to a caseworker. The referral has not been assigned, and you will need to start again.'
+          )
+        })
+    })
   })
 })
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -53,7 +53,6 @@ import EndOfServiceReportCheckAnswersView from '../service-provider/end-of-servi
 import EndOfServiceReportConfirmationPresenter from '../service-provider/end-of-service-report/confirmation/endOfServiceReportConfirmationPresenter'
 import EndOfServiceReportConfirmationView from '../service-provider/end-of-service-report/confirmation/endOfServiceReportConfirmationView'
 import ControllerUtils from '../../utils/controllerUtils'
-import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
 import ServiceCategory from '../../models/serviceCategory'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 import ActionPlanPresenter from '../shared/action-plan/actionPlanPresenter'
@@ -73,13 +72,19 @@ import InitialAssessmentFeedbackConfirmationPresenter from '../appointments/feed
 import InitialAssessmentFeedbackConfirmationView from '../appointments/feedback/initialAssessment/confirmation/initialAssessmentFeedbackConfirmationView'
 import ActionPlanSessionBehaviourFeedbackPresenter from '../appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
 import InitialAssessmentBehaviourFeedbackPresenter from '../appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter'
+import DraftsService from '../../services/draftsService'
+
+export interface DraftAssignmentData {
+  email: string | null
+}
 
 export default class ServiceProviderReferralsController {
   constructor(
     private readonly interventionsService: InterventionsService,
     private readonly communityApiService: CommunityApiService,
     private readonly hmppsAuthService: HmppsAuthService,
-    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService
+    private readonly assessRisksAndNeedsService: AssessRisksAndNeedsService,
+    private readonly draftsService: DraftsService
   ) {}
 
   async showDashboard(req: Request, res: Response): Promise<void> {
@@ -200,9 +205,15 @@ export default class ServiceProviderReferralsController {
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async checkAssignment(req: Request, res: Response): Promise<void> {
-    const email = req.query.email as string
+  async backwardsCompatibilityStartAssignment(req: Request, res: Response): Promise<void> {
+    await this.startAssignmentWithEmail(req.query.email as string | undefined, req, res)
+  }
 
+  async startAssignment(req: Request, res: Response): Promise<void> {
+    await this.startAssignmentWithEmail(req.body.email, req, res)
+  }
+
+  async startAssignmentWithEmail(email: string | undefined, req: Request, res: Response): Promise<void> {
     if (email === undefined || email === '') {
       return res.redirect(
         `/service-provider/referrals/${req.params.id}/details?${querystring.stringify({
@@ -211,11 +222,10 @@ export default class ServiceProviderReferralsController {
       )
     }
 
-    let assignee: AuthUserDetails
     const token = await this.hmppsAuthService.getApiClientToken()
 
     try {
-      assignee = await this.hmppsAuthService.getSPUserByEmailAddress(token, email)
+      await this.hmppsAuthService.getSPUserByEmailAddress(token, email)
     } catch (e) {
       return res.redirect(
         `/service-provider/referrals/${req.params.id}/details?${querystring.stringify({
@@ -224,25 +234,78 @@ export default class ServiceProviderReferralsController {
       )
     }
 
+    const draftAssignment = await this.draftsService.createDraft<DraftAssignmentData>(
+      'assignment',
+      { email },
+      { userId: res.locals.user.userId }
+    )
+
+    return res.redirect(`/service-provider/referrals/${req.params.id}/assignment/${draftAssignment.id}/check`)
+  }
+
+  private async fetchDraftAssignmentOrThrowSpecificError(req: Request, res: Response) {
+    const id = req.params.draftAssignmentId
+    const draftAssignment = await this.draftsService.fetchDraft<DraftAssignmentData>(id, {
+      userId: res.locals.user.userId,
+    })
+
+    if (draftAssignment === null) {
+      throw createError(500, `Draft assignment with ID ${id} not found by drafts service`, {
+        userMessage:
+          'Too much time has passed since you started assigning this intervention to a caseworker. The referral has not been assigned, and you will need to start again.',
+      })
+    }
+
+    return draftAssignment
+  }
+
+  async checkAssignment(req: Request, res: Response): Promise<void> {
+    const draftAssignment = await this.fetchDraftAssignmentOrThrowSpecificError(req, res)
+
+    const { email } = draftAssignment.data
+
+    if (email === null) {
+      throw new Error('Got unexpectedly null email')
+    }
+
+    const token = await this.hmppsAuthService.getApiClientToken()
+    const assignee = await this.hmppsAuthService.getSPUserByEmailAddress(token, email)
     const referral = await this.interventionsService.getSentReferral(res.locals.user.token.accessToken, req.params.id)
     const [intervention, serviceUser] = await Promise.all([
       this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn),
     ])
 
-    const presenter = new CheckAssignmentPresenter(referral.id, assignee, email, intervention)
+    const presenter = new CheckAssignmentPresenter(referral.id, draftAssignment.id, assignee, email, intervention)
     const view = new CheckAssignmentView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async assignReferral(req: Request, res: Response): Promise<void> {
+  async backwardsCompatibilitySubmitAssignment(req: Request, res: Response): Promise<void> {
     const { email } = req.body
     if (email === undefined || email === null || email === '') {
       res.sendStatus(400)
       return
     }
 
+    await this.submitAssignmentWithEmail(email, req, res)
+  }
+
+  async submitAssignment(req: Request, res: Response): Promise<void> {
+    const draftAssignment = await this.fetchDraftAssignmentOrThrowSpecificError(req, res)
+
+    const { email } = draftAssignment.data
+    if (email === null) {
+      throw new Error('Got unexpectedly null email')
+    }
+
+    await this.submitAssignmentWithEmail(email, req, res)
+
+    await this.draftsService.deleteDraft(draftAssignment.id, { userId: res.locals.user.userId })
+  }
+
+  async submitAssignmentWithEmail(email: string, req: Request, res: Response): Promise<void> {
     const assignee = await this.hmppsAuthService.getSPUserByEmailAddress(res.locals.user.token.accessToken, email)
 
     await this.interventionsService.assignSentReferral(res.locals.user.token.accessToken, req.params.id, {

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -9,7 +9,8 @@ export default function serviceProviderRoutes(router: Router, services: Services
     services.interventionsService,
     services.communityApiService,
     services.hmppsAuthService,
-    services.assessRisksAndNeedsService
+    services.assessRisksAndNeedsService,
+    services.draftsService
   )
 
   get(router, '/dashboard', (req, res) => serviceProviderReferralsController.showDashboard(req, res))
@@ -18,9 +19,22 @@ export default function serviceProviderRoutes(router: Router, services: Services
     serviceProviderReferralsController.showInterventionProgress(req, res)
   )
   get(router, '/referrals/:id/assignment/check', (req, res) =>
+    // This keeps the assign button on any pre-drafts version of the referral details page working
+    serviceProviderReferralsController.backwardsCompatibilityStartAssignment(req, res)
+  )
+  post(router, '/referrals/:id/assignment/start', (req, res) =>
+    serviceProviderReferralsController.startAssignment(req, res)
+  )
+  get(router, '/referrals/:id/assignment/:draftAssignmentId/check', (req, res) =>
     serviceProviderReferralsController.checkAssignment(req, res)
   )
-  post(router, '/referrals/:id/assignment', (req, res) => serviceProviderReferralsController.assignReferral(req, res))
+  post(router, '/referrals/:id/assignment', (req, res) =>
+    // This keeps a submission of the any pre-drafts version of the assignment check your answers page working
+    serviceProviderReferralsController.backwardsCompatibilitySubmitAssignment(req, res)
+  )
+  post(router, '/referrals/:id/assignment/:draftAssignmentId/submit', (req, res) =>
+    serviceProviderReferralsController.submitAssignment(req, res)
+  )
   get(router, '/referrals/:id/assignment/confirmation', (req, res) =>
     serviceProviderReferralsController.confirmAssignment(req, res)
   )

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -51,7 +51,7 @@ describe(ShowReferralPresenter, () => {
   const responsibleOfficer = [deliusOffenderManagerFactory.build()]
 
   describe('assignmentFormAction', () => {
-    it('returns the relative URL for the check assignment page', () => {
+    it('returns the relative URL for the start assignment page', () => {
       const referral = sentReferralFactory.build(referralParams)
 
       const presenter = new ShowReferralPresenter(
@@ -70,7 +70,7 @@ describe(ShowReferralPresenter, () => {
         responsibleOfficer
       )
 
-      expect(presenter.assignmentFormAction).toEqual(`/service-provider/referrals/${referral.id}/assignment/check`)
+      expect(presenter.assignmentFormAction).toEqual(`/service-provider/referrals/${referral.id}/assignment/start`)
     })
   })
 

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -52,7 +52,7 @@ export default class ShowReferralPresenter {
     this.riskPresenter = new RiskPresenter(riskSummary)
   }
 
-  readonly assignmentFormAction = `/service-provider/referrals/${this.sentReferral.id}/assignment/check`
+  readonly assignmentFormAction = `/service-provider/referrals/${this.sentReferral.id}/assignment/start`
 
   readonly text = {
     assignedTo: this.assigneeFullNameOrUnassigned,

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -15,6 +15,7 @@ import LoggedInUserFactory from '../../../testutils/factories/loggedInUser'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 import config from '../../config'
 import probationPractitionerRoutes, { probationPractitionerUrlPrefix } from '../probationPractitionerRoutes'
+import DraftsService from '../../services/draftsService'
 
 export enum AppSetupUserType {
   probationPractitioner = 'delius',
@@ -78,6 +79,7 @@ export default function appWithAllRoutes({
     interventionsService: {} as InterventionsService,
     hmppsAuthService: new MockedHmppsAuthService(),
     assessRisksAndNeedsService: {} as AssessRisksAndNeedsService,
+    draftsService: {} as DraftsService,
     ...overrides,
   }
 

--- a/server/services/draftsService.test.ts
+++ b/server/services/draftsService.test.ts
@@ -1,0 +1,353 @@
+import { Callback, RedisClient } from 'redis'
+import { mocked } from 'ts-jest/utils'
+import uuid from 'uuid'
+import DraftsService from './draftsService'
+
+jest.mock('uuid')
+const mockedUuid = mocked(uuid)
+
+interface ChosenRedisOverloads {
+  get: (key: string, cb?: Callback<string | null>) => boolean
+  set: (key: string, value: string, mode: string, duration: number, cb?: Callback<'OK' | undefined>) => boolean
+  del: (key: string, cb?: Callback<number>) => boolean
+}
+
+const redis = {
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+} as unknown as jest.Mocked<ChosenRedisOverloads> & RedisClient
+
+const expiry = { seconds: 24 * 60 * 60 }
+
+describe(DraftsService, () => {
+  const clock = { now: () => new Date('2021-04-01T10:25:00Z') }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('.createDraft', () => {
+    it('generates a random UUID and stores the data in Redis under a key derived from that UUID, with the given expiry time', async () => {
+      mockedUuid.v4.mockReturnValue('2dc7ef56-58dd-4339-9924-c33318738068')
+
+      redis.set.mockImplementation((_key, _value, _mode, _duration, cb) => {
+        cb!(null, 'OK')
+        return true
+      })
+
+      const draftsService = new DraftsService(redis, expiry, clock)
+
+      const draft = await draftsService.createDraft('someExampleType', { a: 1, b: 2 }, { userId: 'someUserId' })
+
+      expect(draft).toEqual({
+        id: '2dc7ef56-58dd-4339-9924-c33318738068',
+        type: 'someExampleType',
+        createdAt: new Date('2021-04-01T10:25:00Z'),
+        createdBy: { id: 'someUserId' },
+        updatedAt: new Date('2021-04-01T10:25:00Z'),
+        data: { a: 1, b: 2 },
+      })
+
+      expect(redis.set).toHaveBeenCalledWith(
+        'draft:2dc7ef56-58dd-4339-9924-c33318738068',
+        expect.anything(),
+        'EX',
+        expiry.seconds,
+        expect.anything()
+      )
+
+      expect(JSON.parse(redis.set.mock.calls[0][1])).toEqual({
+        id: '2dc7ef56-58dd-4339-9924-c33318738068',
+        type: 'someExampleType',
+        createdAt: '2021-04-01T10:25:00.000Z',
+        createdBy: { id: 'someUserId' },
+        updatedAt: '2021-04-01T10:25:00.000Z',
+        data: { a: 1, b: 2 },
+      })
+    })
+  })
+
+  describe('.fetchDraft', () => {
+    describe('when Redis contains a draft for that ID, created by the specified user', () => {
+      it('returns that draft', async () => {
+        const dto = {
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: '2021-04-01T10:25:00Z',
+          createdBy: { id: 'someUserId' },
+          updatedAt: '2021-04-01T10:25:00Z',
+          data: { a: 1, b: 2 },
+        }
+        const data = JSON.stringify(dto)
+
+        redis.get.mockImplementation((_key, cb) => {
+          cb!(null, data)
+          return true
+        })
+
+        const draftsService = new DraftsService(redis, expiry, clock)
+
+        const draft = await draftsService.fetchDraft('2dc7ef56-58dd-4339-9924-c33318738068', { userId: 'someUserId' })
+
+        expect(draft).toEqual({
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: new Date('2021-04-01T10:25:00Z'),
+          createdBy: { id: 'someUserId' },
+          updatedAt: new Date('2021-04-01T10:25:00Z'),
+          data: { a: 1, b: 2 },
+        })
+
+        expect(redis.get).toHaveBeenCalledWith('draft:2dc7ef56-58dd-4339-9924-c33318738068', expect.anything())
+      })
+    })
+
+    describe('when Redis contains a draft for that ID, created by a different user', () => {
+      it('throws an error', async () => {
+        const dto = {
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: '2021-04-01T10:25:00Z',
+          createdBy: { id: 'someOtherUserId' },
+          updatedAt: '2021-04-01T10:25:00Z',
+          data: { a: 1, b: 2 },
+        }
+        const data = JSON.stringify(dto)
+
+        redis.get.mockImplementation((_key, cb) => {
+          cb!(null, data)
+          return true
+        })
+
+        const draftsService = new DraftsService(redis, expiry, clock)
+
+        await expect(
+          draftsService.fetchDraft('2dc7ef56-58dd-4339-9924-c33318738068', { userId: 'someUserId' })
+        ).rejects.toThrow()
+
+        expect(redis.get).toHaveBeenCalledWith('draft:2dc7ef56-58dd-4339-9924-c33318738068', expect.anything())
+      })
+    })
+
+    describe('when Redis doesn’t contain a draft for that ID', () => {
+      it('returns null', async () => {
+        const draftsService = new DraftsService(redis, expiry, clock)
+
+        redis.get.mockImplementation((_key, cb) => {
+          cb!(null, null)
+          return true
+        })
+
+        expect(
+          await draftsService.fetchDraft('2dc7ef56-58dd-4339-9924-c33318738068', { userId: 'someUserId' })
+        ).toBeNull()
+
+        expect(redis.get).toHaveBeenCalledWith('draft:2dc7ef56-58dd-4339-9924-c33318738068', expect.anything())
+      })
+    })
+  })
+
+  describe('.updateDraft', () => {
+    describe('when Redis contains a draft for that ID, created by the specified user', () => {
+      it('updates that draft in Redis and bumps the updatedAt property', async () => {
+        const initialDto = {
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: '2021-03-10T11:50:00Z',
+          createdBy: { id: 'someUserId' },
+          updatedAt: '2021-03-10T11:50:00Z',
+          data: { a: 1, b: 2 },
+        }
+        const initialData = JSON.stringify(initialDto)
+
+        redis.get.mockImplementation((_key, cb) => {
+          cb!(null, initialData)
+          return true
+        })
+
+        redis.set.mockImplementation((_key, _value, _mode, _duration, cb) => {
+          cb!(null, 'OK')
+          return true
+        })
+
+        const draftsService = new DraftsService(redis, expiry, clock)
+
+        await draftsService.updateDraft(
+          '2dc7ef56-58dd-4339-9924-c33318738068',
+          { c: 3, d: 4 },
+          { userId: 'someUserId' }
+        )
+
+        expect(redis.set).toHaveBeenCalledWith(
+          'draft:2dc7ef56-58dd-4339-9924-c33318738068',
+          expect.anything(),
+          'EX',
+          expiry.seconds,
+          expect.anything()
+        )
+
+        expect(JSON.parse(redis.set.mock.calls[0][1])).toEqual({
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: '2021-03-10T11:50:00.000Z',
+          createdBy: { id: 'someUserId' },
+          updatedAt: '2021-04-01T10:25:00.000Z',
+          data: { c: 3, d: 4 },
+        })
+      })
+    })
+
+    describe('when Redis contains a draft for that ID, created by a different user', () => {
+      it('throws an error and does not update the draft', async () => {
+        const initialDto = {
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: '2021-03-10T11:50:00Z',
+          createdBy: { id: 'someOtherUserId' },
+          updatedAt: '2021-03-10T11:50:00Z',
+          data: { a: 1, b: 2 },
+        }
+        const initialData = JSON.stringify(initialDto)
+
+        redis.get.mockImplementation((_key, cb) => {
+          cb!(null, initialData)
+          return true
+        })
+
+        const draftsService = new DraftsService(redis, expiry, clock)
+
+        await expect(
+          draftsService.updateDraft('2dc7ef56-58dd-4339-9924-c33318738068', { c: 3, d: 4 }, { userId: 'someUserId' })
+        ).rejects.toThrow()
+
+        expect(redis.set).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when Redis doesn’t contain a draft for that ID', () => {
+      it('throws an error', async () => {
+        redis.get.mockImplementation((_key, cb) => {
+          cb!(null, null)
+          return true
+        })
+
+        const draftsService = new DraftsService(redis, expiry, clock)
+
+        await expect(
+          draftsService.updateDraft('2dc7ef56-58dd-4339-9924-c33318738068', { c: 3, d: 4 }, { userId: 'someUserId' })
+        ).rejects.toThrow()
+
+        expect(redis.get).toHaveBeenCalledWith('draft:2dc7ef56-58dd-4339-9924-c33318738068', expect.anything())
+
+        expect(redis.set).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('.deleteDraft', () => {
+    describe('when Redis contains a draft for that ID, created by the specified user', () => {
+      it('removes that draft from Redis', async () => {
+        const dto = {
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: '2021-04-01T10:25:00Z',
+          createdBy: { id: 'someUserId' },
+          updatedAt: '2021-04-01T10:25:00Z',
+          data: { a: 1, b: 2 },
+        }
+        const data = JSON.stringify(dto)
+
+        redis.get.mockImplementation((_key, cb) => {
+          cb!(null, data)
+          return true
+        })
+
+        redis.del.mockImplementation((_key, cb) => {
+          cb!(null, 1)
+          return true
+        })
+
+        const draftsService = new DraftsService(redis, expiry, clock)
+
+        await draftsService.deleteDraft('2dc7ef56-58dd-4339-9924-c33318738068', { userId: 'someUserId' })
+
+        expect(redis.del).toHaveBeenCalledWith('draft:2dc7ef56-58dd-4339-9924-c33318738068', expect.anything())
+      })
+    })
+
+    describe('when Redis contains a draft for that ID, created by a different user', () => {
+      it('throws an error and does not remove that draft', async () => {
+        const dto = {
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: '2021-04-01T10:25:00Z',
+          createdBy: { id: 'someOtherUserId' },
+          updatedAt: '2021-04-01T10:25:00Z',
+          data: { a: 1, b: 2 },
+        }
+        const data = JSON.stringify(dto)
+
+        redis.get.mockImplementation((_key, cb) => {
+          cb!(null, data)
+          return true
+        })
+
+        const draftsService = new DraftsService(redis, expiry, clock)
+
+        await expect(
+          draftsService.deleteDraft('2dc7ef56-58dd-4339-9924-c33318738068', { userId: 'someUserId' })
+        ).rejects.toThrow()
+
+        expect(redis.del).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when Redis doesn’t contain a draft for that ID, as indicated by the Redis GET command', () => {
+      it('throws an error', async () => {
+        redis.get.mockImplementation((_key, cb) => {
+          cb!(null, null)
+          return true
+        })
+
+        const draftsService = new DraftsService(redis, expiry, clock)
+
+        await expect(
+          draftsService.deleteDraft('2dc7ef56-58dd-4339-9924-c33318738068', { userId: 'someUserId' })
+        ).rejects.toThrow()
+
+        expect(redis.del).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when Redis doesn’t contain a draft for that ID, as indicated by the Redis DEL command', () => {
+      it('throws an error', async () => {
+        const dto = {
+          id: '2dc7ef56-58dd-4339-9924-c33318738068',
+          type: 'someExampleType',
+          createdAt: '2021-04-01T10:25:00Z',
+          createdBy: { id: 'someUserId' },
+          updatedAt: '2021-04-01T10:25:00Z',
+          data: { a: 1, b: 2 },
+        }
+        const data = JSON.stringify(dto)
+
+        redis.get.mockImplementation((_key, cb) => {
+          cb!(null, data)
+          return true
+        })
+
+        redis.del.mockImplementation((_key, cb) => {
+          cb!(null, 0)
+          return true
+        })
+
+        const draftsService = new DraftsService(redis, expiry, clock)
+
+        await expect(
+          draftsService.deleteDraft('2dc7ef56-58dd-4339-9924-c33318738068', { userId: 'someUserId' })
+        ).rejects.toThrow()
+      })
+    })
+  })
+})

--- a/server/services/draftsService.ts
+++ b/server/services/draftsService.ts
@@ -1,0 +1,116 @@
+import { RedisClient } from 'redis'
+import uuid from 'uuid'
+import { promisify } from 'util'
+
+export interface Draft<T> {
+  id: string
+  type: string
+  createdAt: Date
+  createdBy: { id: string }
+  updatedAt: Date
+  data: T
+}
+
+interface DraftDTO {
+  id: string
+  type: string
+  createdAt: string
+  createdBy: { id: string }
+  updatedAt: string
+  data: unknown
+}
+
+export interface Clock {
+  now: () => Date
+}
+
+export default class DraftsService {
+  constructor(
+    private readonly redis: RedisClient,
+    private readonly expiry: { seconds: number },
+    private readonly clock: Clock
+  ) {}
+
+  private redisKey(id: string): string {
+    return `draft:${id}`
+  }
+
+  private async fetchDraftDTO(id: string): Promise<DraftDTO | null> {
+    const response = await promisify(this.redis.get).bind(this.redis)(this.redisKey(id))
+
+    if (response === null) {
+      return null
+    }
+
+    return JSON.parse(response)
+  }
+
+  private async writeDraft<Data>(draft: Draft<Data>): Promise<void> {
+    const dto: DraftDTO = {
+      ...draft,
+      createdAt: draft.createdAt.toISOString(),
+      updatedAt: draft.updatedAt.toISOString(),
+    }
+
+    await promisify<string, string, string, number>(this.redis.set).bind(this.redis)(
+      this.redisKey(draft.id),
+      JSON.stringify(dto),
+      'EX', // Set the following expiry time on this key
+      this.expiry.seconds
+    )
+  }
+
+  async createDraft<Data>(type: string, initialData: Data, { userId }: { userId: string }): Promise<Draft<Data>> {
+    const now = this.clock.now()
+    const draft: Draft<Data> = {
+      id: uuid.v4(),
+      type,
+      data: initialData,
+      createdAt: now,
+      createdBy: { id: userId },
+      updatedAt: now,
+    }
+
+    await this.writeDraft(draft)
+
+    return draft
+  }
+
+  async fetchDraft<Data>(id: string, { userId }: { userId: string }): Promise<Draft<Data> | null> {
+    const dto = await this.fetchDraftDTO(id)
+
+    if (dto === null) {
+      return null
+    }
+
+    if (dto.createdBy.id !== userId) {
+      throw new Error(`Attempted to fetch DTO for draft ${id} not created by requesting user.`)
+    }
+
+    return { ...dto, createdAt: new Date(dto.createdAt), updatedAt: new Date(dto.updatedAt), data: dto.data as Data }
+  }
+
+  async updateDraft<Data>(id: string, newData: Data, { userId }: { userId: string }): Promise<void> {
+    const draft = await this.fetchDraft(id, { userId })
+
+    if (draft === null) {
+      throw new Error(`Draft with ID ${id} not found in Redis`)
+    }
+
+    await this.writeDraft({ ...draft, data: newData, updatedAt: this.clock.now() })
+  }
+
+  async deleteDraft(id: string, { userId }: { userId: string }): Promise<void> {
+    const draft = await this.fetchDraft(id, { userId })
+
+    if (draft === null) {
+      throw new Error(`Draft with ID ${id} not found in Redis`)
+    }
+
+    const numberRemoved = await promisify<string, number>(this.redis.del).bind(this.redis)(this.redisKey(id))
+
+    if (numberRemoved === 0) {
+      throw new Error(`Draft with ID ${id} not found in Redis`)
+    }
+  }
+}

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -14,8 +14,6 @@
     </div>
     <form method="post" action="{{ presenter.confirmCancellationHref }}">
       <input type="hidden" name="_csrf" value="{{csrfToken}}">
-      <input type="hidden" name="cancellation-reason" value="{{ hiddenFields.cancellationReason }}">
-      <input type="hidden" name="cancellation-comments" value="{{ hiddenFields.cancellationComments }}">
 
       {{ govukButton({ text: "Cancel referral", preventDoubleClick: true }) }}
     </form>

--- a/server/views/probationPractitionerReferrals/referralCancellationReason.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationReason.njk
@@ -19,7 +19,7 @@
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <p class="govuk-body-m govuk-!-margin-bottom-8">{{ presenter.text.information }}</p>
     </div>
-    <form method="post" action="{{ presenter.checkAnswersHref }}">
+    <form method="post">
       <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
       {{ govukRadios(referralCancellationRadiosArgs) }}

--- a/server/views/serviceProviderReferrals/checkAssignment.njk
+++ b/server/views/serviceProviderReferrals/checkAssignment.njk
@@ -24,10 +24,6 @@
       <form method="post" action={{ presenter.formAction }}>
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
-        {% for name, value in presenter.hiddenFields %}
-          <input type="hidden" name={{ name }} value={{ value }}>
-        {% endfor %}
-
         {{ govukButton({ text: "Confirm assignment", preventDoubleClick: true }) }}
       </form>
     </div>

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -10,7 +10,8 @@
 
       {% if presenter.canAssignReferral %}
         <h2 class="govuk-heading-m">Who do you want to assign this referral to?</h2>
-        <form method="get" action={{ presenter.assignmentFormAction }}>
+        <form method="post" action={{ presenter.assignmentFormAction }}>
+              <input type="hidden" name="_csrf" value="{{csrfToken}}">
               {{ govukInput(emailInputArgs) }}
               {{ govukButton({ text: "Save and continue" }) }}
         </form>

--- a/testutils/factories/draft.ts
+++ b/testutils/factories/draft.ts
@@ -1,0 +1,17 @@
+import { Factory } from 'fishery'
+import { Draft } from '../../server/services/draftsService'
+
+// eslint-disable-next-line import/prefer-default-export
+export function createDraftFactory<Data>(defaultData: Data): Factory<Draft<Data>> {
+  return Factory.define<Draft<Data>>(({ sequence }) => {
+    const now = new Date()
+    return {
+      id: sequence.toString(),
+      type: 'someExampleType',
+      createdAt: now,
+      createdBy: { id: 'someUserId' },
+      updatedAt: now,
+      data: defaultData,
+    }
+  })
+}

--- a/testutils/factories/draftCancellationData.ts
+++ b/testutils/factories/draftCancellationData.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery'
+import DraftCancellationData from '../../server/routes/probationPractitionerReferrals/draftCancellationData'
+
+class DraftCancellationDataFactory extends Factory<DraftCancellationData> {}
+
+export default DraftCancellationDataFactory.define(() => ({
+  cancellationReason: null,
+  cancellationComments: null,
+}))


### PR DESCRIPTION
## What does this pull request do?

Proposes a consistent manner for building multi-page journeys where there isn't a permanent backing data store for the data submitted on each page, and refactors the referral assignment and cancellation journeys to use it.

**Note: this is a second pass at this functionality, first attempted in #506.**

## What is the intent behind these changes?

To allow us to build things like the check your answers page for the scheduling journey: https://dsdmoj.atlassian.net/browse/IC-1919, and to tidy up existing journeys like the referral assignment and cancellation.

## Next steps after merge

- &gt; 1 week after deploy, remove the legacy routes / actions (IC-2022)