### PR TITLE
IC-2189: Allow SPs to create new versions of an Action Plan after approval

### DIFF
--- a/assets/sass/components/_inset-text.scss
+++ b/assets/sass/components/_inset-text.scss
@@ -1,4 +1,8 @@
-.app-inset-text--grey {
+.app-inset-text {
   background: govuk-colour('light-grey');
-  border-left: 10px solid govuk-colour('blue');
+  padding: 15px;
+
+  &--left-border {
+    border-left: 10px solid govuk-colour('blue');
+  }
 }

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -619,111 +619,237 @@ describe('Service provider referrals dashboard', () => {
     cy.get('.action-plan-submitted-date').contains(/\d{1,2} [A-Z][a-z]{2} \d{4}/)
   })
 
-  it('User edits an unapproved action plan and submits it for approval', () => {
-    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-    const accommodationIntervention = interventionFactory.build({
-      contractType: { code: 'SOC', name: 'Social inclusion' },
-      serviceCategories: [serviceCategory],
+  describe('editing a submitted action plan', () => {
+    it('User edits an unapproved action plan and submits it for approval', () => {
+      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const accommodationIntervention = interventionFactory.build({
+        contractType: { code: 'SOC', name: 'Social inclusion' },
+        serviceCategories: [serviceCategory],
+      })
+
+      const actionPlanId = '2763d6e8-1847-4191-9c3f-0eea9a3b0c41'
+      const referralParams = {
+        referral: {
+          interventionId: accommodationIntervention.id,
+          serviceCategoryIds: [serviceCategory.id],
+        },
+      }
+      const deliusServiceUser = deliusServiceUserFactory.build()
+      const deliusUser = deliusUserFactory.build()
+      const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
+      const assignedReferral = sentReferralFactory
+        .assigned()
+        .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username }, actionPlanId })
+
+      const activityId = '1'
+      const submittedActionPlan = actionPlanFactory.submitted(assignedReferral.id).build({
+        id: actionPlanId,
+        activities: [actionPlanActivityFactory.build({ id: activityId, description: 'First activity version 1' })],
+        submittedAt: '2021-08-19T11:03:47.061Z',
+      })
+      const referralSummary = serviceProviderSentReferralSummaryFactory
+        .fromReferralAndIntervention(assignedReferral, accommodationIntervention)
+        .withAssignedUser(hmppsAuthUser.username)
+        .build()
+
+      cy.stubGetSentReferralsForUserToken([assignedReferral])
+
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([referralSummary])
+      cy.stubGetActionPlan(submittedActionPlan.id, submittedActionPlan)
+      cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+      cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
+      cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+      cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+      cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubGetActionPlanAppointments(submittedActionPlan.id, [])
+      cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
+
+      cy.login()
+
+      cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
+      cy.get('#action-plan-status').contains('Awaiting approval')
+      cy.contains('19 Aug 2021')
+      cy.contains('View action plan').click()
+
+      cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/action-plan`)
+
+      cy.contains('Edit action plan').click()
+      cy.contains('Are you sure you want to change the action plan while it is being reviewed?')
+      cy.stubCreateDraftActionPlan(submittedActionPlan)
+      cy.stubGetSentReferral(submittedActionPlan.referralId, assignedReferral)
+
+      cy.contains('Confirm and continue').click()
+
+      const activity = actionPlanActivityFactory.build({ id: activityId, description: 'First activity version 2' })
+
+      const actionPlanWithUpdatedActivities = actionPlanFactory.build({
+        ...submittedActionPlan,
+        activities: [activity],
+      })
+
+      cy.contains('First activity version 1').clear().type('First activity version 2')
+      cy.stubUpdateActionPlanActivity(submittedActionPlan.id, activity.id, actionPlanWithUpdatedActivities)
+      cy.contains('Save and add activity 1').click()
+
+      cy.contains('Continue without adding other activities').click()
+
+      cy.get('#number-of-sessions').clear().type('5')
+
+      const actionPlanWithUpdatedSessions = actionPlanFactory.build({
+        ...actionPlanWithUpdatedActivities,
+        numberOfSessions: 5,
+      })
+
+      cy.stubUpdateDraftActionPlan(actionPlanWithUpdatedActivities.id, actionPlanWithUpdatedSessions)
+      cy.stubGetActionPlan(actionPlanWithUpdatedSessions.id, {
+        ...actionPlanWithUpdatedSessions,
+        submittedAt: '2021-08-20T11:03:47.061Z',
+      })
+      cy.contains('Save and continue').click()
+
+      cy.contains('First activity version 2')
+      cy.contains('Suggested number of sessions: 5')
+
+      cy.stubSubmitActionPlan(actionPlanWithUpdatedSessions.id, actionPlanWithUpdatedSessions)
+
+      cy.contains('Submit for approval').click()
+
+      cy.contains('Action plan submitted for approval')
+      cy.location('pathname').should(
+        'equal',
+        `/service-provider/action-plan/${actionPlanWithUpdatedSessions.id}/confirmation`
+      )
+      cy.contains('Return to service progress').click()
+
+      cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/progress`)
+      cy.get('#action-plan-status').contains('Awaiting approval')
+      cy.contains('20 Aug 2021')
     })
 
-    const actionPlanId = '2763d6e8-1847-4191-9c3f-0eea9a3b0c41'
-    const referralParams = {
-      referral: {
-        interventionId: accommodationIntervention.id,
-        serviceCategoryIds: [serviceCategory.id],
-      },
-    }
-    const deliusServiceUser = deliusServiceUserFactory.build()
-    const deliusUser = deliusUserFactory.build()
-    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
-    const assignedReferral = sentReferralFactory
-      .assigned()
-      .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username }, actionPlanId })
+    it('User edits an approved action plan and submits it for approval', () => {
+      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+      const accommodationIntervention = interventionFactory.build({
+        contractType: { code: 'SOC', name: 'Social inclusion' },
+        serviceCategories: [serviceCategory],
+      })
 
-    const activityId = '1'
-    const submittedActionPlan = actionPlanFactory.submitted(assignedReferral.id).build({
-      id: actionPlanId,
-      activities: [actionPlanActivityFactory.build({ id: activityId, description: 'First activity version 1' })],
-      submittedAt: '2021-08-19T11:03:47.061Z',
+      const actionPlanId = '2763d6e8-1847-4191-9c3f-0eea9a3b0c41'
+      const referralParams = {
+        referral: {
+          interventionId: accommodationIntervention.id,
+          serviceCategoryIds: [serviceCategory.id],
+        },
+      }
+      const deliusServiceUser = deliusServiceUserFactory.build()
+      const deliusUser = deliusUserFactory.build()
+      const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
+      const assignedReferral = sentReferralFactory
+        .assigned()
+        .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username }, actionPlanId })
+
+      const activityId = '1'
+      const approvedActionPlan = actionPlanFactory.approved(assignedReferral.id).build({
+        id: actionPlanId,
+        activities: [actionPlanActivityFactory.build({ id: activityId, description: 'First activity version 1' })],
+        submittedAt: '2021-08-19T11:03:47.061Z',
+      })
+      const referralSummary = serviceProviderSentReferralSummaryFactory
+        .fromReferralAndIntervention(assignedReferral, accommodationIntervention)
+        .withAssignedUser(hmppsAuthUser.username)
+        .build()
+
+      cy.stubGetSentReferralsForUserToken([assignedReferral])
+
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([referralSummary])
+      cy.stubGetActionPlan(approvedActionPlan.id, approvedActionPlan)
+      cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+      cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
+      cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+      cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+      cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubGetActionPlanAppointments(approvedActionPlan.id, [])
+      cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
+
+      cy.login()
+
+      cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
+      cy.get('#action-plan-status').contains('Approved')
+      cy.contains('19 Aug 2021')
+      cy.contains('View action plan').click()
+
+      cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/action-plan`)
+
+      cy.contains('Create action plan').click()
+      cy.contains('Are you sure you want to create a new action plan?')
+
+      const newActionPlanVersion = actionPlanFactory.build({
+        referralId: assignedReferral.id,
+        activities: approvedActionPlan.activities,
+        numberOfSessions: approvedActionPlan.numberOfSessions,
+      })
+
+      cy.stubCreateDraftActionPlan(newActionPlanVersion)
+      cy.stubGetActionPlan(newActionPlanVersion.id, newActionPlanVersion)
+      cy.stubGetSentReferral(newActionPlanVersion.referralId, assignedReferral)
+
+      cy.contains('Confirm and continue').click()
+
+      const activity = actionPlanActivityFactory.build({ id: activityId, description: 'First activity version 2' })
+
+      const actionPlanWithUpdatedActivities = actionPlanFactory.build({
+        ...newActionPlanVersion,
+        activities: [activity],
+      })
+
+      cy.contains('First activity version 1').clear().type('First activity version 2')
+      cy.stubUpdateActionPlanActivity(newActionPlanVersion.id, activity.id, actionPlanWithUpdatedActivities)
+      cy.contains('Save and add activity 1').click()
+
+      cy.contains('Continue without adding other activities').click()
+
+      cy.get('#number-of-sessions').clear().type('5')
+
+      const actionPlanWithUpdatedSessions = actionPlanFactory.build({
+        ...actionPlanWithUpdatedActivities,
+        numberOfSessions: 5,
+      })
+
+      cy.stubUpdateDraftActionPlan(actionPlanWithUpdatedActivities.id, actionPlanWithUpdatedSessions)
+      const submittedActionPlanVersionTwo = actionPlanFactory.build({
+        ...actionPlanWithUpdatedSessions,
+        submittedAt: '2021-08-20T11:03:47.061Z',
+      })
+      cy.stubGetActionPlan(actionPlanWithUpdatedSessions.id, submittedActionPlanVersionTwo)
+
+      cy.contains('Save and continue').click()
+
+      cy.contains('First activity version 2')
+      cy.contains('Suggested number of sessions: 5')
+
+      cy.stubSubmitActionPlan(submittedActionPlanVersionTwo.id, submittedActionPlanVersionTwo)
+
+      cy.contains('Submit for approval').click()
+
+      cy.contains('Action plan submitted for approval')
+      cy.location('pathname').should(
+        'equal',
+        `/service-provider/action-plan/${submittedActionPlanVersionTwo.id}/confirmation`
+      )
+
+      cy.stubGetSentReferral(assignedReferral.id, {
+        ...assignedReferral,
+        actionPlanId: actionPlanWithUpdatedSessions.id,
+      })
+      cy.stubGetActionPlanAppointments(actionPlanWithUpdatedSessions.id, [])
+
+      cy.contains('Return to service progress').click()
+
+      cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/progress`)
+      cy.get('#action-plan-status').contains('Awaiting approval')
+      cy.contains('20 Aug 2021')
     })
-    const referralSummary = serviceProviderSentReferralSummaryFactory
-      .fromReferralAndIntervention(assignedReferral, accommodationIntervention)
-      .withAssignedUser(hmppsAuthUser.username)
-      .build()
-
-    cy.stubGetSentReferralsForUserToken([assignedReferral])
-
-    cy.stubGetServiceProviderSentReferralsSummaryForUserToken([referralSummary])
-    cy.stubGetActionPlan(submittedActionPlan.id, submittedActionPlan)
-    cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
-    cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
-    cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
-    cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
-    cy.stubGetUserByUsername(deliusUser.username, deliusUser)
-    cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
-    cy.stubGetActionPlanAppointments(submittedActionPlan.id, [])
-    cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
-
-    cy.login()
-
-    cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
-    cy.get('#action-plan-status').contains('Awaiting approval')
-    cy.contains('19 Aug 2021')
-    cy.contains('View action plan').click()
-
-    cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/action-plan`)
-
-    cy.contains('Edit action plan').click()
-    cy.contains('Are you sure you want to change the action plan while it is being reviewed?')
-    cy.stubCreateDraftActionPlan(submittedActionPlan)
-    cy.stubGetSentReferral(submittedActionPlan.referralId, assignedReferral)
-
-    cy.contains('Confirm and continue').click()
-
-    const activity = actionPlanActivityFactory.build({ id: activityId, description: 'First activity version 2' })
-
-    const actionPlanWithUpdatedActivities = actionPlanFactory.build({
-      ...submittedActionPlan,
-      activities: [activity],
-    })
-
-    cy.contains('First activity version 1').clear().type('First activity version 2')
-    cy.stubUpdateActionPlanActivity(submittedActionPlan.id, activity.id, actionPlanWithUpdatedActivities)
-    cy.contains('Save and add activity 1').click()
-
-    cy.contains('Continue without adding other activities').click()
-
-    cy.get('#number-of-sessions').clear().type('5')
-
-    const actionPlanWithUpdatedSessions = actionPlanFactory.build({
-      ...actionPlanWithUpdatedActivities,
-      numberOfSessions: 5,
-    })
-
-    cy.stubUpdateDraftActionPlan(actionPlanWithUpdatedActivities.id, actionPlanWithUpdatedSessions)
-    cy.stubGetActionPlan(actionPlanWithUpdatedSessions.id, {
-      ...actionPlanWithUpdatedSessions,
-      submittedAt: '2021-08-20T11:03:47.061Z',
-    })
-    cy.contains('Save and continue').click()
-
-    cy.contains('First activity version 2')
-    cy.contains('Suggested number of sessions: 5')
-
-    cy.stubSubmitActionPlan(actionPlanWithUpdatedSessions.id, actionPlanWithUpdatedSessions)
-
-    cy.contains('Submit for approval').click()
-
-    cy.contains('Action plan submitted for approval')
-    cy.location('pathname').should(
-      'equal',
-      `/service-provider/action-plan/${actionPlanWithUpdatedSessions.id}/confirmation`
-    )
-    cy.contains('Return to service progress').click()
-
-    cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/progress`)
-    cy.get('#action-plan-status').contains('Awaiting approval')
-    cy.contains('20 Aug 2021')
   })
 
   describe('User schedules and views an action plan appointment', () => {

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -15,6 +15,7 @@ import supplierAssessmentFactory from '../../testutils/factories/supplierAssessm
 import initialAssessmentAppointmentFactory from '../../testutils/factories/initialAssessmentAppointment'
 import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
 import serviceProviderSentReferralSummaryFactory from '../../testutils/factories/serviceProviderSentReferralSummary'
+import actionPlanActivityFactory from '../../testutils/factories/actionPlanActivity'
 
 describe('Service provider referrals dashboard', () => {
   beforeEach(() => {
@@ -616,6 +617,113 @@ describe('Service provider referrals dashboard', () => {
     cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/progress`)
     cy.get('#action-plan-status').contains('Awaiting approval')
     cy.get('.action-plan-submitted-date').contains(/\d{1,2} [A-Z][a-z]{2} \d{4}/)
+  })
+
+  it('User edits an unapproved action plan and submits it for approval', () => {
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const accommodationIntervention = interventionFactory.build({
+      contractType: { code: 'SOC', name: 'Social inclusion' },
+      serviceCategories: [serviceCategory],
+    })
+
+    const actionPlanId = '2763d6e8-1847-4191-9c3f-0eea9a3b0c41'
+    const referralParams = {
+      referral: {
+        interventionId: accommodationIntervention.id,
+        serviceCategoryIds: [serviceCategory.id],
+      },
+    }
+    const deliusServiceUser = deliusServiceUserFactory.build()
+    const deliusUser = deliusUserFactory.build()
+    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
+    const assignedReferral = sentReferralFactory
+      .assigned()
+      .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username }, actionPlanId })
+
+    const activityId = '1'
+    const submittedActionPlan = actionPlanFactory.submitted(assignedReferral.id).build({
+      id: actionPlanId,
+      activities: [actionPlanActivityFactory.build({ id: activityId, description: 'First activity version 1' })],
+      submittedAt: '2021-08-19T11:03:47.061Z',
+    })
+    const referralSummary = serviceProviderSentReferralSummaryFactory
+      .fromReferralAndIntervention(assignedReferral, accommodationIntervention)
+      .withAssignedUser(hmppsAuthUser.username)
+      .build()
+
+    cy.stubGetSentReferralsForUserToken([assignedReferral])
+
+    cy.stubGetServiceProviderSentReferralsSummaryForUserToken([referralSummary])
+    cy.stubGetActionPlan(submittedActionPlan.id, submittedActionPlan)
+    cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+    cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
+    cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+    cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+    cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+    cy.stubGetActionPlanAppointments(submittedActionPlan.id, [])
+    cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
+
+    cy.login()
+
+    cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
+    cy.get('#action-plan-status').contains('Awaiting approval')
+    cy.contains('19 Aug 2021')
+    cy.contains('View action plan').click()
+
+    cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/action-plan`)
+
+    cy.contains('Edit action plan').click()
+    cy.contains('Are you sure you want to change the action plan while it is being reviewed?')
+    cy.stubCreateDraftActionPlan(submittedActionPlan)
+    cy.stubGetSentReferral(submittedActionPlan.referralId, assignedReferral)
+
+    cy.contains('Confirm and continue').click()
+
+    const activity = actionPlanActivityFactory.build({ id: activityId, description: 'First activity version 2' })
+
+    const actionPlanWithUpdatedActivities = actionPlanFactory.build({
+      ...submittedActionPlan,
+      activities: [activity],
+    })
+
+    cy.contains('First activity version 1').clear().type('First activity version 2')
+    cy.stubUpdateActionPlanActivity(submittedActionPlan.id, activity.id, actionPlanWithUpdatedActivities)
+    cy.contains('Save and add activity 1').click()
+
+    cy.contains('Continue without adding other activities').click()
+
+    cy.get('#number-of-sessions').clear().type('5')
+
+    const actionPlanWithUpdatedSessions = actionPlanFactory.build({
+      ...actionPlanWithUpdatedActivities,
+      numberOfSessions: 5,
+    })
+
+    cy.stubUpdateDraftActionPlan(actionPlanWithUpdatedActivities.id, actionPlanWithUpdatedSessions)
+    cy.stubGetActionPlan(actionPlanWithUpdatedSessions.id, {
+      ...actionPlanWithUpdatedSessions,
+      submittedAt: '2021-08-20T11:03:47.061Z',
+    })
+    cy.contains('Save and continue').click()
+
+    cy.contains('First activity version 2')
+    cy.contains('Suggested number of sessions: 5')
+
+    cy.stubSubmitActionPlan(actionPlanWithUpdatedSessions.id, actionPlanWithUpdatedSessions)
+
+    cy.contains('Submit for approval').click()
+
+    cy.contains('Action plan submitted for approval')
+    cy.location('pathname').should(
+      'equal',
+      `/service-provider/action-plan/${actionPlanWithUpdatedSessions.id}/confirmation`
+    )
+    cy.contains('Return to service progress').click()
+
+    cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/progress`)
+    cy.get('#action-plan-status').contains('Awaiting approval')
+    cy.contains('20 Aug 2021')
   })
 
   describe('User schedules and views an action plan appointment', () => {

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -144,7 +144,7 @@ module.exports = on => {
     },
 
     stubUpdateActionPlanActivity: arg => {
-      return interventionsService.stubActionPlanActivity(arg.actionPlanId, arg.activityId, arg.responseJson)
+      return interventionsService.stubUpdateActionPlanActivity(arg.actionPlanId, arg.activityId, arg.responseJson)
     },
 
     stubSubmitActionPlan: arg => {

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -283,6 +283,26 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubUpdateActionPlanActivity = async (
+    actionPlanId: string,
+    activityId: string,
+    responseJson: Record<string, unknown>
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/action-plan/${actionPlanId}/activities/${activityId}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
   stubSubmitActionPlan = async (id: string, responseJson: Record<string, unknown>): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationPresenter.test.ts
@@ -1,0 +1,37 @@
+import actionPlanFactory from '../../../../../testutils/factories/actionPlan'
+import sentReferralFactory from '../../../../../testutils/factories/sentReferral'
+import ActionPlanEditConfirmationPresenter from './actionPlanEditConfirmationPresenter'
+
+describe(ActionPlanEditConfirmationPresenter, () => {
+  describe('text', () => {
+    describe('when editing an approved action plan', () => {
+      it('contains the correct warning message to the user', () => {
+        const sentReferral = sentReferralFactory.build()
+        const approvedActionPlan = actionPlanFactory.approved().build()
+
+        const presenter = new ActionPlanEditConfirmationPresenter(sentReferral, approvedActionPlan)
+
+        expect(presenter.text.title).toEqual('Are you sure you want to create a new action plan?')
+        expect(presenter.text.note).toEqual(
+          'Note: Creating a new action plan will overwrite the current one once the probation practitioner approves it.'
+        )
+      })
+    })
+
+    describe('when editing a not-yet-approved action plan', () => {
+      it('contains the correct warning message to the user', () => {
+        const sentReferral = sentReferralFactory.build()
+        const approvedActionPlan = actionPlanFactory.submitted().build()
+
+        const presenter = new ActionPlanEditConfirmationPresenter(sentReferral, approvedActionPlan)
+
+        expect(presenter.text.title).toEqual(
+          'Are you sure you want to change the action plan while it is being reviewed?'
+        )
+        expect(presenter.text.note).toEqual(
+          'Note: This will withdraw the current action plan and the probation practitioner will no longer be able to view it.'
+        )
+      })
+    })
+  })
+})

--- a/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationPresenter.ts
+++ b/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationPresenter.ts
@@ -1,9 +1,29 @@
+import ActionPlan from '../../../../models/actionPlan'
 import SentReferral from '../../../../models/sentReferral'
+import ActionPlanSummaryPresenter from '../../../shared/action-plan/actionPlanSummaryPresenter'
 
 export default class ActionPlanEditConfirmationPresenter {
-  constructor(private readonly sentReferral: SentReferral) {}
+  actionPlanSummaryPresenter: ActionPlanSummaryPresenter
+
+  constructor(private readonly sentReferral: SentReferral, private readonly actionPlan: ActionPlan) {
+    this.actionPlanSummaryPresenter = new ActionPlanSummaryPresenter(sentReferral, actionPlan, 'service-provider')
+  }
 
   readonly viewActionPlanUrl = `/service-provider/referrals/${this.sentReferral.id}/action-plan`
 
   readonly editConfirmAction = `/service-provider/referrals/${this.sentReferral.id}/action-plan/edit`
+
+  get text(): { title: string; note: string } {
+    if (this.actionPlanSummaryPresenter.actionPlanApproved) {
+      return {
+        title: 'Are you sure you want to create a new action plan?',
+        note: 'Note: Creating a new action plan will overwrite the current one once the probation practitioner approves it.',
+      }
+    }
+
+    return {
+      title: 'Are you sure you want to change the action plan while it is being reviewed?',
+      note: 'Note: This will withdraw the current action plan and the probation practitioner will no longer be able to view it.',
+    }
+  }
 }

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -82,4 +82,8 @@ export default class ActionPlanPresenter {
   get showEditButton(): boolean {
     return this.userType === 'service-provider' && this.actionPlanSummaryPresenter.actionPlanUnderReview
   }
+
+  get showCreateNewActionPlanVersionButton(): boolean {
+    return this.userType === 'service-provider' && this.actionPlanSummaryPresenter.actionPlanApproved
+  }
 }

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -7,6 +7,7 @@ import utils from '../../../utils/utils'
 import ServiceCategory from '../../../models/serviceCategory'
 import ApprovedActionPlanSummary from '../../../models/approvedActionPlanSummary'
 import dateUtils from '../../../utils/dateUtils'
+import config from '../../../config'
 
 export default class ActionPlanPresenter {
   actionPlanSummaryPresenter: ActionPlanSummaryPresenter
@@ -84,6 +85,10 @@ export default class ActionPlanPresenter {
   }
 
   get showCreateNewActionPlanVersionButton(): boolean {
-    return this.userType === 'service-provider' && this.actionPlanSummaryPresenter.actionPlanApproved
+    if (config.features.previouslyApprovedActionPlans) {
+      return this.userType === 'service-provider' && this.actionPlanSummaryPresenter.actionPlanApproved
+    }
+
+    return false
   }
 }

--- a/server/routes/shared/action-plan/actionPlanView.ts
+++ b/server/routes/shared/action-plan/actionPlanView.ts
@@ -20,7 +20,7 @@ export default class ActionPlanView {
   insetTextActivityArgs(index: number, description: string): InsetTextArgs {
     return {
       html: `<h3 class="govuk-heading-m govuk-!-font-weight-bold">Activity ${index}</h3><p class="govuk-body">${description}</p>`,
-      classes: 'app-inset-text--grey',
+      classes: 'app-inset-text app-inset-text--left-border',
     }
   }
 

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanEditConfirmation.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanEditConfirmation.njk
@@ -9,9 +9,9 @@
         <div class="govuk-grid-column-two-thirds">
             {{ govukBackLink(backLinkArgs) }}
 
-            <h1 class="govuk-heading-l">Are you sure you want to change the action plan while it is being reviewed?</h1>
+            <h1 class="govuk-heading-l">{{ presenter.text.title }}</h1>
 
-            <p class="govuk-body">Note: This will withdraw the current action plan and the probation practitioner will no longer be able to view it.</p>
+            <p class="govuk-body">{{ presenter.text.note }}</p>
 
             <form action="{{ presenter.editConfirmAction }}" method="post">
                 <input type="hidden" name="_csrf" value="{{csrfToken}}">

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -81,6 +81,16 @@
           </form>
         {% endif %}
 
+        {% if presenter.showCreateNewActionPlanVersionButton %}
+          <h2 class="govuk-heading-m">Create a new action plan</h2>
+          <div class="app-inset-text">
+            <p class="govuk-body">If you want to amend the activities or number of sessions, please click the button below to start a new action plan.</p>
+            <form method="get" action="{{ presenter.actionPlanEditConfirmationUrl }}">
+              {{ govukButton({ text: "Create action plan", preventDoubleClick: true, classes: 'govuk-!-margin-bottom-4' }) }}
+            </form>
+          </div>
+        {% endif %}
+
         {% if presenter.showActionPlanVersions %}
           <h2 class="govuk-heading-m">Action plan versions</h2>
           {{ govukTable(approvedActionPlansTableArgs) }}

--- a/testutils/factories/actionPlan.ts
+++ b/testutils/factories/actionPlan.ts
@@ -9,7 +9,11 @@ class ActionPlanFactory extends Factory<ActionPlan> {
   }
 
   submitted() {
-    return this.params({ submittedAt: new Date().toISOString() })
+    return this.params({
+      submittedAt: new Date().toISOString(),
+      numberOfSessions: 4,
+      activities: actionPlanActivityFactory.buildList(2),
+    })
   }
 
   approved() {


### PR DESCRIPTION
## What does this pull request do?

Allow SPs to create new versions of an Action Plan after approval

This works in the same way as editing an unapproved action plan, in that it copies the fields across to a new action plan. The new Action Plan replaces the existing previously-approved Action Plan on the Intervention Progress page and is marked as "Awaiting Approval".

This PR also adds some integration tests for editing both an approved and non-approved action plan (which was missing from the previous work) - these were a bit of a pain to write due to the constant stubbing of requests, I wonder if there's a way we can simplify these somewhat.

## What is the intent behind these changes?

To allow SPs to change the Action Plan based on their service user's needs.

## Screenshots

### See previously approved action plan

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/19826940/130245317-3fa6ac53-2d6e-471c-ae3e-f87ecad01922.png">

### Create new version button

<img width="986" alt="image" src="https://user-images.githubusercontent.com/19826940/130245358-d54bbdee-1a5b-4e89-aebd-12e7fa63d958.png">

### Confirmation

<img width="998" alt="image" src="https://user-images.githubusercontent.com/19826940/130245640-1fd64bee-d61d-4a18-a73e-07c621be05b6.png">

### New action plan

<img width="988" alt="image" src="https://user-images.githubusercontent.com/19826940/130245686-850cb666-66e0-4b0c-a5f9-d5695057d27f.png">

