### PR TITLE
Refactor: Favour composition over inheritance for feedback pages.

### DIFF
--- a/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.ts
@@ -2,6 +2,7 @@ import { ActionPlanAppointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import AttendanceFeedbackPresenter from '../../shared/attendance/attendanceFeedbackPresenter'
+import AttendanceFeedbackQuestionnaire from '../../shared/attendance/attendanceFeedbackQuestionnaire'
 
 export default class ActionPlanPostSessionAttendanceFeedbackPresenter extends AttendanceFeedbackPresenter {
   constructor(
@@ -11,30 +12,15 @@ export default class ActionPlanPostSessionAttendanceFeedbackPresenter extends At
     userInputData: Record<string, unknown> | null = null,
     private readonly referralId: string | null = null
   ) {
-    super(actionPlanAppointment, error, userInputData)
-  }
-
-  readonly text = {
-    title: `Add attendance feedback`,
-    subTitle: 'Session details',
-    attendanceQuestion: this.attendanceQuestion,
-    attendanceQuestionHint: 'Select one option',
-    additionalAttendanceInformationLabel: `Add additional information about ${this.serviceUser.firstName}'s attendance:`,
+    super(
+      actionPlanAppointment,
+      `Add attendance feedback`,
+      'Session details',
+      new AttendanceFeedbackQuestionnaire(actionPlanAppointment, serviceUser),
+      error,
+      userInputData
+    )
   }
 
   readonly backLinkHref = this.referralId ? `/service-provider/referrals/${this.referralId}/progress` : null
-
-  private get attendanceQuestion(): string {
-    switch (this.actionPlanAppointment.appointmentDeliveryType) {
-      case 'PHONE_CALL':
-        return `Did ${this.serviceUser.firstName} join this phone call?`
-      case 'VIDEO_CALL':
-        return `Did ${this.serviceUser.firstName} join this video call?`
-      case 'IN_PERSON_MEETING_OTHER':
-      case 'IN_PERSON_MEETING_PROBATION_OFFICE':
-        return `Did ${this.serviceUser.firstName} attend this in-person meeting?`
-      default:
-        return `Did ${this.serviceUser.firstName} attend this session?`
-    }
-  }
 }

--- a/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.test.ts
@@ -3,27 +3,6 @@ import deliusServiceUserFactory from '../../../../../../testutils/factories/deli
 import ActionPlanSessionBehaviourFeedbackPresenter from './actionPlanSessionBehaviourFeedbackPresenter'
 
 describe(ActionPlanSessionBehaviourFeedbackPresenter, () => {
-  describe('text', () => {
-    it('contains the text for the title and questions to be displayed on the page', () => {
-      const appointment = actionPlanAppointmentFactory.build()
-      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-      const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointment, serviceUser, 'action-plan-id')
-
-      expect(presenter.text).toMatchObject({
-        title: 'Add behaviour feedback',
-        behaviourDescription: {
-          question: `Describe Alex's behaviour in this session`,
-          hint: 'For example, consider how well-engaged they were and what their body language was like.',
-        },
-        notifyProbationPractitioner: {
-          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-          explanation: 'If you select yes, the probation practitioner will be notified by email.',
-          hint: 'Select one option',
-        },
-      })
-    })
-  })
-
   describe('backLinkHref', () => {
     it('contains the link to the attendance page with the action plan id and session number', () => {
       const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 2 })

--- a/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.ts
@@ -2,6 +2,7 @@ import { ActionPlanAppointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import BehaviourFeedbackInputsPresenter from '../../shared/behaviour/behaviourFeedbackInputsPresenter'
+import BehaviourFeedbackQuestionnaire from '../../shared/behaviour/behaviourFeedbackQuestionnaire'
 
 export default class ActionPlanSessionBehaviourFeedbackPresenter {
   constructor(
@@ -14,16 +15,9 @@ export default class ActionPlanSessionBehaviourFeedbackPresenter {
 
   readonly text = {
     title: `Add behaviour feedback`,
-    behaviourDescription: {
-      question: `Describe ${this.serviceUser.firstName}'s behaviour in this session`,
-      hint: 'For example, consider how well-engaged they were and what their body language was like.',
-    },
-    notifyProbationPractitioner: {
-      question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-      explanation: 'If you select yes, the probation practitioner will be notified by email.',
-      hint: 'Select one option',
-    },
   }
+
+  readonly questionnaire = new BehaviourFeedbackQuestionnaire(this.appointment, this.serviceUser)
 
   readonly backLinkHref = this.actionPlanId
     ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.appointment.sessionNumber}/post-session-feedback/attendance`

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
@@ -1,14 +1,10 @@
 import { ActionPlanAppointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
-import AttendanceFeedbackPresenter from '../../shared/attendance/attendanceFeedbackPresenter'
 import CheckFeedbackAnswersPresenter from '../../shared/checkYourAnswers/checkFeedbackAnswersPresenter'
-import ActionPlanPostSessionAttendanceFeedbackPresenter from '../attendance/actionPlanPostSessionAttendanceFeedbackPresenter'
-import ActionPlanSessionBehaviourFeedbackPresenter from '../behaviour/actionPlanSessionBehaviourFeedbackPresenter'
+import FeedbackAnswersPresenter from '../../shared/viewFeedback/feedbackAnswersPresenter'
 
 export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends CheckFeedbackAnswersPresenter {
-  protected readonly attendancePresenter: AttendanceFeedbackPresenter
-
-  protected readonly behaviourPresenter: ActionPlanSessionBehaviourFeedbackPresenter
+  readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
 
   constructor(
     private readonly actionPlanAppointment: ActionPlanAppointment,
@@ -16,15 +12,7 @@ export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends 
     private readonly actionPlanId: string
   ) {
     super(actionPlanAppointment)
-    this.attendancePresenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
-      this.actionPlanAppointment,
-      this.serviceUser
-    )
-    this.behaviourPresenter = new ActionPlanSessionBehaviourFeedbackPresenter(
-      this.actionPlanAppointment,
-      this.serviceUser,
-      this.actionPlanId
-    )
+    this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(actionPlanAppointment, serviceUser)
   }
 
   readonly submitHref = `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/submit`

--- a/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.ts
@@ -2,6 +2,7 @@ import { InitialAssessmentAppointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import AttendanceFeedbackPresenter from '../../shared/attendance/attendanceFeedbackPresenter'
+import AttendanceFeedbackQuestionnaire from '../../shared/attendance/attendanceFeedbackQuestionnaire'
 
 export default class InitialAssessmentAttendanceFeedbackPresenter extends AttendanceFeedbackPresenter {
   constructor(
@@ -11,16 +12,15 @@ export default class InitialAssessmentAttendanceFeedbackPresenter extends Attend
     userInputData: Record<string, unknown> | null = null,
     private readonly referralId: string | null = null
   ) {
-    super(initialAssessmentAppointment, error, userInputData)
+    super(
+      initialAssessmentAppointment,
+      'Add feedback',
+      'Appointment details',
+      new AttendanceFeedbackQuestionnaire(initialAssessmentAppointment, serviceUser),
+      error,
+      userInputData
+    )
   }
 
   readonly backLinkHref = this.referralId ? `/service-provider/referrals/${this.referralId}/progress` : null
-
-  readonly text = {
-    title: `Add feedback`,
-    subTitle: 'Appointment details',
-    attendanceQuestion: `Did ${this.serviceUser.firstName} attend the initial assessment appointment?`,
-    attendanceQuestionHint: 'Select one option',
-    additionalAttendanceInformationLabel: `Add additional information about ${this.serviceUser.firstName}'s attendance:`,
-  }
 }

--- a/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.test.ts
@@ -3,31 +3,6 @@ import deliusServiceUserFactory from '../../../../../../testutils/factories/deli
 import InitialAssessmentBehaviourFeedbackPresenter from './initialAssessmentBehaviourFeedbackPresenter'
 
 describe(InitialAssessmentBehaviourFeedbackPresenter, () => {
-  describe('text', () => {
-    it('contains the text for the title and questions to be displayed on the page', () => {
-      const initialAssessmentAppointment = initialAssessmentAppointmentFactory.build()
-      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-      const presenter = new InitialAssessmentBehaviourFeedbackPresenter(
-        initialAssessmentAppointment,
-        serviceUser,
-        'test-referral-id'
-      )
-
-      expect(presenter.text).toMatchObject({
-        title: 'Add behaviour feedback',
-        behaviourDescription: {
-          question: `Describe Alex's behaviour in the assessment appointment`,
-          hint: 'For example, consider how well-engaged they were and what their body language was like.',
-        },
-        notifyProbationPractitioner: {
-          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-          explanation: 'If you select yes, the probation practitioner will be notified by email.',
-          hint: 'Select one option',
-        },
-      })
-    })
-  })
-
   describe('backLinkHref', () => {
     it('contains the link to the attendance page with the referral id', () => {
       const initialAssessmentAppointment = initialAssessmentAppointmentFactory.build()

--- a/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.ts
@@ -2,6 +2,7 @@ import { InitialAssessmentAppointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import BehaviourFeedbackInputsPresenter from '../../shared/behaviour/behaviourFeedbackInputsPresenter'
+import BehaviourFeedbackQuestionnaire from '../../shared/behaviour/behaviourFeedbackQuestionnaire'
 
 export default class InitialAssessmentBehaviourFeedbackPresenter {
   constructor(
@@ -12,17 +13,10 @@ export default class InitialAssessmentBehaviourFeedbackPresenter {
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
+  readonly questionnaire = new BehaviourFeedbackQuestionnaire(this.appointment, this.serviceUser)
+
   readonly text = {
     title: `Add behaviour feedback`,
-    behaviourDescription: {
-      question: `Describe ${this.serviceUser.firstName}'s behaviour in the assessment appointment`,
-      hint: 'For example, consider how well-engaged they were and what their body language was like.',
-    },
-    notifyProbationPractitioner: {
-      question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-      explanation: 'If you select yes, the probation practitioner will be notified by email.',
-      hint: 'Select one option',
-    },
   }
 
   readonly backLinkHref = this.referralId

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
@@ -1,14 +1,10 @@
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import CheckFeedbackAnswersPresenter from '../../shared/checkYourAnswers/checkFeedbackAnswersPresenter'
-import AttendanceFeedbackPresenter from '../../shared/attendance/attendanceFeedbackPresenter'
-import InitialAssessmentAttendanceFeedbackPresenter from '../attendance/initialAssessmentAttendanceFeedbackPresenter'
 import { InitialAssessmentAppointment } from '../../../../../models/appointment'
-import InitialAssessmentBehaviourFeedbackPresenter from '../behaviour/initialAssessmentBehaviourFeedbackPresenter'
+import FeedbackAnswersPresenter from '../../shared/viewFeedback/feedbackAnswersPresenter'
 
 export default class InitialAssessmentFeedbackCheckAnswersPresenter extends CheckFeedbackAnswersPresenter {
-  protected readonly attendancePresenter: AttendanceFeedbackPresenter
-
-  protected readonly behaviourPresenter: InitialAssessmentBehaviourFeedbackPresenter
+  readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
 
   constructor(
     appointment: InitialAssessmentAppointment,
@@ -16,8 +12,7 @@ export default class InitialAssessmentFeedbackCheckAnswersPresenter extends Chec
     private readonly referralId: string
   ) {
     super(appointment)
-    this.attendancePresenter = new InitialAssessmentAttendanceFeedbackPresenter(appointment, this.serviceUser)
-    this.behaviourPresenter = new InitialAssessmentBehaviourFeedbackPresenter(appointment, this.serviceUser)
+    this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(appointment, serviceUser)
   }
 
   readonly submitHref = `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/submit`

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.test.ts
@@ -2,6 +2,8 @@ import AttendanceFeedbackPresenter from './attendanceFeedbackPresenter'
 import initialAssessmentAppointmentFactory from '../../../../../../testutils/factories/initialAssessmentAppointment'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import { InitialAssessmentAppointment } from '../../../../../models/appointment'
+import AttendanceFeedbackQuestionnaire from './attendanceFeedbackQuestionnaire'
+import deliusServiceUser from '../../../../../../testutils/factories/deliusServiceUser'
 
 describe(AttendanceFeedbackPresenter, () => {
   class ExtendedAttendanceFeedbackPresenter extends AttendanceFeedbackPresenter {
@@ -10,15 +12,14 @@ describe(AttendanceFeedbackPresenter, () => {
       error: FormValidationError | null = null,
       userInputData: Record<string, unknown> | null = null
     ) {
-      super(appointment, error, userInputData)
-    }
-
-    readonly text = {
-      title: 'title',
-      subTitle: 'subTitle',
-      attendanceQuestion: 'attendanceQuestion',
-      attendanceQuestionHint: 'attendanceQuestionHint',
-      additionalAttendanceInformationLabel: 'additionalAttendanceInformationLabel',
+      super(
+        appointment,
+        'title',
+        'subTitle',
+        new AttendanceFeedbackQuestionnaire(appointment, deliusServiceUser.build()),
+        error,
+        userInputData
+      )
     }
   }
 

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
@@ -3,6 +3,7 @@ import { SummaryListItem } from '../../../../../utils/summaryList'
 import DateUtils from '../../../../../utils/dateUtils'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
+import AttendanceFeedbackQuestionnaire from './attendanceFeedbackQuestionnaire'
 
 interface AttendanceFeedbackFormText {
   title: string
@@ -13,13 +14,24 @@ interface AttendanceFeedbackFormText {
 }
 
 export default abstract class AttendanceFeedbackPresenter {
+  readonly text: AttendanceFeedbackFormText
+
   protected constructor(
     private readonly appointment: ActionPlanAppointment | InitialAssessmentAppointment,
+    private readonly title: string,
+    private readonly subTitle: string,
+    private readonly attendanceFeedbackQuestionnaire: AttendanceFeedbackQuestionnaire,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
-  ) {}
-
-  abstract readonly text: AttendanceFeedbackFormText
+  ) {
+    this.text = {
+      title,
+      subTitle,
+      attendanceQuestion: attendanceFeedbackQuestionnaire.attendanceQuestion.text,
+      attendanceQuestionHint: attendanceFeedbackQuestionnaire.attendanceQuestion.hint,
+      additionalAttendanceInformationLabel: attendanceFeedbackQuestionnaire.additionalAttendanceInformationQuestion,
+    }
+  }
 
   readonly backLinkHref: string | null = null
 

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.test.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.test.ts
@@ -1,0 +1,28 @@
+import initialAssessmentAppointment from '../../../../../../testutils/factories/initialAssessmentAppointment'
+import deliusServiceUser from '../../../../../../testutils/factories/deliusServiceUser'
+import actionPlanAppointment from '../../../../../../testutils/factories/actionPlanAppointment'
+import AttendanceFeedbackQuestionnaire from './attendanceFeedbackQuestionnaire'
+
+describe(AttendanceFeedbackQuestionnaire, () => {
+  describe('attendanceQuestion', () => {
+    describe('when the appointment is an initial assessment', () => {
+      it('should produce a question specific to initial assessment', () => {
+        const questionnaire = new AttendanceFeedbackQuestionnaire(
+          initialAssessmentAppointment.build(),
+          deliusServiceUser.build({ firstName: 'Alex' })
+        )
+        expect(questionnaire.attendanceQuestion.text).toEqual('Did Alex attend the initial assessment appointment?')
+      })
+    })
+
+    describe('when the appointment is an action plan session', () => {
+      it('should produce a question specific to action plan session', () => {
+        const questionnaire = new AttendanceFeedbackQuestionnaire(
+          actionPlanAppointment.build({ appointmentDeliveryType: 'PHONE_CALL' }),
+          deliusServiceUser.build({ firstName: 'Alex' })
+        )
+        expect(questionnaire.attendanceQuestion.text).toEqual('Did Alex join this phone call?')
+      })
+    })
+  })
+})

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.ts
@@ -1,0 +1,42 @@
+import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
+import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
+import AppointmentDecorator from '../../../../../decorators/appointmentDecorator'
+
+export default class AttendanceFeedbackQuestionnaire {
+  private readonly appointmentDecorator: AppointmentDecorator
+
+  constructor(
+    private appointment: InitialAssessmentAppointment | ActionPlanAppointment,
+    private serviceUser: DeliusServiceUser
+  ) {
+    this.appointmentDecorator = new AppointmentDecorator(appointment)
+  }
+
+  get attendanceQuestion(): { text: string; hint: string } {
+    if (this.appointmentDecorator.isInitialAssessmentAppointment) {
+      return {
+        text: `Did ${this.serviceUser.firstName} attend the initial assessment appointment?`,
+        hint: 'Select one option',
+      }
+    }
+    return { text: this.methodSpecificAttendanceQuestion, hint: 'Select one option' }
+  }
+
+  get additionalAttendanceInformationQuestion(): string {
+    return `Add additional information about ${this.serviceUser.firstName}'s attendance:`
+  }
+
+  private get methodSpecificAttendanceQuestion(): string {
+    switch (this.appointment.appointmentDeliveryType) {
+      case 'PHONE_CALL':
+        return `Did ${this.serviceUser.firstName} join this phone call?`
+      case 'VIDEO_CALL':
+        return `Did ${this.serviceUser.firstName} join this video call?`
+      case 'IN_PERSON_MEETING_OTHER':
+      case 'IN_PERSON_MEETING_PROBATION_OFFICE':
+        return `Did ${this.serviceUser.firstName} attend this in-person meeting?`
+      default:
+        return `Did ${this.serviceUser.firstName} attend this session?`
+    }
+  }
+}

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackPresenter.ts
@@ -1,20 +1,9 @@
 import BehaviourFeedbackInputsPresenter from './behaviourFeedbackInputsPresenter'
-
-interface BehaviourText {
-  title: string
-  behaviourDescription: {
-    question: string
-    hint: string
-  }
-  notifyProbationPractitioner: {
-    question: string
-    explanation: string
-    hint: string
-  }
-}
+import BehaviourFeedbackQuestionnaire from './behaviourFeedbackQuestionnaire'
 
 export interface BehaviourFeedbackPresenter {
-  text: BehaviourText
+  text: { title: string }
+  questionnaire: BehaviourFeedbackQuestionnaire
   inputsPresenter: BehaviourFeedbackInputsPresenter
   backLinkHref: string | null
 }

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackQuestionnaire.test.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackQuestionnaire.test.ts
@@ -1,0 +1,28 @@
+import BehaviourFeedbackQuestionnaire from './behaviourFeedbackQuestionnaire'
+import initialAssessmentAppointment from '../../../../../../testutils/factories/initialAssessmentAppointment'
+import deliusServiceUser from '../../../../../../testutils/factories/deliusServiceUser'
+import actionPlanAppointment from '../../../../../../testutils/factories/actionPlanAppointment'
+
+describe(BehaviourFeedbackQuestionnaire, () => {
+  describe('behaviourQuestion', () => {
+    describe('when the appointment is an initial assessment', () => {
+      it('should produce a question specific to initial assessment', () => {
+        const questionnaire = new BehaviourFeedbackQuestionnaire(
+          initialAssessmentAppointment.build(),
+          deliusServiceUser.build({ firstName: 'Alex' })
+        )
+        expect(questionnaire.behaviourQuestion.text).toEqual("Describe Alex's behaviour in the assessment appointment")
+      })
+    })
+
+    describe('when the appointment is an action plan session', () => {
+      it('should produce a question specific to action plan session', () => {
+        const questionnaire = new BehaviourFeedbackQuestionnaire(
+          actionPlanAppointment.build(),
+          deliusServiceUser.build({ firstName: 'Alex' })
+        )
+        expect(questionnaire.behaviourQuestion.text).toEqual("Describe Alex's behaviour in this session")
+      })
+    })
+  })
+})

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackQuestionnaire.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackQuestionnaire.ts
@@ -1,0 +1,35 @@
+import AppointmentDecorator from '../../../../../decorators/appointmentDecorator'
+import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
+import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
+
+export default class BehaviourFeedbackQuestionnaire {
+  private readonly appointmentDecorator: AppointmentDecorator
+
+  constructor(
+    private appointment: InitialAssessmentAppointment | ActionPlanAppointment,
+    private serviceUser: DeliusServiceUser
+  ) {
+    this.appointmentDecorator = new AppointmentDecorator(appointment)
+  }
+
+  get behaviourQuestion(): { text: string; hint: string } {
+    if (this.appointmentDecorator.isInitialAssessmentAppointment) {
+      return {
+        text: `Describe ${this.serviceUser.firstName}'s behaviour in the assessment appointment`,
+        hint: 'For example, consider how well-engaged they were and what their body language was like.',
+      }
+    }
+    return {
+      text: `Describe ${this.serviceUser.firstName}'s behaviour in this session`,
+      hint: 'For example, consider how well-engaged they were and what their body language was like.',
+    }
+  }
+
+  get notifyProbationPractitionerQuestion(): { text: string; hint: string; explanation: string } {
+    return {
+      text: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+      explanation: 'If you select yes, the probation practitioner will be notified by email.',
+      hint: 'Select one option',
+    }
+  }
+}

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackView.ts
@@ -19,12 +19,12 @@ export default class BehaviourFeedbackView {
       name: 'behaviour-description',
       id: 'behaviour-description',
       label: {
-        text: this.presenter.text.behaviourDescription.question,
+        text: this.presenter.questionnaire.behaviourQuestion.text,
         classes: 'govuk-label--m govuk-!-margin-bottom-4',
         isPageHeading: false,
       },
       hint: {
-        text: this.presenter.text.behaviourDescription.hint,
+        text: this.presenter.questionnaire.behaviourQuestion.hint,
       },
       value: this.inputsPresenter.fields.behaviourDescription.value,
       errorMessage: ViewUtils.govukErrorMessage(this.inputsPresenter.fields.behaviourDescription.errorMessage),
@@ -39,15 +39,15 @@ export default class BehaviourFeedbackView {
       fieldset: {
         legend: {
           html: `<h2 class=govuk-fieldset__legend--m>${ViewUtils.escape(
-            this.presenter.text.notifyProbationPractitioner.question
+            this.presenter.questionnaire.notifyProbationPractitionerQuestion.text
           )}</h2><p class="govuk-body--m">${ViewUtils.escape(
-            this.presenter.text.notifyProbationPractitioner.explanation
+            this.presenter.questionnaire.notifyProbationPractitionerQuestion.explanation
           )}</p>`,
           isPageHeading: false,
         },
       },
       hint: {
-        text: this.presenter.text.notifyProbationPractitioner.hint,
+        text: this.presenter.questionnaire.notifyProbationPractitionerQuestion.hint,
       },
       items: [
         {

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.test.ts
@@ -1,12 +1,10 @@
 // eslint-disable-next-line max-classes-per-file
 import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
 import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
-import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
-import AttendanceFeedbackPresenter from '../attendance/attendanceFeedbackPresenter'
 import CheckFeedbackAnswersPresenter from './checkFeedbackAnswersPresenter'
-import { BehaviourFeedbackPresenter } from '../behaviour/behaviourFeedbackPresenter'
-import BehaviourFeedbackInputsPresenter from '../behaviour/behaviourFeedbackInputsPresenter'
 import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
+import FeedbackAnswersPresenter from '../viewFeedback/feedbackAnswersPresenter'
+import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 
 describe('for a class that extends abstract class CheckFeedbackAnswersPresenter', () => {
   class ExtendedCheckFeedbackAnswersPresenter extends CheckFeedbackAnswersPresenter {
@@ -14,46 +12,11 @@ describe('for a class that extends abstract class CheckFeedbackAnswersPresenter'
 
     readonly backLinkHref = ''
 
-    constructor(
-      appointment: ActionPlanAppointment | InitialAssessmentAppointment,
-      private readonly serviceUser: DeliusServiceUser
-    ) {
+    readonly feedbackAnswersPresenter
+
+    constructor(appointment: ActionPlanAppointment | InitialAssessmentAppointment, serviceUser: DeliusServiceUser) {
       super(appointment)
-    }
-
-    protected get attendancePresenter(): AttendanceFeedbackPresenter {
-      return new (class extends AttendanceFeedbackPresenter {
-        constructor(appointment: ActionPlanAppointment | InitialAssessmentAppointment) {
-          super(appointment)
-        }
-
-        readonly text = {
-          title: `title`,
-          subTitle: 'subTitle',
-          attendanceQuestion: 'attendanceQuestion',
-          attendanceQuestionHint: 'attendanceQuestionHint',
-          additionalAttendanceInformationLabel: 'additionalAttendanceInformationLabel',
-        }
-      })(this.appointment)
-    }
-
-    protected get behaviourPresenter(): BehaviourFeedbackPresenter {
-      return {
-        backLinkHref: null,
-        inputsPresenter: new BehaviourFeedbackInputsPresenter(this.appointment),
-        text: {
-          title: `Add behaviour feedback`,
-          behaviourDescription: {
-            question: `Describe ${this.serviceUser.firstName}'s behaviour in this session`,
-            hint: 'For example, consider how well-engaged they were and what their body language was like.',
-          },
-          notifyProbationPractitioner: {
-            question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-            explanation: 'If you select yes, the probation practitioner will be notified by email.',
-            hint: 'Select one option',
-          },
-        },
-      }
+      this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(appointment, serviceUser)
     }
   }
 

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.ts
@@ -3,14 +3,14 @@ import DateUtils from '../../../../../utils/dateUtils'
 import { SummaryListItem } from '../../../../../utils/summaryList'
 import FeedbackAnswersPresenter from '../viewFeedback/feedbackAnswersPresenter'
 
-export default abstract class CheckFeedbackAnswersPresenter extends FeedbackAnswersPresenter {
-  protected constructor(appointment: ActionPlanAppointment | InitialAssessmentAppointment) {
-    super(appointment)
-  }
+export default abstract class CheckFeedbackAnswersPresenter {
+  protected constructor(protected appointment: ActionPlanAppointment | InitialAssessmentAppointment) {}
 
   abstract readonly submitHref: string
 
   abstract readonly backLinkHref: string
+
+  abstract readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
 
   readonly text = {
     title: `Confirm feedback`,

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersView.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersView.ts
@@ -18,6 +18,7 @@ export default class CheckFeedbackAnswersView {
       'appointments/feedback/shared/postSessionFeedbackCheckAnswers',
       {
         presenter: this.presenter,
+        feedbackAnswersPresenter: this.presenter.feedbackAnswersPresenter,
         summaryListArgs: this.summaryListArgs,
         backLinkArgs: this.backLinkArgs,
       },

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
@@ -1,58 +1,9 @@
 // eslint-disable-next-line max-classes-per-file
-import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import FeedbackAnswersPresenter from './feedbackAnswersPresenter'
-import AttendanceFeedbackPresenter from '../attendance/attendanceFeedbackPresenter'
 import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
 import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
-import { BehaviourFeedbackPresenter } from '../behaviour/behaviourFeedbackPresenter'
-import BehaviourFeedbackInputsPresenter from '../behaviour/behaviourFeedbackInputsPresenter'
-import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
 
 describe(FeedbackAnswersPresenter, () => {
-  class ExtendedFeedbackAnswersPresenter extends FeedbackAnswersPresenter {
-    constructor(appointment: ActionPlanAppointment, private readonly serviceUser: DeliusServiceUser) {
-      super(appointment)
-    }
-
-    protected get attendancePresenter(): AttendanceFeedbackPresenter {
-      return new (class extends AttendanceFeedbackPresenter {
-        constructor(
-          appointment: ActionPlanAppointment | InitialAssessmentAppointment,
-          private readonly serviceUser: DeliusServiceUser
-        ) {
-          super(appointment)
-        }
-
-        readonly text = {
-          title: `Add attendance feedback`,
-          subTitle: 'Session details',
-          attendanceQuestion: `Did ${this.serviceUser.firstName} attend this session?`,
-          attendanceQuestionHint: 'Select one option',
-          additionalAttendanceInformationLabel: `Add additional information about ${this.serviceUser.firstName}'s attendance:`,
-        }
-      })(this.appointment, this.serviceUser)
-    }
-
-    protected get behaviourPresenter(): BehaviourFeedbackPresenter {
-      return {
-        backLinkHref: null,
-        inputsPresenter: new BehaviourFeedbackInputsPresenter(this.appointment),
-        text: {
-          title: `Add behaviour feedback`,
-          behaviourDescription: {
-            question: `Describe ${this.serviceUser.firstName}'s behaviour in this session`,
-            hint: 'For example, consider how well-engaged they were and what their body language was like.',
-          },
-          notifyProbationPractitioner: {
-            question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-            explanation: 'If you select yes, the probation practitioner will be notified by email.',
-            hint: 'Select one option',
-          },
-        },
-      }
-    }
-  }
-
   describe('attendedAnswers', () => {
     it('returns an object with the question and answer given', () => {
       const appointment = actionPlanAppointmentFactory.build({
@@ -68,7 +19,7 @@ describe(FeedbackAnswersPresenter, () => {
       })
       const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-      const presenter = new ExtendedFeedbackAnswersPresenter(appointment, serviceUser)
+      const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
       expect(presenter.attendedAnswers).toEqual({
         question: 'Did Alex attend this session?',
@@ -91,7 +42,7 @@ describe(FeedbackAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new ExtendedFeedbackAnswersPresenter(appointment, serviceUser)
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
         expect(presenter.attendedAnswers).toBeNull()
       })
     })
@@ -114,7 +65,7 @@ describe(FeedbackAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new ExtendedFeedbackAnswersPresenter(appointment, serviceUser)
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
         expect(presenter.additionalAttendanceAnswers).toEqual({
           question: "Add additional information about Alex's attendance:",
@@ -139,7 +90,7 @@ describe(FeedbackAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new ExtendedFeedbackAnswersPresenter(appointment, serviceUser)
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
         expect(presenter.additionalAttendanceAnswers).toEqual({
           question: "Add additional information about Alex's attendance:",
@@ -164,7 +115,7 @@ describe(FeedbackAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new ExtendedFeedbackAnswersPresenter(appointment, serviceUser)
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
         expect(presenter.additionalAttendanceAnswers).toBeNull()
       })
     })
@@ -186,7 +137,7 @@ describe(FeedbackAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new ExtendedFeedbackAnswersPresenter(appointment, serviceUser)
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
         expect(presenter.behaviourDescriptionAnswers).toEqual({
           question: "Describe Alex's behaviour in this session",
@@ -210,7 +161,7 @@ describe(FeedbackAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new ExtendedFeedbackAnswersPresenter(appointment, serviceUser)
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
         expect(presenter.behaviourDescriptionAnswers).toBeNull()
       })
@@ -231,7 +182,7 @@ describe(FeedbackAnswersPresenter, () => {
 
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new ExtendedFeedbackAnswersPresenter(appointment, serviceUser)
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
         expect(presenter.notifyProbationPractitionerAnswers).toEqual({
           question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
@@ -253,7 +204,7 @@ describe(FeedbackAnswersPresenter, () => {
 
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new ExtendedFeedbackAnswersPresenter(appointment, serviceUser)
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
         expect(presenter.notifyProbationPractitionerAnswers).toEqual({
           question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
@@ -274,7 +225,7 @@ describe(FeedbackAnswersPresenter, () => {
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
 
-        const presenter = new ExtendedFeedbackAnswersPresenter(appointment, serviceUser)
+        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
         expect(presenter.notifyProbationPractitionerAnswers).toBeNull()
       })

--- a/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
@@ -3,18 +3,10 @@ import User from '../../../../models/hmppsAuth/user'
 import DateUtils from '../../../../utils/dateUtils'
 import { SummaryListItem } from '../../../../utils/summaryList'
 import FeedbackAnswersPresenter from '../../../appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter'
-import AttendanceFeedbackPresenter from '../../../appointments/feedback/shared/attendance/attendanceFeedbackPresenter'
-import ActionPlanPostSessionAttendanceFeedbackPresenter from '../../../appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter'
 import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../models/appointment'
-import InitialAssessmentAttendanceFeedbackPresenter from '../../../appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter'
-import ActionPlanSessionBehaviourFeedbackPresenter from '../../../appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter'
-import InitialAssessmentBehaviourFeedbackPresenter from '../../../appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter'
-import { BehaviourFeedbackPresenter } from '../../../appointments/feedback/shared/behaviour/behaviourFeedbackPresenter'
 
-export default class SubmittedFeedbackPresenter extends FeedbackAnswersPresenter {
-  protected readonly attendancePresenter: AttendanceFeedbackPresenter
-
-  protected readonly behaviourPresenter: BehaviourFeedbackPresenter
+export default class SubmittedFeedbackPresenter {
+  readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
 
   constructor(
     protected readonly appointment: ActionPlanAppointment | InitialAssessmentAppointment,
@@ -24,28 +16,10 @@ export default class SubmittedFeedbackPresenter extends FeedbackAnswersPresenter
     private readonly actionPlanId: string | null = null,
     private readonly assignedCaseworker: User | null = null
   ) {
-    super(appointment)
-
-    if (this.isActionPlanAppointment(appointment)) {
-      this.attendancePresenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(appointment, this.serviceUser)
-      this.behaviourPresenter = new ActionPlanSessionBehaviourFeedbackPresenter(
-        appointment,
-        this.serviceUser,
-        this.actionPlanId
-      )
-    } else {
-      this.attendancePresenter = new InitialAssessmentAttendanceFeedbackPresenter(appointment, this.serviceUser)
-      this.behaviourPresenter = new InitialAssessmentBehaviourFeedbackPresenter(appointment, this.serviceUser)
-    }
+    this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(appointment, serviceUser)
   }
 
   readonly backLinkHref = `/${this.userType}/referrals/${this.referralId}/progress`
-
-  private isActionPlanAppointment(
-    appointment: InitialAssessmentAppointment | ActionPlanAppointment
-  ): appointment is ActionPlanAppointment {
-    return (<ActionPlanAppointment>appointment).sessionNumber !== undefined
-  }
 
   readonly text = {
     title: `View feedback`,

--- a/server/routes/shared/appointment/feedback/submittedFeedbackView.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackView.ts
@@ -18,6 +18,7 @@ export default class SubmittedFeedbackView {
       'shared/viewSubmittedPostSessionFeedback',
       {
         presenter: this.presenter,
+        feedbackAnswersPresenter: this.presenter.feedbackAnswersPresenter,
         summaryListArgs: this.summaryListArgs,
         backLinkArgs: this.backLinkArgs,
       },

--- a/server/views/partials/postSessionFeedbackResponses.njk
+++ b/server/views/partials/postSessionFeedbackResponses.njk
@@ -1,20 +1,20 @@
 
-{% if presenter.attendedAnswers %}
-  <h3 class="govuk-heading-s">{{ presenter.attendedAnswers.question }}</h3>
-  <p>{{ presenter.attendedAnswers.answer }}</p>
+{% if feedbackAnswersPresenter.attendedAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.attendedAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.attendedAnswers.answer }}</p>
 {% endif %}
 
-{% if presenter.additionalAttendanceAnswers %}
-  <h3 class="govuk-heading-s">{{ presenter.additionalAttendanceAnswers.question }}</h3>
-  <p>{{ presenter.additionalAttendanceAnswers.answer }}</p>
+{% if feedbackAnswersPresenter.additionalAttendanceAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.additionalAttendanceAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.additionalAttendanceAnswers.answer }}</p>
 {% endif %}
 
-{% if presenter.behaviourDescriptionAnswers %}
-  <h3 class="govuk-heading-s">{{ presenter.behaviourDescriptionAnswers.question }}</h3>
-  <p>{{ presenter.behaviourDescriptionAnswers.answer }}</p>
+{% if feedbackAnswersPresenter.behaviourDescriptionAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.behaviourDescriptionAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.behaviourDescriptionAnswers.answer }}</p>
 {% endif %}
 
-{% if presenter.notifyProbationPractitionerAnswers %}
-  <h3 class="govuk-heading-s">{{ presenter.notifyProbationPractitionerAnswers.question }}</h3>
-  <p>{{ presenter.notifyProbationPractitionerAnswers.answer }}</p>
+{% if feedbackAnswersPresenter.notifyProbationPractitionerAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.notifyProbationPractitionerAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.notifyProbationPractitionerAnswers.answer }}</p>
 {% endif %}


### PR DESCRIPTION
Created a questionnaire class for attendance and behaviour. This holds all the questions for the feedback page.

The reason for this class is because presenting the attendance/behaviour feedback is used on multiple pages:
1. postSessionAttendanceFeedback.njk: this is the page where the user supplies the answers. It is used by both initial assessment and action plan session.
2. postSessionFeedbackResponses.njk: this is a partial page where the user can view/review their answers. It is used by three pages: (review answers before submitting, view feedback and reschedule appointment - this last one is still to be done).

The current attendanceFeedbackPresenter and behaviourFeedbackPresenter classes are coupled with backlinks and page title. For presenting the feedback we just want the actual question and answers; so by making it a seperate component it should reduce coupling.