### PR TITLE
Improve the way team details are handed in the referral details page

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -7,7 +7,6 @@ import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
-import deliusStaffDetailsFactory from '../../testutils/factories/deliusStaffDetails'
 import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
 import supplierAssessmentFactory from '../../testutils/factories/supplierAssessment'
 import initialAssessmentAppointmentFactory from '../../testutils/factories/initialAssessmentAppointment'
@@ -192,7 +191,6 @@ describe('Probation practitioner referrals dashboard', () => {
           },
         })
         const deliusUser = deliusUserFactory.build()
-        const staffDetails = deliusStaffDetailsFactory.build()
         cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
         cy.stubGetIntervention(intervention.id, intervention)
         cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUserFactory.build())
@@ -206,7 +204,6 @@ describe('Probation practitioner referrals dashboard', () => {
           assignedReferral.supplementaryRiskId,
           supplementaryRiskInformationFactory.build()
         )
-        cy.stubGetStaffDetails(assignedReferral.sentBy.username, staffDetails)
 
         cy.stubGetAuthUserByEmailAddress([hmppsAuthUser])
         cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
@@ -428,22 +425,17 @@ describe('Probation practitioner referrals dashboard', () => {
       },
     })
 
-    const staffDetails = deliusStaffDetailsFactory.build({
-      teams: [
-        {
-          telephone: '07890 123456',
-          emailAddress: 'probation-team4692@justice.gov.uk',
-          startDate: '2021-01-01',
-        },
-      ],
-    })
-
     const responsibleOfficer = deliusOffenderManagerFactory.build({
       staff: {
         forenames: 'Peter',
         surname: 'Practitioner',
         email: 'p.practitioner@justice.gov.uk',
         phoneNumber: '01234567890',
+      },
+      team: {
+        telephone: '07890 123456',
+        emailAddress: 'probation-team4692@justice.gov.uk',
+        startDate: '2021-01-01',
       },
     })
 
@@ -454,7 +446,6 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
     cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
-    cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
     cy.stubGetResponsibleOfficerForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
 
     cy.login()
@@ -512,16 +503,14 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.contains('Responsible officer details').next().contains('Name').next().contains('Peter Practitioner')
     cy.contains('Responsible officer details').next().contains('Phone').next().contains('01234567890')
     cy.contains('Responsible officer details').next().contains('Email').next().contains('p.practitioner@justice.gov.uk')
+    cy.contains('Responsible officer details').next().contains('Team phone').next().contains('07890 123456')
+    cy.contains('Responsible officer details')
+      .next()
+      .contains('Team email address')
+      .next()
+      .contains('probation-team4692@justice.gov.uk')
 
     cy.contains('Bernard Beaks')
     cy.contains('bernard.beaks@justice.gov.uk')
-
-    cy.contains('Team contact details').next().contains('Phone').next().contains('07890 123456')
-
-    cy.contains('Team contact details')
-      .next()
-      .contains('Email address')
-      .next()
-      .contains('probation-team4692@justice.gov.uk')
   })
 })

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -10,7 +10,6 @@ import interventionFactory from '../../testutils/factories/intervention'
 import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
-import deliusStaffDetailsFactory from '../../testutils/factories/deliusStaffDetails'
 import supplierAssessmentFactory from '../../testutils/factories/supplierAssessment'
 import initialAssessmentAppointmentFactory from '../../testutils/factories/initialAssessmentAppointment'
 import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
@@ -160,22 +159,17 @@ describe('Service provider referrals dashboard', () => {
       riskSummaryComments: 'They are low risk.',
     })
 
-    const staffDetails = deliusStaffDetailsFactory.build({
-      teams: [
-        {
-          telephone: '07890 123456',
-          emailAddress: 'probation-team4692@justice.gov.uk',
-          startDate: '2021-01-01',
-        },
-      ],
-    })
-
     const responsibleOfficer = deliusOffenderManagerFactory.build({
       staff: {
         forenames: 'Peter',
         surname: 'Practitioner',
         email: 'p.practitioner@justice.gov.uk',
         phoneNumber: '01234567890',
+      },
+      team: {
+        telephone: '07890 123456',
+        emailAddress: 'probation-team4692@justice.gov.uk',
+        startDate: '2021-01-01',
       },
     })
     const sentReferralsSummary = [
@@ -197,7 +191,6 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetExpandedServiceUserByCRN(referralToSelect.referral.serviceUser.crn, expandedDeliusServiceUser)
     cy.stubGetConvictionById(referralToSelect.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetSupplementaryRiskInformation(referralToSelect.supplementaryRiskId, supplementaryRiskInformation)
-    cy.stubGetStaffDetails(referralToSelect.sentBy.username, staffDetails)
     cy.stubGetResponsibleOfficerForServiceUser(referralToSelect.referral.serviceUser.crn, [responsibleOfficer])
 
     cy.login()
@@ -278,17 +271,15 @@ describe('Service provider referrals dashboard', () => {
     cy.contains('Responsible officer details').next().contains('Name').next().contains('Peter Practitioner')
     cy.contains('Responsible officer details').next().contains('Phone').next().contains('01234567890')
     cy.contains('Responsible officer details').next().contains('Email').next().contains('p.practitioner@justice.gov.uk')
+    cy.contains('Responsible officer details').next().contains('Team phone').next().contains('07890 123456')
+    cy.contains('Responsible officer details')
+      .next()
+      .contains('Team email address')
+      .next()
+      .contains('probation-team4692@justice.gov.uk')
 
     cy.contains('Bernard Beaks')
     cy.contains('bernard.beaks@justice.gov.uk')
-
-    cy.contains('Team contact details').next().contains('Phone').next().contains('07890 123456')
-
-    cy.contains('Team contact details')
-      .next()
-      .contains('Email address')
-      .next()
-      .contains('probation-team4692@justice.gov.uk')
   })
 
   describe('Assigning a referral to a caseworker', () => {
@@ -310,7 +301,6 @@ describe('Service provider referrals dashboard', () => {
       const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({ ...deliusServiceUser })
       const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
       const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const staffDetails = deliusStaffDetailsFactory.build()
       const responsibleOfficer = deliusOffenderManagerFactory.build()
       let referralSummary = serviceProviderSentReferralSummaryFactory
         .fromReferralAndIntervention(referral, intervention)
@@ -327,7 +317,6 @@ describe('Service provider referrals dashboard', () => {
       cy.stubAssignSentReferral(referral.id, referral)
       cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
       cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
-      cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
       cy.stubGetResponsibleOfficerForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
 
       cy.login()
@@ -395,7 +384,6 @@ describe('Service provider referrals dashboard', () => {
       const deliusServiceUser = deliusServiceUserFactory.build()
       const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({ ...deliusServiceUser })
       const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const staffDetails = deliusStaffDetailsFactory.build()
       const responsibleOfficer = deliusOffenderManagerFactory.build()
       let referralSummary = serviceProviderSentReferralSummaryFactory
         .fromReferralAndIntervention(referral, intervention)
@@ -413,7 +401,6 @@ describe('Service provider referrals dashboard', () => {
       cy.stubAssignSentReferral(referral.id, referral)
       cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
       cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
-      cy.stubGetStaffDetails(referral.sentBy.username, staffDetails)
       cy.stubGetResponsibleOfficerForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
 
       cy.login()

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -55,10 +55,6 @@ module.exports = on => {
       return communityApi.stubGetConvictionById(arg.crn, arg.id, arg.responseJson)
     },
 
-    stubGetStaffDetails: arg => {
-      return communityApi.stubGetStaffDetails(arg.username, arg.responseJson)
-    },
-
     stubGetResponsibleOfficerForServiceUser: arg => {
       return communityApi.stubGetResponsibleOfficerForServiceUser(arg.crn, arg.responseJson)
     },

--- a/integration_tests/support/communityApiStubs.js
+++ b/integration_tests/support/communityApiStubs.js
@@ -18,10 +18,6 @@ Cypress.Commands.add('stubGetConvictionById', (crn, id, responseJson) => {
   cy.task('stubGetConvictionById', { crn, id, responseJson })
 })
 
-Cypress.Commands.add('stubGetStaffDetails', (username, responseJson) => {
-  cy.task('stubGetStaffDetails', { username, responseJson })
-})
-
 Cypress.Commands.add('stubGetResponsibleOfficerForServiceUser', (crn, responseJson) => {
   cy.task('stubGetResponsibleOfficerForServiceUser', { crn, responseJson })
 })

--- a/mockApis/communityApi.ts
+++ b/mockApis/communityApi.ts
@@ -83,22 +83,6 @@ export default class CommunityApiMocks {
     })
   }
 
-  stubGetStaffDetails = async (username: string, responseJson: unknown): Promise<unknown> => {
-    return this.wiremock.stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: `${this.mockPrefix}/secure/staff/username/${username}`,
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        jsonBody: responseJson,
-      },
-    })
-  }
-
   stubGetResponsibleOfficerForServiceUser = async (crn: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/models/delius/deliusOffenderManager.ts
+++ b/server/models/delius/deliusOffenderManager.ts
@@ -1,3 +1,5 @@
+import { DeliusTeam } from './deliusStaffDetails'
+
 export interface DeliusOffenderManager {
   isResponsibleOfficer: boolean
   staff?: {
@@ -6,4 +8,5 @@ export interface DeliusOffenderManager {
     email?: string | null
     phoneNumber?: string | null
   }
+  team?: DeliusTeam
 }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -28,8 +28,6 @@ import SentReferral from '../../models/sentReferral'
 import DeliusUser from '../../models/delius/deliusUser'
 import { ExpandedDeliusServiceUser } from '../../models/delius/deliusServiceUser'
 import { SupplementaryRiskInformation } from '../../models/assessRisksAndNeeds/supplementaryRiskInformation'
-import { DeliusStaffDetails } from '../../models/delius/deliusStaffDetails'
-import deliusStaffDetailsFactory from '../../../testutils/factories/deliusStaffDetails'
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
 import supplierAssessmentFactory from '../../../testutils/factories/supplierAssessment'
 import initialAssessmentAppointmentFactory from '../../../testutils/factories/initialAssessmentAppointment'
@@ -694,7 +692,6 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
   let deliusUser: DeliusUser
   let expandedDeliusServiceUser: ExpandedDeliusServiceUser
   let supplementaryRiskInformation: SupplementaryRiskInformation
-  let staffDetails: DeliusStaffDetails
   let responsibleOfficer: DeliusOffenderManager
 
   beforeEach(() => {
@@ -702,7 +699,6 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
     deliusUser = deliusUserFactory.build()
     expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build()
     supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-    staffDetails = deliusStaffDetailsFactory.build()
     responsibleOfficer = deliusOffenderManagerFactory.responsibleOfficer().build()
 
     interventionsService.getIntervention.mockResolvedValue(intervention)
@@ -713,7 +709,6 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
     communityApiService.getConvictionById.mockResolvedValue(conviction)
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
     assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
-    communityApiService.getStaffDetails.mockResolvedValue(staffDetails)
     communityApiService.getResponsibleOfficerForServiceUser.mockResolvedValue(responsibleOfficer)
   })
 
@@ -779,7 +774,6 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
         expect(res.text).toContain("service user's Risk of Serious Harm (ROSH) levels")
         expect(res.text).toContain('Children')
         expect(res.text).toContain('HIGH')
-        expect(res.text).toContain('Team contact details')
         expect(res.text).toContain('07890 123456')
         expect(res.text).toContain('probation-team4692@justice.gov.uk')
       })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -146,25 +146,16 @@ export default class ProbationPractitionerReferralsController {
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
 
     const { crn } = sentReferral.referral.serviceUser
-    const [
-      intervention,
-      sentBy,
-      expandedServiceUser,
-      conviction,
-      riskInformation,
-      riskSummary,
-      staffDetails,
-      responsibleOfficer,
-    ] = await Promise.all([
-      this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
-      this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
-      this.communityApiService.getExpandedServiceUserByCRN(crn),
-      this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
-      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
-      this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
-      this.communityApiService.getStaffDetails(sentReferral.sentBy.username),
-      this.communityApiService.getResponsibleOfficerForServiceUser(crn),
-    ])
+    const [intervention, sentBy, expandedServiceUser, conviction, riskInformation, riskSummary, responsibleOfficer] =
+      await Promise.all([
+        this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
+        this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
+        this.communityApiService.getExpandedServiceUserByCRN(crn),
+        this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
+        this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
+        this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
+        this.communityApiService.getResponsibleOfficerForServiceUser(crn),
+      ])
 
     const assignee =
       sentReferral.assignedTo === null
@@ -186,7 +177,6 @@ export default class ProbationPractitionerReferralsController {
       false,
       expandedServiceUser,
       riskSummary,
-      staffDetails,
       responsibleOfficer
     )
     const view = new ShowReferralView(presenter)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -24,12 +24,10 @@ import expandedDeliusServiceUserFactory from '../../../testutils/factories/expan
 import initialAssessmentAppointmentFactory from '../../../testutils/factories/initialAssessmentAppointment'
 import supplierAssessmentFactory from '../../../testutils/factories/supplierAssessment'
 import riskSummaryFactory from '../../../testutils/factories/riskSummary'
-import deliusStaffDetailsFactory from '../../../testutils/factories/deliusStaffDetails'
 import SentReferral from '../../models/sentReferral'
 import DeliusUser from '../../models/delius/deliusUser'
 import { ExpandedDeliusServiceUser } from '../../models/delius/deliusServiceUser'
 import { SupplementaryRiskInformation } from '../../models/assessRisksAndNeeds/supplementaryRiskInformation'
-import { DeliusStaffDetails } from '../../models/delius/deliusStaffDetails'
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
 import { DeliusOffenderManager } from '../../models/delius/deliusOffenderManager'
 import deliusOffenderManagerFactory from '../../../testutils/factories/deliusOffenderManager'
@@ -135,7 +133,6 @@ describe('GET /service-provider/referrals/:id/details', () => {
   let deliusUser: DeliusUser
   let deliusServiceUser: ExpandedDeliusServiceUser
   let supplementaryRiskInformation: SupplementaryRiskInformation
-  let staffDetails: DeliusStaffDetails
   let responsibleOfficer: DeliusOffenderManager
 
   beforeEach(() => {
@@ -143,7 +140,6 @@ describe('GET /service-provider/referrals/:id/details', () => {
     deliusUser = deliusUserFactory.build()
     deliusServiceUser = expandedDeliusServiceUserFactory.build()
     supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-    staffDetails = deliusStaffDetailsFactory.build()
     responsibleOfficer = deliusOffenderManagerFactory.responsibleOfficer().build()
 
     interventionsService.getIntervention.mockResolvedValue(intervention)
@@ -154,7 +150,6 @@ describe('GET /service-provider/referrals/:id/details', () => {
     communityApiService.getConvictionById.mockResolvedValue(conviction)
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
     assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
-    communityApiService.getStaffDetails.mockResolvedValue(staffDetails)
     communityApiService.getResponsibleOfficerForServiceUser.mockResolvedValue(responsibleOfficer)
   })
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -127,25 +127,17 @@ export default class ServiceProviderReferralsController {
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
 
     const { crn } = sentReferral.referral.serviceUser
-    const [
-      intervention,
-      sentBy,
-      expandedServiceUser,
-      conviction,
-      riskInformation,
-      riskSummary,
-      staffDetails,
-      responsibleOfficer,
-    ] = await Promise.all([
-      this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
-      this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
-      this.communityApiService.getExpandedServiceUserByCRN(crn),
-      this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
-      this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
-      this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
-      this.communityApiService.getStaffDetails(sentReferral.sentBy.username),
-      this.communityApiService.getResponsibleOfficerForServiceUser(crn),
-    ])
+    const [intervention, sentBy, expandedServiceUser, conviction, riskInformation, riskSummary, responsibleOfficer] =
+      await Promise.all([
+        this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
+        this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
+        this.communityApiService.getExpandedServiceUserByCRN(crn),
+        this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
+        this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
+        this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
+        this.communityApiService.getResponsibleOfficerForServiceUser(crn),
+      ])
+
     const assignee =
       sentReferral.assignedTo === null
         ? null
@@ -179,7 +171,6 @@ export default class ServiceProviderReferralsController {
       true,
       expandedServiceUser,
       riskSummary,
-      staffDetails,
       responsibleOfficer
     )
     const view = new ShowReferralView(presenter)

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -10,9 +10,6 @@ import deliusConvictionFactory from '../../../testutils/factories/deliusConvicti
 import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
 import riskSummaryFactory from '../../../testutils/factories/riskSummary'
-import deliusStaffDetailsFactory from '../../../testutils/factories/deliusStaffDetails'
-import { DeliusStaffDetails } from '../../models/delius/deliusStaffDetails'
-import deliusTeam from '../../../testutils/factories/deliusTeam'
 import deliusOffenderManagerFactory from '../../../testutils/factories/deliusOffenderManager'
 
 describe(ShowReferralPresenter, () => {
@@ -47,7 +44,6 @@ describe(ShowReferralPresenter, () => {
 
   const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
   const riskSummary = riskSummaryFactory.build()
-  const defaultStaffDetails = deliusStaffDetailsFactory.build()
   const responsibleOfficer = deliusOffenderManagerFactory.build()
 
   describe('assignmentFormAction', () => {
@@ -66,7 +62,6 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        defaultStaffDetails,
         responsibleOfficer
       )
 
@@ -91,7 +86,6 @@ describe(ShowReferralPresenter, () => {
             true,
             deliusServiceUser,
             riskSummary,
-            defaultStaffDetails,
             responsibleOfficer
           )
 
@@ -114,7 +108,6 @@ describe(ShowReferralPresenter, () => {
             true,
             deliusServiceUser,
             riskSummary,
-            defaultStaffDetails,
             responsibleOfficer
           )
 
@@ -139,7 +132,6 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        defaultStaffDetails,
         responsibleOfficer
       )
 
@@ -147,143 +139,6 @@ describe(ShowReferralPresenter, () => {
         { key: 'Name', lines: ['Bernard Beaks'] },
         { key: 'Email address', lines: ['bernard.beaks@justice.gov.uk'] },
       ])
-    })
-  })
-
-  describe('probationPractitionerTeamDetails', () => {
-    function createShowReferralPresenterWithStaffDetails(staffDetails: DeliusStaffDetails) {
-      return new ShowReferralPresenter(
-        sentReferralFactory.build(referralParams),
-        intervention,
-        deliusConviction,
-        supplementaryRiskInformation,
-        deliusUser,
-        null,
-        null,
-        'service-provider',
-        true,
-        deliusServiceUser,
-        riskSummary,
-        staffDetails,
-        responsibleOfficer
-      )
-    }
-
-    describe('when a single active team exists on staff details', () => {
-      it('should display the team details', () => {
-        const presenter = createShowReferralPresenterWithStaffDetails(defaultStaffDetails)
-        expect(presenter.probationPractitionerTeamDetails).toEqual([
-          { key: 'Phone', lines: ['07890 123456'] },
-          { key: 'Email address', lines: ['probation-team4692@justice.gov.uk'] },
-        ])
-      })
-      describe('when start date is empty', () => {
-        it('should display the team details', () => {
-          const staffDetails = deliusStaffDetailsFactory.build({
-            teams: [
-              {
-                telephone: '07890 123456',
-                emailAddress: 'probation-team4692@justice.gov.uk',
-              },
-            ],
-          })
-          const presenter = createShowReferralPresenterWithStaffDetails(staffDetails)
-          expect(presenter.probationPractitionerTeamDetails).toEqual([
-            { key: 'Phone', lines: ['07890 123456'] },
-            { key: 'Email address', lines: ['probation-team4692@justice.gov.uk'] },
-          ])
-        })
-      })
-      describe('when ended date is null', () => {
-        it('should display the team details', () => {
-          const staffDetails = deliusStaffDetailsFactory.build({
-            teams: [deliusTeam.build({ endDate: null })],
-          })
-          const presenter = createShowReferralPresenterWithStaffDetails(staffDetails)
-          expect(presenter.probationPractitionerTeamDetails).toEqual([
-            { key: 'Phone', lines: ['07890 123456'] },
-            { key: 'Email address', lines: ['probation-team4692@justice.gov.uk'] },
-          ])
-        })
-      })
-    })
-    describe('when no teams exist for staff', () => {
-      it('should not show any team details', () => {
-        const presenterWithEmptyListTeams = createShowReferralPresenterWithStaffDetails(
-          deliusStaffDetailsFactory.build({ teams: [] })
-        )
-        expect(presenterWithEmptyListTeams.probationPractitionerTeamDetails).toEqual([
-          { key: 'Phone', lines: [] },
-          { key: 'Email address', lines: [] },
-        ])
-        const presenterWithUndefinedTeams = createShowReferralPresenterWithStaffDetails({ username: 'username' })
-        expect(presenterWithUndefinedTeams.probationPractitionerTeamDetails).toEqual([
-          { key: 'Phone', lines: [] },
-          { key: 'Email address', lines: [] },
-        ])
-      })
-    })
-    describe('when all teams are ended in the past', () => {
-      it('should not show any team details', () => {
-        const staffDetails = deliusStaffDetailsFactory.build({
-          teams: [deliusTeam.build({ endDate: '2021-01-01' })],
-        })
-        const presenter = createShowReferralPresenterWithStaffDetails(staffDetails)
-        expect(presenter.probationPractitionerTeamDetails).toEqual([
-          { key: 'Phone', lines: [] },
-          { key: 'Email address', lines: [] },
-        ])
-      })
-    })
-
-    describe('when a team is ended in the future', () => {
-      it('should show the team details', () => {
-        const staffDetails = deliusStaffDetailsFactory.build({
-          teams: [deliusTeam.build({ endDate: '3021-01-01' })],
-        })
-        const presenter = createShowReferralPresenterWithStaffDetails(staffDetails)
-        expect(presenter.probationPractitionerTeamDetails).toEqual([
-          { key: 'Phone', lines: ['07890 123456'] },
-          { key: 'Email address', lines: ['probation-team4692@justice.gov.uk'] },
-        ])
-      })
-    })
-    describe('when there are multiple active teams', () => {
-      it('should show the latest team details', () => {
-        const newerTeam = deliusTeam.build({
-          telephone: '07890 123456',
-          emailAddress: 'probation-team4692@justice.gov.uk',
-          startDate: '2021-01-02',
-        })
-        const olderTeam = deliusTeam.build({
-          telephone: 'incorrect number',
-          emailAddress: 'incorrect-team@justice.gov.uk',
-          startDate: '2021-01-01',
-        })
-        const teamWithNoStartDate = deliusTeam.build({
-          telephone: 'incorrect number - nsd',
-          emailAddress: 'incorrect-team@justice.gov.uk',
-        })
-        const orderedAsc = createShowReferralPresenterWithStaffDetails(
-          deliusStaffDetailsFactory.build({
-            teams: [teamWithNoStartDate, teamWithNoStartDate, olderTeam, newerTeam],
-          })
-        )
-        const orderedDesc = createShowReferralPresenterWithStaffDetails(
-          deliusStaffDetailsFactory.build({
-            teams: [newerTeam, olderTeam, teamWithNoStartDate, teamWithNoStartDate],
-          })
-        )
-
-        expect(orderedAsc.probationPractitionerTeamDetails).toEqual([
-          { key: 'Phone', lines: ['07890 123456'] },
-          { key: 'Email address', lines: ['probation-team4692@justice.gov.uk'] },
-        ])
-        expect(orderedDesc.probationPractitionerTeamDetails).toEqual([
-          { key: 'Phone', lines: ['07890 123456'] },
-          { key: 'Email address', lines: ['probation-team4692@justice.gov.uk'] },
-        ])
-      })
     })
   })
 
@@ -303,14 +158,16 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails,
-
           deliusOffenderManagerFactory.build({
             staff: {
               forenames: 'Peter',
               surname: 'Practitioner',
               email: 'p.practitioner@example.com',
               phoneNumber: '01234567890',
+            },
+            team: {
+              telephone: '01141234567',
+              emailAddress: 'team@nps.gov.uk',
             },
           })
         )
@@ -319,6 +176,8 @@ describe(ShowReferralPresenter, () => {
           { key: 'Name', lines: ['Peter Practitioner'] },
           { key: 'Phone', lines: ['01234567890'] },
           { key: 'Email address', lines: ['p.practitioner@example.com'] },
+          { key: 'Team phone', lines: ['01141234567'] },
+          { key: 'Team email address', lines: ['team@nps.gov.uk'] },
         ])
       })
     })
@@ -338,7 +197,6 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails,
           {
             isResponsibleOfficer: true,
             staff: {
@@ -357,6 +215,8 @@ describe(ShowReferralPresenter, () => {
             key: 'Email address',
             lines: ['Not found - email notifications for this referral will be sent to the referring officer'],
           },
+          { key: 'Team phone', lines: ['Not found'] },
+          { key: 'Team email address', lines: ['Not found'] },
         ])
       })
     })
@@ -376,7 +236,6 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails,
           null
         )
 
@@ -455,7 +314,6 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails,
           responsibleOfficer
         )
 
@@ -546,7 +404,6 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails,
           responsibleOfficer
         )
 
@@ -603,7 +460,6 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        defaultStaffDetails,
         responsibleOfficer
       )
       expect(
@@ -644,7 +500,6 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        defaultStaffDetails,
         responsibleOfficer
       )
 
@@ -688,7 +543,6 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        defaultStaffDetails,
         responsibleOfficer
       )
 
@@ -756,7 +610,6 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails,
           responsibleOfficer
         )
 
@@ -846,7 +699,6 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          defaultStaffDetails,
           responsibleOfficer
         )
 

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -19,8 +19,6 @@ import { SupplementaryRiskInformation } from '../../models/assessRisksAndNeeds/s
 import { ExpandedDeliusServiceUser } from '../../models/delius/deliusServiceUser'
 import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
 import RiskPresenter from './riskPresenter'
-import { DeliusStaffDetails, DeliusTeam } from '../../models/delius/deliusStaffDetails'
-import CalendarDay from '../../utils/calendarDay'
 import { DeliusOffenderManager } from '../../models/delius/deliusOffenderManager'
 import DateUtils from '../../utils/dateUtils'
 
@@ -41,7 +39,6 @@ export default class ShowReferralPresenter {
     readonly canAssignReferral: boolean,
     private readonly deliusServiceUser: ExpandedDeliusServiceUser,
     private readonly riskSummary: RiskSummary | null,
-    private readonly staffDetails: DeliusStaffDetails | null,
     private readonly responsibleOfficer: DeliusOffenderManager | null
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
@@ -65,23 +62,10 @@ export default class ShowReferralPresenter {
     { key: 'Email address', lines: [this.sentBy.email ?? ''] },
   ]
 
-  get probationPractitionerTeamDetails(): SummaryListItem[] {
-    const { activeTeam } = this
-    return activeTeam == null
-      ? [
-          { key: 'Phone', lines: [] },
-          { key: 'Email address', lines: [] },
-        ]
-      : [
-          { key: 'Phone', lines: [`${activeTeam.telephone}`] },
-          { key: 'Email address', lines: [`${activeTeam.emailAddress}`] },
-        ]
-  }
-
   get responsibleOfficersDetails(): SummaryListItem[] {
     if (this.responsibleOfficer === null) return []
 
-    const { staff } = this.responsibleOfficer
+    const { staff, team } = this.responsibleOfficer
     return [
       {
         key: 'Name',
@@ -97,43 +81,20 @@ export default class ShowReferralPresenter {
         ],
         key: 'Email address',
       },
+      {
+        key: 'Team phone',
+        lines: [team?.telephone || 'Not found'],
+      },
+      {
+        key: 'Team email address',
+        lines: [team?.emailAddress || 'Not found'],
+      },
     ]
   }
 
   get referralServiceCategories(): ServiceCategory[] {
     const { serviceCategoryIds } = this.sentReferral.referral
     return this.intervention.serviceCategories.filter(it => serviceCategoryIds.includes(it.id))
-  }
-
-  private get activeTeam(): DeliusTeam | null {
-    const today = new Date()
-    const firstTeam = this.staffDetails?.teams
-      ?.filter(team => {
-        // teams without an end date are assumed to be active
-        if (!team.endDate) {
-          return true
-        }
-
-        // otherwise filter out teams with an end date in the past
-        const endDate = CalendarDay.parseIso8601Date(team.endDate)?.utcDate
-        return endDate && endDate >= today
-      })
-      .sort((teamA, teamB) => {
-        // the ordering of teams with no start date is entirely arbitrary
-        // we are going to guess that they are older than those with a start date
-        if (!teamA.startDate) {
-          return 1
-        }
-
-        if (!teamB.startDate) {
-          return 0
-        }
-
-        const teamAStartDate = CalendarDay.parseIso8601Date(teamA.startDate)!.utcDate
-        const teamBStartDate = CalendarDay.parseIso8601Date(teamB.startDate)!.utcDate
-        return teamBStartDate.getDate() - teamAStartDate.getDate()
-      })[0]
-    return firstTeam || null
   }
 
   serviceCategorySection(serviceCategory: ServiceCategory, tagMacro: (args: TagArgs) => string): SummaryListItem[] {

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -17,10 +17,6 @@ export default class ShowReferralView {
     this.presenter.probationPractitionerDetails
   )
 
-  private readonly probationPractitionerTeamSummaryListArgs = ViewUtils.summaryListArgs(
-    this.presenter.probationPractitionerTeamDetails
-  )
-
   private readonly responsibleOfficerSummaryListArgs = ViewUtils.summaryListArgs(
     this.presenter.responsibleOfficersDetails
   )
@@ -67,7 +63,6 @@ export default class ShowReferralView {
         presenter: this.presenter,
         subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         probationPractitionerSummaryListArgs: this.probationPractitionerSummaryListArgs,
-        probationPractitionerTeamSummaryListArgs: this.probationPractitionerTeamSummaryListArgs,
         responsibleOfficerSummaryListArgs: this.responsibleOfficerSummaryListArgs,
         interventionDetailsSummaryListArgs: this.interventionDetailsSummaryListArgs,
         serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs,

--- a/server/services/communityApiService.test.ts
+++ b/server/services/communityApiService.test.ts
@@ -8,7 +8,6 @@ import deliusServiceUser from '../../testutils/factories/deliusServiceUser'
 import deliusUserFactory from '../../testutils/factories/deliusUser'
 import deliusConviction from '../../testutils/factories/deliusConviction'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
-import deliusStaffDetails from '../../testutils/factories/deliusStaffDetails'
 import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
 
 jest.mock('../data/restClient')
@@ -113,43 +112,6 @@ describe(CommunityApiService, () => {
       })
 
       expect(result).toMatchObject(conviction)
-    })
-  })
-
-  describe('getStaffDetails', () => {
-    const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
-    const service = new CommunityApiService(hmppsAuthClientMock, restClientMock)
-    const staffDetails = deliusStaffDetails.build()
-    it('makes a request to the Community API and casts the response as Delius Staff Details', async () => {
-      restClientMock.get.mockResolvedValue(staffDetails)
-
-      hmppsAuthClientMock.getApiClientToken.mockResolvedValue('token')
-
-      const result = await service.getStaffDetails('BERNARD.BEAKS')
-      expect(restClientMock.get).toHaveBeenCalledWith({
-        path: `/secure/staff/username/BERNARD.BEAKS`,
-        token: 'token',
-      })
-
-      expect(result).toMatchObject(staffDetails)
-    })
-    describe('when user can not be found', () => {
-      it('makes a request to Community API and returns null', async () => {
-        restClientMock.get.mockRejectedValue(createError(404))
-        const result = await service.getStaffDetails('UNKNOWN_USER')
-        expect(result).toEqual(null)
-      })
-    })
-    describe('when Community API has unexpected behaviour', () => {
-      it('makes a request to Community API and returns a user message', async () => {
-        restClientMock.get.mockRejectedValue(createError(500))
-        try {
-          await service.getStaffDetails('BERNARD.BEAKS')
-        } catch (err) {
-          expect(err.status).toBe(500)
-          expect(err.userMessage).toBe('Could retrieve staff details from nDelius.')
-        }
-      })
     })
   })
 

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -5,7 +5,6 @@ import logger from '../../log'
 import DeliusUser from '../models/delius/deliusUser'
 import DeliusServiceUser, { ExpandedDeliusServiceUser } from '../models/delius/deliusServiceUser'
 import DeliusConviction from '../models/delius/deliusConviction'
-import { DeliusStaffDetails } from '../models/delius/deliusStaffDetails'
 import { DeliusOffenderManager } from '../models/delius/deliusOffenderManager'
 
 export default class CommunityApiService {
@@ -59,25 +58,6 @@ export default class CommunityApiService {
       path: `/secure/offenders/crn/${crn}/convictions/${id}`,
       token,
     })) as DeliusConviction
-  }
-
-  async getStaffDetails(username: string): Promise<DeliusStaffDetails | null> {
-    const token = await this.hmppsAuthService.getApiClientToken()
-
-    logger.info({ username }, 'getting staff details for officer')
-    try {
-      return (await this.restClient.get({
-        path: `/secure/staff/username/${username}`,
-        token,
-      })) as DeliusStaffDetails
-    } catch (err) {
-      if (err.status === 404) {
-        // not all users will have staff details on delius
-        return null
-      }
-
-      throw createError(err.status, err, { userMessage: 'Could retrieve staff details from nDelius.' })
-    }
   }
 
   async getResponsibleOfficerForServiceUser(crn: string): Promise<DeliusOffenderManager | null> {

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -59,7 +59,5 @@
 
       <h2 class="govuk-heading-m">Referring probation practitioner details</h2>
       {{ govukSummaryList(probationPractitionerSummaryListArgs) }}
-      <h2 class="govuk-heading-m">Team contact details</h2>
-      {{ govukSummaryList(probationPractitionerTeamSummaryListArgs) }}
 
 {% endblock %}

--- a/testutils/factories/deliusOffenderManager.ts
+++ b/testutils/factories/deliusOffenderManager.ts
@@ -19,4 +19,9 @@ export default DeliusOffenderManagerFactory.define(() => ({
     phoneNumber: '0123411278',
     surname: 'Hancock',
   },
+  team: {
+    telephone: '07890 123456',
+    emailAddress: 'probation-team4692@justice.gov.uk',
+    startDate: '2021-01-01',
+  },
 }))


### PR DESCRIPTION
## What does this pull request do?

    1) display team details for the responsible officer, not referring officer.
    2) group the team details for the responsible officer with the other contact details.
    3) internally, get the team details directly from the offender manager response,
       saving us a bunch of hassle parsing the team list in the staff details response.
       
 before:
 
<img width="873" alt="Screenshot 2021-08-26 at 15 50 51" src="https://user-images.githubusercontent.com/63233073/131147547-b239d5bc-4612-45bb-9a58-479e5a969bb2.png">

after:

<img width="861" alt="Screenshot 2021-08-27 at 11 47 14" src="https://user-images.githubusercontent.com/63233073/131147578-845ab87d-70b0-4deb-83ee-355e235118a7.png">

## What is the intent behind these changes?

ensure team details are for the correct PP. reduce complexity. make the page more resilient to CAPI errors.
