### PR TITLE
IC-2180: Updated help and support page to reflect the latest

### DIFF
--- a/server/views/common/reportAProblem.njk
+++ b/server/views/common/reportAProblem.njk
@@ -5,7 +5,12 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Report a problem</h1>
 
-      <p class="govuk-body">To report a problem with this digital service, please contact the helpdesk on <a href="tel:+44800 917 5148">0800 917 5148</a> or complete this <a href="https://docs.google.com/forms/d/e/1FAIpQLScKz91VMetK49hYdZfkjiU2VkMUL2Bsvh-5QzyTqErJTpQKLw/viewform?usp=sf_link">support form</a></p>
+      <h3 class="govuk-heading-s">NPS staff</h3>
+      <p class="govuk-body">To report a problem with this digital service, please contact the helpdesk on 0800 917 5148</p>
+
+      <h3 class="govuk-heading-s">Suppliers</h3>
+      <p class="govuk-body">To report a problem with this digital service, please contact your helpdesk who will contact the digital service team if necessary.</p>
+      <p class="govuk-body">If your organisation does not have an IT helpdesk, please contact the helpdesk on 0800 917 5148</p>
 
       <h2 class="govuk-heading-m">Learning and resources for NPS staff</h2>
 


### PR DESCRIPTION
Updated help and support page to reflect the latest in https://docs.google.com/document/d/1oam57tb4LUV3pZ8SfxUHFe9r5pwSEJ-ZmVFsbFiHBEA/edit

Page now looks like:
![image](https://user-images.githubusercontent.com/83066216/129218999-ead806f2-8bae-4d96-af63-d45991fd7752.png)
