### PR TITLE
Mute log output when running Jest tests

### DIFF
--- a/log.ts
+++ b/log.ts
@@ -2,7 +2,16 @@ import Logger from 'bunyan'
 import type { ResponseError } from 'superagent'
 import config from './server/config'
 
-const level = config.production || config.testMode ? 'warn' : 'debug'
+const level = (() => {
+  if (config.production) {
+    return 'warn'
+  }
+  if (config.testMode) {
+    return 'fatal'
+  }
+
+  return 'debug'
+})()
 
 function responseErrorSerializer(err: ResponseError) {
   const baseErr = Logger.stdSerializers.err(err)


### PR DESCRIPTION
## What does this pull request do?

Disables log output when running Jest tests.

The test output (e.g. when we’re testing error cases in controllers) has
a tendency to swamp all of the Jest output, making it hard to find the
part of the output that actually describes the failing test assertion.

## What is the intent behind these changes?

To be able to more easily locate information relating to the tests that are being run.
