### PR TITLE
Refactor dependency inversion for appointment summary

### DIFF
--- a/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.test.ts
@@ -1,13 +1,18 @@
 import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
 import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
 import ActionPlanPostSessionAttendanceFeedbackPresenter from './actionPlanPostSessionAttendanceFeedbackPresenter'
+import AppointmentSummary from '../../../appointmentSummary'
 
 describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
   describe('text', () => {
     it('contains a title including the name of the service category and a subtitle, and the attendance questions', () => {
       const appointment = actionPlanAppointmentFactory.build()
       const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-      const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+      const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
+        appointment,
+        serviceUser,
+        new AppointmentSummary(appointment)
+      )
 
       expect(presenter.text).toMatchObject({
         title: 'Add attendance feedback',
@@ -22,7 +27,11 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
       it('contains an attendance question to indicate the meeting was a phone call', () => {
         const appointment = actionPlanAppointmentFactory.build({ appointmentDeliveryType: 'PHONE_CALL' })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
+          appointment,
+          serviceUser,
+          new AppointmentSummary(appointment)
+        )
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex join this phone call?')
       })
     })
@@ -31,7 +40,11 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
       it('contains an attendance question to indicate the meeting was a video call', () => {
         const appointment = actionPlanAppointmentFactory.build({ appointmentDeliveryType: 'VIDEO_CALL' })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
+          appointment,
+          serviceUser,
+          new AppointmentSummary(appointment)
+        )
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex join this video call?')
       })
     })
@@ -40,7 +53,11 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
       it('contains an attendance question to indicate the meeting was an in-person meeting', () => {
         const appointment = actionPlanAppointmentFactory.build({ appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER' })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
+          appointment,
+          serviceUser,
+          new AppointmentSummary(appointment)
+        )
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex attend this in-person meeting?')
       })
     })
@@ -51,7 +68,11 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
           appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
         })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
+          appointment,
+          serviceUser,
+          new AppointmentSummary(appointment)
+        )
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex attend this in-person meeting?')
       })
     })
@@ -65,6 +86,7 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
           appointment,
           serviceUser,
+          new AppointmentSummary(appointment),
           null,
           null,
           'test-referral-id'
@@ -77,7 +99,11 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
       it('is null', () => {
         const appointment = actionPlanAppointmentFactory.build()
         const serviceUser = deliusServiceUserFactory.build()
-        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(appointment, serviceUser)
+        const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
+          appointment,
+          serviceUser,
+          new AppointmentSummary(appointment)
+        )
         expect(presenter.backLinkHref).toEqual(null)
       })
     })

--- a/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.ts
@@ -3,11 +3,13 @@ import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import AttendanceFeedbackPresenter from '../../shared/attendance/attendanceFeedbackPresenter'
 import AttendanceFeedbackQuestionnaire from '../../shared/attendance/attendanceFeedbackQuestionnaire'
+import AppointmentSummary from '../../../appointmentSummary'
 
 export default class ActionPlanPostSessionAttendanceFeedbackPresenter extends AttendanceFeedbackPresenter {
   constructor(
     private readonly actionPlanAppointment: ActionPlanAppointment,
     private readonly serviceUser: DeliusServiceUser,
+    readonly appointmentSummary: AppointmentSummary,
     error: FormValidationError | null = null,
     userInputData: Record<string, unknown> | null = null,
     private readonly referralId: string | null = null
@@ -17,6 +19,7 @@ export default class ActionPlanPostSessionAttendanceFeedbackPresenter extends At
       `Add attendance feedback`,
       'Session details',
       new AttendanceFeedbackQuestionnaire(actionPlanAppointment, serviceUser),
+      appointmentSummary,
       error,
       userInputData
     )

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/ActionPlanPostSessionFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/ActionPlanPostSessionFeedbackCheckAnswersPresenter.test.ts
@@ -1,6 +1,7 @@
 import ActionPlanPostSessionFeedbackCheckAnswersPresenter from './actionPlanPostSessionFeedbackCheckAnswersPresenter'
 import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
 import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
+import AppointmentSummary from '../../../appointmentSummary'
 
 describe(ActionPlanPostSessionFeedbackCheckAnswersPresenter, () => {
   describe('text', () => {
@@ -9,7 +10,12 @@ describe(ActionPlanPostSessionFeedbackCheckAnswersPresenter, () => {
       const serviceUser = deliusServiceUserFactory.build()
       const actionPlanId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
 
-      const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
+      const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(
+        appointment,
+        serviceUser,
+        actionPlanId,
+        new AppointmentSummary(appointment)
+      )
 
       expect(presenter.text).toMatchObject({
         title: 'Confirm feedback',
@@ -23,7 +29,12 @@ describe(ActionPlanPostSessionFeedbackCheckAnswersPresenter, () => {
       const serviceUser = deliusServiceUserFactory.build()
       const actionPlanId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
 
-      const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, actionPlanId)
+      const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(
+        appointment,
+        serviceUser,
+        actionPlanId,
+        new AppointmentSummary(appointment)
+      )
 
       expect(presenter.submitHref).toEqual(
         '/service-provider/action-plan/77f0d8fc-9443-492c-b352-4cab66acbf3c/appointment/1/post-session-feedback/submit'
@@ -43,7 +54,12 @@ describe(ActionPlanPostSessionFeedbackCheckAnswersPresenter, () => {
         const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
 
         attendedAppointments.forEach(appointment => {
-          const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, referralId)
+          const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(
+            appointment,
+            serviceUser,
+            referralId,
+            new AppointmentSummary(appointment)
+          )
 
           expect(presenter.backLinkHref).toEqual(
             '/service-provider/action-plan/77f0d8fc-9443-492c-b352-4cab66acbf3c/appointment/1/post-session-feedback/behaviour'
@@ -58,7 +74,12 @@ describe(ActionPlanPostSessionFeedbackCheckAnswersPresenter, () => {
         const serviceUser = deliusServiceUserFactory.build()
         const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
 
-        const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(appointment, serviceUser, referralId)
+        const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(
+          appointment,
+          serviceUser,
+          referralId,
+          new AppointmentSummary(appointment)
+        )
 
         expect(presenter.backLinkHref).toEqual(
           '/service-provider/action-plan/77f0d8fc-9443-492c-b352-4cab66acbf3c/appointment/1/post-session-feedback/attendance'

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
@@ -2,6 +2,7 @@ import { ActionPlanAppointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import CheckFeedbackAnswersPresenter from '../../shared/checkYourAnswers/checkFeedbackAnswersPresenter'
 import FeedbackAnswersPresenter from '../../shared/viewFeedback/feedbackAnswersPresenter'
+import AppointmentSummary from '../../../appointmentSummary'
 
 export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends CheckFeedbackAnswersPresenter {
   readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
@@ -9,9 +10,10 @@ export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends 
   constructor(
     private readonly actionPlanAppointment: ActionPlanAppointment,
     private readonly serviceUser: DeliusServiceUser,
-    private readonly actionPlanId: string
+    private readonly actionPlanId: string,
+    readonly appointmentSummary: AppointmentSummary
   ) {
-    super(actionPlanAppointment)
+    super(actionPlanAppointment, appointmentSummary)
     this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(actionPlanAppointment, serviceUser)
   }
 

--- a/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.test.ts
@@ -1,13 +1,18 @@
 import initialAssessmentAppointmentFactory from '../../../../../../testutils/factories/initialAssessmentAppointment'
 import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
 import InitialAssessmentAttendanceFeedbackPresenter from './initialAssessmentAttendanceFeedbackPresenter'
+import AppointmentSummary from '../../../appointmentSummary'
 
 describe(InitialAssessmentAttendanceFeedbackPresenter, () => {
   describe('text', () => {
     it('contains a title including the name of the service category and a subtitle, and the attendance questions', () => {
       const appointment = initialAssessmentAppointmentFactory.build()
       const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-      const presenter = new InitialAssessmentAttendanceFeedbackPresenter(appointment, serviceUser)
+      const presenter = new InitialAssessmentAttendanceFeedbackPresenter(
+        appointment,
+        serviceUser,
+        new AppointmentSummary(appointment)
+      )
 
       expect(presenter.text).toMatchObject({
         title: 'Add feedback',
@@ -27,6 +32,7 @@ describe(InitialAssessmentAttendanceFeedbackPresenter, () => {
         const presenter = new InitialAssessmentAttendanceFeedbackPresenter(
           appointment,
           serviceUser,
+          new AppointmentSummary(appointment),
           null,
           null,
           'test-referral-id'
@@ -40,7 +46,11 @@ describe(InitialAssessmentAttendanceFeedbackPresenter, () => {
       it('is null', () => {
         const appointment = initialAssessmentAppointmentFactory.build()
         const serviceUser = deliusServiceUserFactory.build()
-        const presenter = new InitialAssessmentAttendanceFeedbackPresenter(appointment, serviceUser)
+        const presenter = new InitialAssessmentAttendanceFeedbackPresenter(
+          appointment,
+          serviceUser,
+          new AppointmentSummary(appointment)
+        )
 
         expect(presenter.backLinkHref).toEqual(null)
       })

--- a/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.ts
@@ -3,11 +3,13 @@ import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import AttendanceFeedbackPresenter from '../../shared/attendance/attendanceFeedbackPresenter'
 import AttendanceFeedbackQuestionnaire from '../../shared/attendance/attendanceFeedbackQuestionnaire'
+import AppointmentSummary from '../../../appointmentSummary'
 
 export default class InitialAssessmentAttendanceFeedbackPresenter extends AttendanceFeedbackPresenter {
   constructor(
     private readonly initialAssessmentAppointment: InitialAssessmentAppointment,
     private readonly serviceUser: DeliusServiceUser,
+    readonly appointmentSummary: AppointmentSummary,
     error: FormValidationError | null = null,
     userInputData: Record<string, unknown> | null = null,
     private readonly referralId: string | null = null
@@ -17,6 +19,7 @@ export default class InitialAssessmentAttendanceFeedbackPresenter extends Attend
       'Add feedback',
       'Appointment details',
       new AttendanceFeedbackQuestionnaire(initialAssessmentAppointment, serviceUser),
+      appointmentSummary,
       error,
       userInputData
     )

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.test.ts
@@ -1,6 +1,7 @@
 import InitialAssessmentFeedbackCheckAnswersPresenter from './initialAssessmentFeedbackCheckAnswersPresenter'
 import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
 import initialAssessmentAppointmentFactory from '../../../../../../testutils/factories/initialAssessmentAppointment'
+import AppointmentSummary from '../../../appointmentSummary'
 
 describe(InitialAssessmentFeedbackCheckAnswersPresenter, () => {
   describe('submitHref', () => {
@@ -9,7 +10,12 @@ describe(InitialAssessmentFeedbackCheckAnswersPresenter, () => {
       const serviceUser = deliusServiceUserFactory.build()
       const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
 
-      const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(appointment, serviceUser, referralId)
+      const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(
+        appointment,
+        serviceUser,
+        referralId,
+        new AppointmentSummary(appointment)
+      )
 
       expect(presenter.submitHref).toEqual(
         '/service-provider/referrals/77f0d8fc-9443-492c-b352-4cab66acbf3c/supplier-assessment/post-assessment-feedback/submit'
@@ -29,7 +35,12 @@ describe(InitialAssessmentFeedbackCheckAnswersPresenter, () => {
         const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
 
         attendedAppointments.forEach(appointment => {
-          const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(appointment, serviceUser, referralId)
+          const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(
+            appointment,
+            serviceUser,
+            referralId,
+            new AppointmentSummary(appointment)
+          )
 
           expect(presenter.backLinkHref).toEqual(
             '/service-provider/referrals/77f0d8fc-9443-492c-b352-4cab66acbf3c/supplier-assessment/post-assessment-feedback/behaviour'
@@ -46,7 +57,12 @@ describe(InitialAssessmentFeedbackCheckAnswersPresenter, () => {
         const serviceUser = deliusServiceUserFactory.build()
         const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
 
-        const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(appointment, serviceUser, referralId)
+        const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(
+          appointment,
+          serviceUser,
+          referralId,
+          new AppointmentSummary(appointment)
+        )
 
         expect(presenter.backLinkHref).toEqual(
           '/service-provider/referrals/77f0d8fc-9443-492c-b352-4cab66acbf3c/supplier-assessment/post-assessment-feedback/attendance'

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
@@ -2,6 +2,7 @@ import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import CheckFeedbackAnswersPresenter from '../../shared/checkYourAnswers/checkFeedbackAnswersPresenter'
 import { InitialAssessmentAppointment } from '../../../../../models/appointment'
 import FeedbackAnswersPresenter from '../../shared/viewFeedback/feedbackAnswersPresenter'
+import AppointmentSummary from '../../../appointmentSummary'
 
 export default class InitialAssessmentFeedbackCheckAnswersPresenter extends CheckFeedbackAnswersPresenter {
   readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
@@ -9,9 +10,10 @@ export default class InitialAssessmentFeedbackCheckAnswersPresenter extends Chec
   constructor(
     appointment: InitialAssessmentAppointment,
     private readonly serviceUser: DeliusServiceUser,
-    private readonly referralId: string
+    private readonly referralId: string,
+    readonly appointmentSummary: AppointmentSummary
   ) {
-    super(appointment)
+    super(appointment, appointmentSummary)
     this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(appointment, serviceUser)
   }
 

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.test.ts
@@ -4,6 +4,7 @@ import { FormValidationError } from '../../../../../utils/formValidationError'
 import { InitialAssessmentAppointment } from '../../../../../models/appointment'
 import AttendanceFeedbackQuestionnaire from './attendanceFeedbackQuestionnaire'
 import deliusServiceUser from '../../../../../../testutils/factories/deliusServiceUser'
+import AppointmentSummary from '../../../appointmentSummary'
 
 describe(AttendanceFeedbackPresenter, () => {
   class ExtendedAttendanceFeedbackPresenter extends AttendanceFeedbackPresenter {
@@ -17,6 +18,7 @@ describe(AttendanceFeedbackPresenter, () => {
         'title',
         'subTitle',
         new AttendanceFeedbackQuestionnaire(appointment, deliusServiceUser.build()),
+        new AppointmentSummary(appointment),
         error,
         userInputData
       )

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
@@ -20,6 +20,7 @@ export default abstract class AttendanceFeedbackPresenter {
     private readonly title: string,
     private readonly subTitle: string,
     private readonly attendanceFeedbackQuestionnaire: AttendanceFeedbackQuestionnaire,
+    readonly appointmentSummary: AppointmentSummary,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {
@@ -35,8 +36,6 @@ export default abstract class AttendanceFeedbackPresenter {
   readonly backLinkHref: string | null = null
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
-
-  readonly appointmentSummary = new AppointmentSummary(this.appointment, null)
 
   readonly fields = {
     attended: {

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.ts
@@ -3,7 +3,10 @@ import FeedbackAnswersPresenter from '../viewFeedback/feedbackAnswersPresenter'
 import AppointmentSummary from '../../../appointmentSummary'
 
 export default abstract class CheckFeedbackAnswersPresenter {
-  protected constructor(protected appointment: ActionPlanAppointment | InitialAssessmentAppointment) {}
+  protected constructor(
+    protected appointment: ActionPlanAppointment | InitialAssessmentAppointment,
+    readonly appointmentSummary: AppointmentSummary
+  ) {}
 
   abstract readonly submitHref: string
 
@@ -14,6 +17,4 @@ export default abstract class CheckFeedbackAnswersPresenter {
   readonly text = {
     title: `Confirm feedback`,
   }
-
-  readonly appointmentSummary = new AppointmentSummary(this.appointment, null)
 }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -37,6 +37,7 @@ import FileUtils from '../../utils/fileUtils'
 import DraftsService from '../../services/draftsService'
 import DraftCancellationData from './draftCancellationData'
 import config from '../../config'
+import AppointmentSummary from '../appointments/appointmentSummary'
 
 export default class ProbationPractitionerReferralsController {
   constructor(
@@ -207,11 +208,11 @@ export default class ProbationPractitionerReferralsController {
 
     const presenter = new SubmittedFeedbackPresenter(
       currentAppointment,
+      new AppointmentSummary(currentAppointment, referral.assignedTo),
       serviceUser,
       'probation-practitioner',
       referral.id,
-      null,
-      referral.assignedTo
+      null
     )
     const view = new SubmittedFeedbackView(presenter)
 
@@ -241,6 +242,7 @@ export default class ProbationPractitionerReferralsController {
 
     const presenter = new SubmittedFeedbackPresenter(
       currentAppointment,
+      new AppointmentSummary(currentAppointment),
       serviceUser,
       'probation-practitioner',
       referralId
@@ -589,11 +591,15 @@ export default class ProbationPractitionerReferralsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new SupplierAssessmentAppointmentPresenter(referral, appointment, assignee, {
-      includeAssignee: true,
-      readonly: true,
-      userType: 'probation-practitioner',
-    })
+    const presenter = new SupplierAssessmentAppointmentPresenter(
+      referral,
+      appointment,
+      new AppointmentSummary(appointment, assignee),
+      {
+        readonly: true,
+        userType: 'probation-practitioner',
+      }
+    )
     const view = new SupplierAssessmentAppointmentView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.test.ts
@@ -1,6 +1,7 @@
 import ScheduleActionPlanSessionPresenter from './scheduleActionPlanSessionPresenter'
 import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
 import sentReferralFactory from '../../../../../../testutils/factories/sentReferral'
+import AppointmentSummary from '../../../../appointments/appointmentSummary'
 
 describe(ScheduleActionPlanSessionPresenter, () => {
   const referral = sentReferralFactory.build()
@@ -10,7 +11,12 @@ describe(ScheduleActionPlanSessionPresenter, () => {
   describe('text.title', () => {
     it('contains the appointment number', () => {
       const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 1 })
-      const presenter = new ScheduleActionPlanSessionPresenter(referral, appointment, [])
+      const presenter = new ScheduleActionPlanSessionPresenter(
+        referral,
+        appointment,
+        new AppointmentSummary(appointment),
+        []
+      )
 
       expect(presenter.text).toEqual({ title: 'Add session 1 details' })
     })

--- a/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.ts
+++ b/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.ts
@@ -2,15 +2,15 @@ import { ActionPlanAppointment } from '../../../../../models/appointment'
 import SentReferral from '../../../../../models/sentReferral'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import ScheduleAppointmentPresenter from '../../../../serviceProviderReferrals/scheduleAppointmentPresenter'
-import AuthUserDetails from '../../../../../models/hmppsAuth/authUserDetails'
 import DeliusOfficeLocation from '../../../../../models/deliusOfficeLocation'
+import AppointmentSummary from '../../../../appointments/appointmentSummary'
 
 export default class ScheduleActionPlanSessionPresenter extends ScheduleAppointmentPresenter {
   constructor(
     referral: SentReferral,
     currentAppointment: ActionPlanAppointment,
+    currentAppointmentSummary: AppointmentSummary,
     deliusOfficeLocations: DeliusOfficeLocation[],
-    assignedCaseworker: AuthUserDetails | null = null,
     validationError: FormValidationError | null = null,
     userInputData: Record<string, unknown> | null = null,
     serverError: FormValidationError | null = null
@@ -18,8 +18,8 @@ export default class ScheduleActionPlanSessionPresenter extends ScheduleAppointm
     super(
       referral,
       currentAppointment,
+      currentAppointmentSummary,
       deliusOfficeLocations,
-      assignedCaseworker,
       validationError,
       userInputData,
       serverError

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -6,15 +6,14 @@ import SentReferral from '../../models/sentReferral'
 import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
 import AppointmentSummary from '../appointments/appointmentSummary'
 import { SummaryListItem } from '../../utils/summaryList'
-import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
 import config from '../../config'
 
 export default class ScheduleAppointmentPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly currentAppointment: InitialAssessmentAppointment | ActionPlanAppointment | null,
+    private readonly currentAppointmentSummary: AppointmentSummary | null,
     private readonly deliusOfficeLocations: DeliusOfficeLocation[],
-    private readonly assignedCaseworker: AuthUserDetails | null = null,
     private readonly validationError: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null,
     private readonly serverError: FormValidationError | null = null,
@@ -32,8 +31,8 @@ export default class ScheduleAppointmentPresenter {
   private readonly utils = new PresenterUtils(this.userInputData)
 
   get appointmentSummary(): SummaryListItem[] {
-    if (this.appointmentAlreadyAttended) {
-      return new AppointmentSummary(this.currentAppointment!, this.assignedCaseworker).appointmentSummaryList
+    if (this.appointmentAlreadyAttended && this.currentAppointmentSummary) {
+      return this.currentAppointmentSummary.appointmentSummaryList
     }
     return []
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -83,6 +83,7 @@ import { ActionPlanAppointment, AppointmentSchedulingDetails } from '../../model
 import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
 import DeliusOfficeLocationFilter from '../../services/deliusOfficeLocationFilter'
 import config from '../../config'
+import AppointmentSummary from '../appointments/appointmentSummary'
 
 export interface DraftAssignmentData {
   email: string | null
@@ -596,8 +597,8 @@ export default class ServiceProviderReferralsController {
           new ScheduleActionPlanSessionPresenter(
             referral,
             appointment,
+            new AppointmentSummary(appointment),
             deliusOfficeLocations,
-            null,
             formError,
             userInputData,
             serverError
@@ -664,8 +665,8 @@ export default class ServiceProviderReferralsController {
           return new ScheduleAppointmentPresenter(
             referral,
             appointment,
+            appointment === null ? null : new AppointmentSummary(appointment, assignedCaseworker),
             deliusOfficeLocations,
-            assignedCaseworker,
             formError,
             userInputData,
             serverError,
@@ -696,9 +697,14 @@ export default class ServiceProviderReferralsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new SupplierAssessmentAppointmentPresenter(referral, appointment, null, {
-      userType: 'service-provider',
-    })
+    const presenter = new SupplierAssessmentAppointmentPresenter(
+      referral,
+      appointment,
+      new AppointmentSummary(appointment),
+      {
+        userType: 'service-provider',
+      }
+    )
     const view = new SupplierAssessmentAppointmentView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
@@ -811,6 +817,7 @@ export default class ServiceProviderReferralsController {
     const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
       appointment,
       serviceUser,
+      new AppointmentSummary(appointment),
       formError,
       userInputData,
       referral.id
@@ -862,6 +869,7 @@ export default class ServiceProviderReferralsController {
     const presenter = new InitialAssessmentAttendanceFeedbackPresenter(
       appointment,
       serviceUser,
+      new AppointmentSummary(appointment),
       formError,
       userInputData,
       referralId
@@ -930,7 +938,12 @@ export default class ServiceProviderReferralsController {
     }
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
-    const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(appointment, serviceUser, referralId)
+    const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(
+      appointment,
+      serviceUser,
+      referralId,
+      new AppointmentSummary(appointment)
+    )
     const view = new CheckFeedbackAnswersView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
@@ -983,7 +996,13 @@ export default class ServiceProviderReferralsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new SubmittedFeedbackPresenter(currentAppointment, serviceUser, 'service-provider', referralId)
+    const presenter = new SubmittedFeedbackPresenter(
+      currentAppointment,
+      new AppointmentSummary(currentAppointment),
+      serviceUser,
+      'service-provider',
+      referralId
+    )
     const view = new SubmittedFeedbackView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
@@ -1060,7 +1079,8 @@ export default class ServiceProviderReferralsController {
     const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(
       currentAppointment,
       serviceUser,
-      actionPlanId
+      actionPlanId,
+      new AppointmentSummary(currentAppointment)
     )
     const view = new CheckFeedbackAnswersView(presenter)
 
@@ -1095,7 +1115,13 @@ export default class ServiceProviderReferralsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new SubmittedFeedbackPresenter(currentAppointment, serviceUser, 'service-provider', referral.id)
+    const presenter = new SubmittedFeedbackPresenter(
+      currentAppointment,
+      new AppointmentSummary(currentAppointment),
+      serviceUser,
+      'service-provider',
+      referral.id
+    )
     const view = new SubmittedFeedbackView(presenter)
 
     return ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.test.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.test.ts
@@ -2,6 +2,7 @@ import actionPlanAppointmentFactory from '../../../../../testutils/factories/act
 import initialAssessmentAppointmentFactory from '../../../../../testutils/factories/initialAssessmentAppointment'
 import deliusServiceUserFactory from '../../../../../testutils/factories/deliusServiceUser'
 import SubmittedFeedbackPresenter from './submittedFeedbackPresenter'
+import AppointmentSummary from '../../../appointments/appointmentSummary'
 
 describe(SubmittedFeedbackPresenter, () => {
   const userType = 'service-provider'
@@ -11,12 +12,24 @@ describe(SubmittedFeedbackPresenter, () => {
     it('includes the title of the page', () => {
       const serviceUser = deliusServiceUserFactory.build()
       const actionPlanAppointment = actionPlanAppointmentFactory.build()
-      let presenter = new SubmittedFeedbackPresenter(actionPlanAppointment, serviceUser, userType, referralId)
+      let presenter = new SubmittedFeedbackPresenter(
+        actionPlanAppointment,
+        new AppointmentSummary(actionPlanAppointment),
+        serviceUser,
+        userType,
+        referralId
+      )
       expect(presenter.text).toMatchObject({
         title: 'View feedback',
       })
       const initialAssessmentAppointment = initialAssessmentAppointmentFactory.build()
-      presenter = new SubmittedFeedbackPresenter(initialAssessmentAppointment, serviceUser, userType, referralId)
+      presenter = new SubmittedFeedbackPresenter(
+        initialAssessmentAppointment,
+        new AppointmentSummary(actionPlanAppointment),
+        serviceUser,
+        userType,
+        referralId
+      )
       expect(presenter.text).toMatchObject({
         title: 'View feedback',
       })
@@ -29,6 +42,7 @@ describe(SubmittedFeedbackPresenter, () => {
       const actionPlanAppointment = actionPlanAppointmentFactory.build()
       const presenter = new SubmittedFeedbackPresenter(
         actionPlanAppointment,
+        new AppointmentSummary(actionPlanAppointment),
         serviceUser,
         'probation-practitioner',
         'test-referral-id'

--- a/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
@@ -1,5 +1,4 @@
 import DeliusServiceUser from '../../../../models/delius/deliusServiceUser'
-import User from '../../../../models/hmppsAuth/user'
 import FeedbackAnswersPresenter from '../../../appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter'
 import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../models/appointment'
 import AppointmentSummary from '../../../appointments/appointmentSummary'
@@ -9,11 +8,11 @@ export default class SubmittedFeedbackPresenter {
 
   constructor(
     protected readonly appointment: ActionPlanAppointment | InitialAssessmentAppointment,
+    readonly appointmentSummary: AppointmentSummary,
     private readonly serviceUser: DeliusServiceUser,
     private readonly userType: 'probation-practitioner' | 'service-provider',
     private readonly referralId: string,
-    private readonly actionPlanId: string | null = null,
-    private readonly assignedCaseworker: User | null = null
+    private readonly actionPlanId: string | null = null
   ) {
     this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(appointment, serviceUser)
   }
@@ -23,6 +22,4 @@ export default class SubmittedFeedbackPresenter {
   readonly text = {
     title: `View feedback`,
   }
-
-  readonly appointmentSummary = new AppointmentSummary(this.appointment, this.assignedCaseworker)
 }

--- a/server/routes/shared/supplierAssessmentAppointmentPresenter.ts
+++ b/server/routes/shared/supplierAssessmentAppointmentPresenter.ts
@@ -1,13 +1,11 @@
 import SentReferral from '../../models/sentReferral'
 import sessionStatus, { SessionStatus } from '../../utils/sessionStatus'
 import { SummaryListItem } from '../../utils/summaryList'
-import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
 import AppointmentSummary from '../appointments/appointmentSummary'
 import { InitialAssessmentAppointment } from '../../models/appointment'
 
 interface SupplierAssessmentAppointmentPresenterOptions {
   readonly?: boolean
-  includeAssignee?: boolean
   readonly userType: 'service-provider' | 'probation-practitioner'
 }
 
@@ -15,17 +13,12 @@ export default class SupplierAssessmentAppointmentPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly appointment: InitialAssessmentAppointment,
-    private readonly assignee: AuthUserDetails | null,
+    readonly appointmentSummary: AppointmentSummary,
     private readonly options: SupplierAssessmentAppointmentPresenterOptions = { userType: 'service-provider' }
   ) {}
 
-  private readonly appointmentSummaryComponent = new AppointmentSummary(
-    this.appointment,
-    this.options.includeAssignee ? this.assignee : null
-  )
-
   get summary(): SummaryListItem[] {
-    return this.appointmentSummaryComponent.appointmentSummaryList
+    return this.appointmentSummary.appointmentSummaryList
   }
 
   get actionLink(): { href: string; text: string } | null {


### PR DESCRIPTION
Refactored code so that AppointmentSummary is constructed outside of the Presenter classes and the responsibility of the Controller classes.

The reason for this change:

1. AppointmentSummary acts as a Presenter component - Controller is currently responsible for constructing Presenters. Constructing inside Presenter classes violated Dependency Inversion principle.
2. AppointmentSummary will eventually need to be modified to accept addition parameters (nps office address). This will make the constructor parameters in each of the components longer and longer.