### PR TITLE
Added the ability to use wiremock for community-api calls.

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -8,7 +8,7 @@ import AssessRisksAndNeedsServiceMocks from '../../mockApis/assessRisksAndNeedsS
 const wiremock = new Wiremock('http://localhost:9091/__admin')
 const auth = new AuthServiceMocks(wiremock)
 const tokenVerification = new TokenVerificationMocks(wiremock)
-const communityApi = new CommunityApiMocks(wiremock)
+const communityApi = new CommunityApiMocks(wiremock, '/community-api')
 const interventionsService = new InterventionsServiceMocks(wiremock, '/interventions')
 const assessRisksAndNeedsService = new AssessRisksAndNeedsServiceMocks(wiremock)
 

--- a/mockApis/communityApi.ts
+++ b/mockApis/communityApi.ts
@@ -1,13 +1,13 @@
 import Wiremock from './wiremock'
 
 export default class CommunityApiMocks {
-  constructor(private readonly wiremock: Wiremock) {}
+  constructor(private readonly wiremock: Wiremock, private readonly mockPrefix: string) {}
 
   stubGetServiceUserByCRN = async (crn: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/community-api/secure/offenders/crn/${crn}`,
+        urlPattern: `${this.mockPrefix}/secure/offenders/crn/${crn}`,
       },
       response: {
         status: 200,
@@ -23,7 +23,7 @@ export default class CommunityApiMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/community-api/secure/offenders/crn/${crn}/all`,
+        urlPattern: `${this.mockPrefix}/secure/offenders/crn/${crn}/all`,
       },
       response: {
         status: 200,
@@ -39,7 +39,7 @@ export default class CommunityApiMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/community-api/secure/users/${username}/details`,
+        urlPattern: `${this.mockPrefix}/secure/users/${username}/details`,
       },
       response: {
         status: 200,
@@ -55,7 +55,7 @@ export default class CommunityApiMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/community-api/secure/offenders/crn/${crn}/convictions`,
+        urlPattern: `${this.mockPrefix}/secure/offenders/crn/${crn}/convictions`,
       },
       response: {
         status: 200,
@@ -71,7 +71,7 @@ export default class CommunityApiMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/community-api/secure/offenders/crn/${crn}/convictions/${id}`,
+        urlPattern: `${this.mockPrefix}/secure/offenders/crn/${crn}/convictions/${id}`,
       },
       response: {
         status: 200,
@@ -87,7 +87,7 @@ export default class CommunityApiMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/community-api/secure/staff/username/${username}`,
+        urlPattern: `${this.mockPrefix}/secure/staff/username/${username}`,
       },
       response: {
         status: 200,
@@ -103,7 +103,7 @@ export default class CommunityApiMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/community-api/secure/offenders/crn/${crn}/allOffenderManagers`,
+        urlPattern: `${this.mockPrefix}/secure/offenders/crn/${crn}/allOffenderManagers`,
       },
       response: {
         status: 200,

--- a/mocks.ts
+++ b/mocks.ts
@@ -9,9 +9,12 @@ import interventionFactory from './testutils/factories/intervention'
 import actionPlanAppointmentFactory from './testutils/factories/actionPlanAppointment'
 import draftReferralFactory from './testutils/factories/draftReferral'
 import serviceCategoryFactory from './testutils/factories/serviceCategory'
+import CommunityApiMocks from './mockApis/communityApi'
+import deliusConvictionFactory from './testutils/factories/deliusConviction'
 
 const wiremock = new Wiremock('http://localhost:9092/__admin')
 const interventionsMocks = new InterventionsServiceMocks(wiremock, '')
+const communityApiMocks = new CommunityApiMocks(wiremock, '')
 
 export default async function setUpMocks(): Promise<void> {
   await wiremock.resetStubs()
@@ -144,8 +147,8 @@ export default async function setUpMocks(): Promise<void> {
         disabilities: ['Autism spectrum condition', 'sciatica'],
       },
     })
-
   await Promise.all([
+    communityApiMocks.stubGetActiveConvictionsByCRN('CRN11', [deliusConvictionFactory.build()]),
     interventionsMocks.stubGetActionPlanAppointment(
       '1',
       1,
@@ -155,7 +158,6 @@ export default async function setUpMocks(): Promise<void> {
         durationInMinutes: 75,
       })
     ),
-
     interventionsMocks.stubGetIntervention(draftReferral.interventionId, intervention),
     interventionsMocks.stubGetDraftReferral(draftReferral.id, draftReferral),
     [accommodationServiceCategory, socialInclusionServiceCategory].forEach(async serviceCategory => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -80,7 +80,7 @@ export default {
   },
   apis: {
     communityApi: {
-      url: get('COMMUNITY_API_URL', 'http://localhost:8091', requiredInProduction),
+      url: get('COMMUNITY_API_URL', 'http://localhost:9092', requiredInProduction),
       timeout: {
         response: Number(get('COMMUNITY_API_TIMEOUT_RESPONSE', 10000)),
         deadline: Number(get('COMMUNITY_API_TIMEOUT_DEADLINE', 10000)),

--- a/wiremock_mappings/communityApiProxy.json
+++ b/wiremock_mappings/communityApiProxy.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "ANY",
+    "urlPattern": "/secure/.*"
+  },
+  "response": {
+    "proxyBaseUrl": "http://community-api:8080"
+  },
+  "priority": 9
+}


### PR DESCRIPTION
Added the ability to use wiremock for community-api calls.
The default url for community-api is now wiremock service.

This was added to have control of errors being thrown in local dev run when a user does not have any active convictions when making a referral.

Wiremock has been configured to proxy any requests that are unresolved and that start with /secure/ to community-api service, the default proxy for all calls still goes to intervention-service but it is at a lower priority in wiremock resolutions.

Ideally I would have proxied based on the urlPattern of '/community-api.\*' and '/interventions-service/.\*'; however it's not possible to strip the url path when proxying (at least in the standalone version - it's possible to write a custom transformer if you programmatically set up wiremock service). To fix this we could extend wiremock in a new project, write the transformer and have it available as a docker container.

Alternatively I could have added a custom header only for dev run whereby we set up a pattern based on the header being present, but I didn't want to play around too much with the rest client/ service classes.

