### PR TITLE
Ic 1927/add specific page title for each page

### DIFF
--- a/server/views/appointments/feedback/actionPlanSessions/postSessionFeedbackConfirmation.njk
+++ b/server/views/appointments/feedback/actionPlanSessions/postSessionFeedbackConfirmation.njk
@@ -3,6 +3,9 @@
 
 {% extends "../../../partials/layout.njk" %}
 
+{% set pageTitle = "Appointment feedback" %}
+{% set pageSubTitle = "Submission confirmation" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/appointments/feedback/actionPlanSessions/postSessionFeedbackConfirmation.njk
+++ b/server/views/appointments/feedback/actionPlanSessions/postSessionFeedbackConfirmation.njk
@@ -3,10 +3,6 @@
 
 {% extends "../../../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Inteventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/appointments/feedback/initialAssessment/initialAssessmentFeedbackConfirmation.njk
+++ b/server/views/appointments/feedback/initialAssessment/initialAssessmentFeedbackConfirmation.njk
@@ -3,6 +3,9 @@
 
 {% extends "../../../partials/layout.njk" %}
 
+{% set pageTitle = "Appointment feedback" %}
+{% set pageSubTitle = "Submission confirmation" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/appointments/feedback/initialAssessment/initialAssessmentFeedbackConfirmation.njk
+++ b/server/views/appointments/feedback/initialAssessment/initialAssessmentFeedbackConfirmation.njk
@@ -3,10 +3,6 @@
 
 {% extends "../../../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Inteventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/appointments/feedback/shared/postSessionAttendanceFeedback.njk
+++ b/server/views/appointments/feedback/shared/postSessionAttendanceFeedback.njk
@@ -1,9 +1,13 @@
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% extends "../../../serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk" %}
+
+{% set pageTitle = "Appointment feedback" %}
+{% set pageSubTitle = "Add attendance feedback" %}
 
 {% block formSection %}
   {{ govukSummaryList(summaryListArgs) }}

--- a/server/views/appointments/feedback/shared/postSessionBehaviourFeedback.njk
+++ b/server/views/appointments/feedback/shared/postSessionBehaviourFeedback.njk
@@ -5,6 +5,9 @@
 
 {% extends "../../../serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk" %}
 
+{% set pageTitle = "Appointment feedback" %}
+{% set pageSubTitle = "Add behaviour feedback" %}
+
 {% block formSection %}
   <form method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/server/views/appointments/feedback/shared/postSessionFeedbackCheckAnswers.njk
+++ b/server/views/appointments/feedback/shared/postSessionFeedbackCheckAnswers.njk
@@ -3,6 +3,9 @@
 
 {% extends "../../../serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk" %}
 
+{% set pageTitle = "Appointment feedback" %}
+{% set pageSubTitle = "Confirm answers" %}
+
 {% block formSection %}
   {{ govukSummaryList(summaryListArgs) }}
 

--- a/server/views/errors/authError.njk
+++ b/server/views/errors/authError.njk
@@ -1,9 +1,5 @@
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-    HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
     {% block content %}
         <div class="govuk-grid-row">

--- a/server/views/errors/notFound.njk
+++ b/server/views/errors/notFound.njk
@@ -1,9 +1,5 @@
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-    HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
     {% block content %}
         <div class="govuk-grid-row">

--- a/server/views/errors/unhandledError.njk
+++ b/server/views/errors/unhandledError.njk
@@ -1,9 +1,5 @@
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-    HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
     {% block content %}
         <div class="govuk-grid-row">

--- a/server/views/findInterventions/interventionDetails.njk
+++ b/server/views/findInterventions/interventionDetails.njk
@@ -4,6 +4,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Find interventions" %}
+{% set pageSubTitle = "Intervention summary" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row govuk-!-margin-bottom-7">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/findInterventions/interventionDetails.njk
+++ b/server/views/findInterventions/interventionDetails.njk
@@ -4,12 +4,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row govuk-!-margin-bottom-7">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -4,6 +4,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Find interventions" %}
+{% set pageSubTitle = "Find results" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row govuk-!-margin-bottom-7">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -4,12 +4,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row govuk-!-margin-bottom-7">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/logoutSuccess.njk
+++ b/server/views/logoutSuccess.njk
@@ -1,9 +1,5 @@
 {% extends "./partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <h1 class="govuk-heading-l">You have been logged out</h1>
 {% endblock %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -26,7 +26,16 @@
 
 {% endblock %}
 
-{% block pageTitle %}HMPPS Interventions{% endblock %}
+{% block pageTitle %}
+    HMPPS Interventions
+    {% if pageTitle %}
+    - {{ pageTitle }}
+    {% endif %}
+    {% if pageSubTitle %}
+    - {{ pageSubTitle }}
+    {% endif %}
+    - GOV.UK
+{% endblock %}
 
 {% block content %} 
   {% if broadcastMessage %}

--- a/server/views/partials/referralNavigationTemplate.njk
+++ b/server/views/partials/referralNavigationTemplate.njk
@@ -6,8 +6,6 @@
 
 {% extends "./layout.njk" %}
 
-{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/probationPractitionerReferrals/actionPlanApproved.njk
+++ b/server/views/probationPractitionerReferrals/actionPlanApproved.njk
@@ -2,6 +2,9 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
+{% set pageTitle = "Action plan" %}
+{% set pageSubTitle = "Approved" %}
+
 {% block pageContent %}
     {% block content %}
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/probationPractitionerReferrals/actionPlanApproved.njk
+++ b/server/views/probationPractitionerReferrals/actionPlanApproved.njk
@@ -2,10 +2,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% block pageTitle %}
-    HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
     {% block content %}
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/probationPractitionerReferrals/endOfServiceReport.njk
+++ b/server/views/probationPractitionerReferrals/endOfServiceReport.njk
@@ -2,8 +2,6 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/probationPractitionerReferrals/endOfServiceReport.njk
+++ b/server/views/probationPractitionerReferrals/endOfServiceReport.njk
@@ -2,6 +2,9 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "End of service report" %}
+{% set pageSubTitle = "View" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/probationPractitionerReferrals/findStart.njk
+++ b/server/views/probationPractitionerReferrals/findStart.njk
@@ -3,6 +3,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Find interventions" %}
+{% set pageSubTitle = "Start screen" %}
+
 {% block primaryNav %}
   {{ mojPrimaryNavigation(primaryNavArgs) }}
 {% endblock %}

--- a/server/views/probationPractitionerReferrals/findStart.njk
+++ b/server/views/probationPractitionerReferrals/findStart.njk
@@ -3,10 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}{{ pageTitle }}
-  - GOV.UK{% endblock %}
-
 {% block primaryNav %}
   {{ mojPrimaryNavigation(primaryNavArgs) }}
 {% endblock %}

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -4,6 +4,9 @@
 
 {% extends "../partials/referralNavigationTemplate.njk" %}
 
+{% set pageTitle = "Referral" %}
+{% set pageSubTitle = "Progress" %}
+
 {% block referralPageSection %}
 
   <h2 class="govuk-heading-m">Initial assessment appointment</h2>

--- a/server/views/probationPractitionerReferrals/myCases.njk
+++ b/server/views/probationPractitionerReferrals/myCases.njk
@@ -3,6 +3,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Referral" %}
+{% set pageSubTitle = "My cases" %}
+
 {% block primaryNav %}
   {{ mojPrimaryNavigation(primaryNavArgs) }}
 {% endblock %}

--- a/server/views/probationPractitionerReferrals/myCases.njk
+++ b/server/views/probationPractitionerReferrals/myCases.njk
@@ -3,9 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
-
 {% block primaryNav %}
   {{ mojPrimaryNavigation(primaryNavArgs) }}
 {% endblock %}

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -2,9 +2,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}{{ pageTitle }}
-  - GOV.UK{% endblock %}
 
 {% block pageContent %}
   <div class="govuk-grid-row">

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -2,6 +2,8 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Referral cancellation" %}
+{% set pageSubTitle = "Confirm" %}
 
 {% block pageContent %}
   <div class="govuk-grid-row">

--- a/server/views/probationPractitionerReferrals/referralCancellationConfirmation.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationConfirmation.njk
@@ -3,6 +3,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Referral cancellation" %}
+{% set pageSubTitle = "Cancellation confirmation" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/probationPractitionerReferrals/referralCancellationConfirmation.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationConfirmation.njk
@@ -3,10 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Inteventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/probationPractitionerReferrals/referralCancellationReason.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationReason.njk
@@ -5,6 +5,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Referral cancellation" %}
+{% set pageSubTitle = "Provide cancellation reason" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">

--- a/server/views/probationPractitionerReferrals/referralCancellationReason.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationReason.njk
@@ -5,10 +5,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}{{ pageTitle }}
-  - GOV.UK{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -3,6 +3,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Check your answers" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -3,12 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/completionDeadline.njk
+++ b/server/views/referrals/completionDeadline.njk
@@ -4,6 +4,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Provide intervention completion date" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/completionDeadline.njk
+++ b/server/views/referrals/completionDeadline.njk
@@ -4,12 +4,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/complexityLevel.njk
+++ b/server/views/referrals/complexityLevel.njk
@@ -4,12 +4,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/complexityLevel.njk
+++ b/server/views/referrals/complexityLevel.njk
@@ -4,6 +4,10 @@
 
 {% extends "../partials/layout.njk" %}
 
+
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Select complexity level" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/confirmation.njk
+++ b/server/views/referrals/confirmation.njk
@@ -3,12 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/confirmation.njk
+++ b/server/views/referrals/confirmation.njk
@@ -3,6 +3,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Submit confirmation" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/desiredOutcomes.njk
+++ b/server/views/referrals/desiredOutcomes.njk
@@ -4,11 +4,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
 
 {% block pageContent %}
   <div class="govuk-grid-row">

--- a/server/views/referrals/desiredOutcomes.njk
+++ b/server/views/referrals/desiredOutcomes.njk
@@ -5,6 +5,9 @@
 {% extends "../partials/layout.njk" %}
 
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Select desired outcomes" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/enforceableDays.njk
+++ b/server/views/referrals/enforceableDays.njk
@@ -5,12 +5,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/enforceableDays.njk
+++ b/server/views/referrals/enforceableDays.njk
@@ -5,6 +5,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Provide enforceable days" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/form.njk
+++ b/server/views/referrals/form.njk
@@ -1,11 +1,5 @@
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/form.njk
+++ b/server/views/referrals/form.njk
@@ -1,5 +1,8 @@
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Overview" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/furtherInformation.njk
+++ b/server/views/referrals/furtherInformation.njk
@@ -4,6 +4,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Provide further information" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/furtherInformation.njk
+++ b/server/views/referrals/furtherInformation.njk
@@ -4,12 +4,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/needsAndRequirements.njk
+++ b/server/views/referrals/needsAndRequirements.njk
@@ -8,6 +8,8 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Service user's needs and requirements" %}
 
 {% block pageContent %}
   <div class="govuk-grid-row">

--- a/server/views/referrals/needsAndRequirements.njk
+++ b/server/views/referrals/needsAndRequirements.njk
@@ -8,11 +8,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
 
 {% block pageContent %}
   <div class="govuk-grid-row">

--- a/server/views/referrals/relevantSentence.njk
+++ b/server/views/referrals/relevantSentence.njk
@@ -4,6 +4,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Select relevant sentence" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -8,12 +8,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/riskInformation.njk
+++ b/server/views/referrals/riskInformation.njk
@@ -8,6 +8,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Service user's risk information" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/serviceUserDetails.njk
+++ b/server/views/referrals/serviceUserDetails.njk
@@ -2,12 +2,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/serviceUserDetails.njk
+++ b/server/views/referrals/serviceUserDetails.njk
@@ -2,6 +2,9 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Service user's information" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/start.njk
+++ b/server/views/referrals/start.njk
@@ -3,12 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/start.njk
+++ b/server/views/referrals/start.njk
@@ -3,6 +3,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Enter user's case identifier" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/updateServiceCategories.njk
+++ b/server/views/referrals/updateServiceCategories.njk
@@ -4,6 +4,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Update service categories" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/referrals/updateServiceCategories.njk
+++ b/server/views/referrals/updateServiceCategories.njk
@@ -4,10 +4,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanEditConfirmation.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanEditConfirmation.njk
@@ -2,8 +2,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}%}
 
-{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
-
 {% block pageContent %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormBase.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormBase.njk
@@ -1,7 +1,5 @@
 {% extends "../../partials/layout.njk" %}
 
-{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
@@ -3,8 +3,6 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -3,6 +3,9 @@
 
 {% extends "./actionPlanFormTemplate.njk" %}
 
+{% set pageTitle = "Action plan" %}
+{% set pageSubTitle = "Add activity" %}
+
 {% block formSection %}
   <p class="govuk-body-m">This will be shared with the service user's probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
 

--- a/server/views/serviceProviderReferrals/actionPlan/numberOfSessions.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/numberOfSessions.njk
@@ -3,6 +3,9 @@
 
 {% extends "./actionPlanFormTemplate.njk" %}
 
+{% set pageTitle = "Action plan" %}
+{% set pageSubTitle = "Add number of sessions" %}
+
 {% block formSection %}
     <h3 class="govuk-heading-m">Add number of sessions for {{ presenter.text.serviceUserFirstName | capitalize }}’s action plan</h3>
 

--- a/server/views/serviceProviderReferrals/actionPlanConfirmation.njk
+++ b/server/views/serviceProviderReferrals/actionPlanConfirmation.njk
@@ -3,6 +3,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Action plan" %}
+{% set pageSubTitle = "Submission confirmation" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/actionPlanConfirmation.njk
+++ b/server/views/serviceProviderReferrals/actionPlanConfirmation.njk
@@ -3,10 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Inteventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/assignmentConfirmation.njk
+++ b/server/views/serviceProviderReferrals/assignmentConfirmation.njk
@@ -3,12 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/checkAssignment.njk
+++ b/server/views/serviceProviderReferrals/checkAssignment.njk
@@ -3,12 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -3,9 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
-
 {% block primaryNav %}
   {{ mojPrimaryNavigation(primaryNavArgs) }}
 {% endblock %}

--- a/server/views/serviceProviderReferrals/endOfServiceReport/checkAnswers.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/checkAnswers.njk
@@ -4,6 +4,9 @@
 
 {% extends "./formTemplate.njk" %}
 
+{% set pageTitle = "End of service report" %}
+{% set pageSubTitle = "Confirm answers" %}
+
 {% block formSection %}
   {% include "../../partials/endOfServiceReportAnswers.njk" %}
 

--- a/server/views/serviceProviderReferrals/endOfServiceReport/confirmation.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/confirmation.njk
@@ -3,10 +3,6 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/endOfServiceReport/confirmation.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/confirmation.njk
@@ -3,6 +3,9 @@
 
 {% extends "../../partials/layout.njk" %}
 
+{% set pageTitle = "End of service report" %}
+{% set pageSubTitle = "Submission confirmation" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/endOfServiceReport/formTemplate.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/formTemplate.njk
@@ -2,8 +2,6 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% block pageTitle %}HMPPS Interventions - GOV.UK{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/endOfServiceReport/furtherInformation.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/furtherInformation.njk
@@ -3,6 +3,9 @@
 
 {% extends "./formTemplate.njk" %}
 
+{% set pageTitle = "End of service report" %}
+{% set pageSubTitle = "Add additional information" %}
+
 {% block formSection %}
   <form method="post">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">

--- a/server/views/serviceProviderReferrals/endOfServiceReport/outcome.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/outcome.njk
@@ -4,10 +4,6 @@
 
 {% extends "./formTemplate.njk" %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block formSection %}
   <p class="govuk-body">
   <strong>{{ presenter.text.desiredOutcomeNumberDescription }}</strong>

--- a/server/views/serviceProviderReferrals/endOfServiceReport/outcome.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/outcome.njk
@@ -4,6 +4,9 @@
 
 {% extends "./formTemplate.njk" %}
 
+{% set pageTitle = "End of service report" %}
+{% set pageSubTitle = "Add desired outcome feedback" %}
+
 {% block formSection %}
   <p class="govuk-body">
   <strong>{{ presenter.text.desiredOutcomeNumberDescription }}</strong>

--- a/server/views/serviceProviderReferrals/initialAssessmentCheckAnswers.njk
+++ b/server/views/serviceProviderReferrals/initialAssessmentCheckAnswers.njk
@@ -4,10 +4,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/initialAssessmentCheckAnswers.njk
+++ b/server/views/serviceProviderReferrals/initialAssessmentCheckAnswers.njk
@@ -4,6 +4,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Appointment" %}
+{% set pageSubTitle = "Confirm answers" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -5,6 +5,9 @@
 
 {% extends "../partials/referralNavigationTemplate.njk" %}
 
+{% set pageTitle = "Referral" %}
+{% set pageSubTitle = "Progress" %}
+
 {% block referralPageSection %}
 
   {% if presenter.referralEnded %}

--- a/server/views/serviceProviderReferrals/performanceReportConfirmation.njk
+++ b/server/views/serviceProviderReferrals/performanceReportConfirmation.njk
@@ -2,10 +2,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/performanceReportDownload.njk
+++ b/server/views/serviceProviderReferrals/performanceReportDownload.njk
@@ -2,10 +2,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-    HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/reporting.njk
+++ b/server/views/serviceProviderReferrals/reporting.njk
@@ -7,10 +7,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/reviewActionPlan.njk
+++ b/server/views/serviceProviderReferrals/reviewActionPlan.njk
@@ -4,6 +4,9 @@
 
 {% extends "./actionPlan/actionPlanFormTemplate.njk" %}
 
+{% set pageTitle = "Action plan" %}
+{% set pageSubTitle = "Confirm answers" %}
+
 {% block formSection %}
   <h2 class="govuk-heading-l">
     Desired outcomes and activities

--- a/server/views/serviceProviderReferrals/scheduleAppointment.njk
+++ b/server/views/serviceProviderReferrals/scheduleAppointment.njk
@@ -10,6 +10,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Appointment" %}
+{% set pageSubTitle = "Schedule Appointment" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/scheduleAppointment.njk
+++ b/server/views/serviceProviderReferrals/scheduleAppointment.njk
@@ -10,10 +10,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/supplierAssessmentAppointmentConfirmation.njk
+++ b/server/views/serviceProviderReferrals/supplierAssessmentAppointmentConfirmation.njk
@@ -2,6 +2,9 @@
 
 {% extends "../partials/layout.njk" %}
 
+{% set pageTitle = "Appointment" %}
+{% set pageSubTitle = "Scheduled confirmation" %}
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/serviceProviderReferrals/supplierAssessmentAppointmentConfirmation.njk
+++ b/server/views/serviceProviderReferrals/supplierAssessmentAppointmentConfirmation.njk
@@ -2,10 +2,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Inteventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -9,10 +9,6 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   {% block content %}
     <div class="govuk-!-width-two-thirds">

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -9,6 +9,9 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
+{% set pageTitle = "Action plan" %}
+{% set pageSubTitle = "View" %}
+
 {% block pageContent %}
   {% block content %}
     <div class="govuk-!-width-two-thirds">

--- a/server/views/shared/draftSoftDeleted.njk
+++ b/server/views/shared/draftSoftDeleted.njk
@@ -1,9 +1,5 @@
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -3,6 +3,9 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
+{% set pageTitle = "Referral" %}
+{% set pageSubTitle = "Details" %}
+
 {% block referralPageSection %}
       {% if presenter.text.assignedTo != null %}
         <p class="govuk-body">This intervention is assigned to <strong>{{ presenter.text.assignedTo }}</strong>.</p>

--- a/server/views/shared/supplierAssessmentAppointment.njk
+++ b/server/views/shared/supplierAssessmentAppointment.njk
@@ -3,10 +3,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% block pageTitle %}
-  HMPPS Interventions - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/shared/viewSubmittedPostSessionFeedback.njk
+++ b/server/views/shared/viewSubmittedPostSessionFeedback.njk
@@ -2,6 +2,9 @@
 
 {% extends "../serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk" %}
 
+{% set pageTitle = "Appointment feedback" %}
+{% set pageSubTitle = "View" %}
+
 {% block formSection %}
   {{ govukSummaryList(summaryListArgs) }}
 

--- a/server/views/staticContent/exampleStaticPage.njk
+++ b/server/views/staticContent/exampleStaticPage.njk
@@ -1,8 +1,5 @@
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
-
 {% block pageContent %}
 <div class="govuk-grid-row">
     {# TO DO #}

--- a/server/views/staticContent/index.njk
+++ b/server/views/staticContent/index.njk
@@ -2,12 +2,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "HMPPS Interventions" %}
-{% block pageTitle %}
-  {{ pageTitle }}
-  - GOV.UK
-{% endblock %}
-
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">


### PR DESCRIPTION
## What does this pull request do?

Consolidated all the pageTitle logic into a single place located in layout.njk. The default pageTitle will be "HMPPS Interventions - GOV.UK".

Any page that extends this layout partial may modify the pageTitle by setting the variable pageTitle; in doing so the pageTitle will be displayed as "HMPPS Interventions - $PAGE_TITLE - GOV.UK".

There is also the option of a page subtitle which appends onto the pageTitle as : "HMPPS Interventions - $PAGE_TITLE - $PAGE_SUB_TITLE - GOV.UK"

In addition most pages now have a specific page title and page sub title associated with them.

## What is the intent behind these changes?

Provide users with additional information on the page that they're on.
Improve flow of pages in Google Analytics.

Example:
![image](https://user-images.githubusercontent.com/83066216/130779153-a99979b6-26f0-4ad6-9722-9c571b5b7e4f.png)
