### PR TITLE
Ic 1481/display correctly formatted date and time across app

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -209,19 +209,19 @@ describe('Probation Practitioner monitor journey', () => {
         .should('deep.equal', [
           {
             'Session details': 'Session 1',
-            'Date and time': '24 Mar 2021, 09:02',
+            'Date and time': '9:02am on 24 Mar 2021',
             Status: 'completed',
             Action: 'View feedback form',
           },
           {
             'Session details': 'Session 2',
-            'Date and time': '30 Apr 2021, 10:02',
+            'Date and time': '10:02am on 30 Apr 2021',
             Status: 'did not attend',
             Action: 'View feedback form',
           },
           {
             'Session details': 'Session 3',
-            'Date and time': '31 May 2021, 10:02',
+            'Date and time': '10:02am on 31 May 2021',
             Status: 'scheduled',
             Action: '',
           },
@@ -394,7 +394,7 @@ describe('Probation Practitioner monitor journey', () => {
 
       cy.visit(`/probation-practitioner/referrals/${referralWithEndRequested.id}/progress`)
 
-      cy.contains('You requested to end this service on 04 Apr 2021')
+      cy.contains('You requested to end this service on 4 April 2021')
     })
   })
 
@@ -565,10 +565,10 @@ describe('Probation Practitioner monitor journey', () => {
         .getTable()
         .should('deep.equal', [
           {
-            'Approval date': '04 Jun 2021',
+            'Approval date': '4 Jun 2021',
           },
           {
-            'Approval date': '03 Jun 2021',
+            'Approval date': '3 Jun 2021',
           },
         ])
     })

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -596,7 +596,7 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('Save and continue').click()
 
     const referralWithActionPlanId = { ...assignedReferral, actionPlanId: draftActionPlan.id }
-    const submittedActionPlan = { ...draftActionPlanWithNumberOfSessions, submittedAt: new Date().toISOString() }
+    const submittedActionPlan = { ...draftActionPlanWithNumberOfSessions, submittedAt: new Date(2021, 7, 18) }
 
     cy.stubGetSentReferral(assignedReferral.id, referralWithActionPlanId)
     cy.stubSubmitActionPlan(draftActionPlan.id, submittedActionPlan)
@@ -616,7 +616,7 @@ describe('Service provider referrals dashboard', () => {
 
     cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/progress`)
     cy.get('#action-plan-status').contains('Awaiting approval')
-    cy.get('.action-plan-submitted-date').contains(/\d{1,2} [A-Z][a-z]{2} \d{4}/)
+    cy.get('.action-plan-submitted-date').contains('18 August 2021')
   })
 
   describe('editing a submitted action plan', () => {
@@ -669,7 +669,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
       cy.get('#action-plan-status').contains('Awaiting approval')
-      cy.contains('19 Aug 2021')
+      cy.contains('19 August 2021')
       cy.contains('View action plan').click()
 
       cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/action-plan`)
@@ -724,7 +724,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/progress`)
       cy.get('#action-plan-status').contains('Awaiting approval')
-      cy.contains('20 Aug 2021')
+      cy.contains('20 August 2021')
     })
 
     it('User edits an approved action plan and submits it for approval', () => {
@@ -776,7 +776,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
       cy.get('#action-plan-status').contains('Approved')
-      cy.contains('19 Aug 2021')
+      cy.contains('19 August 2021')
       cy.contains('View action plan').click()
 
       cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/action-plan`)
@@ -848,7 +848,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/progress`)
       cy.get('#action-plan-status').contains('Awaiting approval')
-      cy.contains('20 Aug 2021')
+      cy.contains('20 August 2021')
     })
   })
 
@@ -1176,7 +1176,7 @@ describe('Service provider referrals dashboard', () => {
       cy.get('form').contains('Confirm').click()
 
       cy.contains('Session feedback added and submitted to the probation practitioner')
-      cy.contains('You can now deliver the next session scheduled for 31 Mar 2021.')
+      cy.contains('You can now deliver the next session scheduled for 31 March 2021.')
 
       const updatedAppointments = [appointmentWithSubmittedFeedback, appointments[1]]
       cy.stubGetActionPlanAppointments(actionPlan.id, updatedAppointments)
@@ -1188,13 +1188,13 @@ describe('Service provider referrals dashboard', () => {
         .should('deep.equal', [
           {
             'Session details': 'Session 1',
-            'Date and time': '24 Mar 2021, 09:02',
+            'Date and time': '9:02am on 24 Mar 2021',
             Status: 'completed',
             Action: 'View feedback form',
           },
           {
             'Session details': 'Session 2',
-            'Date and time': '31 Mar 2021, 10:02',
+            'Date and time': '10:02am on 31 Mar 2021',
             Status: 'scheduled',
             Action: 'Reschedule sessionGive feedback',
           },
@@ -1310,7 +1310,7 @@ describe('Service provider referrals dashboard', () => {
       cy.get('form').contains('Confirm').click()
 
       cy.contains('Session feedback added and submitted to the probation practitioner')
-      cy.contains('You can now deliver the next session scheduled for 31 Mar 2021.')
+      cy.contains('You can now deliver the next session scheduled for 31 March 2021.')
 
       const updatedAppointments = [appointmentWithSubmittedFeedback, appointments[1]]
       cy.stubGetActionPlanAppointments(actionPlan.id, updatedAppointments)
@@ -1322,13 +1322,13 @@ describe('Service provider referrals dashboard', () => {
         .should('deep.equal', [
           {
             'Session details': 'Session 1',
-            'Date and time': '24 Mar 2021, 09:02',
+            'Date and time': '9:02am on 24 Mar 2021',
             Status: 'did not attend',
             Action: 'View feedback form',
           },
           {
             'Session details': 'Session 2',
-            'Date and time': '31 Mar 2021, 10:02',
+            'Date and time': '10:02am on 31 Mar 2021',
             Status: 'scheduled',
             Action: 'Reschedule sessionGive feedback',
           },
@@ -1401,7 +1401,7 @@ describe('Service provider referrals dashboard', () => {
       cy.visit(`/service-provider/referrals/${endedReferral.id}/progress`)
       cy.contains('Intervention ended')
       cy.contains(
-        'The probation practitioner ended this intervention on 28 Apr 2021 with reason: Service user was recalled'
+        'The probation practitioner ended this intervention on 28 April 2021 with reason: Service user was recalled'
       )
       cy.contains('Please note that an end of service report must still be submitted within 10 working days.').should(
         'not.exist'

--- a/server/routes/appointments/appointmentSummary.test.ts
+++ b/server/routes/appointments/appointmentSummary.test.ts
@@ -28,7 +28,7 @@ describe(AppointmentSummary, () => {
 
       expect(summaryComponent.appointmentSummaryList.slice(0, 2)).toEqual([
         { key: 'Date', lines: ['9 March 2021'] },
-        { key: 'Time', lines: ['11:00am to 12:00pm'] },
+        { key: 'Time', lines: ['11:00am to midday'] },
       ])
     })
 

--- a/server/routes/appointments/appointmentSummary.test.ts
+++ b/server/routes/appointments/appointmentSummary.test.ts
@@ -19,16 +19,16 @@ describe(AppointmentSummary, () => {
         expect(summaryComponent.appointmentSummaryList).toEqual([])
       })
     })
-    it('contains the date and time of the appointment', () => {
+    it('contains the date and time of the appointment and it is capitalized', () => {
       const appointment = initialAssessmentAppointmentFactory.build({
-        appointmentTime: '2021-03-09T11:00:00Z',
+        appointmentTime: '2021-03-09T12:00:00Z',
         durationInMinutes: 60,
       })
       const summaryComponent = new AppointmentSummary(appointment, null)
 
       expect(summaryComponent.appointmentSummaryList.slice(0, 2)).toEqual([
         { key: 'Date', lines: ['9 March 2021'] },
-        { key: 'Time', lines: ['11:00am to midday'] },
+        { key: 'Time', lines: ['Midday to 1:00pm'] },
       ])
     })
 

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -38,7 +38,8 @@ export default class AppointmentSummary {
         lines: [
           DateUtils.formattedTimeRange(
             this.appointmentDecorator.britishTime!,
-            this.appointmentDecorator.britishEndsAtTime!
+            this.appointmentDecorator.britishEndsAtTime!,
+            { casing: 'capitalized' }
           ),
         ],
       })

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -1,9 +1,9 @@
 import { SummaryListItem } from '../../utils/summaryList'
 import AppointmentDecorator from '../../decorators/appointmentDecorator'
-import PresenterUtils from '../../utils/presenterUtils'
 import { AppointmentDeliveryType } from '../../models/appointmentDeliveryType'
 import Address from '../../models/address'
 import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
+import DateUtils from '../../utils/dateUtils'
 import { AppointmentSchedulingDetails } from '../../models/appointment'
 
 interface Caseworker {
@@ -29,14 +29,14 @@ export default class AppointmentSummary {
     if (this.appointmentDecorator.britishDay) {
       summary.push({
         key: 'Date',
-        lines: [PresenterUtils.govukFormattedDate(this.appointmentDecorator.britishDay!)],
+        lines: [DateUtils.formattedDate(this.appointmentDecorator.britishDay!)],
       })
     }
     if (this.appointmentDecorator.britishTime && this.appointmentDecorator.britishEndsAtTime) {
       summary.push({
         key: 'Time',
         lines: [
-          PresenterUtils.formattedTimeRange(
+          DateUtils.formattedTimeRange(
             this.appointmentDecorator.britishTime!,
             this.appointmentDecorator.britishEndsAtTime!
           ),

--- a/server/routes/appointments/feedback/actionPlanSessions/confirmation/postSessionFeedbackConfirmationPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/confirmation/postSessionFeedbackConfirmationPresenter.test.ts
@@ -44,7 +44,7 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
           const presenter = new PostSessionFeedbackConfirmationPresenter(actionPlan, appointments[0], appointments[1])
 
           expect(presenter.text.whatHappensNext).toEqual(
-            'You can now deliver the next session scheduled for 31 Mar 2021.'
+            'You can now deliver the next session scheduled for 31 March 2021.'
           )
         })
       })
@@ -81,7 +81,6 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
               },
             }),
             actionPlanAppointment.build({
-              appointmentTime: '',
               durationInMinutes: 60,
               sessionNumber: 2,
             }),

--- a/server/routes/appointments/feedback/actionPlanSessions/confirmation/postSessionFeedbackConfirmationPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/confirmation/postSessionFeedbackConfirmationPresenter.ts
@@ -16,10 +16,9 @@ export default class PostSessionFeedbackConfirmationPresenter {
   }
 
   get whatHappensNextText(): string {
-    if (this.hasNextSessionDate) {
-      return `You can now deliver the next session scheduled for ${DateUtils.getDateStringFromDateTimeString(
-        this.nextAppointment!.appointmentTime
-      )}.`
+    if (this.nextAppointment !== null && this.nextAppointment.appointmentTime !== null) {
+      const formattedDate = DateUtils.formattedDate(this.nextAppointment.appointmentTime)
+      return `You can now deliver the next session scheduled for ${formattedDate}.`
     }
 
     if (this.isFinalSession) {
@@ -27,12 +26,6 @@ export default class PostSessionFeedbackConfirmationPresenter {
     }
 
     return 'The probation practitioner has been sent a copy of the session feedback form.'
-  }
-
-  private get hasNextSessionDate() {
-    return (
-      this.nextAppointment !== null && DateUtils.getDateStringFromDateTimeString(this.nextAppointment!.appointmentTime)
-    )
   }
 
   private get isFinalSession() {

--- a/server/routes/probationPractitionerReferrals/findStartPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/findStartPresenter.ts
@@ -1,7 +1,7 @@
 import DraftReferral from '../../models/draftReferral'
-import CalendarDay from '../../utils/calendarDay'
 import PresenterUtils from '../../utils/presenterUtils'
 import DashboardNavPresenter from './dashboardNavPresenter'
+import DateUtils from '../../utils/dateUtils'
 
 export default class FindStartPresenter {
   constructor(
@@ -17,7 +17,7 @@ export default class FindStartPresenter {
       .sort((a, b) => (new Date(a.createdAt) < new Date(b.createdAt) ? -1 : 1))
       .map(referral => ({
         serviceUserFullName: PresenterUtils.fullName(referral.serviceUser),
-        createdAt: PresenterUtils.govukShortFormattedDate(CalendarDay.britishDayForDate(new Date(referral.createdAt))),
+        createdAt: DateUtils.formattedDate(referral.createdAt, { month: 'short' }),
         url: `/referrals/${referral.id}/form`,
       }))
   }

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -57,7 +57,7 @@ describe(InterventionProgressPresenter, () => {
             [
               actionPlanAppointmentFactory.build({
                 sessionNumber: 1,
-                appointmentTime: '3020-12-07T13:00:00.000000Z',
+                appointmentTime: '3020-12-07T12:00:00.000000Z',
                 durationInMinutes: 120,
               }),
             ],
@@ -68,7 +68,7 @@ describe(InterventionProgressPresenter, () => {
           expect(presenter.sessionTableRows).toEqual([
             {
               sessionNumber: 1,
-              appointmentTime: '1:00pm on 7 Dec 3020',
+              appointmentTime: 'Midday on 7 Dec 3020',
               tagArgs: {
                 text: 'scheduled',
                 classes: 'govuk-tag--blue',

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -68,7 +68,7 @@ describe(InterventionProgressPresenter, () => {
           expect(presenter.sessionTableRows).toEqual([
             {
               sessionNumber: 1,
-              appointmentTime: '07 Dec 3020, 13:00',
+              appointmentTime: '1:00pm on 7 Dec 3020',
               tagArgs: {
                 text: 'scheduled',
                 classes: 'govuk-tag--blue',
@@ -101,7 +101,7 @@ describe(InterventionProgressPresenter, () => {
           expect(presenter.sessionTableRows).toEqual([
             {
               sessionNumber: 1,
-              appointmentTime: '07 Dec 1920, 13:00',
+              appointmentTime: '1:00pm on 7 Dec 1920',
               tagArgs: {
                 text: 'scheduled',
                 classes: 'govuk-tag--blue',
@@ -266,7 +266,7 @@ describe(InterventionProgressPresenter, () => {
       const supplierAssessment = supplierAssessmentFactory.build()
       const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
 
-      expect(presenter.referralEndRequestedText).toEqual('You requested to end this service on 28 Apr 2021.')
+      expect(presenter.referralEndRequestedText).toEqual('You requested to end this service on 28 April 2021.')
     })
 
     it('returns an empty string when an end has not been requested', () => {

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -90,7 +90,7 @@ export default class InterventionProgressPresenter {
       return {
         sessionNumber: appointment.sessionNumber,
         appointmentTime: appointment.appointmentTime
-          ? DateUtils.formattedDateTime(appointment.appointmentTime, { month: 'short' })
+          ? DateUtils.formattedDateTime(appointment.appointmentTime, { month: 'short', timeCasing: 'capitalized' })
           : '',
         tagArgs: { text: sessionTableParams.text, classes: sessionTableParams.tagClass },
         link: sessionTableParams.link,

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -62,12 +62,10 @@ export default class InterventionProgressPresenter {
   }
 
   get referralEndRequestedText(): string {
-    const shortenedDateString = DateUtils.getDateStringFromDateTimeString(this.referral.endRequestedAt)
-
-    if (!shortenedDateString) {
+    if (!this.referral.endRequestedAt) {
       return ''
     }
-
+    const shortenedDateString = DateUtils.formattedDate(this.referral.endRequestedAt)
     return `You requested to end this service on ${shortenedDateString}.`
   }
 
@@ -91,7 +89,9 @@ export default class InterventionProgressPresenter {
 
       return {
         sessionNumber: appointment.sessionNumber,
-        appointmentTime: DateUtils.formatDateTimeOrEmptyString(appointment.appointmentTime),
+        appointmentTime: appointment.appointmentTime
+          ? DateUtils.formattedDateTime(appointment.appointmentTime, { month: 'short' })
+          : '',
         tagArgs: { text: sessionTableParams.text, classes: sessionTableParams.tagClass },
         link: sessionTableParams.link,
       }

--- a/server/routes/referrals/check-answers/checkAnswersPresenter.ts
+++ b/server/routes/referrals/check-answers/checkAnswersPresenter.ts
@@ -10,8 +10,8 @@ import Intervention from '../../../models/intervention'
 import InterventionDecorator from '../../../decorators/interventionDecorator'
 import DeliusConviction from '../../../models/delius/deliusConviction'
 import SentencePresenter from '../relevant-sentence/sentencePresenter'
-import PresenterUtils from '../../../utils/presenterUtils'
 import { ExpandedDeliusServiceUser } from '../../../models/delius/deliusServiceUser'
+import DateUtils from '../../../utils/dateUtils'
 
 export default class CheckAnswersPresenter {
   constructor(
@@ -173,7 +173,7 @@ export default class CheckAnswersPresenter {
       summary: [
         {
           key: 'Date',
-          lines: [PresenterUtils.govukFormattedDate(completionDeadline)],
+          lines: [DateUtils.formattedDate(completionDeadline)],
           changeLink: `/referrals/${this.referral.id}/completion-deadline`,
         },
       ],

--- a/server/routes/referrals/relevant-sentence/sentencePresenter.ts
+++ b/server/routes/referrals/relevant-sentence/sentencePresenter.ts
@@ -1,5 +1,5 @@
 import DeliusConviction from '../../../models/delius/deliusConviction'
-import PresenterUtils from '../../../utils/presenterUtils'
+import DateUtils from '../../../utils/dateUtils'
 
 export default class SentencePresenter {
   readonly category: string
@@ -22,7 +22,8 @@ export default class SentencePresenter {
     this.category = mainOffence.detail.mainCategoryDescription
     this.subcategory = mainOffence.detail.subCategoryDescription
 
-    this.endOfSentenceDate =
-      PresenterUtils.govukFormattedDateFromStringOrNull(this.conviction.sentence.expectedSentenceEndDate) ?? 'Not found'
+    this.endOfSentenceDate = this.conviction?.sentence?.expectedSentenceEndDate
+      ? DateUtils.formattedDate(this.conviction.sentence.expectedSentenceEndDate)
+      : 'Not found'
   }
 }

--- a/server/routes/referrals/service-user-details/serviceUserDetailsPresenter.ts
+++ b/server/routes/referrals/service-user-details/serviceUserDetailsPresenter.ts
@@ -1,9 +1,8 @@
 import ServiceUser from '../../../models/serviceUser'
-import CalendarDay from '../../../utils/calendarDay'
-import PresenterUtils from '../../../utils/presenterUtils'
 import { ListStyle, SummaryListItem } from '../../../utils/summaryList'
 import { ExpandedDeliusServiceUser } from '../../../models/delius/deliusServiceUser'
 import ExpandedDeliusServiceUserDecorator from '../../../decorators/expandedDeliusServiceUserDecorator'
+import DateUtils from '../../../utils/dateUtils'
 
 export default class ServiceUserDetailsPresenter {
   constructor(
@@ -67,13 +66,6 @@ export default class ServiceUserDetailsPresenter {
     if (this.serviceUser.dateOfBirth === null) {
       return ''
     }
-
-    const day = CalendarDay.parseIso8601Date(this.serviceUser.dateOfBirth)
-
-    if (day === null) {
-      return ''
-    }
-
-    return PresenterUtils.govukFormattedDate(day)
+    return DateUtils.formattedDate(this.serviceUser.dateOfBirth)
   }
 }

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -1,9 +1,9 @@
 import CalendarDay from '../../utils/calendarDay'
-import PresenterUtils from '../../utils/presenterUtils'
 import { SortableTableHeaders, SortableTableRow } from '../../utils/viewUtils'
 import DashboardNavPresenter from './dashboardNavPresenter'
 import ServiceProviderSentReferralSummary from '../../models/serviceProviderSentReferralSummary'
 import utils from '../../utils/utils'
+import DateUtils from '../../utils/dateUtils'
 
 export default class DashboardPresenter {
   constructor(private readonly referralsSummary: ServiceProviderSentReferralSummary[]) {}
@@ -23,7 +23,7 @@ export default class DashboardPresenter {
     const sentAtDay = CalendarDay.britishDayForDate(new Date(referralSummary.sentAt))
     return [
       {
-        text: PresenterUtils.govukShortFormattedDate(sentAtDay),
+        text: DateUtils.formattedDate(sentAtDay, { month: 'short' }),
         sortValue: sentAtDay.iso8601,
         href: null,
       },

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -156,7 +156,7 @@ describe(InterventionProgressPresenter, () => {
         expect(presenter.sessionTableRows).toEqual([
           {
             sessionNumber: 1,
-            appointmentTime: '07 Dec 2020, 13:00',
+            appointmentTime: '1:00pm on 7 Dec 2020',
             statusPresenter: new SessionStatusPresenter(SessionStatus.scheduled),
             links: [
               {

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -147,7 +147,7 @@ describe(InterventionProgressPresenter, () => {
           [
             actionPlanAppointmentFactory.build({
               sessionNumber: 1,
-              appointmentTime: '2020-12-07T13:00:00.000000Z',
+              appointmentTime: '2020-12-07T12:00:00.000000Z',
               durationInMinutes: 120,
             }),
           ],
@@ -156,7 +156,7 @@ describe(InterventionProgressPresenter, () => {
         expect(presenter.sessionTableRows).toEqual([
           {
             sessionNumber: 1,
-            appointmentTime: '1:00pm on 7 Dec 2020',
+            appointmentTime: 'Midday on 7 Dec 2020',
             statusPresenter: new SessionStatusPresenter(SessionStatus.scheduled),
             links: [
               {

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -85,7 +85,9 @@ export default class InterventionProgressPresenter {
 
         return {
           sessionNumber: appointment.sessionNumber,
-          appointmentTime: DateUtils.formatDateTimeOrEmptyString(appointment.appointmentTime),
+          appointmentTime: appointment.appointmentTime
+            ? DateUtils.formattedDateTime(appointment.appointmentTime, { month: 'short' })
+            : '',
           ...sessionTableParams,
         }
       })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -86,7 +86,7 @@ export default class InterventionProgressPresenter {
         return {
           sessionNumber: appointment.sessionNumber,
           appointmentTime: appointment.appointmentTime
-            ? DateUtils.formattedDateTime(appointment.appointmentTime, { month: 'short' })
+            ? DateUtils.formattedDateTime(appointment.appointmentTime, { month: 'short', timeCasing: 'capitalized' })
             : '',
           ...sessionTableParams,
         }

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -23,9 +23,7 @@ export default class InterventionProgressView {
     let cancellationCommentsHTML = ''
     let notConcludedWarningHTML = ''
     if (this.presenter.referralEndedFields.endRequestedAt && this.presenter.referralEndedFields.endRequestedReason) {
-      const formattedEndDate = DateUtils.getDateStringFromDateTimeString(
-        this.presenter.referralEndedFields.endRequestedAt
-      )
+      const formattedEndDate = DateUtils.formattedDate(this.presenter.referralEndedFields.endRequestedAt)
       cancellationReasonHTML = `
         <p>
             The probation practitioner ended this intervention on ${formattedEndDate} 

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -76,7 +76,7 @@ describe(ScheduleAppointmentPresenter, () => {
           expect(presenter.appointmentSummary).toEqual([
             { key: 'Caseworker', lines: ['firstName lastName'] },
             { key: 'Date', lines: ['2 January 2021'] },
-            { key: 'Time', lines: ['midday to 1:00pm'] },
+            { key: 'Time', lines: ['Midday to 1:00pm'] },
             { key: 'Method', lines: ['Video call'] },
           ])
         })
@@ -98,7 +98,7 @@ describe(ScheduleAppointmentPresenter, () => {
           )
           expect(presenter.appointmentSummary).toEqual([
             { key: 'Date', lines: ['2 January 2021'] },
-            { key: 'Time', lines: ['midday to 1:00pm'] },
+            { key: 'Time', lines: ['Midday to 1:00pm'] },
             { key: 'Method', lines: ['Video call'] },
           ])
         })

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -76,7 +76,7 @@ describe(ScheduleAppointmentPresenter, () => {
           expect(presenter.appointmentSummary).toEqual([
             { key: 'Caseworker', lines: ['firstName lastName'] },
             { key: 'Date', lines: ['2 January 2021'] },
-            { key: 'Time', lines: ['12:00pm to 1:00pm'] },
+            { key: 'Time', lines: ['midday to 1:00pm'] },
             { key: 'Method', lines: ['Video call'] },
           ])
         })
@@ -98,7 +98,7 @@ describe(ScheduleAppointmentPresenter, () => {
           )
           expect(presenter.appointmentSummary).toEqual([
             { key: 'Date', lines: ['2 January 2021'] },
-            { key: 'Time', lines: ['12:00pm to 1:00pm'] },
+            { key: 'Time', lines: ['midday to 1:00pm'] },
             { key: 'Method', lines: ['Video call'] },
           ])
         })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1343,7 +1343,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNu
         )
         .expect(200)
         .expect(res => {
-          expect(res.text).toContain('You can now deliver the next session scheduled for 31 Mar 2021.')
+          expect(res.text).toContain('You can now deliver the next session scheduled for 31 March 2021.')
         })
     })
   })

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -72,7 +72,7 @@ export default class ActionPlanPresenter {
     return this.approvedActionPlanSummaries
       .sort((summaryA, summaryB) => new Date(summaryB.approvedAt).getTime() - new Date(summaryA.approvedAt).getTime())
       .map(summary => ({
-        approvalDate: dateUtils.getDateStringFromDateTimeString(summary.approvedAt),
+        approvalDate: dateUtils.formattedDate(summary.approvedAt, { month: 'short' }),
       }))
   }
 

--- a/server/routes/shared/action-plan/actionPlanSummaryPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanSummaryPresenter.ts
@@ -19,8 +19,8 @@ export default class ActionPlanSummaryPresenter {
 
   readonly text = {
     actionPlanStatus: this.actionPlanStatus,
-    actionPlanSubmittedDate: DateUtils.getDateStringFromDateTimeString(this.actionPlan?.submittedAt || null),
-    actionPlanApprovalDate: DateUtils.getDateStringFromDateTimeString(this.actionPlan?.approvedAt || null),
+    actionPlanSubmittedDate: this.actionPlan?.submittedAt ? DateUtils.formattedDate(this.actionPlan?.submittedAt) : '',
+    actionPlanApprovalDate: this.actionPlan?.approvedAt ? DateUtils.formattedDate(this.actionPlan?.approvedAt) : '',
   }
 
   private get actionPlanStatus(): string {

--- a/server/routes/shared/serviceUserBannerPresenter.ts
+++ b/server/routes/shared/serviceUserBannerPresenter.ts
@@ -1,6 +1,6 @@
 import DeliusServiceUser from '../../models/delius/deliusServiceUser'
 import utils from '../../utils/utils'
-import PresenterUtils from '../../utils/presenterUtils'
+import DateUtils from '../../utils/dateUtils'
 
 export default class ServiceUserBannerPresenter {
   constructor(private readonly serviceUser: DeliusServiceUser) {}
@@ -10,7 +10,7 @@ export default class ServiceUserBannerPresenter {
   }
 
   get dateOfBirth(): string {
-    return PresenterUtils.govukFormattedDateFromStringOrNull(this.serviceUser.dateOfBirth)
+    return this.serviceUser.dateOfBirth ? DateUtils.formattedDate(this.serviceUser.dateOfBirth) : 'Not found'
   }
 
   get serviceUserEmail(): string {

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -22,6 +22,7 @@ import RiskPresenter from './riskPresenter'
 import { DeliusStaffDetails, DeliusTeam } from '../../models/delius/deliusStaffDetails'
 import CalendarDay from '../../utils/calendarDay'
 import { DeliusOffenderManager } from '../../models/delius/deliusOffenderManager'
+import DateUtils from '../../utils/dateUtils'
 
 export default class ShowReferralPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
@@ -256,7 +257,11 @@ export default class ShowReferralPresenter {
       },
       {
         key: 'Date to be completed by',
-        lines: [PresenterUtils.govukFormattedDateFromStringOrNull(this.sentReferral.referral.completionDeadline)],
+        lines: [
+          this.sentReferral.referral.completionDeadline
+            ? DateUtils.formattedDate(this.sentReferral.referral.completionDeadline)
+            : '',
+        ],
       },
       {
         key: 'Maximum number of enforceable days',

--- a/server/routes/shared/supplierAssessmentAppointmentPresenter.test.ts
+++ b/server/routes/shared/supplierAssessmentAppointmentPresenter.test.ts
@@ -39,7 +39,7 @@ describe(SupplierAssessmentAppointmentPresenter, () => {
 
       expect(presenter.summary.slice(0, 2)).toEqual([
         { key: 'Date', lines: ['9 March 2021'] },
-        { key: 'Time', lines: ['11:00am to 12:00pm'] },
+        { key: 'Time', lines: ['11:00am to midday'] },
       ])
     })
 

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -71,6 +71,11 @@ describe('DateUtils', () => {
       // Note that js Dates are 0 indexed for months
       expect(DateUtils.formattedTime(new Date(Date.UTC(2021, 5, 2, 17, 30)))).toEqual('6:30pm')
     })
+
+    it('returns capitalized words when capitalized option is specified', () => {
+      expect(DateUtils.formattedTime('2021-06-02T12:00:00+01:00', { casing: 'capitalized' })).toEqual('Midday')
+      expect(DateUtils.formattedTime('2021-06-02T24:00:00+01:00', { casing: 'capitalized' })).toEqual('Midnight')
+    })
   })
 
   describe('formattedTimeRange', () => {
@@ -93,6 +98,19 @@ describe('DateUtils', () => {
       expect(
         DateUtils.formattedTimeRange(new Date(Date.UTC(2021, 5, 2, 5, 30)), new Date(Date.UTC(2021, 5, 2, 18, 30)))
       ).toEqual('6:30am to 7:30pm')
+    })
+
+    it('returns capitalized words when capitalized option is specified', () => {
+      expect(
+        DateUtils.formattedTimeRange('2021-06-02T12:00:00+01:00', '2021-06-02T24:00:00+01:00', {
+          casing: 'capitalized',
+        })
+      ).toEqual('Midday to midnight')
+      expect(
+        DateUtils.formattedTimeRange('2021-06-02T24:00:00+01:00', '2021-06-02T12:00:00+01:00', {
+          casing: 'capitalized',
+        })
+      ).toEqual('Midnight to midday')
     })
   })
 })

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,58 +1,98 @@
 import DateUtils from './dateUtils'
+import CalendarDay from './calendarDay'
+import ClockTime from './clockTime'
 
 describe('DateUtils', () => {
-  describe('formatDateTime', () => {
-    it('returns empty string for null datetime input', () => {
-      expect(DateUtils.formatDateTimeOrEmptyString(null)).toEqual('')
-    })
-
+  describe('formattedDateTime', () => {
     it('returns a formatted string with local timezone offset for a valid ISO8601 datetime input', () => {
-      expect(DateUtils.formatDateTimeOrEmptyString('2021-02-01T13:00:00Z')).toEqual('01 Feb 2021, 13:00')
-      expect(DateUtils.formatDateTimeOrEmptyString('2021-06-01T13:00:00Z')).toEqual('01 Jun 2021, 14:00')
-      expect(DateUtils.formatDateTimeOrEmptyString('2020-12-07T13:00:00.000000Z')).toEqual('07 Dec 2020, 13:00')
-
-      expect(DateUtils.formatDateTimeOrEmptyString('2021-02-02T00:30:00+01:00')).toEqual('01 Feb 2021, 23:30')
-      expect(DateUtils.formatDateTimeOrEmptyString('2021-06-02T00:30:00+01:00')).toEqual('02 Jun 2021, 00:30')
-    })
-
-    it('returns an emtpy string for invalid datetime input', () => {
-      expect(DateUtils.formatDateTimeOrEmptyString(' ')).toEqual('')
-      expect(DateUtils.formatDateTimeOrEmptyString('abcdefg')).toEqual('')
-      expect(DateUtils.formatDateTimeOrEmptyString('2021-06-02T00:30:00+01000:00')).toEqual('')
+      expect(DateUtils.formattedDateTime('2021-02-01T13:00:00Z')).toEqual('1:00pm on 1 February 2021')
+      expect(DateUtils.formattedDateTime('2021-06-01T13:00:00Z')).toEqual('2:00pm on 1 June 2021')
+      expect(DateUtils.formattedDateTime('2020-12-07T13:00:00.000000Z')).toEqual('1:00pm on 7 December 2020')
+      // Display BST as GMT during winter
+      expect(DateUtils.formattedDateTime('2021-02-02T00:30:00+01:00')).toEqual('11:30pm on 1 February 2021')
+      expect(DateUtils.formattedDateTime('2021-02-01T23:30:00+00:00')).toEqual('11:30pm on 1 February 2021')
+      // Display BST as BST during summer
+      expect(DateUtils.formattedDateTime('2021-06-02T00:30:00+01:00')).toEqual('12:30am on 2 June 2021')
+      expect(DateUtils.formattedDateTime('2021-06-01T23:30:00+00:00')).toEqual('12:30am on 2 June 2021')
     })
   })
 
-  describe('getDateStringFromDateTimeString', () => {
-    it('returns the time section of the formatted date time string', () => {
-      const dateTimeString = '2021-06-02T00:30:00+01:00'
-      expect(DateUtils.getDateStringFromDateTimeString(dateTimeString)).toEqual('02 Jun 2021')
+  describe('formattedDate', () => {
+    describe('with various date formats', () => {
+      it('returns the correctly formatted date', () => {
+        expect(DateUtils.formattedDate('2021-06-02')).toEqual('2 June 2021')
+        // Display as GMT during winter
+        expect(DateUtils.formattedDate('2021-02-02T00:30:00+01:00')).toEqual('1 February 2021')
+        // Display as BST during summer
+        expect(DateUtils.formattedDate('2021-06-02T00:30:00+01:00')).toEqual('2 June 2021')
+        expect(DateUtils.formattedDate('2021-06-02T00:30:00')).toEqual('2 June 2021')
+      })
     })
 
-    it('returns an empty string for null datetime input', () => {
-      expect(DateUtils.getDateStringFromDateTimeString(null)).toEqual('')
+    it('returns the correctly formatted date for CalendarDay', () => {
+      expect(DateUtils.formattedDate(CalendarDay.fromComponents(2, 6, 2021)!)).toEqual('2 June 2021')
     })
 
-    it('returns an empty string for invalid datetime input', () => {
-      expect(DateUtils.getDateStringFromDateTimeString(' ')).toEqual('')
-      expect(DateUtils.getDateStringFromDateTimeString('abcdefg')).toEqual('')
-      expect(DateUtils.getDateStringFromDateTimeString('2021-06-02T00:30:00+01000:00')).toEqual('')
+    it('returns the correctly formatted date for js Date', () => {
+      // Note that js Dates are 0 indexed for months
+      expect(DateUtils.formattedDate(new Date(2021, 5, 2))).toEqual('2 June 2021')
+    })
+
+    describe('with short month option', () => {
+      it('returns the shortened month', () => {
+        expect(DateUtils.formattedDate('2021-06-02', { month: 'short' })).toEqual('2 Jun 2021')
+      })
     })
   })
 
-  describe('getTimeStringFromDateTimeString', () => {
+  describe('formattedTime', () => {
+    // No official guidance on how to display 12:30pm/am (should it be something like '12:30 midday/midnight' instead)?
+    it('returns the correct values for midday and midnight', () => {
+      expect(DateUtils.formattedTime('2021-06-02T12:00:00+01:00')).toEqual('midday')
+      expect(DateUtils.formattedTime('2021-06-02T12:30:00+01:00')).toEqual('12:30pm')
+      expect(DateUtils.formattedTime('2021-06-02T24:00:00+01:00')).toEqual('midnight')
+      expect(DateUtils.formattedTime('2021-06-02T00:30:00+01:00')).toEqual('12:30am')
+    })
+
     it('returns the time section of the formatted date time string', () => {
-      const dateTimeString = '2021-06-02T00:30:00+01:00'
-      expect(DateUtils.getTimeStringFromDateTimeString(dateTimeString)).toEqual('00:30')
+      // Display BST as GMT during winter
+      expect(DateUtils.formattedTime('2021-06-02T00:30:00+01:00')).toEqual('12:30am')
+      expect(DateUtils.formattedTime('2021-06-02T23:30:00+00:00')).toEqual('12:30am')
+      // Display BST as BST during summer
+      expect(DateUtils.formattedTime('2021-02-02T00:30:00+01:00')).toEqual('11:30pm')
+      expect(DateUtils.formattedTime('2021-02-02T23:30:00+00:00')).toEqual('11:30pm')
     })
 
-    it('returns an empty string for null datetime input', () => {
-      expect(DateUtils.getTimeStringFromDateTimeString(null)).toEqual('')
+    it('returns the correctly formatted date for ClockTime', () => {
+      expect(DateUtils.formattedTime(ClockTime.fromTwentyFourHourComponents(17, 30, 30)!)).toEqual('5:30pm')
     })
 
-    it('returns an empty string for invalid datetime input', () => {
-      expect(DateUtils.getTimeStringFromDateTimeString(' ')).toEqual('')
-      expect(DateUtils.getTimeStringFromDateTimeString('abcdefg')).toEqual('')
-      expect(DateUtils.getTimeStringFromDateTimeString('2021-06-02T00:30:00+01000:00')).toEqual('')
+    it('returns the correctly formatted date for js Date', () => {
+      // Note that js Dates are 0 indexed for months
+      expect(DateUtils.formattedTime(new Date(Date.UTC(2021, 5, 2, 17, 30)))).toEqual('6:30pm')
+    })
+  })
+
+  describe('formattedTimeRange', () => {
+    it('returns the correctly formatted time range for string', () => {
+      expect(DateUtils.formattedTimeRange('2021-06-02T05:30:00+01:00', '2021-06-02T18:30:00+01:00')).toEqual(
+        '5:30am to 6:30pm'
+      )
+    })
+
+    it('returns the correctly formatted time range for ClockTime', () => {
+      expect(
+        DateUtils.formattedTimeRange(
+          ClockTime.fromTwentyFourHourComponents(5, 30, 30)!,
+          ClockTime.fromTwentyFourHourComponents(18, 30, 30)!
+        )
+      ).toEqual('5:30am to 6:30pm')
+    })
+
+    it('returns the correctly formatted time range for js Date', () => {
+      expect(
+        DateUtils.formattedTimeRange(new Date(Date.UTC(2021, 5, 2, 5, 30)), new Date(Date.UTC(2021, 5, 2, 18, 30)))
+      ).toEqual('6:30am to 7:30pm')
     })
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,10 +1,18 @@
 import ClockTime from './clockTime'
 import CalendarDay from './calendarDay'
 
+type casing = 'lowercase' | 'capitalized'
 export default class DateUtils {
   // example output: 1:00pm on 12 April 2021
-  static formattedDateTime(dateTime: Date | string, options: { month: 'short' | 'long' } = { month: 'long' }): string {
-    return `${this.formattedTime(dateTime)} on ${this.formattedDate(dateTime, options)}`
+  static formattedDateTime(
+    dateTime: Date | string,
+    options: { month?: 'short' | 'long'; timeCasing?: casing } = { month: 'long', timeCasing: 'lowercase' }
+  ): string {
+    const nonNullableOptions = {
+      month: options.month ? options.month : 'long',
+      casing: options.timeCasing ? options.timeCasing : 'lowercase',
+    }
+    return `${this.formattedTime(dateTime, nonNullableOptions)} on ${this.formattedDate(dateTime, nonNullableOptions)}`
   }
 
   // Docs: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
@@ -35,7 +43,7 @@ export default class DateUtils {
   // Docs: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times
   // string input: 2021-06-02T00:30:00+01:00 or 2021-06-02T00:30:00
   // example output: 1:00pm
-  static formattedTime(time: ClockTime | Date | string): string {
+  static formattedTime(time: ClockTime | Date | string, options: { casing: casing } = { casing: 'lowercase' }): string {
     let clockTime: ClockTime
     if (time instanceof ClockTime) {
       clockTime = time
@@ -47,11 +55,11 @@ export default class DateUtils {
       clockTime = ClockTime.britishTimeForDate(new Date(time))
     }
     if (clockTime.twelveHourClockHour === 12 && clockTime.minute === 0 && clockTime.partOfDay === 'pm') {
-      return 'midday'
+      return options.casing === 'capitalized' ? 'Midday' : 'midday'
     }
     if (clockTime.twelveHourClockHour === 0 && clockTime.partOfDay === 'am') {
       if (clockTime.minute === 0) {
-        return 'midnight'
+        return options.casing === 'capitalized' ? 'Midnight' : 'midnight'
       }
       return `12:${clockTime.minute.toString().padStart(2, '0')}am`
     }
@@ -59,7 +67,11 @@ export default class DateUtils {
   }
 
   // example output: 11:00am to 1:00pm
-  static formattedTimeRange(startsAt: ClockTime | Date | string, endsAt: ClockTime | Date | string): string {
-    return `${this.formattedTime(startsAt)} to ${this.formattedTime(endsAt)}`
+  static formattedTimeRange(
+    startsAt: ClockTime | Date | string,
+    endsAt: ClockTime | Date | string,
+    options: { casing: casing } = { casing: 'lowercase' }
+  ): string {
+    return `${this.formattedTime(startsAt, options)} to ${this.formattedTime(endsAt)}`
   }
 }

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,58 +1,65 @@
-import { findTimeZone, getZonedTime } from 'timezone-support'
+import ClockTime from './clockTime'
+import CalendarDay from './calendarDay'
 
 export default class DateUtils {
-  static getMonthName(num: number): string {
-    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec']
-    return months[num - 1]
+  // example output: 1:00pm on 12 April 2021
+  static formattedDateTime(dateTime: Date | string, options: { month: 'short' | 'long' } = { month: 'long' }): string {
+    return `${this.formattedTime(dateTime)} on ${this.formattedDate(dateTime, options)}`
   }
 
-  static formatDateTimeOrEmptyString(dateTimeString: string | null): string {
-    const date = DateUtils.getDateStringFromDateTimeString(dateTimeString)
-    const time = DateUtils.getTimeStringFromDateTimeString(dateTimeString)
-
-    if (!date || !time) {
-      return ''
+  // Docs: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
+  // string input: 2021-06-02 from delius (i.e. serviceUser.dateOfBirth)
+  // string input: 2021-06-02T00:30:00+01:00 from interventions
+  // example output: 12 January 2021
+  static formattedDate(
+    date: CalendarDay | Date | string,
+    options: { month: 'short' | 'long' } = { month: 'long' }
+  ): string {
+    let calendarDay: CalendarDay
+    if (date instanceof CalendarDay) {
+      calendarDay = date
+    } else if (date instanceof Date) {
+      calendarDay = CalendarDay.britishDayForDate(date)
+    } else {
+      calendarDay = CalendarDay.britishDayForDate(new Date(date))!
     }
-
-    return `${date}, ${time}`
+    const format = new Intl.DateTimeFormat('en-GB', {
+      day: 'numeric',
+      month: options.month,
+      year: 'numeric',
+      timeZone: 'UTC',
+    })
+    return format.format(calendarDay.utcDate)
   }
 
-  static getDateStringFromDateTimeString(dateTime: string | null): string {
-    if (dateTime === null) {
-      return ''
+  // Docs: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times
+  // string input: 2021-06-02T00:30:00+01:00 or 2021-06-02T00:30:00
+  // example output: 1:00pm
+  static formattedTime(time: ClockTime | Date | string): string {
+    let clockTime: ClockTime
+    if (time instanceof ClockTime) {
+      clockTime = time
+    } else if (time instanceof CalendarDay) {
+      clockTime = ClockTime.britishTimeForDate(time.utcDate)
+    } else if (time instanceof Date) {
+      clockTime = ClockTime.britishTimeForDate(time)
+    } else {
+      clockTime = ClockTime.britishTimeForDate(new Date(time))
     }
-
-    const date = new Date(dateTime)
-
-    if (Number.isNaN(Number(date))) {
-      return ''
+    if (clockTime.twelveHourClockHour === 12 && clockTime.minute === 0 && clockTime.partOfDay === 'pm') {
+      return 'midday'
     }
-
-    const ukDate = getZonedTime(date, findTimeZone('Europe/London'))
-
-    const { year } = ukDate
-    const month = DateUtils.getMonthName(ukDate.month)
-    const day = `0${ukDate.day}`.slice(-2)
-
-    return `${day} ${month} ${year}`
+    if (clockTime.twelveHourClockHour === 0 && clockTime.partOfDay === 'am') {
+      if (clockTime.minute === 0) {
+        return 'midnight'
+      }
+      return `12:${clockTime.minute.toString().padStart(2, '0')}am`
+    }
+    return `${clockTime.twelveHourClockHour}:${clockTime.minute.toString().padStart(2, '0')}${clockTime.partOfDay}`
   }
 
-  static getTimeStringFromDateTimeString(dateTime: string | null): string {
-    if (dateTime === null) {
-      return ''
-    }
-
-    const date = new Date(dateTime)
-
-    if (Number.isNaN(Number(date))) {
-      return ''
-    }
-
-    const ukDate = getZonedTime(date, findTimeZone('Europe/London'))
-
-    const hour = `0${ukDate.hours}`.slice(-2)
-    const minutes = `0${ukDate.minutes}`.slice(-2)
-
-    return `${hour}:${minutes}`
+  // example output: 11:00am to 1:00pm
+  static formattedTimeRange(startsAt: ClockTime | Date | string, endsAt: ClockTime | Date | string): string {
+    return `${this.formattedTime(startsAt)} to ${this.formattedTime(endsAt)}`
   }
 }

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -864,20 +864,6 @@ describe(PresenterUtils, () => {
     })
   })
 
-  describe('govukFormattedDate', () => {
-    it('returns a formatted date', () => {
-      const date = CalendarDay.fromComponents(4, 6, 2017)!
-      expect(PresenterUtils.govukFormattedDate(date)).toEqual('4 June 2017')
-    })
-  })
-
-  describe('govukShortFormattedDate', () => {
-    it('returns a formatted date', () => {
-      const date = CalendarDay.fromComponents(4, 6, 2017)!
-      expect(PresenterUtils.govukShortFormattedDate(date)).toEqual('4 Jun 2017')
-    })
-  })
-
   describe('fullName', () => {
     // There’s probably going to turn out to be a whole bunch of nuance here but let’s start with this
     it('returns the service user’s first name followed by last name', () => {
@@ -899,26 +885,6 @@ describe(PresenterUtils, () => {
     it('returns a value which, when lexicographically sorted, gives a (last name, first name) sort order', () => {
       const { serviceUser } = draftReferralFactory.build({ serviceUser: { firstName: 'Daniel', lastName: 'Grove' } })
       expect(PresenterUtils.fullNameSortValue(serviceUser)).toEqual('grove, daniel')
-    })
-  })
-
-  describe('formattedTime', () => {
-    it('returns a 12-hour description of the time', () => {
-      expect(PresenterUtils.formattedTime(ClockTime.fromTwentyFourHourComponents(9, 5, 0)!)).toEqual('9:05am')
-      expect(PresenterUtils.formattedTime(ClockTime.fromTwentyFourHourComponents(10, 30, 0)!)).toEqual('10:30am')
-      expect(PresenterUtils.formattedTime(ClockTime.fromTwentyFourHourComponents(12, 30, 0)!)).toEqual('12:30pm')
-      expect(PresenterUtils.formattedTime(ClockTime.fromTwentyFourHourComponents(15, 45, 0)!)).toEqual('3:45pm')
-    })
-  })
-
-  describe('formattedTimeRange', () => {
-    it('returns a 12-hour description of the period from the start time to the end time', () => {
-      expect(
-        PresenterUtils.formattedTimeRange(
-          ClockTime.fromTwentyFourHourComponents(10, 30, 0)!,
-          ClockTime.fromTwentyFourHourComponents(15, 45, 0)!
-        )
-      ).toEqual('10:30am to 3:45pm')
     })
   })
 

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -344,44 +344,12 @@ export default class PresenterUtils {
     return !!error.errors.find(subError => subError.formFields.includes(field))
   }
 
-  // https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
-  static govukFormattedDate(day: CalendarDay): string {
-    const format = new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'long', year: 'numeric', timeZone: 'UTC' })
-    const date = day.utcDate
-
-    return format.format(date)
-  }
-
-  static govukShortFormattedDate(day: CalendarDay): string {
-    const format = new Intl.DateTimeFormat('en-GB', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-      timeZone: 'UTC',
-    })
-    const date = day.utcDate
-
-    return format.format(date)
-  }
-
   static fullName(user: ServiceUser | AuthUserDetails): string {
     return utils.convertToTitleCase(`${user.firstName ?? ''} ${user.lastName ?? ''}`)
   }
 
   static fullNameSortValue(serviceUser: ServiceUser): string {
     return `${serviceUser.lastName ?? ''}, ${serviceUser.firstName ?? ''}`.toLocaleLowerCase('en-GB')
-  }
-
-  static govukFormattedDateFromStringOrNull(date: string | null): string {
-    const notFoundMessage = 'Not found'
-
-    if (date) {
-      const iso8601date = CalendarDay.parseIso8601Date(date)
-
-      return iso8601date ? this.govukFormattedDate(iso8601date) : notFoundMessage
-    }
-
-    return notFoundMessage
   }
 
   static complexityLevelTagArgs(complexityLevel: ComplexityLevel): TagArgs {
@@ -412,14 +380,6 @@ export default class PresenterUtils {
       text: 'UNKNOWN',
       classes: 'govuk-tag--grey',
     }
-  }
-
-  static formattedTime(time: ClockTime): string {
-    return `${time.twelveHourClockHour}:${time.minute.toString().padStart(2, '0')}${time.partOfDay}`
-  }
-
-  static formattedTimeRange(startsAt: ClockTime, endsAt: ClockTime): string {
-    return `${this.formattedTime(startsAt)} to ${this.formattedTime(endsAt)}`
   }
 
   // This is a useful type guard that can be used to filter an array to modify the types defined in the array.


### PR DESCRIPTION
This change is to make sure that we are using the correct GOV UK styling for dates and times.

Documentation is located here:
 Dates: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
 Times: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times

Essentially the changes ask for:

1. Use long names for months unless space is an issue
2. Day of month should not have a leading 0
3. Time should be 12 hour clock (am/pm)
4. Use midday and middnight for 12:00pm and 12:00am
5. Range of time should follow the format: 1:00pm to 2:00pm
6. DateTime should follow the format: 1:00pm on 1 April 2021


This changes also involves a bit of refactoring to consolidate all Date presentation logic into DateUtils. There was logic in PresenterUtils that also dealt with dates.

The intent is to just have a single class responsible that returns the correct format; providing the correct formats for:
- a date
- a time
- a date and time
- a duration between times

It is still the responsibility of the caller of the methods to handle null values and ensure that they're passing in a correct string input for the date.

I thought this was preferrable to either returning an empty value or 'Not found' as the caller expects a valid formatted date to be produced.
