### PR TITLE
Improve handling of responsible officer details on referral details page

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -455,7 +455,7 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
     cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
-    cy.stubGetResponsibleOfficersForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
+    cy.stubGetResponsibleOfficerForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
 
     cy.login()
 

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -198,7 +198,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetConvictionById(referralToSelect.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetSupplementaryRiskInformation(referralToSelect.supplementaryRiskId, supplementaryRiskInformation)
     cy.stubGetStaffDetails(referralToSelect.sentBy.username, staffDetails)
-    cy.stubGetResponsibleOfficersForServiceUser(referralToSelect.referral.serviceUser.crn, [responsibleOfficer])
+    cy.stubGetResponsibleOfficerForServiceUser(referralToSelect.referral.serviceUser.crn, [responsibleOfficer])
 
     cy.login()
 
@@ -328,7 +328,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
       cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
       cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
-      cy.stubGetResponsibleOfficersForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
+      cy.stubGetResponsibleOfficerForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
 
       cy.login()
 
@@ -414,7 +414,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
       cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
       cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
-      cy.stubGetResponsibleOfficersForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
+      cy.stubGetResponsibleOfficerForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
 
       cy.login()
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -59,8 +59,8 @@ module.exports = on => {
       return communityApi.stubGetStaffDetails(arg.username, arg.responseJson)
     },
 
-    stubGetResponsibleOfficersForServiceUser: arg => {
-      return communityApi.stubGetResponsibleOfficersForServiceUser(arg.crn, arg.responseJson)
+    stubGetResponsibleOfficerForServiceUser: arg => {
+      return communityApi.stubGetResponsibleOfficerForServiceUser(arg.crn, arg.responseJson)
     },
 
     stubGetDraftReferral: arg => {

--- a/integration_tests/support/communityApiStubs.js
+++ b/integration_tests/support/communityApiStubs.js
@@ -22,6 +22,6 @@ Cypress.Commands.add('stubGetStaffDetails', (username, responseJson) => {
   cy.task('stubGetStaffDetails', { username, responseJson })
 })
 
-Cypress.Commands.add('stubGetResponsibleOfficersForServiceUser', (crn, responseJson) => {
-  cy.task('stubGetResponsibleOfficersForServiceUser', { crn, responseJson })
+Cypress.Commands.add('stubGetResponsibleOfficerForServiceUser', (crn, responseJson) => {
+  cy.task('stubGetResponsibleOfficerForServiceUser', { crn, responseJson })
 })

--- a/mockApis/communityApi.ts
+++ b/mockApis/communityApi.ts
@@ -99,7 +99,7 @@ export default class CommunityApiMocks {
     })
   }
 
-  stubGetResponsibleOfficersForServiceUser = async (crn: string, responseJson: unknown): Promise<unknown> => {
+  stubGetResponsibleOfficerForServiceUser = async (crn: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -695,7 +695,7 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
   let expandedDeliusServiceUser: ExpandedDeliusServiceUser
   let supplementaryRiskInformation: SupplementaryRiskInformation
   let staffDetails: DeliusStaffDetails
-  let responsibleOfficers: DeliusOffenderManager[]
+  let responsibleOfficer: DeliusOffenderManager
 
   beforeEach(() => {
     sentReferral = sentReferralFactory.build()
@@ -703,7 +703,7 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
     expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build()
     supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
     staffDetails = deliusStaffDetailsFactory.build()
-    responsibleOfficers = [deliusOffenderManagerFactory.responsibleOfficer().build()]
+    responsibleOfficer = deliusOffenderManagerFactory.responsibleOfficer().build()
 
     interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
@@ -714,7 +714,7 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
     assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
     communityApiService.getStaffDetails.mockResolvedValue(staffDetails)
-    communityApiService.getResponsibleOfficersForServiceUser.mockResolvedValue(responsibleOfficers)
+    communityApiService.getResponsibleOfficerForServiceUser.mockResolvedValue(responsibleOfficer)
   })
 
   it('displays information about the referral and service user', async () => {
@@ -754,18 +754,15 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
         ],
       },
     })
-
-    responsibleOfficers = [
-      deliusOffenderManagerFactory
-        .responsibleOfficer()
-        .build({ staff: { forenames: 'Peter', surname: 'Practitioner' } }),
-    ]
+    responsibleOfficer = deliusOffenderManagerFactory
+      .responsibleOfficer()
+      .build({ staff: { forenames: 'Peter', surname: 'Practitioner' } })
 
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
     communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(expandedDeliusServiceUser)
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
-    communityApiService.getResponsibleOfficersForServiceUser.mockResolvedValue(responsibleOfficers)
+    communityApiService.getResponsibleOfficerForServiceUser.mockResolvedValue(responsibleOfficer)
 
     await request(app)
       .get(`/probation-practitioner/referrals/${sentReferral.id}/details`)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -154,7 +154,7 @@ export default class ProbationPractitionerReferralsController {
       riskInformation,
       riskSummary,
       staffDetails,
-      responsibleOfficers,
+      responsibleOfficer,
     ] = await Promise.all([
       this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
@@ -163,7 +163,7 @@ export default class ProbationPractitionerReferralsController {
       this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
       this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
       this.communityApiService.getStaffDetails(sentReferral.sentBy.username),
-      this.communityApiService.getResponsibleOfficersForServiceUser(crn),
+      this.communityApiService.getResponsibleOfficerForServiceUser(crn),
     ])
 
     const assignee =
@@ -187,7 +187,7 @@ export default class ProbationPractitionerReferralsController {
       expandedServiceUser,
       riskSummary,
       staffDetails,
-      responsibleOfficers
+      responsibleOfficer
     )
     const view = new ShowReferralView(presenter)
     ControllerUtils.renderWithLayout(res, view, expandedServiceUser)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -136,7 +136,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
   let deliusServiceUser: ExpandedDeliusServiceUser
   let supplementaryRiskInformation: SupplementaryRiskInformation
   let staffDetails: DeliusStaffDetails
-  let responsibleOfficers: DeliusOffenderManager[]
+  let responsibleOfficer: DeliusOffenderManager
 
   beforeEach(() => {
     sentReferral = sentReferralFactory.build()
@@ -144,7 +144,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
     deliusServiceUser = expandedDeliusServiceUserFactory.build()
     supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
     staffDetails = deliusStaffDetailsFactory.build()
-    responsibleOfficers = [deliusOffenderManagerFactory.responsibleOfficer().build()]
+    responsibleOfficer = deliusOffenderManagerFactory.responsibleOfficer().build()
 
     interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
@@ -155,7 +155,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
     assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
     communityApiService.getStaffDetails.mockResolvedValue(staffDetails)
-    communityApiService.getResponsibleOfficersForServiceUser.mockResolvedValue(responsibleOfficers)
+    communityApiService.getResponsibleOfficerForServiceUser.mockResolvedValue(responsibleOfficer)
   })
 
   it('displays information about the referral and service user', async () => {
@@ -195,18 +195,16 @@ describe('GET /service-provider/referrals/:id/details', () => {
         ],
       },
     })
-    responsibleOfficers = [
-      deliusOffenderManagerFactory
-        .responsibleOfficer()
-        .build({ staff: { forenames: 'Peter', surname: 'Practitioner' } }),
-    ]
+    responsibleOfficer = deliusOffenderManagerFactory
+      .responsibleOfficer()
+      .build({ staff: { forenames: 'Peter', surname: 'Practitioner' } })
 
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
     communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(deliusServiceUser)
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
     assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
-    communityApiService.getResponsibleOfficersForServiceUser.mockResolvedValue(responsibleOfficers)
+    communityApiService.getResponsibleOfficerForServiceUser.mockResolvedValue(responsibleOfficer)
 
     await request(app)
       .get(`/service-provider/referrals/${sentReferral.id}/details`)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -135,7 +135,7 @@ export default class ServiceProviderReferralsController {
       riskInformation,
       riskSummary,
       staffDetails,
-      responsibleOfficers,
+      responsibleOfficer,
     ] = await Promise.all([
       this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
@@ -144,7 +144,7 @@ export default class ServiceProviderReferralsController {
       this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
       this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
       this.communityApiService.getStaffDetails(sentReferral.sentBy.username),
-      this.communityApiService.getResponsibleOfficersForServiceUser(crn),
+      this.communityApiService.getResponsibleOfficerForServiceUser(crn),
     ])
     const assignee =
       sentReferral.assignedTo === null
@@ -180,7 +180,7 @@ export default class ServiceProviderReferralsController {
       expandedServiceUser,
       riskSummary,
       staffDetails,
-      responsibleOfficers
+      responsibleOfficer
     )
     const view = new ShowReferralView(presenter)
 

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -48,7 +48,7 @@ describe(ShowReferralPresenter, () => {
   const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
   const riskSummary = riskSummaryFactory.build()
   const defaultStaffDetails = deliusStaffDetailsFactory.build()
-  const responsibleOfficer = [deliusOffenderManagerFactory.build()]
+  const responsibleOfficer = deliusOffenderManagerFactory.build()
 
   describe('assignmentFormAction', () => {
     it('returns the relative URL for the start assignment page', () => {
@@ -289,7 +289,7 @@ describe(ShowReferralPresenter, () => {
 
   describe('responsibleOfficerDetails', () => {
     describe('when all fields are present', () => {
-      it('returns an array of summary lists of the responsible officer(s)', () => {
+      it('returns a summary list of the responsible officer details', () => {
         const sentReferral = sentReferralFactory.build(referralParams)
         const presenter = new ShowReferralPresenter(
           sentReferral,
@@ -304,30 +304,27 @@ describe(ShowReferralPresenter, () => {
           deliusServiceUser,
           riskSummary,
           defaultStaffDetails,
-          [
-            deliusOffenderManagerFactory.build({
-              staff: {
-                forenames: 'Peter',
-                surname: 'Practitioner',
-                email: 'p.practitioner@example.com',
-                phoneNumber: '01234567890',
-              },
-            }),
-          ]
+
+          deliusOffenderManagerFactory.build({
+            staff: {
+              forenames: 'Peter',
+              surname: 'Practitioner',
+              email: 'p.practitioner@example.com',
+              phoneNumber: '01234567890',
+            },
+          })
         )
 
         expect(presenter.responsibleOfficersDetails).toEqual([
-          [
-            { key: 'Name', lines: ['Peter Practitioner'] },
-            { key: 'Phone', lines: ['01234567890'] },
-            { key: 'Email address', lines: ['p.practitioner@example.com'] },
-          ],
+          { key: 'Name', lines: ['Peter Practitioner'] },
+          { key: 'Phone', lines: ['01234567890'] },
+          { key: 'Email address', lines: ['p.practitioner@example.com'] },
         ])
       })
     })
 
     describe('when optional fields are missing', () => {
-      it('returns an array of summary lists of the responsible officer(s) with "not found" or empty values', () => {
+      it('returns a summary list of the responsible officer details with "not found" or empty values', () => {
         const sentReferral = sentReferralFactory.build(referralParams)
         const presenter = new ShowReferralPresenter(
           sentReferral,
@@ -342,62 +339,24 @@ describe(ShowReferralPresenter, () => {
           deliusServiceUser,
           riskSummary,
           defaultStaffDetails,
-          [
-            {
-              isResponsibleOfficer: true,
-              staff: undefined,
+          {
+            isResponsibleOfficer: true,
+            staff: {
+              forenames: 'Peter',
+              surname: undefined,
+              email: undefined,
+              phoneNumber: undefined,
             },
-            {
-              isResponsibleOfficer: true,
-              staff: {
-                forenames: undefined,
-                surname: undefined,
-                email: undefined,
-                phoneNumber: undefined,
-              },
-            },
-            {
-              isResponsibleOfficer: true,
-              staff: {
-                forenames: undefined,
-                surname: 'Practitioner',
-                email: undefined,
-                phoneNumber: undefined,
-              },
-            },
-            {
-              isResponsibleOfficer: true,
-              staff: {
-                forenames: 'Peter',
-                surname: undefined,
-                email: undefined,
-                phoneNumber: undefined,
-              },
-            },
-          ]
+          }
         )
 
         expect(presenter.responsibleOfficersDetails).toEqual([
-          [
-            { key: 'Name', lines: ['Not found'] },
-            { key: 'Phone', lines: ['Not found'] },
-            { key: 'Email address', lines: ['Not found'] },
-          ],
-          [
-            { key: 'Name', lines: ['Not found'] },
-            { key: 'Phone', lines: ['Not found'] },
-            { key: 'Email address', lines: ['Not found'] },
-          ],
-          [
-            { key: 'Name', lines: ['Practitioner'] },
-            { key: 'Phone', lines: ['Not found'] },
-            { key: 'Email address', lines: ['Not found'] },
-          ],
-          [
-            { key: 'Name', lines: ['Peter'] },
-            { key: 'Phone', lines: ['Not found'] },
-            { key: 'Email address', lines: ['Not found'] },
-          ],
+          { key: 'Name', lines: ['Peter'] },
+          { key: 'Phone', lines: ['Not found'] },
+          {
+            key: 'Email address',
+            lines: ['Not found - email notifications for this referral will be sent to the referring officer'],
+          },
         ])
       })
     })
@@ -418,16 +377,10 @@ describe(ShowReferralPresenter, () => {
           deliusServiceUser,
           riskSummary,
           defaultStaffDetails,
-          []
+          null
         )
 
-        expect(presenter.responsibleOfficersDetails).toEqual([
-          [
-            { key: 'Name', lines: ['Not found'] },
-            { key: 'Phone', lines: ['Not found'] },
-            { key: 'Email address', lines: ['Not found'] },
-          ],
-        ])
+        expect(presenter.responsibleOfficersDetails).toEqual([])
       })
     })
   })

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -42,7 +42,7 @@ export default class ShowReferralPresenter {
     private readonly deliusServiceUser: ExpandedDeliusServiceUser,
     private readonly riskSummary: RiskSummary | null,
     private readonly staffDetails: DeliusStaffDetails | null,
-    private readonly responsibleOfficers: DeliusOffenderManager[]
+    private readonly responsibleOfficer: DeliusOffenderManager | null
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,
@@ -78,46 +78,26 @@ export default class ShowReferralPresenter {
         ]
   }
 
-  get responsibleOfficersDetails(): SummaryListItem[][] {
-    // This is a temporary step - I want to not break the page if fields are missing, most likely with dev data.
-    // It will be removed / simplified when we switch to using a dedicated Responsible Officer endpoint.
-    if (this.responsibleOfficers.length < 1) {
-      return [
-        [
-          {
-            key: 'Name',
-            lines: ['Not found'],
-          },
-          {
-            key: 'Phone',
-            lines: ['Not found'],
-          },
-          {
-            key: 'Email address',
-            lines: ['Not found'],
-          },
+  get responsibleOfficersDetails(): SummaryListItem[] {
+    if (this.responsibleOfficer === null) return []
+
+    const { staff } = this.responsibleOfficer
+    return [
+      {
+        key: 'Name',
+        lines: [`${staff?.forenames || ''} ${staff?.surname || ''}`.trim() || 'Not found'],
+      },
+      {
+        key: 'Phone',
+        lines: [staff?.phoneNumber || 'Not found'],
+      },
+      {
+        lines: [
+          staff?.email || 'Not found - email notifications for this referral will be sent to the referring officer',
         ],
-      ]
-    }
-
-    return this.responsibleOfficers.map(responsibleOfficer => {
-      const { staff } = responsibleOfficer
-
-      return [
-        {
-          key: 'Name',
-          lines: [`${staff?.forenames || ''} ${staff?.surname || ''}`.trim() || 'Not found'],
-        },
-        {
-          key: 'Phone',
-          lines: [staff?.phoneNumber || 'Not found'],
-        },
-        {
-          key: 'Email address',
-          lines: [staff?.email || 'Not found'],
-        },
-      ]
-    })
+        key: 'Email address',
+      },
+    ]
   }
 
   get referralServiceCategories(): ServiceCategory[] {

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -21,8 +21,8 @@ export default class ShowReferralView {
     this.presenter.probationPractitionerTeamDetails
   )
 
-  private readonly responsibleOfficerSummaryListsArgs = this.presenter.responsibleOfficersDetails.map(details =>
-    ViewUtils.summaryListArgs(details)
+  private readonly responsibleOfficerSummaryListArgs = ViewUtils.summaryListArgs(
+    this.presenter.responsibleOfficersDetails
   )
 
   private readonly interventionDetailsSummaryListArgs = ViewUtils.summaryListArgs(this.presenter.interventionDetails)
@@ -68,7 +68,7 @@ export default class ShowReferralView {
         subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         probationPractitionerSummaryListArgs: this.probationPractitionerSummaryListArgs,
         probationPractitionerTeamSummaryListArgs: this.probationPractitionerTeamSummaryListArgs,
-        responsibleOfficerSummaryListsArgs: this.responsibleOfficerSummaryListsArgs,
+        responsibleOfficerSummaryListArgs: this.responsibleOfficerSummaryListArgs,
         interventionDetailsSummaryListArgs: this.interventionDetailsSummaryListArgs,
         serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs,
         serviceUserRisksSummaryListArgs: this.serviceUserRisksSummaryListArgs,

--- a/server/services/communityApiService.test.ts
+++ b/server/services/communityApiService.test.ts
@@ -10,7 +10,6 @@ import deliusConviction from '../../testutils/factories/deliusConviction'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
 import deliusStaffDetails from '../../testutils/factories/deliusStaffDetails'
 import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
-import { DeliusOffenderManager } from '../models/delius/deliusOffenderManager'
 
 jest.mock('../data/restClient')
 
@@ -162,7 +161,6 @@ describe(CommunityApiService, () => {
       it('makes a request to the Community API, retrieves the Responsible Officers and casts them as a DeliusResponsibleOfficer', async () => {
         const deliusOffenderManagers = [
           deliusOffenderManagerFactory.responsibleOfficer().build({ staff: { forenames: 'Jerry' } }),
-          deliusOffenderManagerFactory.responsibleOfficer().build({ staff: { forenames: 'Linda' } }),
           deliusOffenderManagerFactory.notResponsibleOfficer().build({ staff: { forenames: 'Roger' } }),
         ]
 
@@ -170,17 +168,16 @@ describe(CommunityApiService, () => {
 
         hmppsAuthClientMock.getApiClientToken.mockResolvedValue('token')
 
-        const responsibleOfficers = await service.getResponsibleOfficersForServiceUser('X123456')
+        const responsibleOfficer = await service.getResponsibleOfficerForServiceUser('X123456')
 
         expect(restClientMock.get).toHaveBeenCalledWith({
           path: '/secure/offenders/crn/X123456/allOffenderManagers',
           token: 'token',
         })
 
-        const names = responsibleOfficers!.map((officer: DeliusOffenderManager) => officer.staff!.forenames)
+        const name = responsibleOfficer!.staff!.forenames
 
-        expect(names).toEqual(['Jerry', 'Linda'])
-        expect(names).not.toContainEqual('Roger')
+        expect(name).toEqual('Jerry')
       })
     })
 
@@ -189,7 +186,7 @@ describe(CommunityApiService, () => {
         restClientMock.get.mockRejectedValue(createError(500))
 
         try {
-          await service.getResponsibleOfficersForServiceUser('X123456')
+          await service.getResponsibleOfficerForServiceUser('X123456')
         } catch (err) {
           expect(err.status).toBe(500)
           expect(err.userMessage).toBe('Could retrieve Responsible Officer from nDelius.')

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -80,7 +80,7 @@ export default class CommunityApiService {
     }
   }
 
-  async getResponsibleOfficersForServiceUser(crn: string): Promise<DeliusOffenderManager[]> {
+  async getResponsibleOfficerForServiceUser(crn: string): Promise<DeliusOffenderManager | null> {
     const token = await this.hmppsAuthService.getApiClientToken()
 
     logger.info({ crn }, 'getting offender managers for service user')
@@ -90,7 +90,9 @@ export default class CommunityApiService {
         token,
       })) as DeliusOffenderManager[]
 
-      return deliusOffenderManagers.filter(offenderManager => offenderManager.isResponsibleOfficer)
+      // we have an assumption that a SU only ever has one RO. this has been tested
+      // in production and found to be true in 100% of cases we have seen so far.
+      return deliusOffenderManagers.find(offenderManager => offenderManager.isResponsibleOfficer) || null
     } catch (err) {
       throw createError(err.status, err, { userMessage: 'Could retrieve Responsible Officer from nDelius.' })
     }

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -51,9 +51,11 @@
       {{ govukSummaryList(serviceUserNeedsSummaryListArgs) }}
 
       <h2 class="govuk-heading-m">Responsible officer details</h2>
-      {% for summaryListArgs in responsibleOfficerSummaryListsArgs %}
-        {{ govukSummaryList(summaryListArgs) }}
-      {% endfor %}
+      {%  if responsibleOfficerSummaryListArgs | length %}
+          {{ govukSummaryList(responsibleOfficerSummaryListArgs) }}
+      {% else %}
+          <p class="govuk-body">No responsible officer details found in nDelius. Email notifications for this referral will be sent to the referring officer.</p>
+      {% endif %}
 
       <h2 class="govuk-heading-m">Referring probation practitioner details</h2>
       {{ govukSummaryList(probationPractitionerSummaryListArgs) }}


### PR DESCRIPTION
## What does this pull request do?


a) simplify the community API service method to just return one RO.
b) improve the messaging in the case the either the RO email is missing or the SU doesn't have an RO at all.

old content:

<img width="899" alt="Screenshot 2021-08-26 at 15 21 52" src="https://user-images.githubusercontent.com/63233073/130980696-a1c59ae6-15c3-4fce-b091-000d7fb9aae4.png">

new content: 

<img width="853" alt="Screenshot 2021-08-26 at 15 11 05" src="https://user-images.githubusercontent.com/63233073/130980732-15d9efd5-ffc8-4f80-a74c-cfbc49937ce5.png">

content when no RO details are found at all:

<img width="862" alt="Screenshot 2021-08-26 at 15 22 25" src="https://user-images.githubusercontent.com/63233073/130980777-e65db2d0-71e1-4a9b-918b-5f324098e8a1.png">

## What is the intent behind these changes?

Make the SP aware of the consequences of a missing RO email address
