### PR TITLE
IC-2049: Shows the full address details if an appointment is an in-person meeting (probation office).

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -29,6 +29,7 @@ import ControllerUtils from './utils/controllerUtils'
 import broadcastMessageConfig from './broadcast-message-config.json'
 import probationPractitionerRoutes, { probationPractitionerUrlPrefix } from './routes/probationPractitionerRoutes'
 import DraftsService from './services/draftsService'
+import ReferenceDataService from './services/referenceDataService'
 
 const RedisStore = connectRedis(session)
 
@@ -36,7 +37,8 @@ export default function createApp(
   communityApiService: CommunityApiService,
   interventionsService: InterventionsService,
   hmppsAuthService: HmppsAuthService,
-  assessRisksAndNeedsService: AssessRisksAndNeedsService
+  assessRisksAndNeedsService: AssessRisksAndNeedsService,
+  referenceDataService: ReferenceDataService
 ): express.Application {
   const app = express()
 
@@ -208,6 +210,7 @@ export default function createApp(
     hmppsAuthService,
     assessRisksAndNeedsService,
     draftsService,
+    referenceDataService,
   }
 
   app.use('/', indexRoutes(standardRouter(), services))

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import config from './config'
 import InterventionsService from './services/interventionsService'
 import RestClient from './data/restClient'
 import AssessRisksAndNeedsService from './services/assessRisksAndNeedsService'
+import ReferenceDataService from './services/referenceDataService'
 
 const assessRisksAndNeedsRestClient = new RestClient('assessRisksAndNeedsClient', config.apis.assessRisksAndNeedsApi)
 const communityApiRestClient = new RestClient('communityApiClient', config.apis.communityApi)
@@ -16,7 +17,14 @@ const assessRisksAndNeedsService = new AssessRisksAndNeedsService(
   assessRisksAndNeedsRestClient,
   config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
 )
+const referenceDataService = new ReferenceDataService()
 
-const app = createApp(communityApiService, interventionsService, hmppsAuthService, assessRisksAndNeedsService)
+const app = createApp(
+  communityApiService,
+  interventionsService,
+  hmppsAuthService,
+  assessRisksAndNeedsService,
+  referenceDataService
+)
 
 export default app

--- a/server/routes/appointments/appointmentSummary.test.ts
+++ b/server/routes/appointments/appointmentSummary.test.ts
@@ -2,6 +2,7 @@ import initialAssessmentAppointmentFactory from '../../../testutils/factories/in
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 import { AppointmentDeliveryType } from '../../models/appointmentDeliveryType'
 import AppointmentSummary from './appointmentSummary'
+import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
 
 describe(AppointmentSummary, () => {
   describe('appointmentDetails', () => {
@@ -102,7 +103,7 @@ describe(AppointmentSummary, () => {
       })
     })
 
-    describe('when the appointment has a delivery address', () => {
+    describe('when the appointment has an in-person meeting other address', () => {
       const address = {
         firstAddressLine: '123 Fake Street',
         secondAddressLine: 'Fakesvillage',
@@ -113,6 +114,7 @@ describe(AppointmentSummary, () => {
 
       it('contains the address', () => {
         const appointment = initialAssessmentAppointmentFactory.build({
+          appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
           appointmentDeliveryAddress: address,
         })
         const summaryComponent = new AppointmentSummary(appointment, null)
@@ -126,6 +128,7 @@ describe(AppointmentSummary, () => {
       describe('when the second address line is absent', () => {
         it('doesn’t contain a line for the second address line', () => {
           const appointment = initialAssessmentAppointmentFactory.build({
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
             appointmentDeliveryAddress: { ...address, secondAddressLine: null },
           })
           const summaryComponent = new AppointmentSummary(appointment, null)
@@ -134,6 +137,29 @@ describe(AppointmentSummary, () => {
             key: 'Address',
             lines: ['123 Fake Street', 'Manchester', 'Greater Manchester', 'N4 1HG'],
           })
+        })
+      })
+    })
+    describe('when the appointment has an in-person meeting probation office address', () => {
+      const deliusOfficeLocation: DeliusOfficeLocation = {
+        probationOfficeId: 1,
+        name: 'name',
+        address: 'address line 1,address line 2,address line 3',
+        probationRegionId: 'probationRegionId',
+        govUkURL: 'govUkURL',
+        deliusCRSLocationId: 'deliusCRSLocationId',
+      }
+
+      it('contains the address', () => {
+        const appointment = initialAssessmentAppointmentFactory.build({
+          appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
+          npsOfficeCode: 'NPS_CODE',
+        })
+        const summaryComponent = new AppointmentSummary(appointment, null, deliusOfficeLocation)
+
+        expect(summaryComponent.appointmentSummaryList[3]).toEqual({
+          key: 'Address',
+          lines: ['name', 'address line 1', 'address line 2', 'address line 3'],
         })
       })
     })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -10,6 +10,7 @@ import AssessRisksAndNeedsService from '../services/assessRisksAndNeedsService'
 import ReferralsController from './referrals/referralsController'
 import FindInterventionsController from './findInterventions/findInterventionsController'
 import DraftsService from '../services/draftsService'
+import ReferenceDataService from '../services/referenceDataService'
 
 export interface Services {
   communityApiService: CommunityApiService
@@ -17,6 +18,7 @@ export interface Services {
   hmppsAuthService: HmppsAuthService
   assessRisksAndNeedsService: AssessRisksAndNeedsService
   draftsService: DraftsService
+  referenceDataService: ReferenceDataService
 }
 
 export const get = (router: Router, path: string, handler: RequestHandler): Router =>

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -10,7 +10,8 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     services.communityApiService,
     services.hmppsAuthService,
     services.assessRisksAndNeedsService,
-    services.draftsService
+    services.draftsService,
+    services.referenceDataService
   )
 
   get(router, '/dashboard', (req, res) => probationPractitionerReferralsController.showMyCases(req, res))

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -38,6 +38,8 @@ import CalendarDay from '../../utils/calendarDay'
 import { createDraftFactory } from '../../../testutils/factories/draft'
 import { DraftAssignmentData } from './serviceProviderReferralsController'
 import DraftsService from '../../services/draftsService'
+import MockReferenceDataService from '../testutils/mocks/mockReferenceDataService'
+import ReferenceDataService from '../../services/referenceDataService'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -50,6 +52,8 @@ const draftAssignmentFactory = createDraftFactory<DraftAssignmentData>({ email: 
 const interventionsService = new InterventionsService(
   apiConfig.apis.interventionsService
 ) as jest.Mocked<InterventionsService>
+
+const referenceDataService = new MockReferenceDataService() as jest.Mocked<ReferenceDataService>
 
 const communityApiService = new MockCommunityApiService() as jest.Mocked<CommunityApiService>
 
@@ -74,6 +78,7 @@ beforeEach(() => {
       hmppsAuthService,
       assessRisksAndNeedsService,
       draftsService,
+      referenceDataService,
     },
     userType: AppSetupUserType.serviceProvider,
   })
@@ -917,6 +922,8 @@ describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', 
         sessionNumber: 1,
         appointmentTime: '2021-03-24T09:02:02Z',
         durationInMinutes: 75,
+        appointmentDeliveryType: 'PHONE_CALL',
+        sessionType: 'ONE_TO_ONE',
       })
 
       interventionsService.getActionPlan.mockResolvedValue(actionPlan)

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -2,20 +2,17 @@ import { Router } from 'express'
 import { Services, get, post } from './index'
 import ServiceProviderReferralsController from './serviceProviderReferrals/serviceProviderReferralsController'
 import config from '../config'
-import DeliusOfficeLocationFilter from '../services/deliusOfficeLocationFilter'
-import ReferenceDataService from '../services/referenceDataService'
 
 export const serviceProviderUrlPrefix = '/service-provider'
 
 export default function serviceProviderRoutes(router: Router, services: Services): Router {
-  const deliusOfficeLocationFilter = new DeliusOfficeLocationFilter(new ReferenceDataService())
   const serviceProviderReferralsController = new ServiceProviderReferralsController(
     services.interventionsService,
     services.communityApiService,
     services.hmppsAuthService,
     services.assessRisksAndNeedsService,
     services.draftsService,
-    deliusOfficeLocationFilter
+    services.referenceDataService
   )
 
   get(router, '/dashboard', (req, res) => serviceProviderReferralsController.showDashboard(req, res))

--- a/server/routes/shared/supplierAssessmentAppointmentPresenter.test.ts
+++ b/server/routes/shared/supplierAssessmentAppointmentPresenter.test.ts
@@ -90,6 +90,7 @@ describe(SupplierAssessmentAppointmentPresenter, () => {
 
       it('contains the address', () => {
         const appointment = initialAssessmentAppointmentFactory.build({
+          appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
           appointmentDeliveryAddress: address,
         })
         const presenter = new SupplierAssessmentAppointmentPresenter(
@@ -107,6 +108,7 @@ describe(SupplierAssessmentAppointmentPresenter, () => {
       describe('when the second address line is absent', () => {
         it('doesn’t contain a line for the second address line', () => {
           const appointment = initialAssessmentAppointmentFactory.build({
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
             appointmentDeliveryAddress: { ...address, secondAddressLine: null },
           })
           const presenter = new SupplierAssessmentAppointmentPresenter(

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -16,6 +16,7 @@ import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsServic
 import config from '../../config'
 import probationPractitionerRoutes, { probationPractitionerUrlPrefix } from '../probationPractitionerRoutes'
 import DraftsService from '../../services/draftsService'
+import ReferenceDataService from '../../services/referenceDataService'
 
 export enum AppSetupUserType {
   probationPractitioner = 'delius',
@@ -81,6 +82,7 @@ export default function appWithAllRoutes({
     hmppsAuthService: new MockedHmppsAuthService(),
     assessRisksAndNeedsService: {} as AssessRisksAndNeedsService,
     draftsService: {} as DraftsService,
+    referenceDataService: {} as ReferenceDataService,
     ...overrides,
   }
 

--- a/server/services/deliusOfficeLocationFilter.test.ts
+++ b/server/services/deliusOfficeLocationFilter.test.ts
@@ -3,6 +3,7 @@ import DeliusOfficeLocationFilter from './deliusOfficeLocationFilter'
 import MockReferenceDataService from '../routes/testutils/mocks/mockReferenceDataService'
 import interventionFactory from '../../testutils/factories/intervention'
 import deliusOfficeLocationFactory from '../../testutils/factories/deliusOfficeLocation'
+import initialAssessmentAppointment from '../../testutils/factories/initialAssessmentAppointment'
 
 jest.mock('./interventionsService')
 jest.mock('./referenceDataService')
@@ -10,80 +11,116 @@ jest.mock('./referenceDataService')
 describe(DeliusOfficeLocationFilter, () => {
   const referenceDataService = new MockReferenceDataService() as jest.Mocked<ReferenceDataService>
   const deliusOfficeLocationProvider = new DeliusOfficeLocationFilter(referenceDataService)
-  describe('with an intervention having an nps region', () => {
-    it('should return an office within the same nps region', async () => {
-      const intervention = interventionFactory.build({
-        npsRegion: { id: 'B', name: 'North West' },
-        pccRegions: [],
+  describe('when finding offices by intervention', () => {
+    describe('with an intervention having an nps region', () => {
+      it('should return an office within the same nps region', async () => {
+        const intervention = interventionFactory.build({
+          npsRegion: { id: 'B', name: 'North West' },
+          pccRegions: [],
+        })
+        const deliusOfficeLocation = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
+        referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
+        const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
+        expect(offices.length).toEqual(1)
+        expect(offices[0].probationRegionId).toEqual('B')
       })
-      const deliusOfficeLocation = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
-      referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
-      const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
-      expect(offices.length).toEqual(1)
-      expect(offices[0].probationRegionId).toEqual('B')
+
+      it('should filter out offices with empty crs location ids', async () => {
+        const intervention = interventionFactory.build({
+          npsRegion: { id: 'B', name: 'North West' },
+          pccRegions: [],
+        })
+        const emptyOfficeLocation = deliusOfficeLocationFactory.build({
+          deliusCRSLocationId: '',
+        })
+        referenceDataService.getProbationOffices.mockResolvedValue([emptyOfficeLocation])
+        const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
+        expect(offices.length).toEqual(0)
+      })
     })
-    it('should filter out offices with empty crs location ids', async () => {
-      const intervention = interventionFactory.build({
-        npsRegion: { id: 'B', name: 'North West' },
-        pccRegions: [],
+
+    describe('with an intervention having a pcc region', () => {
+      it('should return an office within the same nps region', async () => {
+        const intervention = interventionFactory.build({
+          npsRegion: null,
+          pccRegions: [{ id: 'cheshire', name: 'Cheshire', npsRegion: { id: 'B', name: 'North West' } }],
+        })
+        const deliusOfficeLocation = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
+        referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
+        const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
+        expect(offices.length).toEqual(1)
+        expect(offices[0].probationRegionId).toEqual('B')
       })
-      const emptyOfficeLocation = deliusOfficeLocationFactory.build({
-        deliusCRSLocationId: '',
-      })
-      referenceDataService.getProbationOffices.mockResolvedValue([emptyOfficeLocation])
-      const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
-      expect(offices.length).toEqual(0)
     })
-  })
-  describe('with an intervention having a pcc region', () => {
-    it('should return an office within the same nps region', async () => {
-      const intervention = interventionFactory.build({
-        npsRegion: null,
-        pccRegions: [{ id: 'cheshire', name: 'Cheshire', npsRegion: { id: 'B', name: 'North West' } }],
+
+    describe('with an intervention containing multiple regions', () => {
+      it('should return an an office for each region', async () => {
+        const intervention = interventionFactory.build({
+          npsRegion: { id: 'A', name: 'North West' },
+          pccRegions: [
+            { id: 'cheshire', name: 'Cheshire', npsRegion: { id: 'B', name: 'North West' } },
+            { id: 'cheshire', name: 'Cheshire', npsRegion: { id: 'C', name: 'North West' } },
+          ],
+        })
+        const deliusOfficeLocationA = deliusOfficeLocationFactory.build({ probationRegionId: 'A' })
+        const deliusOfficeLocationB = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
+        const deliusOfficeLocationC = deliusOfficeLocationFactory.build({ probationRegionId: 'C' })
+        referenceDataService.getProbationOffices.mockResolvedValue([
+          deliusOfficeLocationA,
+          deliusOfficeLocationB,
+          deliusOfficeLocationC,
+        ])
+        const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
+        expect(offices.length).toEqual(3)
+        expect(offices[0].probationRegionId).toEqual('A')
+        expect(offices[1].probationRegionId).toEqual('B')
+        expect(offices[2].probationRegionId).toEqual('C')
       })
-      const deliusOfficeLocation = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
-      referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
-      const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
-      expect(offices.length).toEqual(1)
-      expect(offices[0].probationRegionId).toEqual('B')
+    })
+
+    describe('with an intervention having no valid regions', () => {
+      it('should return an empty list of offices', async () => {
+        const intervention = interventionFactory.build({
+          npsRegion: { id: 'UNKNOWN', name: 'Unknown' },
+          pccRegions: [{ id: 'unknown', name: 'Unknown', npsRegion: { id: 'UNKNOWN', name: 'Unknown' } }],
+        })
+        const deliusOfficeLocation = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
+        referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
+        const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
+        expect(offices.length).toEqual(0)
+      })
     })
   })
 
-  describe('with an intervention containing multiple regions', () => {
-    it('should return an an office for each region', async () => {
-      const intervention = interventionFactory.build({
-        npsRegion: { id: 'A', name: 'North West' },
-        pccRegions: [
-          { id: 'cheshire', name: 'Cheshire', npsRegion: { id: 'B', name: 'North West' } },
-          { id: 'cheshire', name: 'Cheshire', npsRegion: { id: 'C', name: 'North West' } },
-        ],
+  describe('when finding an office by appointment', () => {
+    describe('with an empty nps office code', () => {
+      it('should return an empty office location', async () => {
+        const appointment = initialAssessmentAppointment.build({ npsOfficeCode: null })
+        const office = await deliusOfficeLocationProvider.findOfficeByAppointment(appointment)
+        expect(office).toBeNull()
       })
-      const deliusOfficeLocationA = deliusOfficeLocationFactory.build({ probationRegionId: 'A' })
-      const deliusOfficeLocationB = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
-      const deliusOfficeLocationC = deliusOfficeLocationFactory.build({ probationRegionId: 'C' })
-      referenceDataService.getProbationOffices.mockResolvedValue([
-        deliusOfficeLocationA,
-        deliusOfficeLocationB,
-        deliusOfficeLocationC,
-      ])
-      const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
-      expect(offices.length).toEqual(3)
-      expect(offices[0].probationRegionId).toEqual('A')
-      expect(offices[1].probationRegionId).toEqual('B')
-      expect(offices[2].probationRegionId).toEqual('C')
     })
-  })
 
-  describe('with an intervention having no valid regions', () => {
-    it('should return an empty list of offices', async () => {
-      const intervention = interventionFactory.build({
-        npsRegion: { id: 'UNKNOWN', name: 'Unknown' },
-        pccRegions: [{ id: 'unknown', name: 'Unknown', npsRegion: { id: 'UNKNOWN', name: 'Unknown' } }],
+    describe('with a non-existent nps office code', () => {
+      it('should return an empty office location', async () => {
+        const appointment = initialAssessmentAppointment.build({ npsOfficeCode: 'NON_MATCHING_CODE' })
+        const deliusOfficeLocation = deliusOfficeLocationFactory.build({ deliusCRSLocationId: 'SOME_OTHER_CODE' })
+        referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
+
+        const office = await deliusOfficeLocationProvider.findOfficeByAppointment(appointment)
+        expect(office).toBeNull()
       })
-      const deliusOfficeLocation = deliusOfficeLocationFactory.build({ probationRegionId: 'B' })
-      referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
-      const offices = await deliusOfficeLocationProvider.findOfficesByIntervention(intervention)
-      expect(offices.length).toEqual(0)
+    })
+
+    describe('with a matching nps office code', () => {
+      it('should return the matched office location', async () => {
+        const appointment = initialAssessmentAppointment.build({ npsOfficeCode: 'MATCHING_CODE' })
+        const deliusOfficeLocation = deliusOfficeLocationFactory.build({ deliusCRSLocationId: 'MATCHING_CODE' })
+        referenceDataService.getProbationOffices.mockResolvedValue([deliusOfficeLocation])
+
+        const office = await deliusOfficeLocationProvider.findOfficeByAppointment(appointment)
+        expect(office).toEqual(deliusOfficeLocation)
+      })
     })
   })
 })

--- a/server/services/deliusOfficeLocationFilter.ts
+++ b/server/services/deliusOfficeLocationFilter.ts
@@ -1,6 +1,7 @@
 import ReferenceDataService from './referenceDataService'
 import DeliusOfficeLocation from '../models/deliusOfficeLocation'
 import Intervention from '../models/intervention'
+import { ActionPlanAppointment, InitialAssessmentAppointment } from '../models/appointment'
 
 export default class DeliusOfficeLocationFilter {
   constructor(private referenceDataService: ReferenceDataService) {}
@@ -12,6 +13,21 @@ export default class DeliusOfficeLocationFilter {
     }
     intervention.pccRegions.map(pccRegion => npsRegionIds.push(pccRegion.npsRegion?.id))
     return this.findOfficesByNpsRegionIds(npsRegionIds)
+  }
+
+  async findOfficeByAppointment(
+    appointment: InitialAssessmentAppointment | ActionPlanAppointment
+  ): Promise<DeliusOfficeLocation | null> {
+    if (appointment.npsOfficeCode === null) {
+      return null
+    }
+    const officeMatch = (await this.referenceDataService.getProbationOffices()).find(
+      office => office.deliusCRSLocationId === appointment.npsOfficeCode
+    )
+    if (officeMatch === undefined) {
+      return null
+    }
+    return officeMatch
   }
 
   private async findOfficesByNpsRegionIds(npsRegionIds: string[]): Promise<DeliusOfficeLocation[]> {


### PR DESCRIPTION
## What does this pull request do?

It adds the full address details for an appointment Summary. This applies to a lot of places:

1. Viewing feedback
2. Scheduling an appointment (previous missed appointment)
3. Check your answers for scheduling
4. Check your answers for feedback submission
4. Appointment Details screen

## What is the intent behind these changes?

Ensure that user has full visibility of appointment location when displaying appointment details.

The new summary should look like below:

![image](https://user-images.githubusercontent.com/83066216/129545837-bf86b6da-2947-47b2-9f32-0b0445e7a8cd.png)
