### PR TITLE
IC-2188: Fix missing drafts error

### DIFF
--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -594,6 +594,30 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/:draftCancellat
         })
     })
   })
+
+  describe('when the draft cancellation has been soft deleted', () => {
+    it('responds with a 410 Gone status and renders an error message', async () => {
+      const draftCancellation = draftCancellationFactory.build({
+        softDeleted: true,
+      })
+      draftsService.fetchDraft.mockResolvedValue(draftCancellation)
+
+      const referral = sentReferralFactory.assigned().build()
+      const intervention = interventionFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+
+      interventionsService.getSentReferral.mockResolvedValue(referral)
+      communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+      interventionsService.getIntervention.mockResolvedValue(intervention)
+
+      await request(app)
+        .get(`/probation-practitioner/referrals/${referral.id}/cancellation/${draftCancellation.id}/check-your-answers`)
+        .expect(410)
+        .expect(res => {
+          expect(res.text).toContain('This page is no longer available')
+        })
+    })
+  })
 })
 
 describe('POST /probation-practitioner/referrals/:id/cancellation/submit', () => {

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -334,8 +334,8 @@ export default class ProbationPractitionerReferralsController {
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  private async fetchDraftCancellationOrThrowSpecificError(req: Request, res: Response) {
-    return ControllerUtils.fetchDraft<DraftCancellationData>(req, res, this.draftsService, {
+  private async fetchDraftCancellationOrRenderMessage(req: Request, res: Response) {
+    return ControllerUtils.fetchDraftOrRenderMessage<DraftCancellationData>(req, res, this.draftsService, {
       idParamName: 'draftCancellationId',
       notFoundUserMessage:
         'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.',
@@ -348,7 +348,7 @@ export default class ProbationPractitionerReferralsController {
     const { accessToken } = user.token
     const referralId = req.params.id
 
-    const fetchResult = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftCancellationOrRenderMessage(req, res)
     if (fetchResult.rendered) {
       return
     }
@@ -399,7 +399,7 @@ export default class ProbationPractitionerReferralsController {
     const { user } = res.locals
     const { accessToken } = user.token
 
-    const fetchResult = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftCancellationOrRenderMessage(req, res)
     if (fetchResult.rendered) {
       return
     }
@@ -422,7 +422,7 @@ export default class ProbationPractitionerReferralsController {
   }
 
   async submitCancellation(req: Request, res: Response): Promise<void> {
-    const fetchResult = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftCancellationOrRenderMessage(req, res)
     if (fetchResult.rendered) {
       return
     }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -335,19 +335,12 @@ export default class ProbationPractitionerReferralsController {
   }
 
   private async fetchDraftCancellationOrThrowSpecificError(req: Request, res: Response) {
-    const id = req.params.draftCancellationId
-    const draftCancellation = await this.draftsService.fetchDraft<DraftCancellationData>(id, {
-      userId: res.locals.user.userId,
+    return ControllerUtils.fetchDraft<DraftCancellationData>(req, res, this.draftsService, {
+      idParamName: 'draftCancellationId',
+      notFoundUserMessage:
+        'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.',
+      typeName: 'cancellation',
     })
-
-    if (draftCancellation === null) {
-      throw createError(500, `Draft cancellation with ID ${id} not found by drafts service`, {
-        userMessage:
-          'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.',
-      })
-    }
-
-    return draftCancellation
   }
 
   async editCancellationReason(req: Request, res: Response): Promise<void> {

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -348,7 +348,11 @@ export default class ProbationPractitionerReferralsController {
     const { accessToken } = user.token
     const referralId = req.params.id
 
-    const draftCancellation = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+    if (fetchResult.rendered) {
+      return
+    }
+    const draftCancellation = fetchResult.draft
 
     const data = await new ReferralCancellationReasonForm(req).data()
 
@@ -360,9 +364,10 @@ export default class ProbationPractitionerReferralsController {
           userId: res.locals.user.userId,
         })
 
-        return res.redirect(
+        res.redirect(
           `/probation-practitioner/referrals/${referralId}/cancellation/${draftCancellation.id}/check-your-answers`
         )
+        return
       }
 
       res.status(400)
@@ -387,14 +392,18 @@ export default class ProbationPractitionerReferralsController {
     )
     const view = new ReferralCancellationReasonView(presenter)
 
-    return ControllerUtils.renderWithLayout(res, view, serviceUser)
+    ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
   async cancellationCheckAnswers(req: Request, res: Response): Promise<void> {
     const { user } = res.locals
     const { accessToken } = user.token
 
-    const draftCancellation = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+    if (fetchResult.rendered) {
+      return
+    }
+    const draftCancellation = fetchResult.draft
 
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
     const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
@@ -402,7 +411,7 @@ export default class ProbationPractitionerReferralsController {
     const presenter = new ReferralCancellationCheckAnswersPresenter(req.params.id, draftCancellation.id)
     const view = new ReferralCancellationCheckAnswersView(presenter)
 
-    return ControllerUtils.renderWithLayout(res, view, serviceUser)
+    ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
   async backwardsCompatibilitySubmitCancellation(req: Request, res: Response): Promise<void> {
@@ -413,7 +422,11 @@ export default class ProbationPractitionerReferralsController {
   }
 
   async submitCancellation(req: Request, res: Response): Promise<void> {
-    const draftCancellation = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftCancellationOrThrowSpecificError(req, res)
+    if (fetchResult.rendered) {
+      return
+    }
+    const draftCancellation = fetchResult.draft
 
     const { cancellationReason, cancellationComments } = draftCancellation.data
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -268,19 +268,12 @@ export default class ServiceProviderReferralsController {
   }
 
   private async fetchDraftAssignmentOrThrowSpecificError(req: Request, res: Response) {
-    const id = req.params.draftAssignmentId
-    const draftAssignment = await this.draftsService.fetchDraft<DraftAssignmentData>(id, {
-      userId: res.locals.user.userId,
+    return ControllerUtils.fetchDraft<DraftAssignmentData>(req, res, this.draftsService, {
+      idParamName: 'draftAssignmentId',
+      notFoundUserMessage:
+        'Too much time has passed since you started assigning this intervention to a caseworker. The referral has not been assigned, and you will need to start again.',
+      typeName: 'assignment',
     })
-
-    if (draftAssignment === null) {
-      throw createError(500, `Draft assignment with ID ${id} not found by drafts service`, {
-        userMessage:
-          'Too much time has passed since you started assigning this intervention to a caseworker. The referral has not been assigned, and you will need to start again.',
-      })
-    }
-
-    return draftAssignment
   }
 
   async checkAssignment(req: Request, res: Response): Promise<void> {
@@ -899,19 +892,12 @@ export default class ServiceProviderReferralsController {
   }
 
   private async fetchDraftBookingOrThrowSpecificError(req: Request, res: Response) {
-    const id = req.params.draftBookingId
-    const draftAssignment = await this.draftsService.fetchDraft<DraftAppointmentBooking>(id, {
-      userId: res.locals.user.userId,
+    return ControllerUtils.fetchDraft<DraftAppointmentBooking>(req, res, this.draftsService, {
+      idParamName: 'draftBookingId',
+      notFoundUserMessage:
+        'Too much time has passed since you started booking this appointment. Your answers have not been saved, and you will need to start again.',
+      typeName: 'booking',
     })
-
-    if (draftAssignment === null) {
-      throw createError(500, `Draft assignment with ID ${id} not found by drafts service`, {
-        userMessage:
-          'Too much time has passed since you started booking this appointment. Your answers have not been saved, and you will need to start again.',
-      })
-    }
-
-    return draftAssignment
   }
 
   private async submitAppointment(

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -267,8 +267,8 @@ export default class ServiceProviderReferralsController {
     return res.redirect(`/service-provider/referrals/${req.params.id}/assignment/${draftAssignment.id}/check`)
   }
 
-  private async fetchDraftAssignmentOrThrowSpecificError(req: Request, res: Response) {
-    return ControllerUtils.fetchDraft<DraftAssignmentData>(req, res, this.draftsService, {
+  private async fetchDraftAssignmentOrRenderMessage(req: Request, res: Response) {
+    return ControllerUtils.fetchDraftOrRenderMessage<DraftAssignmentData>(req, res, this.draftsService, {
       idParamName: 'draftAssignmentId',
       notFoundUserMessage:
         'Too much time has passed since you started assigning this intervention to a caseworker. The referral has not been assigned, and you will need to start again.',
@@ -277,7 +277,7 @@ export default class ServiceProviderReferralsController {
   }
 
   async checkAssignment(req: Request, res: Response): Promise<void> {
-    const fetchResult = await this.fetchDraftAssignmentOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftAssignmentOrRenderMessage(req, res)
     if (fetchResult.rendered) {
       return
     }
@@ -314,7 +314,7 @@ export default class ServiceProviderReferralsController {
   }
 
   async submitAssignment(req: Request, res: Response): Promise<void> {
-    const fetchResult = await this.fetchDraftAssignmentOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftAssignmentOrRenderMessage(req, res)
     if (fetchResult.rendered) {
       return
     }
@@ -651,7 +651,7 @@ export default class ServiceProviderReferralsController {
   }
 
   async scheduleSupplierAssessmentAppointment(req: Request, res: Response): Promise<void> {
-    const fetchResult = await this.fetchDraftBookingOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftBookingOrRenderMessage(req, res)
     if (fetchResult.rendered) {
       return
     }
@@ -731,7 +731,7 @@ export default class ServiceProviderReferralsController {
     const referral = await this.interventionsService.getSentReferral(res.locals.user.token.accessToken, referralId)
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const fetchResult = await this.fetchDraftBookingOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftBookingOrRenderMessage(req, res)
     if (fetchResult.rendered) {
       return
     }
@@ -905,8 +905,8 @@ export default class ServiceProviderReferralsController {
     return ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  private async fetchDraftBookingOrThrowSpecificError(req: Request, res: Response) {
-    return ControllerUtils.fetchDraft<DraftAppointmentBooking>(req, res, this.draftsService, {
+  private async fetchDraftBookingOrRenderMessage(req: Request, res: Response) {
+    return ControllerUtils.fetchDraftOrRenderMessage<DraftAppointmentBooking>(req, res, this.draftsService, {
       idParamName: 'draftBookingId',
       notFoundUserMessage:
         'Too much time has passed since you started booking this appointment. Your answers have not been saved, and you will need to start again.',
@@ -923,7 +923,7 @@ export default class ServiceProviderReferralsController {
       redirectToOnClash: string
     }
   ): Promise<void> {
-    const fetchResult = await this.fetchDraftBookingOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftBookingOrRenderMessage(req, res)
     if (fetchResult.rendered) {
       return
     }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -277,7 +277,11 @@ export default class ServiceProviderReferralsController {
   }
 
   async checkAssignment(req: Request, res: Response): Promise<void> {
-    const draftAssignment = await this.fetchDraftAssignmentOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftAssignmentOrThrowSpecificError(req, res)
+    if (fetchResult.rendered) {
+      return
+    }
+    const draftAssignment = fetchResult.draft
 
     const { email } = draftAssignment.data
 
@@ -296,7 +300,7 @@ export default class ServiceProviderReferralsController {
     const presenter = new CheckAssignmentPresenter(referral.id, draftAssignment.id, assignee, email, intervention)
     const view = new CheckAssignmentView(presenter)
 
-    return ControllerUtils.renderWithLayout(res, view, serviceUser)
+    ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
   async backwardsCompatibilitySubmitAssignment(req: Request, res: Response): Promise<void> {
@@ -310,7 +314,11 @@ export default class ServiceProviderReferralsController {
   }
 
   async submitAssignment(req: Request, res: Response): Promise<void> {
-    const draftAssignment = await this.fetchDraftAssignmentOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftAssignmentOrThrowSpecificError(req, res)
+    if (fetchResult.rendered) {
+      return
+    }
+    const draftAssignment = fetchResult.draft
 
     const { email } = draftAssignment.data
     if (email === null) {
@@ -643,9 +651,12 @@ export default class ServiceProviderReferralsController {
   }
 
   async scheduleSupplierAssessmentAppointment(req: Request, res: Response): Promise<void> {
-    const draft = await this.fetchDraftBookingOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftBookingOrThrowSpecificError(req, res)
+    if (fetchResult.rendered) {
+      return
+    }
 
-    await this.scheduleSupplierAssessmentAppointmentWithDraft(draft, req, res)
+    await this.scheduleSupplierAssessmentAppointmentWithDraft(fetchResult.draft, req, res)
   }
 
   async scheduleSupplierAssessmentAppointmentWithDraft(
@@ -720,12 +731,15 @@ export default class ServiceProviderReferralsController {
     const referral = await this.interventionsService.getSentReferral(res.locals.user.token.accessToken, referralId)
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const draft = await this.fetchDraftBookingOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftBookingOrThrowSpecificError(req, res)
+    if (fetchResult.rendered) {
+      return
+    }
 
-    const presenter = new InitialAssessmentCheckAnswersPresenter(draft, referral.id)
+    const presenter = new InitialAssessmentCheckAnswersPresenter(fetchResult.draft, referral.id)
     const view = new InitialAssessmentCheckAnswersView(presenter)
 
-    return ControllerUtils.renderWithLayout(res, view, serviceUser)
+    ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
   async submitSupplierAssessment(req: Request, res: Response): Promise<void> {
@@ -909,7 +923,11 @@ export default class ServiceProviderReferralsController {
       redirectToOnClash: string
     }
   ): Promise<void> {
-    const draft = await this.fetchDraftBookingOrThrowSpecificError(req, res)
+    const fetchResult = await this.fetchDraftBookingOrThrowSpecificError(req, res)
+    if (fetchResult.rendered) {
+      return
+    }
+    const { draft } = fetchResult
 
     if (draft.data === null) {
       throw new Error('Draft data was unexpectedly null when submitting appointment')

--- a/server/routes/shared/draftSoftDeletedView.ts
+++ b/server/routes/shared/draftSoftDeletedView.ts
@@ -1,0 +1,5 @@
+export default class DraftSoftDeletedView {
+  get renderArgs(): [string, Record<string, unknown>] {
+    return ['shared/draftSoftDeleted', {}]
+  }
+}

--- a/server/services/draftsService.ts
+++ b/server/services/draftsService.ts
@@ -135,10 +135,6 @@ export default class DraftsService {
       throw new Error(`Draft with ID ${id} not found in Redis`)
     }
 
-    const numberRemoved = await promisify<string, number>(this.redis.del).bind(this.redis)(this.redisKey(id))
-
-    if (numberRemoved === 0) {
-      throw new Error(`Draft with ID ${id} not found in Redis`)
-    }
+    await this.writeDraft({ ...draft, softDeleted: true })
   }
 }

--- a/server/utils/controllerUtils.test.ts
+++ b/server/utils/controllerUtils.test.ts
@@ -62,7 +62,7 @@ describe(ControllerUtils, () => {
         const draft = exampleDraftFactory.build({ data: { a: 1 } })
         draftsService.fetchDraft.mockResolvedValue(draft)
 
-        const fetchedDraft = await ControllerUtils.fetchDraft(
+        const result = await ControllerUtils.fetchDraft(
           { params: { draftBookingId: 'abc123' } } as unknown as Request,
           { locals: { user: { userId: 'jane.bloggs' } } } as unknown as Response,
           draftsService,
@@ -73,7 +73,7 @@ describe(ControllerUtils, () => {
           }
         )
 
-        expect(fetchedDraft).toEqual(draft)
+        expect(result).toEqual({ rendered: false, draft })
 
         expect(draftsService.fetchDraft).toHaveBeenCalledWith('abc123', { userId: 'jane.bloggs' })
       })

--- a/server/utils/controllerUtils.test.ts
+++ b/server/utils/controllerUtils.test.ts
@@ -127,7 +127,7 @@ describe(ControllerUtils, () => {
 
         expect(thrownError).toMatchObject({
           status: 500,
-          message: `Draft booking with ID abc123 not found by drafts service`,
+          message: `UI-only draft booking with ID abc123 not found`,
           userMessage: 'Timed out, start again',
         })
       })

--- a/server/utils/controllerUtils.ts
+++ b/server/utils/controllerUtils.ts
@@ -4,6 +4,7 @@ import LayoutPresenter from '../routes/shared/layoutPresenter'
 import LayoutView, { PageContentView } from '../routes/shared/layoutView'
 import DeliusServiceUser from '../models/delius/deliusServiceUser'
 import DraftsService, { Draft } from '../services/draftsService'
+import DraftSoftDeletedView from '../routes/shared/draftSoftDeletedView'
 
 interface DraftFetchSuccessResult<T> {
   rendered: false
@@ -24,7 +25,7 @@ export default class ControllerUtils {
     res.render(...view.renderArgs)
   }
 
-  static async fetchDraft<T>(
+  static async fetchDraftOrRenderMessage<T>(
     req: Request,
     res: Response,
     draftsService: DraftsService,
@@ -43,6 +44,13 @@ export default class ControllerUtils {
       throw createError(500, `Draft ${typeName} with ID ${id} not found by drafts service`, {
         userMessage: notFoundUserMessage,
       })
+    }
+
+    if (draft.softDeleted) {
+      res.status(410 /* Gone */)
+      const view = new DraftSoftDeletedView()
+      this.renderWithLayout(res, view, null)
+      return { rendered: true }
     }
 
     return { rendered: false, draft }

--- a/server/utils/controllerUtils.ts
+++ b/server/utils/controllerUtils.ts
@@ -5,6 +5,17 @@ import LayoutView, { PageContentView } from '../routes/shared/layoutView'
 import DeliusServiceUser from '../models/delius/deliusServiceUser'
 import DraftsService, { Draft } from '../services/draftsService'
 
+interface DraftFetchSuccessResult<T> {
+  rendered: false
+  draft: Draft<T>
+}
+
+interface DraftFetchRenderedResult {
+  rendered: true
+}
+
+type DraftFetchResult<T> = DraftFetchSuccessResult<T> | DraftFetchRenderedResult
+
 export default class ControllerUtils {
   static renderWithLayout(res: Response, contentView: PageContentView, serviceUser: DeliusServiceUser | null): void {
     const presenter = new LayoutPresenter(res.locals.user, serviceUser)
@@ -22,7 +33,7 @@ export default class ControllerUtils {
       notFoundUserMessage,
       typeName,
     }: { idParamName: string; notFoundUserMessage: string; typeName: string }
-  ): Promise<Draft<T>> {
+  ): Promise<DraftFetchResult<T>> {
     const id = req.params[idParamName]
     const draft = await draftsService.fetchDraft<T>(id, {
       userId: res.locals.user.userId,
@@ -34,6 +45,6 @@ export default class ControllerUtils {
       })
     }
 
-    return draft
+    return { rendered: false, draft }
   }
 }

--- a/server/utils/controllerUtils.ts
+++ b/server/utils/controllerUtils.ts
@@ -1,7 +1,9 @@
-import { Response } from 'express'
+import { Request, Response } from 'express'
+import createError from 'http-errors'
 import LayoutPresenter from '../routes/shared/layoutPresenter'
 import LayoutView, { PageContentView } from '../routes/shared/layoutView'
 import DeliusServiceUser from '../models/delius/deliusServiceUser'
+import DraftsService, { Draft } from '../services/draftsService'
 
 export default class ControllerUtils {
   static renderWithLayout(res: Response, contentView: PageContentView, serviceUser: DeliusServiceUser | null): void {
@@ -9,5 +11,29 @@ export default class ControllerUtils {
     const view = new LayoutView(presenter, contentView)
 
     res.render(...view.renderArgs)
+  }
+
+  static async fetchDraft<T>(
+    req: Request,
+    res: Response,
+    draftsService: DraftsService,
+    {
+      idParamName,
+      notFoundUserMessage,
+      typeName,
+    }: { idParamName: string; notFoundUserMessage: string; typeName: string }
+  ): Promise<Draft<T>> {
+    const id = req.params[idParamName]
+    const draft = await draftsService.fetchDraft<T>(id, {
+      userId: res.locals.user.userId,
+    })
+
+    if (draft === null) {
+      throw createError(500, `Draft ${typeName} with ID ${id} not found by drafts service`, {
+        userMessage: notFoundUserMessage,
+      })
+    }
+
+    return draft
   }
 }

--- a/server/utils/controllerUtils.ts
+++ b/server/utils/controllerUtils.ts
@@ -41,7 +41,7 @@ export default class ControllerUtils {
     })
 
     if (draft === null) {
-      throw createError(500, `Draft ${typeName} with ID ${id} not found by drafts service`, {
+      throw createError(500, `UI-only draft ${typeName} with ID ${id} not found`, {
         userMessage: notFoundUserMessage,
       })
     }

--- a/server/views/shared/draftSoftDeleted.njk
+++ b/server/views/shared/draftSoftDeleted.njk
@@ -1,0 +1,18 @@
+{% extends "../partials/layout.njk" %}
+
+{% block pageTitle %}
+  HMPPS Interventions - GOV.UK
+{% endblock %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">This page is no longer available</h2>
+
+      <p class="govuk-body">
+      You can’t view this page any more. If you want to perform this action again, 
+      you will need to <a href="/" class="govuk-link">return to the dashboard</a> and start again.
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/draft.ts
+++ b/testutils/factories/draft.ts
@@ -7,6 +7,7 @@ export function createDraftFactory<Data>(defaultData: Data): Factory<Draft<Data>
     const now = new Date()
     return {
       id: sequence.toString(),
+      softDeleted: false,
       type: 'someExampleType',
       createdAt: now,
       createdBy: { id: 'someUserId' },


### PR DESCRIPTION
## What does this pull request do?

Displays a helpful message when a user attempts to view a page that uses a draft object after it has been deleted.

## What is the intent behind these changes?

To stop the user from seeing a confusing error page when pressing the browser's Back button after completing a journey (e.g. scheduling a supplier assessment appointment).

## Screenshot

![Screenshot 2021-08-19 at 16-15-14 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/130234643-593fd0e7-3333-40be-b623-80bc19287617.png)
