### PR TITLE
IC-2022: Remove backwards compatibility routes for draft journeys

### DIFF
--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -357,27 +357,6 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/start', () => {
   })
 })
 
-describe('GET /probation-practitioner/referrals/:id/cancellation/reason', () => {
-  it('creates a draft cancellation using the drafts service and redirects to the reason page', async () => {
-    const draftCancellation = draftCancellationFactory.build()
-    draftsService.createDraft.mockResolvedValue(draftCancellation)
-
-    await request(app)
-      .get(`/probation-practitioner/referrals/123/cancellation/reason`)
-      .expect(302)
-      .expect('Location', `/probation-practitioner/referrals/123/cancellation/${draftCancellation.id}/reason`)
-
-    expect(draftsService.createDraft).toHaveBeenCalledWith(
-      'cancellation',
-      {
-        cancellationReason: null,
-        cancellationComments: null,
-      },
-      { userId: '123' }
-    )
-  })
-})
-
 describe('GET /probation-practitioner/referrals/:id/cancellation/:draftCancellationId/reason', () => {
   it('renders a page where the PP can add comments and cancel a referral', async () => {
     const draftCancellation = draftCancellationFactory.build()
@@ -418,60 +397,6 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/:draftCancellat
           expect(res.text).toContain(
             'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.'
           )
-        })
-    })
-  })
-})
-
-describe('POST /probation-practitioner/referrals/:id/cancellation/check-your-answers', () => {
-  it('creates a draft cancellation using the drafts service with the submitted data, and redirects to the check your answers page', async () => {
-    const draftCancellation = draftCancellationFactory.build()
-    draftsService.createDraft.mockResolvedValue(draftCancellation)
-
-    await request(app)
-      .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/check-your-answers`)
-      .type('form')
-      .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
-      .expect(302)
-      .expect(
-        'Location',
-        `/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/${draftCancellation.id}/check-your-answers`
-      )
-
-    expect(draftsService.createDraft).toHaveBeenCalledWith(
-      'cancellation',
-      {
-        cancellationReason: 'MOV',
-        cancellationComments: 'Alex has moved out of the area',
-      },
-      { userId: '123' }
-    )
-  })
-
-  describe('with invalid data', () => {
-    it('renders an error message', async () => {
-      const draftCancellation = draftCancellationFactory.build()
-      draftsService.createDraft.mockResolvedValue(draftCancellation)
-
-      const referral = sentReferralFactory.assigned().build()
-      const intervention = interventionFactory.build()
-      const serviceUser = deliusServiceUserFactory.build()
-
-      interventionsService.getSentReferral.mockResolvedValue(referral)
-      communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
-      interventionsService.getIntervention.mockResolvedValue(intervention)
-      interventionsService.getReferralCancellationReasons.mockResolvedValue([
-        { code: 'MIS', description: 'Referral was made by mistake' },
-        { code: 'MOV', description: 'Service user has moved out of delivery area' },
-      ])
-
-      await request(app)
-        .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/check-your-answers`)
-        .type('form')
-        .send({ 'cancellation-comments': 'Alex has moved out of the area' })
-        .expect(400)
-        .expect(res => {
-          expect(res.text).toContain('Select a reason for cancelling the referral')
         })
     })
   })
@@ -615,27 +540,6 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/:draftCancellat
           expect(res.text).toContain('This page is no longer available')
         })
     })
-  })
-})
-
-describe('POST /probation-practitioner/referrals/:id/cancellation/submit', () => {
-  it('submits a request to cancel the referral on the backend and redirects to the confirmation screen', async () => {
-    await request(app)
-      .post(`/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/submit`)
-      .type('form')
-      .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
-      .expect(302)
-      .expect(
-        'Location',
-        `/probation-practitioner/referrals/9747b7fb-51bc-40e2-bbbd-791a9be9284b/cancellation/confirmation`
-      )
-
-    expect(interventionsService.endReferral).toHaveBeenCalledWith(
-      'token',
-      '9747b7fb-51bc-40e2-bbbd-791a9be9284b',
-      'MOV',
-      'Alex has moved out of the area'
-    )
   })
 })
 

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -28,29 +28,17 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     probationPractitionerReferralsController.viewEndOfServiceReport(req, res)
   )
 
-  get(router, '/referrals/:id/cancellation/reason', (req, res) =>
-    // This keeps the cancel link on any pre-drafts version of the intervention progress page working
-    probationPractitionerReferralsController.startCancellation(req, res)
-  )
   get(router, '/referrals/:id/cancellation/start', (req, res) =>
     probationPractitionerReferralsController.startCancellation(req, res)
   )
   get(router, '/referrals/:id/cancellation/:draftCancellationId/reason', (req, res) =>
     probationPractitionerReferralsController.editCancellationReason(req, res)
   )
-  post(router, '/referrals/:id/cancellation/check-your-answers', (req, res) =>
-    // This keeps a submission of any pre-drafts version of the cancellation reason form working
-    probationPractitionerReferralsController.backwardsCompatibilityUpdateCancellationReason(req, res)
-  )
   post(router, '/referrals/:id/cancellation/:draftCancellationId/reason', (req, res) =>
     probationPractitionerReferralsController.editCancellationReason(req, res)
   )
   get(router, '/referrals/:id/cancellation/:draftCancellationId/check-your-answers', (req, res) =>
     probationPractitionerReferralsController.cancellationCheckAnswers(req, res)
-  )
-  post(router, '/referrals/:id/cancellation/submit', (req, res) =>
-    // This keeps a submission of any pre-drafts version of the cancellation check your answers page working
-    probationPractitionerReferralsController.backwardsCompatibilitySubmitCancellation(req, res)
   )
   post(router, '/referrals/:id/cancellation/:draftCancellationId/submit', (req, res) =>
     probationPractitionerReferralsController.submitCancellation(req, res)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1801,20 +1801,6 @@ describe('GET /service-provider/referrals/:id/supplier-assessment/schedule/start
   })
 })
 
-describe('GET /service-provider/referrals/:id/supplier-assessment/schedule', () => {
-  it('creates a draft booking using the drafts service, and redirects to the scheduling details form', async () => {
-    const draftBooking = draftAppointmentBookingFactory.build()
-    draftsService.createDraft.mockResolvedValue(draftBooking)
-
-    await request(app)
-      .get(`/service-provider/referrals/1/supplier-assessment/schedule`)
-      .expect(302)
-      .expect('Location', `/service-provider/referrals/1/supplier-assessment/schedule/${draftBooking.id}/details`)
-
-    expect(draftsService.createDraft).toHaveBeenCalledWith('supplierAssessmentBooking', null, { userId: '123' })
-  })
-})
-
 describe('GET /service-provider/referrals/:id/supplier-assessment/schedule/:draftBookingId/details', () => {
   describe('when this is the first time to schedule an initial assessment', () => {
     it('renders an empty form', async () => {
@@ -1916,89 +1902,6 @@ describe('GET /service-provider/referrals/:id/supplier-assessment/schedule/:draf
         .expect(200)
         .expect(res => {
           expect(res.text).toContain('The proposed date and time you selected clashes with another appointment.')
-        })
-    })
-  })
-})
-
-describe('POST /service-provider/referrals/:id/supplier-assessment/schedule', () => {
-  describe('with valid data', () => {
-    it('creates and updates a draft booking, and redirects to the check-answers page', async () => {
-      const draftBooking = draftAppointmentBookingFactory.build()
-      draftsService.createDraft.mockResolvedValue(draftBooking)
-
-      const referral = sentReferralFactory.build()
-      const supplierAssessment = supplierAssessmentFactory.justCreated.build()
-
-      interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessment)
-      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
-
-      await request(app)
-        .post(`/service-provider/referrals/${referral.id}/supplier-assessment/schedule`)
-        .type('form')
-        .send({
-          'date-day': '24',
-          'date-month': '3',
-          'date-year': '2021',
-          'time-hour': '9',
-          'time-minute': '02',
-          'time-part-of-day': 'am',
-          'duration-hours': '1',
-          'duration-minutes': '15',
-          'session-type': 'ONE_TO_ONE',
-          'meeting-method': 'PHONE_CALL',
-        })
-        .expect(302)
-        .expect(
-          'Location',
-          `/service-provider/referrals/${referral.id}/supplier-assessment/schedule/${draftBooking.id}/check-answers`
-        )
-
-      expect(draftsService.createDraft).toHaveBeenCalledWith('supplierAssessmentBooking', null, { userId: '123' })
-
-      expect(draftsService.updateDraft).toHaveBeenCalledWith(
-        draftBooking.id,
-        {
-          appointmentTime: '2021-03-24T09:02:00.000Z',
-          durationInMinutes: 75,
-          sessionType: 'ONE_TO_ONE',
-          appointmentDeliveryType: 'PHONE_CALL',
-          appointmentDeliveryAddress: null,
-          npsOfficeCode: null,
-        },
-        { userId: '123' }
-      )
-    })
-  })
-
-  describe('with invalid data', () => {
-    it('renders an error message', async () => {
-      const draftBooking = draftAppointmentBookingFactory.build()
-      draftsService.createDraft.mockResolvedValue(draftBooking)
-
-      interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessmentFactory.build())
-      interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
-      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
-
-      await request(app)
-        .post(`/service-provider/referrals/1/supplier-assessment/schedule`)
-        .type('form')
-        .send({
-          'date-day': '32',
-          'date-month': '3',
-          'date-year': '2021',
-          'time-hour': '9',
-          'time-minute': '02',
-          'time-part-of-day': 'am',
-          'duration-hours': '1',
-          'duration-minutes': '15',
-          'session-type': 'ONE_TO_ONE',
-          'meeting-method': 'PHONE_CALL',
-        })
-        .expect(400)
-        .expect(res => {
-          expect(res.text).toContain('The session date must be a real date')
         })
     })
   })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -617,28 +617,13 @@ export default class ServiceProviderReferralsController {
     res.redirect(`/service-provider/referrals/${req.params.id}/supplier-assessment/schedule/${draftBooking.id}/details`)
   }
 
-  async backwardsCompatibilityScheduleSupplierAssessmentAppointment(req: Request, res: Response): Promise<void> {
-    const draft = await this.draftsService.createDraft<DraftAppointmentBooking>('supplierAssessmentBooking', null, {
-      userId: res.locals.user.userId,
-    })
-
-    await this.scheduleSupplierAssessmentAppointmentWithDraft(draft, req, res)
-  }
-
   async scheduleSupplierAssessmentAppointment(req: Request, res: Response): Promise<void> {
     const fetchResult = await this.fetchDraftBookingOrRenderMessage(req, res)
     if (fetchResult.rendered) {
       return
     }
+    const { draft } = fetchResult
 
-    await this.scheduleSupplierAssessmentAppointmentWithDraft(fetchResult.draft, req, res)
-  }
-
-  async scheduleSupplierAssessmentAppointmentWithDraft(
-    draft: Draft<DraftAppointmentBooking>,
-    req: Request,
-    res: Response
-  ): Promise<void> {
     const referralId = req.params.id
     const { accessToken } = res.locals.user.token
     const referral = await this.interventionsService.getSentReferral(accessToken, referralId)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -220,15 +220,9 @@ export default class ServiceProviderReferralsController {
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async backwardsCompatibilityStartAssignment(req: Request, res: Response): Promise<void> {
-    await this.startAssignmentWithEmail(req.query.email as string | undefined, req, res)
-  }
-
   async startAssignment(req: Request, res: Response): Promise<void> {
-    await this.startAssignmentWithEmail(req.body.email, req, res)
-  }
+    const { email } = req.body
 
-  async startAssignmentWithEmail(email: string | undefined, req: Request, res: Response): Promise<void> {
     if (email === undefined || email === '') {
       return res.redirect(
         `/service-provider/referrals/${req.params.id}/details?${querystring.stringify({
@@ -292,16 +286,6 @@ export default class ServiceProviderReferralsController {
     const view = new CheckAssignmentView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)
-  }
-
-  async backwardsCompatibilitySubmitAssignment(req: Request, res: Response): Promise<void> {
-    const { email } = req.body
-    if (email === undefined || email === null || email === '') {
-      res.sendStatus(400)
-      return
-    }
-
-    await this.submitAssignmentWithEmail(email, req, res)
   }
 
   async submitAssignment(req: Request, res: Response): Promise<void> {

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -111,11 +111,6 @@ export default function serviceProviderRoutes(router: Router, services: Services
   get(router, '/end-of-service-report/:id/confirmation', (req, res) =>
     serviceProviderReferralsController.showEndOfServiceReportConfirmation(req, res)
   )
-  get(router, '/referrals/:id/supplier-assessment/schedule', (req, res) =>
-    // This keeps the Schedule / Change buttons working on any pre-drafts versions
-    // of the intervention details / view supplier assessment pages
-    serviceProviderReferralsController.startSupplierAssessmentAppointmentScheduling(req, res)
-  )
   get(router, '/referrals/:id/supplier-assessment/schedule/start', (req, res) =>
     serviceProviderReferralsController.startSupplierAssessmentAppointmentScheduling(req, res)
   )
@@ -124,10 +119,6 @@ export default function serviceProviderRoutes(router: Router, services: Services
   )
   post(router, '/referrals/:id/supplier-assessment/schedule/:draftBookingId/details', (req, res) =>
     serviceProviderReferralsController.scheduleSupplierAssessmentAppointment(req, res)
-  )
-  post(router, '/referrals/:id/supplier-assessment/schedule', (req, res) =>
-    // This keeps the submit button working on any pre-drafts version of the booking form
-    serviceProviderReferralsController.backwardsCompatibilityScheduleSupplierAssessmentAppointment(req, res)
   )
   get(router, '/referrals/:id/supplier-assessment/schedule/:draftBookingId/check-answers', (req, res) =>
     serviceProviderReferralsController.checkSupplierAssessmentAnswers(req, res)

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -20,19 +20,11 @@ export default function serviceProviderRoutes(router: Router, services: Services
   get(router, '/referrals/:id/progress', (req, res) =>
     serviceProviderReferralsController.showInterventionProgress(req, res)
   )
-  get(router, '/referrals/:id/assignment/check', (req, res) =>
-    // This keeps the assign button on any pre-drafts version of the referral details page working
-    serviceProviderReferralsController.backwardsCompatibilityStartAssignment(req, res)
-  )
   post(router, '/referrals/:id/assignment/start', (req, res) =>
     serviceProviderReferralsController.startAssignment(req, res)
   )
   get(router, '/referrals/:id/assignment/:draftAssignmentId/check', (req, res) =>
     serviceProviderReferralsController.checkAssignment(req, res)
-  )
-  post(router, '/referrals/:id/assignment', (req, res) =>
-    // This keeps a submission of the any pre-drafts version of the assignment check your answers page working
-    serviceProviderReferralsController.backwardsCompatibilitySubmitAssignment(req, res)
   )
   post(router, '/referrals/:id/assignment/:draftAssignmentId/submit', (req, res) =>
     serviceProviderReferralsController.submitAssignment(req, res)


### PR DESCRIPTION
## What does this pull request do?

Removes some routes that are no longer needed. These are routes that we preserved for backwards compatibility with the pre-drafts cancellation / assignment / supplier assessment scheduling journeys, but which we don't need any more now that sufficient time has passed since deploying the new routes.

## What is the intent behind these changes?

To remove now-dead code.
