### PR TITLE
IC-2161: Add function & contract tests for fetching Approved Action Plan Summaries from the Interventions Service

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -127,6 +127,10 @@ module.exports = on => {
       return interventionsService.stubGetActionPlan(arg.id, arg.responseJson)
     },
 
+    stubGetApprovedActionPlanSummaries: arg => {
+      return interventionsService.stubGetApprovedActionPlanSummaries(arg.id, arg.responseJson)
+    },
+
     stubCreateDraftActionPlan: arg => {
       return interventionsService.stubCreateDraftActionPlan(arg.responseJson)
     },

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -66,6 +66,10 @@ Cypress.Commands.add('stubGetActionPlan', (id, responseJson) => {
   cy.task('stubGetActionPlan', { id, responseJson })
 })
 
+Cypress.Commands.add('stubGetApprovedActionPlanSummaries', (id, responseJson) => {
+  cy.task('stubGetApprovedActionPlanSummaries', { id, responseJson })
+})
+
 Cypress.Commands.add('stubCreateDraftActionPlan', responseJson => {
   cy.task('stubCreateDraftActionPlan', { responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -315,6 +315,22 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubGetApprovedActionPlanSummaries = async (referralId: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/sent-referral/${referralId}/approved-action-plans`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
   stubRecordActionPlanAppointmentAttendance = async (
     actionPlanId: string,
     sessionNumber: string,

--- a/server/models/approvedActionPlanSummary.ts
+++ b/server/models/approvedActionPlanSummary.ts
@@ -1,0 +1,4 @@
+export default interface ApprovedActionPlanSummary {
+  id: string
+  approvedAt: string
+}

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -24,6 +24,7 @@ import {
   AppointmentSchedulingDetails,
   InitialAssessmentAppointment,
 } from '../models/appointment'
+import ApprovedActionPlanSummary from '../models/approvedActionPlanSummary'
 
 export interface InterventionsServiceValidationError {
   field: string
@@ -323,6 +324,14 @@ export default class InterventionsService {
       path: `/draft-action-plan/${id}/submit`,
       headers: { Accept: 'application/json' },
     })) as ActionPlan
+  }
+
+  async getApprovedActionPlanSummaries(token: string, referralId: string): Promise<ApprovedActionPlanSummary[]> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.get({
+      path: `/sent-referral/${referralId}/approved-action-plans`,
+      headers: { Accept: 'application/json' },
+    })) as ApprovedActionPlanSummary[]
   }
 
   async getActionPlanAppointments(token: string, actionPlanId: string): Promise<ActionPlanAppointment[]> {

--- a/testutils/factories/approvedActionPlanSummary.ts
+++ b/testutils/factories/approvedActionPlanSummary.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import ApprovedActionPlanSummary from '../../server/models/approvedActionPlanSummary'
+
+export default Factory.define<ApprovedActionPlanSummary>(({ sequence }) => ({
+  id: sequence.toString(),
+  approvedAt: '2021-08-07T20:45:21.986389Z',
+}))


### PR DESCRIPTION
## What does this pull request do?

Adds `GetApprovedActionPlanSummaries` method to the Interventions Service client to fetch a new `ApprovedActionPlanSummary` object from the backend, as well as a contract test for this.

## What is the intent behind these changes?

This will be used to display the list of previously approved action plans in a list, so to keep this small we're using a "summary"-type model here.

## Screenshot of where this will be used:

![image](https://user-images.githubusercontent.com/19826940/128496629-7610cded-8481-445e-b603-57cb79eca99e.png)
