### PR TITLE
See which OWASP rules block user requests in our service

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
@@ -13,6 +13,11 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecAuditEngine RelevantOnly
+      SecAuditLog /var/log/nginx/error.log
+      SecAuditLogType Serial
+      SecAuditLogParts AHKZ
+      SecAuditLogFormat JSON
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6,setvar:tx.outbound_anomaly_score_threshold=4"
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"


### PR DESCRIPTION
## What does this pull request do?

Turn on searchable Web Application Firewall block auditing on for our ingress

## What is the intent behind these changes?

Currently, the nginx mod_security configuration is putting the audit
logs into a location that is not indexed for security reasons.

This means we _cannot_ see why a particular request is blocked, just
that it is blocked. ([With this query](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/goto/47b734020d01ec5197acaa6ddf8197f4))

These changes will put a less verbose version of the audit log into our
ingress configuration, so we can find out why something got blocked, and
tailor our ruleset so we don't do false positives

Relevant discussion:
https://mojdt.slack.com/archives/C026MSZ5HRN/p1625224529031900?thread_ts=1625080484.010600&cid=C026MSZ5HRN

