### PR TITLE
Added assess risks and needs proxy

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -10,7 +10,7 @@ const auth = new AuthServiceMocks(wiremock)
 const tokenVerification = new TokenVerificationMocks(wiremock)
 const communityApi = new CommunityApiMocks(wiremock, '/community-api')
 const interventionsService = new InterventionsServiceMocks(wiremock, '/interventions')
-const assessRisksAndNeedsService = new AssessRisksAndNeedsServiceMocks(wiremock)
+const assessRisksAndNeedsService = new AssessRisksAndNeedsServiceMocks(wiremock, '/assess-risks-and-needs')
 
 module.exports = on => {
   on('task', {

--- a/mockApis/assessRisksAndNeedsService.ts
+++ b/mockApis/assessRisksAndNeedsService.ts
@@ -1,13 +1,13 @@
 import Wiremock from './wiremock'
 
 export default class AssessRisksAndNeedsServiceMocks {
-  constructor(private readonly wiremock: Wiremock) {}
+  constructor(private readonly wiremock: Wiremock, private readonly mockPrefix: string) {}
 
   stubGetSupplementaryRiskInformation = async (riskId: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/assess-risks-and-needs/risks/supplementary/${riskId}`,
+        urlPattern: `${this.mockPrefix}/risks/supplementary/${riskId}`,
       },
       response: {
         status: 200,
@@ -23,7 +23,7 @@ export default class AssessRisksAndNeedsServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/assess-risks-and-needs/risks/crn/${crn}`,
+        urlPattern: `${this.mockPrefix}/risks/crn/${crn}`,
       },
       response: {
         status: 200,

--- a/mocks.ts
+++ b/mocks.ts
@@ -11,10 +11,14 @@ import draftReferralFactory from './testutils/factories/draftReferral'
 import serviceCategoryFactory from './testutils/factories/serviceCategory'
 import CommunityApiMocks from './mockApis/communityApi'
 import deliusConvictionFactory from './testutils/factories/deliusConviction'
+import AssessRisksAndNeedsServiceMocks from './mockApis/assessRisksAndNeedsService'
+import riskSummaryFactory from './testutils/factories/riskSummary'
+import supplementaryRiskInformationFactory from './testutils/factories/supplementaryRiskInformation'
 
 const wiremock = new Wiremock('http://localhost:9092/__admin')
 const interventionsMocks = new InterventionsServiceMocks(wiremock, '')
 const communityApiMocks = new CommunityApiMocks(wiremock, '')
+const assessRisksAndNeedsApiMocks = new AssessRisksAndNeedsServiceMocks(wiremock, '')
 
 export default async function setUpMocks(): Promise<void> {
   await wiremock.resetStubs()
@@ -148,7 +152,13 @@ export default async function setUpMocks(): Promise<void> {
       },
     })
   await Promise.all([
-    communityApiMocks.stubGetActiveConvictionsByCRN('CRN11', [deliusConvictionFactory.build()]),
+    assessRisksAndNeedsApiMocks.stubGetRiskSummary('CRN24', riskSummaryFactory.build()),
+    assessRisksAndNeedsApiMocks.stubGetSupplementaryRiskInformation(
+      '5f2debc5-4c6a-4972-84ce-0689b8f9ec52',
+      supplementaryRiskInformationFactory.build()
+    ),
+    communityApiMocks.stubGetActiveConvictionsByCRN('CRN24', [deliusConvictionFactory.build()]),
+    communityApiMocks.stubGetConvictionById('CRN24', 'null', deliusConvictionFactory.build()),
     interventionsMocks.stubGetActionPlanAppointment(
       '1',
       1,

--- a/server/config.ts
+++ b/server/config.ts
@@ -91,7 +91,7 @@ export default {
       agent: new AgentConfig(),
     },
     assessRisksAndNeedsApi: {
-      url: get('ASSESS_RISKS_AND_NEEDS_API_URL', 'http://localhost:8094', requiredInProduction),
+      url: get('ASSESS_RISKS_AND_NEEDS_API_URL', 'http://localhost:9092', requiredInProduction),
       timeout: {
         response: Number(get('ASSESS_RISKS_AND_NEEDS_API_TIMEOUT_RESPONSE', 20000)),
         deadline: Number(get('ASSESS_RISKS_AND_NEEDS_API_TIMEOUT_DEADLINE', 20000)),

--- a/wiremock_mappings/assessRisksAndNeedsApiProxy.json
+++ b/wiremock_mappings/assessRisksAndNeedsApiProxy.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "ANY",
+    "urlPattern": "/risks/.*"
+  },
+  "response": {
+    "proxyBaseUrl": "http://assess-risks-and-needs:8080"
+  },
+  "priority": 8
+}


### PR DESCRIPTION
Added the ability to stub request with wiremock for assess-risks-and-needs calls. This is only for when you are running the application locally with "npm run:dev".

This will fix errors that are thrown when accessing the referral details page due to no data being available on assess-risks-and-needs service.
    
All stub requests can now be made in "mocks.ts".

Do note that all requests starting with "/risks/" will still be forwarded (by wiremork) to the assess-risks-and-needs container if you wish to use the actual container response instead of mocking.
