### PR TITLE
IC-2134: Add Session Type to Appointments

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -642,6 +642,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetSupplierAssessment(referral.id, supplierAssessmentFactory.build())
       cy.login()
     })
+
     describe('with valid inputs', () => {
       describe('when booking for an In-Person Meeting - Other Location', () => {
         it('should present no errors and display scheduled appointment', () => {
@@ -654,6 +655,7 @@ describe('Service provider referrals dashboard', () => {
           cy.get('#time-part-of-day').select('AM')
           cy.get('#duration-hours').type('1')
           cy.get('#duration-minutes').type('15')
+          cy.contains('Group session').click()
           cy.contains('In-person meeting - Other locations').click()
           cy.get('#method-other-location-address-line-1').type('Harmony Living Office, Room 4')
           cy.get('#method-other-location-address-line-2').type('44 Bouverie Road')
@@ -665,6 +667,7 @@ describe('Service provider referrals dashboard', () => {
             ...appointment,
             appointmentTime: '2021-03-24T09:02:02Z',
             durationInMinutes: 75,
+            sessionType: 'GROUP',
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
             appointmentDeliveryAddress: {
               firstAddressLine: 'Harmony Living Office, Room 4',
@@ -692,6 +695,7 @@ describe('Service provider referrals dashboard', () => {
           cy.get('#time-part-of-day').find('option:selected').should('have.text', 'AM')
           cy.get('#duration-hours').should('have.value', '1')
           cy.get('#duration-minutes').should('have.value', '15')
+          cy.contains('Group session').parent().find('input').should('be.checked')
           cy.get('#method-other-location-address-line-1').should('have.value', 'Harmony Living Office, Room 4')
           cy.get('#method-other-location-address-line-2').should('have.value', '44 Bouverie Road')
           cy.get('#method-other-location-address-town-or-city').should('have.value', 'Blackpool')
@@ -711,6 +715,7 @@ describe('Service provider referrals dashboard', () => {
           cy.get('#time-part-of-day').select('AM')
           cy.get('#duration-hours').type('1')
           cy.get('#duration-minutes').type('15')
+          cy.contains('Group session').click()
           cy.contains('In-person meeting - NPS offices').click()
           cy.get('#delius-office-location-code').select('Blackpool: Blackpool Probation Office')
 
@@ -718,6 +723,7 @@ describe('Service provider referrals dashboard', () => {
             ...appointment,
             appointmentTime: '2021-03-24T09:02:02Z',
             durationInMinutes: 75,
+            sessionType: 'GROUP',
             appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
             appointmentDeliveryAddress: null,
             npsOfficeCode: 'CRS0105',
@@ -741,6 +747,7 @@ describe('Service provider referrals dashboard', () => {
           cy.get('#time-part-of-day').find('option:selected').should('have.text', 'AM')
           cy.get('#duration-hours').should('have.value', '1')
           cy.get('#duration-minutes').should('have.value', '15')
+          cy.contains('Group session').parent().find('input').should('be.checked')
           cy.get('#delius-office-location-code option:selected').should(
             'have.text',
             'Blackpool: Blackpool Probation Office'
@@ -750,6 +757,23 @@ describe('Service provider referrals dashboard', () => {
     })
 
     describe('with invalid inputs', () => {
+      describe("when the user doesn't select a session type", () => {
+        it('should show an error', () => {
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.get('#date-day').type('24')
+          cy.get('#date-month').type('3')
+          cy.get('#date-year').type('2021')
+          cy.get('#time-hour').type('9')
+          cy.get('#time-minute').type('02')
+          cy.get('#time-part-of-day').select('AM')
+          cy.get('#duration-hours').type('1')
+          cy.get('#duration-minutes').type('15')
+          cy.contains('In-person meeting').click()
+          cy.contains('Save and continue').click()
+          cy.contains('There is a problem').next().contains('Select the session type')
+        })
+      })
+
       describe("when the user doesn't select meeting method", () => {
         it('should show an error', () => {
           cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
@@ -761,6 +785,7 @@ describe('Service provider referrals dashboard', () => {
           cy.get('#time-part-of-day').select('AM')
           cy.get('#duration-hours').type('1')
           cy.get('#duration-minutes').type('15')
+          cy.contains('1:1').click()
           cy.contains('Save and continue').click()
           cy.contains('There is a problem').next().contains('Select a meeting method')
         })
@@ -777,6 +802,7 @@ describe('Service provider referrals dashboard', () => {
           cy.get('#time-part-of-day').select('AM')
           cy.get('#duration-hours').type('1')
           cy.get('#duration-minutes').type('15')
+          cy.contains('1:1').click()
           cy.contains('In-person meeting - Other locations').click()
           cy.contains('Save and continue').click()
           cy.contains('There is a problem').next().contains('Enter a value for address line 1')

--- a/server/models/appointment.ts
+++ b/server/models/appointment.ts
@@ -1,6 +1,7 @@
 import Address from './address'
 import { AppointmentDeliveryType } from './appointmentDeliveryType'
 import SessionFeedback from './sessionFeedback'
+import { SessionType } from './sessionType'
 
 export interface InitialAssessmentAppointment extends Appointment {
   id: string
@@ -17,6 +18,7 @@ interface Appointment extends AppointmentSchedulingDetails {
 export interface AppointmentSchedulingDetails {
   appointmentTime: string | null
   durationInMinutes: number | null
+  sessionType: SessionType | null
   appointmentDeliveryType: AppointmentDeliveryType | null
   appointmentDeliveryAddress: Address | null
   npsOfficeCode: string | null

--- a/server/models/sessionType.ts
+++ b/server/models/sessionType.ts
@@ -1,0 +1,1 @@
+export type SessionType = 'ONE_TO_ONE' | 'GROUP'

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
@@ -34,6 +34,7 @@ describe(ScheduleAppointmentForm, () => {
           expect(data.paramsForUpdate).toEqual({
             appointmentTime: '2021-09-12T12:05:00.000Z',
             durationInMinutes: 90,
+            sessionType: null,
             appointmentDeliveryType: 'PHONE_CALL',
             appointmentDeliveryAddress: null,
             npsOfficeCode: null,
@@ -64,6 +65,7 @@ describe(ScheduleAppointmentForm, () => {
           expect(data.paramsForUpdate).toEqual({
             appointmentTime: '2021-09-12T12:05:00.000Z',
             durationInMinutes: 90,
+            sessionType: null,
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
             appointmentDeliveryAddress: {
               firstAddressLine: 'Harmony Living Office, Room 4',
@@ -98,6 +100,7 @@ describe(ScheduleAppointmentForm, () => {
             expect(data.paramsForUpdate).toEqual({
               appointmentTime: '2021-09-12T12:05:00.000Z',
               durationInMinutes: 90,
+              sessionType: null,
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
               appointmentDeliveryAddress: {
                 firstAddressLine: 'Harmony Living Office, Room 4',

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
@@ -26,6 +26,7 @@ describe(ScheduleAppointmentForm, () => {
             'time-part-of-day': 'pm',
             'duration-hours': '1',
             'duration-minutes': '30',
+            'session-type': 'ONE_TO_ONE',
             'meeting-method': 'PHONE_CALL',
           })
 
@@ -34,13 +35,14 @@ describe(ScheduleAppointmentForm, () => {
           expect(data.paramsForUpdate).toEqual({
             appointmentTime: '2021-09-12T12:05:00.000Z',
             durationInMinutes: 90,
-            sessionType: null,
+            sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
             appointmentDeliveryAddress: null,
             npsOfficeCode: null,
           })
         })
       })
+
       describe('with an other locations appointment', () => {
         it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
           const request = TestUtils.createRequest({
@@ -52,6 +54,7 @@ describe(ScheduleAppointmentForm, () => {
             'time-part-of-day': 'pm',
             'duration-hours': '1',
             'duration-minutes': '30',
+            'session-type': 'ONE_TO_ONE',
             'meeting-method': 'IN_PERSON_MEETING_OTHER',
             'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
             'method-other-location-address-line-2': '44 Bouverie Road',
@@ -65,7 +68,7 @@ describe(ScheduleAppointmentForm, () => {
           expect(data.paramsForUpdate).toEqual({
             appointmentTime: '2021-09-12T12:05:00.000Z',
             durationInMinutes: 90,
-            sessionType: null,
+            sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
             appointmentDeliveryAddress: {
               firstAddressLine: 'Harmony Living Office, Room 4',
@@ -89,6 +92,7 @@ describe(ScheduleAppointmentForm, () => {
               'time-part-of-day': 'pm',
               'duration-hours': '1',
               'duration-minutes': '30',
+              'session-type': 'ONE_TO_ONE',
               'meeting-method': 'IN_PERSON_MEETING_OTHER',
               'method-other-location-address-line-1': 'Harmony Living Office, Room 4',
               'method-other-location-address-town-or-city': 'Blackpool',
@@ -100,7 +104,7 @@ describe(ScheduleAppointmentForm, () => {
             expect(data.paramsForUpdate).toEqual({
               appointmentTime: '2021-09-12T12:05:00.000Z',
               durationInMinutes: 90,
-              sessionType: null,
+              sessionType: 'ONE_TO_ONE',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
               appointmentDeliveryAddress: {
                 firstAddressLine: 'Harmony Living Office, Room 4',
@@ -125,6 +129,7 @@ describe(ScheduleAppointmentForm, () => {
             'time-part-of-day': 'pm',
             'duration-hours': '1',
             'duration-minutes': '30',
+            'session-type': 'ONE_TO_ONE',
             'meeting-method': 'IN_PERSON_MEETING_PROBATION_OFFICE',
             'delius-office-location-code': 'CRS0001',
           })
@@ -134,6 +139,7 @@ describe(ScheduleAppointmentForm, () => {
           expect(data.paramsForUpdate).toEqual({
             appointmentTime: '2021-09-12T12:05:00.000Z',
             durationInMinutes: 90,
+            sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
             appointmentDeliveryAddress: null,
             npsOfficeCode: 'CRS0001',
@@ -175,6 +181,11 @@ describe(ScheduleAppointmentForm, () => {
               message: 'Enter a duration',
             },
             {
+              errorSummaryLinkedField: 'session-type',
+              formFields: ['session-type'],
+              message: 'Select the session type',
+            },
+            {
               errorSummaryLinkedField: 'meeting-method',
               formFields: ['meeting-method'],
               message: 'Select a meeting method',
@@ -194,6 +205,7 @@ describe(ScheduleAppointmentForm, () => {
               'time-part-of-day': 'pm',
               'duration-hours': '1',
               'duration-minutes': '30',
+              'session-type': 'ONE_TO_ONE',
               'meeting-method': 'IN_PERSON_MEETING_PROBATION_OFFICE',
               'delius-office-location-code': '',
             })
@@ -222,6 +234,7 @@ describe(ScheduleAppointmentForm, () => {
               'time-part-of-day': 'pm',
               'duration-hours': '1',
               'duration-minutes': '30',
+              'session-type': 'ONE_TO_ONE',
               'meeting-method': 'IN_PERSON_MEETING_PROBATION_OFFICE',
               'delius-office-location-code': 'CRS0002',
             })

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
@@ -73,6 +73,8 @@ export default class ScheduleAppointmentForm {
       paramsForUpdate: {
         appointmentTime: dateResult.value.toISOString(),
         durationInMinutes: durationResult.value.minutes!,
+        // TODO: this will be replaced in IC-2136, but is required now for compilation
+        sessionType: null,
         appointmentDeliveryType: appointmentDeliveryType.value!,
         appointmentDeliveryAddress: appointmentDeliveryAddress.value,
         npsOfficeCode: deliusOfficeLocation.value,

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -231,6 +231,7 @@ describe(ScheduleAppointmentPresenter, () => {
             hours: { value: '', hasError: false },
             minutes: { value: '', hasError: false },
           },
+          sessionType: { value: '', errorMessage: null },
           meetingMethod: { value: null, errorMessage: null },
           address: {
             value: null,
@@ -276,6 +277,7 @@ describe(ScheduleAppointmentPresenter, () => {
             hours: { value: '', hasError: false },
             minutes: { value: '', hasError: false },
           },
+          sessionType: { value: '', errorMessage: null },
           meetingMethod: { value: null, errorMessage: null },
           address: {
             value: null,
@@ -297,6 +299,7 @@ describe(ScheduleAppointmentPresenter, () => {
         const appointment = initialAssessmentAppointmentFactory.build({
           appointmentTime: '2021-03-24T10:30:00Z',
           durationInMinutes: 75,
+          sessionType: 'ONE_TO_ONE',
           appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
           appointmentDeliveryAddress: {
             firstAddressLine: 'Harmony Living Office, Room 4',
@@ -329,6 +332,7 @@ describe(ScheduleAppointmentPresenter, () => {
             hours: { value: '1', hasError: false },
             minutes: { value: '15', hasError: false },
           },
+          sessionType: { value: 'ONE_TO_ONE', errorMessage: null },
           meetingMethod: { value: 'IN_PERSON_MEETING_OTHER', errorMessage: null },
           address: {
             value: {
@@ -356,6 +360,7 @@ describe(ScheduleAppointmentPresenter, () => {
         const appointment = initialAssessmentAppointmentFactory.build({
           appointmentTime: '2021-03-24T10:30:00Z',
           durationInMinutes: 75,
+          sessionType: 'ONE_TO_ONE',
           appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
           npsOfficeCode: 'CRS00001',
         })
@@ -382,6 +387,7 @@ describe(ScheduleAppointmentPresenter, () => {
             hours: { value: '1', hasError: false },
             minutes: { value: '15', hasError: false },
           },
+          sessionType: { value: 'ONE_TO_ONE', errorMessage: null },
           meetingMethod: { value: 'IN_PERSON_MEETING_PROBATION_OFFICE', errorMessage: null },
           address: {
             value: null,
@@ -414,6 +420,21 @@ describe(ScheduleAppointmentPresenter, () => {
 
         expect(presenter.backLinkHref).toEqual('/example-href')
       })
+    })
+  })
+
+  describe('isInitialAssessmentAppointment', () => {
+    it('returns true when there is no "current appointment" passed in', () => {
+      const presenter = new ScheduleAppointmentPresenter(referral, null, [])
+
+      expect(presenter.isInitialAssessmentAppointment).toEqual(true)
+    })
+
+    it('returns false when a "current appointment" is passed in', () => {
+      const appointment = initialAssessmentAppointmentFactory.build()
+      const presenter = new ScheduleAppointmentPresenter(referral, appointment, [])
+
+      expect(presenter.isInitialAssessmentAppointment).toEqual(false)
     })
   })
 })

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -68,11 +68,21 @@ export default class ScheduleAppointmentPresenter {
     return config.features.npsOfficeLocationSelection.enabled
   }
 
+  get isInitialAssessmentAppointment(): boolean {
+    return this.currentAppointment === null
+  }
+
+  readonly initialAssessmentSessionType = 'ONE_TO_ONE'
+
   readonly fields = this.appointmentAlreadyAttended
     ? {
         date: this.utils.dateValue(null, 'date', this.validationError),
         time: this.utils.twelveHourTimeValue(null, 'time', this.validationError),
         duration: this.utils.durationValue(null, 'duration', this.validationError),
+        sessionType: {
+          errorMessage: PresenterUtils.errorMessage(this.validationError, 'session-type'),
+          value: this.utils.stringValue(null, 'session-type'),
+        },
         meetingMethod: this.utils.meetingMethodValue(null, 'meeting-method', this.validationError),
         address: this.utils.addressValue(null, 'method-other-location', this.validationError),
         deliusOfficeLocation: this.utils.selectionValue(null, 'delius-office-location-code', this.validationError),
@@ -89,6 +99,10 @@ export default class ScheduleAppointmentPresenter {
           'duration',
           this.validationError
         ),
+        sessionType: {
+          errorMessage: PresenterUtils.errorMessage(this.validationError, 'session-type'),
+          value: this.utils.stringValue(this.currentAppointment?.sessionType ?? null, 'session-type'),
+        },
         meetingMethod: this.utils.meetingMethodValue(
           this.currentAppointment?.appointmentDeliveryType ?? null,
           'meeting-method',

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
@@ -238,7 +238,7 @@ export default class ScheduleAppointmentView {
       },
       errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.meetingMethod.errorMessage),
       hint: {
-        text: 'Select one option.',
+        text: 'Select one option',
       },
       items,
     }

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
@@ -27,6 +27,7 @@ export default class ScheduleAppointmentView {
         errorSummaryArgs: this.errorSummaryArgs,
         serverError: this.serverError,
         address: this.addressFormView.inputArgs,
+        sessionTypeRadioInputArgs: this.sessionTypeRadioInputArgs,
         meetingMethodRadioInputArgs: this.meetingMethodRadioInputArgs.bind(this),
         backLinkArgs: this.backLinkArgs,
         appointmentSummaryListArgs: ViewUtils.summaryListArgs(this.presenter.appointmentSummary),
@@ -162,6 +163,36 @@ export default class ScheduleAppointmentView {
       id: 'delius-office-location-code',
       name: 'delius-office-location-code',
       items,
+    }
+  }
+
+  private get sessionTypeRadioInputArgs(): RadiosArgs {
+    return {
+      idPrefix: 'session-type',
+      name: 'session-type',
+      fieldset: {
+        legend: {
+          text: 'Type of session',
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--m',
+        },
+      },
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.sessionType.errorMessage),
+      hint: {
+        text: 'Select one option',
+      },
+      items: [
+        {
+          value: 'ONE_TO_ONE',
+          text: '1:1',
+          checked: this.presenter.fields.sessionType.value === 'ONE_TO_ONE',
+        },
+        {
+          value: 'GROUP',
+          text: 'Group session',
+          checked: this.presenter.fields.sessionType.value === 'GROUP',
+        },
+      ],
     }
   }
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -936,6 +936,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
           'time-part-of-day': 'am',
           'duration-hours': '1',
           'duration-minutes': '15',
+          'session-type': 'ONE_TO_ONE',
           'meeting-method': 'PHONE_CALL',
         })
         .expect(302)
@@ -944,7 +945,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
       expect(interventionsService.updateActionPlanAppointment).toHaveBeenCalledWith('token', actionPlan.id, 1, {
         appointmentTime: '2021-03-24T09:02:00.000Z',
         durationInMinutes: 75,
-        sessionType: null,
+        sessionType: 'ONE_TO_ONE',
         appointmentDeliveryType: 'PHONE_CALL',
         appointmentDeliveryAddress: null,
         npsOfficeCode: null,
@@ -972,6 +973,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'session-type': 'ONE_TO_ONE',
             'meeting-method': 'PHONE_CALL',
           })
           .expect(400)
@@ -1001,6 +1003,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'session-type': 'ONE_TO_ONE',
             'meeting-method': 'PHONE_CALL',
           })
           .expect(500)
@@ -1033,6 +1036,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
           'time-part-of-day': 'am',
           'duration-hours': '1',
           'duration-minutes': '15',
+          'session-type': 'ONE_TO_ONE',
           'meeting-method': 'PHONE_CALL',
         })
         .expect(400)
@@ -1906,6 +1910,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'session-type': 'ONE_TO_ONE',
             'meeting-method': 'PHONE_CALL',
           })
           .expect(302)
@@ -1917,7 +1922,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
           {
             appointmentTime: '2021-03-24T09:02:00.000Z',
             durationInMinutes: 75,
-            sessionType: null,
+            sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
             appointmentDeliveryAddress: null,
             npsOfficeCode: null,
@@ -1956,6 +1961,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'session-type': 'ONE_TO_ONE',
             'meeting-method': 'PHONE_CALL',
           })
           .expect(302)
@@ -1967,7 +1973,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
           {
             appointmentTime: '2021-03-24T09:02:00.000Z',
             durationInMinutes: 75,
-            sessionType: null,
+            sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
             appointmentDeliveryAddress: null,
             npsOfficeCode: null,
@@ -1996,6 +2002,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'session-type': 'ONE_TO_ONE',
             'meeting-method': 'PHONE_CALL',
           })
           .expect(400)
@@ -2025,6 +2032,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
             'time-part-of-day': 'am',
             'duration-hours': '1',
             'duration-minutes': '15',
+            'session-type': 'ONE_TO_ONE',
             'meeting-method': 'PHONE_CALL',
           })
           .expect(500)
@@ -2053,6 +2061,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
           'time-part-of-day': 'am',
           'duration-hours': '1',
           'duration-minutes': '15',
+          'session-type': 'ONE_TO_ONE',
           'meeting-method': 'PHONE_CALL',
         })
         .expect(400)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -944,6 +944,7 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
       expect(interventionsService.updateActionPlanAppointment).toHaveBeenCalledWith('token', actionPlan.id, 1, {
         appointmentTime: '2021-03-24T09:02:00.000Z',
         durationInMinutes: 75,
+        sessionType: null,
         appointmentDeliveryType: 'PHONE_CALL',
         appointmentDeliveryAddress: null,
         npsOfficeCode: null,
@@ -1883,6 +1884,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
         const scheduledAppointment = initialAssessmentAppointmentFactory.build({
           appointmentTime: '2021-03-24T09:02:02Z',
           durationInMinutes: 75,
+          sessionType: 'ONE_TO_ONE',
           appointmentDeliveryType: 'PHONE_CALL',
           appointmentDeliveryAddress: null,
         })
@@ -1915,6 +1917,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
           {
             appointmentTime: '2021-03-24T09:02:00.000Z',
             durationInMinutes: 75,
+            sessionType: null,
             appointmentDeliveryType: 'PHONE_CALL',
             appointmentDeliveryAddress: null,
             npsOfficeCode: null,
@@ -1931,6 +1934,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
         const scheduledAppointment = initialAssessmentAppointmentFactory.build({
           appointmentTime: '2021-03-24T09:02:02Z',
           durationInMinutes: 75,
+          sessionType: 'ONE_TO_ONE',
           appointmentDeliveryType: 'PHONE_CALL',
           appointmentDeliveryAddress: null,
         })
@@ -1963,6 +1967,7 @@ describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', ()
           {
             appointmentTime: '2021-03-24T09:02:00.000Z',
             durationInMinutes: 75,
+            sessionType: null,
             appointmentDeliveryType: 'PHONE_CALL',
             appointmentDeliveryAddress: null,
             npsOfficeCode: null,

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2266,18 +2266,21 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         sessionNumber: 1,
         appointmentTime: '2021-05-13T12:30:00Z',
         durationInMinutes: 120,
+        sessionType: 'GROUP',
         appointmentDeliveryType: 'PHONE_CALL',
       }),
       actionPlanAppointmentFactory.build({
         sessionNumber: 2,
         appointmentTime: '2021-05-20T12:30:00Z',
         durationInMinutes: 120,
+        sessionType: 'ONE_TO_ONE',
         appointmentDeliveryType: 'PHONE_CALL',
       }),
       actionPlanAppointmentFactory.build({
         sessionNumber: 3,
         appointmentTime: '2021-05-27T12:30:00Z',
         durationInMinutes: 120,
+        sessionType: 'GROUP',
         appointmentDeliveryType: 'PHONE_CALL',
       }),
     ]
@@ -2316,6 +2319,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       sessionNumber: 1,
       appointmentTime: '2021-05-13T12:30:00Z',
       durationInMinutes: 120,
+      sessionType: 'ONE_TO_ONE',
       appointmentDeliveryType: 'PHONE_CALL',
     })
 
@@ -2349,6 +2353,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(appointment.sessionNumber).toEqual(1)
       expect(appointment.appointmentTime).toEqual('2021-05-13T12:30:00Z')
       expect(appointment.durationInMinutes).toEqual(120)
+      expect(appointment.sessionType).toEqual('ONE_TO_ONE')
       expect(appointment.appointmentDeliveryType).toEqual('PHONE_CALL')
     })
   })
@@ -2404,6 +2409,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           sessionNumber: 2,
           appointmentTime: '2021-05-13T12:30:00Z',
           durationInMinutes: 60,
+          sessionType: 'ONE_TO_ONE',
           appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
           appointmentDeliveryAddress: {
             firstAddressLine: 'Harmony Living Office, Room 4',
@@ -2425,6 +2431,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             body: {
               appointmentTime: '2021-05-13T12:30:00Z',
               durationInMinutes: 60,
+              sessionType: 'ONE_TO_ONE',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
               appointmentDeliveryAddress: {
                 firstAddressLine: 'Harmony Living Office, Room 4',
@@ -2455,6 +2462,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             {
               appointmentTime: '2021-05-13T12:30:00Z',
               durationInMinutes: 60,
+              sessionType: 'ONE_TO_ONE',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
               appointmentDeliveryAddress: {
                 firstAddressLine: 'Harmony Living Office, Room 4',
@@ -2493,6 +2501,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             sessionNumber: 2,
             appointmentTime: '2021-05-13T12:30:00Z',
             durationInMinutes: 60,
+            sessionType: 'GROUP',
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
             appointmentDeliveryAddress: {
               firstAddressLine: 'Harmony Living Office, Room 4',

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -112,6 +112,9 @@ export default {
       empty: 'Enter a duration',
       invalidDuration: 'The session duration must be a real duration',
     },
+    sessionType: {
+      empty: 'Select the session type',
+    },
     meetingMethod: {
       empty: 'Select a meeting method',
     },

--- a/server/views/serviceProviderReferrals/scheduleAppointment.njk
+++ b/server/views/serviceProviderReferrals/scheduleAppointment.njk
@@ -46,6 +46,11 @@
           {{ govukDateInput(dateInputArgs) }}
           {{ appTimeInput(timeInputArgs) }}
           {{ govukDateInput(durationDateInputArgs) }}
+          {% if presenter.isInitialAssessmentAppointment %}
+            <input type="hidden" name="session-type" value="{{ presenter.initialAssessmentSessionType }}">
+          {% else %}
+            {{ govukRadios(sessionTypeRadioInputArgs) }}
+          {% endif %}
           {% set deliusOfficeLocationHtml %}
             {{ govukSelect(deliusOfficeLocationSelectArgs) }}
           {% endset -%}

--- a/testutils/factories/actionPlanAppointment.ts
+++ b/testutils/factories/actionPlanAppointment.ts
@@ -25,6 +25,7 @@ export default ActionPlanAppointmentFactory.define(() => ({
   sessionNumber: 1,
   appointmentTime: null,
   durationInMinutes: null,
+  sessionType: null,
   appointmentDeliveryType: null,
   appointmentDeliveryAddress: null,
   sessionFeedback: initialAssessmentAppointmentFactory.newlyBooked().build().sessionFeedback,

--- a/testutils/factories/initialAssessmentAppointment.ts
+++ b/testutils/factories/initialAssessmentAppointment.ts
@@ -2,6 +2,7 @@ import { Factory } from 'fishery'
 import { InitialAssessmentAppointment } from '../../server/models/appointment'
 import { Attended } from '../../server/models/appointmentAttendance'
 import { AppointmentDeliveryType } from '../../server/models/appointmentDeliveryType'
+import { SessionType } from '../../server/models/sessionType'
 
 class InitialAssessmentAppointmentFactory extends Factory<InitialAssessmentAppointment> {
   newlyBooked() {
@@ -73,12 +74,14 @@ class InitialAssessmentAppointmentFactory extends Factory<InitialAssessmentAppoi
 }
 
 const defaultAppointmentDeliveryType: AppointmentDeliveryType = 'VIDEO_CALL'
+const defaultSessionType: SessionType = 'ONE_TO_ONE'
 
 export default InitialAssessmentAppointmentFactory.define(({ sequence }) => ({
   id: sequence.toString(),
   // one day in the future
   appointmentTime: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).toISOString(),
   durationInMinutes: 60,
+  sessionType: defaultSessionType,
   // For some reason the compiler complains if I write 'VIDEO_CALL' inline
   appointmentDeliveryType: defaultAppointmentDeliveryType,
   appointmentDeliveryAddress: null,


### PR DESCRIPTION
## What does this pull request do?

Adds radio button section for setting the Session Type (1:1 or Group session) for action plan appointments.

Initial assessments are always 1:1, so these are hardcoded to 1:1 - I felt this was more re-usable than creating a specific type of session for Action Plan Appointments, even if we're not going to display this value anywhere at the moment.

I realised we don't have a page for showing the scheduled session from either a PP or SP's point of view, so this value isn't played back on a page anywhere - we have a way of viewing the scheduled initial assessment, but I don't think we need to actually display the session type on that page.

### Note: this introduces breaking changes to the contract tests.

## What is the intent behind these changes?

To allow SPs to specify what type of session the Service User is attending.

# Screenshot

![image](https://user-images.githubusercontent.com/19826940/128045673-a7879fd1-abdc-4de9-a536-2e25ed00d06a.png)

