### PR TITLE
IC-2196: Add a "delivery schedule" page

### DIFF
--- a/integration_tests/integration/login.spec.js
+++ b/integration_tests/integration/login.spec.js
@@ -35,6 +35,14 @@ context('Login', () => {
       cy.contains('To report a problem with this digital service, please contact the helpdesk')
     })
 
+    it('the user can view the delivery schedule', () => {
+      cy.contains('Delivery schedule').click()
+      cy.location('pathname').should('equal', `/delivery-schedule`)
+      cy.contains(
+        'The Refer and monitor an intervention delivery schedule shows the things we’re working on and when we expect to have them ready for you to use.'
+      )
+    })
+
     it('the user can log out', () => {
       cy.get('[data-qa=logout]').click()
       AuthLoginPage.verifyOnPage()
@@ -70,6 +78,14 @@ context('Login', () => {
       cy.contains('Report a problem').click()
       cy.location('pathname').should('equal', `/report-a-problem`)
       cy.contains('To report a problem with this digital service, please contact the helpdesk')
+    })
+
+    it('the user can view the delivery schedule', () => {
+      cy.contains('Delivery schedule').click()
+      cy.location('pathname').should('equal', `/delivery-schedule`)
+      cy.contains(
+        'The Refer and monitor an intervention delivery schedule shows the things we’re working on and when we expect to have them ready for you to use.'
+      )
     })
 
     it('the user can log out', () => {

--- a/server/routes/common/commonController.ts
+++ b/server/routes/common/commonController.ts
@@ -5,4 +5,8 @@ export default class CommonController {
   async reportAProblem(req: Request, res: Response): Promise<void> {
     ControllerUtils.renderWithLayout(res, { renderArgs: ['common/reportAProblem', {}] }, null)
   }
+
+  async deliverySchedule(req: Request, res: Response): Promise<void> {
+    ControllerUtils.renderWithLayout(res, { renderArgs: ['common/deliverySchedule', {}] }, null)
+  }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -47,6 +47,10 @@ export default function routes(router: Router, services: Services): Router {
     return commonController.reportAProblem(req, res)
   })
 
+  get(router, '/delivery-schedule', (req, res) => {
+    return commonController.deliverySchedule(req, res)
+  })
+
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     get(router, '/static-pages', (req, res) => {
       return staticContentController.index(req, res)

--- a/server/views/common/deliverySchedule.njk
+++ b/server/views/common/deliverySchedule.njk
@@ -1,0 +1,38 @@
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "Delivery schedule" %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Refer and monitor an intervention delivery schedule</h1>
+
+      <p>
+      The Refer and monitor an intervention delivery schedule shows the things we’re working on and when we expect to have them ready for you to use.
+      </p>
+
+      <p>
+      The delivery schedule is a guide to what we have planned, but some things might change. If you’re experiencing difficulties using Refer and monitor an intervention, please contact us via the <a href="/report-a-problem">report a problem page</a>.
+      </p>
+
+      <h2 class="govuk-heading-m">August to September 2021</h2>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Supplier reporting CSV</li>
+        <li>Action plan improvements</li>
+        <li>Content improvements to help probation practitioners create quality referrals</li>
+        <li>Case list views improvements – user specific case lists rather than organisation specific</li>
+        <li>Case notes</li>
+        <li>Updated risk flows</li>
+      </ul>
+
+      <h2 class="govuk-heading-m">October to December 2021</h2>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Editing a referral</li>
+        <li>Editing an intervention listing</li>
+        <li>Access revisions and improvements</li>
+      </ul>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/common/reportAProblem.njk
+++ b/server/views/common/reportAProblem.njk
@@ -34,6 +34,11 @@
         <li><a class="govuk-link" href="https://welcome-hub.hmppsintranet.org.uk/wp-content/uploads/2021/05/How-do-I%E2%80%A6-Receive-and-assign-referrals.pptx">How do I receive and assign referrals</a></li>
         <li><a class="govuk-link" href="https://welcome-hub.hmppsintranet.org.uk/wp-content/uploads/2021/05/How-do-I%E2%80%A6-Complete-initial-assessment-and-action-plan.pptx">How do I complete initial assessment and action plan</a></li>
       </ul>
+
+      <h2 class="govuk-heading-m">Delivery schedule</h2>
+
+      <p class="govuk-body">If you’d like to know what the team is working on and what will be added to the service in the near future, you can see the <a href="/delivery-schedule" class="govuk-link">delivery schedule</a>.</p>
+
     </div>
   </div>
 {% endblock %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -80,6 +80,10 @@
                          {
                            href: "/report-a-problem",
                            text: "Report a problem"
+                         },
+                         {
+                           href: "/delivery-schedule",
+                           text: "Delivery schedule"
                          }
                        ]
                      }


### PR DESCRIPTION
## What does this pull request do?

Adds a new static page that gives the user an outline of the delivery schedule for the next couple of months. Linked to from the footer.

It also links to this new page from the "Report a problem" page.

## What is the intent behind these changes?

From the Jira issue:

> We are adding in this new page to begin to adopt a ‘publishing first’ model where we proactively communicate what changes we are making to the service - rather than having to respond to queries from users and stakeholders on an ad hoc basis.

## Screenshot

### New page

![Screenshot 2021-08-26 at 14-44-27 HMPPS Interventions - Delivery schedule - GOV UK](https://user-images.githubusercontent.com/53756884/130974123-73af6924-4a02-4959-a7ba-58d6733396e4.png)

### Updated "Report a problem" page

![Screenshot 2021-08-26 at 14-13-27 HMPPS Interventions - GOV UK](https://user-images.githubusercontent.com/53756884/130970386-bf287a1a-6409-4c86-a72b-b9b7a17b3a47.png)
