### PR TITLE
Turn on the feature to schedule with NPS office locations in prod

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -44,7 +44,7 @@ export default {
   googleAnalyticsTrackingId: get('GA_ID', '', requiredInProduction),
   features: {
     npsOfficeLocationSelection: {
-      enabled: get('FEATURE_NPS_OFFICE_LOCATION_SELECTION_ENABLED', 'false') === 'true',
+      enabled: get('FEATURE_NPS_OFFICE_LOCATION_SELECTION_ENABLED', 'true') === 'true',
     },
     serviceProviderReporting: {
       enabled: get('FEATURE_SP_REPORTING_ENABLED', 'false') === 'true',


### PR DESCRIPTION
Set the default for the feature to sechedule with NPS office locations to true.

At some point I will remove the feature scaffolding completely.
