### PR TITLE
IC-1919: Add a "check your answers" page to the initial assessment scheduling journey

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1644,6 +1644,12 @@ describe('Service provider referrals dashboard', () => {
 
           cy.contains('Initial assessment added')
 
+          const hmppsAuthUser = hmppsAuthUserFactory.build({
+            firstName: 'John',
+            lastName: 'Smith',
+            username: 'john.smith',
+          })
+          cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
           const submittedAppointment = initialAssessmentAppointmentFactory.build({
             appointmentTime: '2021-03-24T09:02:02Z',
             durationInMinutes: 75,
@@ -1654,6 +1660,7 @@ describe('Service provider referrals dashboard', () => {
                 additionalAttendanceInformation: 'Alex did not attend this session',
               },
               submitted: true,
+              submittedBy: { username: hmppsAuthUser.username, userId: hmppsAuthUser.username, authSource: 'auth' },
             },
           })
           supplierAssessment = supplierAssessmentFactory.build({

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -231,6 +231,10 @@ module.exports = on => {
       return interventionsService.stubScheduleSupplierAssessmentAppointment(arg.supplierAssessmentId, arg.responseJson)
     },
 
+    stubScheduleSupplierAssessmentAppointmentClash: arg => {
+      return interventionsService.stubScheduleSupplierAssessmentAppointmentClash(arg.supplierAssessmentId)
+    },
+
     stubSubmitSupplierAssessmentAppointmentFeedback: arg => {
       return interventionsService.stubSubmitSupplierAssessmentAppointmentFeedback(arg.referralId, arg.responseJson)
     },

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -154,6 +154,10 @@ Cypress.Commands.add('stubScheduleSupplierAssessmentAppointment', (supplierAsses
   cy.task('stubScheduleSupplierAssessmentAppointment', { supplierAssessmentId, responseJson })
 })
 
+Cypress.Commands.add('stubScheduleSupplierAssessmentAppointmentClash', supplierAssessmentId => {
+  cy.task('stubScheduleSupplierAssessmentAppointmentClash', { supplierAssessmentId })
+})
+
 Cypress.Commands.add('stubSubmitSupplierAssessmentAppointmentFeedback', (referralId, responseJson) => {
   cy.task('stubSubmitSupplierAssessmentAppointmentFeedback', { referralId, responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -624,6 +624,22 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubScheduleSupplierAssessmentAppointmentClash = async (supplierAssessmentId: string): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PUT',
+        urlPattern: `${this.mockPrefix}/supplier-assessment/${supplierAssessmentId}/schedule-appointment`,
+      },
+      response: {
+        status: 409,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: {},
+      },
+    })
+  }
+
   stubSubmitSupplierAssessmentAppointmentFeedback = async (
     referralId: string,
     responseJson: unknown

--- a/server/decorators/appointmentDecorator.ts
+++ b/server/decorators/appointmentDecorator.ts
@@ -1,10 +1,14 @@
-import { ActionPlanAppointment, InitialAssessmentAppointment } from '../models/appointment'
+import {
+  ActionPlanAppointment,
+  AppointmentSchedulingDetails,
+  InitialAssessmentAppointment,
+} from '../models/appointment'
 import CalendarDay from '../utils/calendarDay'
 import ClockTime from '../utils/clockTime'
 import Duration from '../utils/duration'
 
 export default class AppointmentDecorator {
-  constructor(private readonly appointment: InitialAssessmentAppointment | ActionPlanAppointment) {}
+  constructor(private readonly appointment: AppointmentSchedulingDetails) {}
 
   get britishDay(): CalendarDay | null {
     if (this.appointment.appointmentTime === null) {

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -1,10 +1,10 @@
 import { SummaryListItem } from '../../utils/summaryList'
 import AppointmentDecorator from '../../decorators/appointmentDecorator'
 import PresenterUtils from '../../utils/presenterUtils'
-import { InitialAssessmentAppointment, ActionPlanAppointment } from '../../models/appointment'
 import { AppointmentDeliveryType } from '../../models/appointmentDeliveryType'
 import Address from '../../models/address'
 import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
+import { AppointmentSchedulingDetails } from '../../models/appointment'
 
 interface Caseworker {
   username?: string
@@ -13,7 +13,7 @@ interface Caseworker {
 }
 export default class AppointmentSummary {
   constructor(
-    private readonly appointment: InitialAssessmentAppointment | ActionPlanAppointment,
+    private readonly appointment: AppointmentSchedulingDetails,
     private readonly assignedCaseworker: Caseworker | null = null,
     private readonly deliusOfficeLocation: DeliusOfficeLocation | null = null
   ) {}

--- a/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.ts
+++ b/server/routes/service-provider/action-plan/sessions/edit/scheduleActionPlanSessionPresenter.ts
@@ -22,6 +22,7 @@ export default class ScheduleActionPlanSessionPresenter extends ScheduleAppointm
       currentAppointmentSummary,
       deliusOfficeLocations,
       validationError,
+      null,
       userInputData,
       serverError
     )

--- a/server/routes/serviceProviderReferrals/draftAppointmentBooking.ts
+++ b/server/routes/serviceProviderReferrals/draftAppointmentBooking.ts
@@ -1,0 +1,25 @@
+// This is a copy of the AppointmentSchedulingDetails interface.
+//
+// It’s a separate type to make sure that we handle the migration of existing data
+// when we modify that type or any of its nested types. (Let’s see how this works in practice.)
+interface DraftAppointmentBookingSchedulingDetails {
+  appointmentTime: string | null
+  durationInMinutes: number | null
+  sessionType: 'ONE_TO_ONE' | 'GROUP' | null
+  appointmentDeliveryType:
+    | 'PHONE_CALL'
+    | 'VIDEO_CALL'
+    | 'IN_PERSON_MEETING_PROBATION_OFFICE'
+    | 'IN_PERSON_MEETING_OTHER'
+    | null
+  appointmentDeliveryAddress: {
+    firstAddressLine: string
+    secondAddressLine: string | null
+    townOrCity: string
+    county: string
+    postCode: string
+  } | null
+  npsOfficeCode: string | null
+}
+
+export type DraftAppointmentBooking = null | DraftAppointmentBookingSchedulingDetails

--- a/server/routes/serviceProviderReferrals/initialAssessmentCheckAnswersPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/initialAssessmentCheckAnswersPresenter.test.ts
@@ -1,0 +1,49 @@
+import InitialAssessmentCheckAnswersPresenter from './initialAssessmentCheckAnswersPresenter'
+import { createDraftFactory } from '../../../testutils/factories/draft'
+import { DraftAppointmentBooking } from './serviceProviderReferralsController'
+
+const draftBookingFactory = createDraftFactory<DraftAppointmentBooking>({
+  appointmentTime: '2021-03-24T09:02:00.000Z',
+  durationInMinutes: 75,
+  sessionType: 'ONE_TO_ONE',
+  appointmentDeliveryType: 'PHONE_CALL',
+  appointmentDeliveryAddress: null,
+  npsOfficeCode: null,
+})
+
+describe(InitialAssessmentCheckAnswersPresenter, () => {
+  describe('summary', () => {
+    it('returns a summary of the draft booking', () => {
+      const draft = draftBookingFactory.build()
+      const presenter = new InitialAssessmentCheckAnswersPresenter(draft, '1')
+
+      expect(presenter.summary).toEqual([
+        { key: 'Date', lines: ['24 March 2021'] },
+        { key: 'Time', lines: ['9:02am to 10:17am'] },
+        { key: 'Method', lines: ['Phone call'] },
+      ])
+    })
+  })
+
+  describe('backLinkHref', () => {
+    it('returns the relative URL of the details page', () => {
+      const draft = draftBookingFactory.build()
+      const presenter = new InitialAssessmentCheckAnswersPresenter(draft, '1')
+
+      expect(presenter.backLinkHref).toEqual(
+        `/service-provider/referrals/1/supplier-assessment/schedule/${draft.id}/details`
+      )
+    })
+  })
+
+  describe('formAction', () => {
+    it('returns the relative URL of the submit page', () => {
+      const draft = draftBookingFactory.build()
+      const presenter = new InitialAssessmentCheckAnswersPresenter(draft, '1')
+
+      expect(presenter.formAction).toEqual(
+        `/service-provider/referrals/1/supplier-assessment/schedule/${draft.id}/submit`
+      )
+    })
+  })
+})

--- a/server/routes/serviceProviderReferrals/initialAssessmentCheckAnswersPresenter.ts
+++ b/server/routes/serviceProviderReferrals/initialAssessmentCheckAnswersPresenter.ts
@@ -1,0 +1,19 @@
+import { Draft } from '../../services/draftsService'
+import AppointmentSummary from '../appointments/appointmentSummary'
+import { DraftAppointmentBooking } from './draftAppointmentBooking'
+
+export default class InitialAssessmentCheckAnswersPresenter {
+  constructor(private readonly draft: Draft<DraftAppointmentBooking>, private readonly referralId: string) {}
+
+  readonly backLinkHref = `/service-provider/referrals/${this.referralId}/supplier-assessment/schedule/${this.draft.id}/details`
+
+  readonly formAction = `/service-provider/referrals/${this.referralId}/supplier-assessment/schedule/${this.draft.id}/submit`
+
+  readonly summary = (() => {
+    if (this.draft.data === null) {
+      throw new Error('Draft has null data on check your answers page')
+    }
+
+    return new AppointmentSummary(this.draft.data, null).appointmentSummaryList
+  })()
+}

--- a/server/routes/serviceProviderReferrals/initialAssessmentCheckAnswersView.ts
+++ b/server/routes/serviceProviderReferrals/initialAssessmentCheckAnswersView.ts
@@ -1,0 +1,29 @@
+import { BackLinkArgs, SummaryListArgs } from '../../utils/govukFrontendTypes'
+import ViewUtils from '../../utils/viewUtils'
+import InitialAssessmentCheckAnswersPresenter from './initialAssessmentCheckAnswersPresenter'
+
+export default class InitialAssessmentCheckAnswersView {
+  constructor(private readonly presenter: InitialAssessmentCheckAnswersPresenter) {}
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceProviderReferrals/initialAssessmentCheckAnswers',
+      {
+        presenter: this.presenter,
+        backLinkArgs: this.backLinkArgs,
+        summaryListArgs: this.summaryListArgs,
+      },
+    ]
+  }
+
+  private get backLinkArgs(): BackLinkArgs {
+    return {
+      text: 'Back',
+      href: this.presenter.backLinkHref,
+    }
+  }
+
+  private get summaryListArgs(): SummaryListArgs {
+    return ViewUtils.summaryListArgs(this.presenter.summary)
+  }
+}

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -574,7 +574,7 @@ describe(InterventionProgressPresenter, () => {
           {
             text: 'Schedule',
             hiddenText: ' initial assessment',
-            href: `/service-provider/referrals/${referral.id}/supplier-assessment/schedule`,
+            href: `/service-provider/referrals/${referral.id}/supplier-assessment/schedule/start`,
           },
         ])
       })
@@ -660,7 +660,7 @@ describe(InterventionProgressPresenter, () => {
         expect(presenter.supplierAssessmentLink).toEqual([
           {
             text: 'Reschedule',
-            href: `/service-provider/referrals/${referral.id}/supplier-assessment/schedule`,
+            href: `/service-provider/referrals/${referral.id}/supplier-assessment/schedule/start`,
           },
         ])
       })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -200,7 +200,7 @@ export default class InterventionProgressPresenter {
           {
             text: 'Schedule',
             hiddenText: ' initial assessment',
-            href: `/service-provider/referrals/${this.referral.id}/supplier-assessment/schedule`,
+            href: `/service-provider/referrals/${this.referral.id}/supplier-assessment/schedule/start`,
           },
         ]
       case SessionStatus.scheduled:
@@ -221,7 +221,7 @@ export default class InterventionProgressPresenter {
         return [
           {
             text: 'Reschedule',
-            href: `/service-provider/referrals/${this.referral.id}/supplier-assessment/schedule`,
+            href: `/service-provider/referrals/${this.referral.id}/supplier-assessment/schedule/start`,
           },
         ]
       case SessionStatus.completed:

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -176,6 +176,7 @@ describe(ScheduleAppointmentPresenter, () => {
             ],
           },
           null,
+          null,
           {
             errors: [
               {
@@ -235,7 +236,7 @@ describe(ScheduleAppointmentPresenter, () => {
   })
 
   describe('fields', () => {
-    describe('with a null appointment', () => {
+    describe('with null draft scheduling details and a null appointment', () => {
       it('returns empty fields', () => {
         const presenter = new ScheduleAppointmentPresenter('supplierAssessment', referral, null, null, [])
 
@@ -434,6 +435,117 @@ describe(ScheduleAppointmentPresenter, () => {
         })
       })
     })
+
+    describe('with non-null draft scheduling details', () => {
+      describe('with a null current appointment', () => {
+        it('uses the values from the draft scheduling details', () => {
+          const draftSchedulingDetails = initialAssessmentAppointmentFactory.build({
+            appointmentTime: '2021-03-24T10:30:00Z',
+            durationInMinutes: 75,
+            sessionType: 'ONE_TO_ONE',
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+            appointmentDeliveryAddress: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY4 0RE',
+            },
+          })
+          const presenter = new ScheduleAppointmentPresenter(
+            'supplierAssessment',
+            referral,
+            null,
+            null,
+            [],
+            null,
+            draftSchedulingDetails
+          )
+
+          expect(presenter.fields).toEqual({
+            date: {
+              errorMessage: null,
+              day: { value: '24', hasError: false },
+              month: { value: '3', hasError: false },
+              year: { value: '2021', hasError: false },
+            },
+            time: {
+              errorMessage: null,
+              hour: { value: '10', hasError: false },
+              minute: { value: '30', hasError: false },
+              partOfDay: {
+                value: 'am',
+                hasError: false,
+              },
+            },
+            duration: {
+              errorMessage: null,
+              hours: { value: '1', hasError: false },
+              minutes: { value: '15', hasError: false },
+            },
+            meetingMethod: { value: 'IN_PERSON_MEETING_OTHER', errorMessage: null },
+            sessionType: { value: 'ONE_TO_ONE', errorMessage: null },
+            address: {
+              value: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '44 Bouverie Road',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY4 0RE',
+              },
+              errors: {
+                firstAddressLine: null,
+                postcode: null,
+              },
+            },
+            deliusOfficeLocation: {
+              value: null,
+              errorMessage: null,
+            },
+          })
+        })
+      })
+
+      describe('with a non-null, not attended current appointment', () => {
+        it('still uses the values from the draft scheduling details', () => {
+          const draftSchedulingDetails = initialAssessmentAppointmentFactory.build({
+            appointmentTime: '2021-03-24T10:30:00Z',
+          })
+          const currentAppointment = initialAssessmentAppointmentFactory.build({
+            appointmentTime: '2021-03-27T19:30:00Z',
+          })
+          const presenter = new ScheduleAppointmentPresenter(
+            'supplierAssessment',
+            referral,
+            currentAppointment,
+            null,
+            [],
+            null,
+            draftSchedulingDetails,
+            null,
+            null
+          )
+
+          expect(presenter.fields).toMatchObject({
+            date: {
+              errorMessage: null,
+              day: { value: '24', hasError: false },
+              month: { value: '3', hasError: false },
+              year: { value: '2021', hasError: false },
+            },
+            time: {
+              errorMessage: null,
+              hour: { value: '10', hasError: false },
+              minute: { value: '30', hasError: false },
+              partOfDay: {
+                value: 'am',
+                hasError: false,
+              },
+            },
+          })
+        })
+      })
+    })
   })
 
   describe('backLinkHref', () => {
@@ -453,6 +565,7 @@ describe(ScheduleAppointmentPresenter, () => {
           null,
           null,
           [],
+          null,
           null,
           null,
           null,

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -18,9 +18,12 @@ export default class ScheduleAppointmentPresenter {
     private readonly validationError: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null,
     private readonly serverError: FormValidationError | null = null,
-    private readonly overrideBackLinkHref?: string,
-    private readonly appointmentDecorator = currentAppointment ? new AppointmentDecorator(currentAppointment) : null
+    private readonly overrideBackLinkHref?: string
   ) {}
+
+  private readonly appointmentDecorator = this.currentAppointment
+    ? new AppointmentDecorator(this.currentAppointment)
+    : null
 
   readonly text = {
     title:

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
@@ -199,17 +199,20 @@ export default class ScheduleAppointmentView {
   private meetingMethodRadioInputArgs(deliusOfficeLocationHTML: string, otherLocationHTML: string): RadiosArgs {
     const items = []
     items.push({
+      id: 'meeting-method-phone-call',
       value: 'PHONE_CALL',
       text: 'Phone call',
       checked: this.presenter.fields.meetingMethod.value === 'PHONE_CALL',
     })
     items.push({
+      id: 'meeting-method-video-call',
       value: 'VIDEO_CALL',
       text: 'Video call',
       checked: this.presenter.fields.meetingMethod.value === 'VIDEO_CALL',
     })
     if (this.presenter.deliusOfficeLocationSelectionEnabled) {
       items.push({
+        id: 'meeting-method-meeting-probation-office',
         value: 'IN_PERSON_MEETING_PROBATION_OFFICE',
         text: 'In-person meeting - NPS offices',
         checked: this.presenter.fields.meetingMethod.value === 'IN_PERSON_MEETING_PROBATION_OFFICE',
@@ -219,6 +222,7 @@ export default class ScheduleAppointmentView {
       })
     }
     items.push({
+      id: 'meeting-method-meeting-other',
       value: 'IN_PERSON_MEETING_OTHER',
       text: 'In-person meeting - Other locations',
       checked: this.presenter.fields.meetingMethod.value === 'IN_PERSON_MEETING_OTHER',

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -120,10 +120,28 @@ export default function serviceProviderRoutes(router: Router, services: Services
     serviceProviderReferralsController.showEndOfServiceReportConfirmation(req, res)
   )
   get(router, '/referrals/:id/supplier-assessment/schedule', (req, res) =>
+    // This keeps the Schedule / Change buttons working on any pre-drafts versions
+    // of the intervention details / view supplier assessment pages
+    serviceProviderReferralsController.startSupplierAssessmentAppointmentScheduling(req, res)
+  )
+  get(router, '/referrals/:id/supplier-assessment/schedule/start', (req, res) =>
+    serviceProviderReferralsController.startSupplierAssessmentAppointmentScheduling(req, res)
+  )
+  get(router, '/referrals/:id/supplier-assessment/schedule/:draftBookingId/details', (req, res) =>
+    serviceProviderReferralsController.scheduleSupplierAssessmentAppointment(req, res)
+  )
+  post(router, '/referrals/:id/supplier-assessment/schedule/:draftBookingId/details', (req, res) =>
     serviceProviderReferralsController.scheduleSupplierAssessmentAppointment(req, res)
   )
   post(router, '/referrals/:id/supplier-assessment/schedule', (req, res) =>
-    serviceProviderReferralsController.scheduleSupplierAssessmentAppointment(req, res)
+    // This keeps the submit button working on any pre-drafts version of the booking form
+    serviceProviderReferralsController.backwardsCompatibilityScheduleSupplierAssessmentAppointment(req, res)
+  )
+  get(router, '/referrals/:id/supplier-assessment/schedule/:draftBookingId/check-answers', (req, res) =>
+    serviceProviderReferralsController.checkSupplierAssessmentAnswers(req, res)
+  )
+  post(router, '/referrals/:id/supplier-assessment/schedule/:draftBookingId/submit', (req, res) =>
+    serviceProviderReferralsController.submitSupplierAssessment(req, res)
   )
   get(router, '/referrals/:id/supplier-assessment', (req, res) =>
     serviceProviderReferralsController.showSupplierAssessmentAppointment(req, res)

--- a/server/routes/shared/supplierAssessmentAppointmentPresenter.test.ts
+++ b/server/routes/shared/supplierAssessmentAppointmentPresenter.test.ts
@@ -138,7 +138,7 @@ describe(SupplierAssessmentAppointmentPresenter, () => {
 
         expect(presenter.actionLink).toEqual({
           text: 'Change appointment details',
-          href: `/service-provider/referrals/${referral.id}/supplier-assessment/schedule`,
+          href: `/service-provider/referrals/${referral.id}/supplier-assessment/schedule/start`,
         })
       })
 

--- a/server/routes/shared/supplierAssessmentAppointmentPresenter.ts
+++ b/server/routes/shared/supplierAssessmentAppointmentPresenter.ts
@@ -28,7 +28,7 @@ export default class SupplierAssessmentAppointmentPresenter {
 
     return sessionStatus.forAppointment(this.appointment) === SessionStatus.scheduled
       ? {
-          href: `/service-provider/referrals/${this.referral.id}/supplier-assessment/schedule`,
+          href: `/service-provider/referrals/${this.referral.id}/supplier-assessment/schedule/start`,
           text: 'Change appointment details',
         }
       : null

--- a/server/views/serviceProviderReferrals/initialAssessmentCheckAnswers.njk
+++ b/server/views/serviceProviderReferrals/initialAssessmentCheckAnswers.njk
@@ -1,0 +1,27 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}
+  HMPPS Interventions - GOV.UK
+{% endblock %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukBackLink(backLinkArgs) }}
+
+      <form method="post" action="{{ presenter.formAction }}" novalidate="novalidate">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        <h1 class="govuk-heading-xl">Confirm appointment details</h1>
+
+        {{ govukSummaryList(summaryListArgs) }}
+
+        {{ govukButton({ text: "Confirm", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a page to the service provider initial assessment scheduling journey, which replays the answers they have submitted so that they can check them.

## What is the intent behind these changes?

To allow the service provider to check their answers before scheduling the appointment.

## Screenshot

![Screenshot 2021-08-17 at 11-55-08 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/129714691-90a8e63d-f4f0-4f0d-ab6e-b2ebfe3abbd7.png)