### PR TITLE
IC-1910: Order the sessions on referral details

### DIFF
--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -87,6 +87,26 @@ describe(InterventionProgressPresenter, () => {
       expect(presenter.sessionTableRows).toEqual([])
     })
 
+    describe('when there are multiple sessions', () => {
+      it('they must be ordered by session number', () => {
+        const referral = sentReferralFactory.build()
+        const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          actionPlan,
+          [
+            actionPlanAppointmentFactory.build({ sessionNumber: 2 }),
+            actionPlanAppointmentFactory.build({ sessionNumber: 3 }),
+            actionPlanAppointmentFactory.build({ sessionNumber: 1 }),
+          ],
+          supplierAssessmentFactory.build()
+        )
+        expect(presenter.sessionTableRows.map(row => row.sessionNumber)).toEqual([1, 2, 3])
+      })
+    })
+
     describe('when a session exists but an appointment has not yet been scheduled', () => {
       it('populates the table with formatted session information, with the "Edit session details" link displayed', () => {
         const referral = sentReferralFactory.build()

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -79,15 +79,17 @@ export default class InterventionProgressPresenter {
       return []
     }
 
-    return this.actionPlanAppointments.map(appointment => {
-      const sessionTableParams = this.sessionTableParams(appointment)
+    return this.actionPlanAppointments
+      .map(appointment => {
+        const sessionTableParams = this.sessionTableParams(appointment)
 
-      return {
-        sessionNumber: appointment.sessionNumber,
-        appointmentTime: DateUtils.formatDateTimeOrEmptyString(appointment.appointmentTime),
-        ...sessionTableParams,
-      }
-    })
+        return {
+          sessionNumber: appointment.sessionNumber,
+          appointmentTime: DateUtils.formatDateTimeOrEmptyString(appointment.appointmentTime),
+          ...sessionTableParams,
+        }
+      })
+      .sort((a, b) => a.sessionNumber - b.sessionNumber)
   }
 
   private sessionTableParams(appointment: ActionPlanAppointment): {


### PR DESCRIPTION
## What does this pull request do?

There is a bug whereby the order of the sessions is not always in the correct order. This change ensures that the order is guaranteed to always be in order of the session number.

## What is the intent behind these changes?

Ensures that users do not get out of order sessions.
