### PR TITLE
Framework for pagination.

### DIFF
--- a/server/models/pagination.ts
+++ b/server/models/pagination.ts
@@ -1,0 +1,8 @@
+export interface Page<T> {
+  content: T[]
+  totalElements: number
+  totalPages: number
+  numberOfElements: number
+  number: number
+  size: number
+}

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -64,6 +64,16 @@ export interface CreateReportDateParams {
   toIncludingDate: CalendarDay
 }
 
+// Pagination parameters for resources that use spring pageable
+export interface PaginationParams {
+  // Page number to retrieve -- starts from 1
+  page?: number
+  // Number of elements in a page
+  size?: number
+  // Sort by property, defaults to ascending order. If descending is required then add ',DESC' at the end of the property you want sorted i.e. ['$PROPERTY_NAME,DESC']
+  sort?: string[]
+}
+
 export default class InterventionsService {
   constructor(private readonly config: ApiConfig) {}
 

--- a/server/utils/pagination/pagination.test.ts
+++ b/server/utils/pagination/pagination.test.ts
@@ -1,0 +1,170 @@
+import Pagination from './pagination'
+import pageFactory from '../../../testutils/factories/page'
+
+describe(Pagination, () => {
+  describe('when constructing pagination arguments', () => {
+    describe('the arguments for next and previous', () => {
+      describe('when there is more than one page', () => {
+        describe('when it is the first page', () => {
+          it('should only show next', () => {
+            const page = pageFactory.pageContent([]).build({
+              totalElements: 20,
+              totalPages: 2,
+              numberOfElements: 10,
+              number: 0, // page=1
+              size: 10,
+            })
+            const { previous } = new Pagination(page).mojPaginationArgs
+            const { next } = new Pagination(page).mojPaginationArgs
+            expect(previous).toBeUndefined()
+            expect(next).toEqual({ text: 'Next', href: '?page=2' })
+          })
+        })
+        describe('when it is the last page', () => {
+          it('should only show previous', () => {
+            const page = pageFactory.pageContent([]).build({
+              totalElements: 20,
+              totalPages: 2,
+              numberOfElements: 10,
+              number: 1, // page=2
+              size: 10,
+            })
+            const { previous } = new Pagination(page).mojPaginationArgs
+            const { next } = new Pagination(page).mojPaginationArgs
+            expect(previous).toEqual({ text: 'Previous', href: '?page=1' })
+            expect(next).toBeUndefined()
+          })
+        })
+        describe('when it is one of the middle pages', () => {
+          it('should show both next and previous', () => {
+            const page = pageFactory.pageContent([]).build({
+              totalElements: 20,
+              totalPages: 3,
+              numberOfElements: 10,
+              number: 1, // page=2
+              size: 10,
+            })
+            const { previous } = new Pagination(page).mojPaginationArgs
+            const { next } = new Pagination(page).mojPaginationArgs
+            expect(previous).toEqual({ text: 'Previous', href: '?page=1' })
+            expect(next).toEqual({ text: 'Next', href: '?page=3' })
+          })
+        })
+      })
+    })
+    describe('the arguments for pagination items', () => {
+      describe('when there is only one page', () => {
+        it('should be empty', () => {
+          const page = pageFactory.pageContent([]).build({
+            totalElements: 10,
+            totalPages: 1,
+            numberOfElements: 10,
+            number: 0, // page=1
+            size: 10,
+          })
+          const { items } = new Pagination(page).mojPaginationArgs
+          expect(items).toEqual([])
+        })
+      })
+      describe('for pagination with less than 6 pages', () => {
+        it('should contain all pages', () => {
+          const page = pageFactory.pageContent([]).build({
+            totalElements: 50,
+            totalPages: 5,
+            numberOfElements: 10,
+            number: 4, // page=5
+            size: 10,
+          })
+          const { items } = new Pagination(page).mojPaginationArgs
+          expect(items).toEqual([
+            { type: 'pageNumber', selected: false, text: 1, href: '?page=1' },
+            { type: 'pageNumber', selected: false, text: 2, href: '?page=2' },
+            { type: 'pageNumber', selected: false, text: 3, href: '?page=3' },
+            { type: 'pageNumber', selected: false, text: 4, href: '?page=4' },
+            { type: 'pageNumber', selected: true, text: 5, href: '?page=5' },
+          ])
+        })
+      })
+      describe('for pagination greater than 5 pages', () => {
+        describe('and the chosen page is within the first 3 pages', () => {
+          it('should contain first 4 pages and last page', () => {
+            const page = pageFactory.pageContent([]).build({
+              totalElements: 50,
+              totalPages: 6,
+              numberOfElements: 10,
+              number: 2, // page=3
+              size: 10,
+            })
+            const { items } = new Pagination(page).mojPaginationArgs
+            expect(items).toEqual([
+              { type: 'pageNumber', selected: false, text: 1, href: '?page=1' },
+              { type: 'pageNumber', selected: false, text: 2, href: '?page=2' },
+              { type: 'pageNumber', selected: true, text: 3, href: '?page=3' },
+              { type: 'pageNumber', selected: false, text: 4, href: '?page=4' },
+              { type: 'dots' },
+              { type: 'pageNumber', selected: false, text: 6, href: '?page=6' },
+            ])
+          })
+        })
+        describe('and the chosen page is within the last 3 pages', () => {
+          it('should contain last 4 pages and first page', () => {
+            const page = pageFactory.pageContent([]).build({
+              totalElements: 50,
+              totalPages: 6,
+              numberOfElements: 10,
+              number: 3, // page=4
+              size: 10,
+            })
+            const { items } = new Pagination(page).mojPaginationArgs
+            expect(items).toEqual([
+              { type: 'pageNumber', selected: false, text: 1, href: '?page=1' },
+              { type: 'dots' },
+              { type: 'pageNumber', selected: false, text: 3, href: '?page=3' },
+              { type: 'pageNumber', selected: true, text: 4, href: '?page=4' },
+              { type: 'pageNumber', selected: false, text: 5, href: '?page=5' },
+              { type: 'pageNumber', selected: false, text: 6, href: '?page=6' },
+            ])
+          })
+        })
+        describe('and the chosen page is somewhere within the middle', () => {
+          it('should show first and last page, current page and next and previous page', () => {
+            const page = pageFactory.pageContent([]).build({
+              totalElements: 50,
+              totalPages: 7,
+              numberOfElements: 10,
+              number: 3, // page=4
+              size: 10,
+            })
+            const { items } = new Pagination(page).mojPaginationArgs
+            expect(items).toEqual([
+              { type: 'pageNumber', selected: false, text: 1, href: '?page=1' },
+              { type: 'dots' },
+              { type: 'pageNumber', selected: false, text: 3, href: '?page=3' },
+              { type: 'pageNumber', selected: true, text: 4, href: '?page=4' },
+              { type: 'pageNumber', selected: false, text: 5, href: '?page=5' },
+              { type: 'dots' },
+              { type: 'pageNumber', selected: false, text: 7, href: '?page=7' },
+            ])
+          })
+        })
+      })
+    })
+    describe('the arguments for page summary results', () => {
+      it('should show the correct range or values', () => {
+        const page = pageFactory.pageContent([]).build({
+          totalElements: 50,
+          totalPages: 5,
+          numberOfElements: 10,
+          number: 2, // page=3
+          size: 10,
+        })
+        const { results } = new Pagination(page).mojPaginationArgs
+        expect(results).toEqual({
+          from: 21,
+          to: 30,
+          count: 50,
+        })
+      })
+    })
+  })
+})

--- a/server/utils/pagination/pagination.ts
+++ b/server/utils/pagination/pagination.ts
@@ -1,0 +1,94 @@
+import { Page } from '../../models/pagination'
+
+interface MojPaginationArgs {
+  classes?: string
+  items: (
+    | {
+        type: 'dots'
+      }
+    | {
+        type: 'pageNumber'
+        selected: boolean
+        text: number
+        href: string
+      }
+  )[]
+  previous?: {
+    text: string
+    href: string
+  }
+  next?: {
+    text: string
+    href: string
+  }
+  results?: {
+    from: number
+    to: number
+    count: number
+  }
+}
+
+export default class Pagination {
+  constructor(private readonly page: Page<unknown>) {}
+
+  private constructPageItems(pageNumberRange: number[], chosenPageNumber: number): MojPaginationArgs['items'] {
+    return pageNumberRange.map(pageNumber => {
+      return {
+        type: 'pageNumber',
+        selected: chosenPageNumber === pageNumber,
+        text: pageNumber,
+        href: `?page=${pageNumber}`,
+      }
+    })
+  }
+
+  get mojPaginationArgs(): MojPaginationArgs {
+    const { totalPages } = this.page
+    if (totalPages <= 1) {
+      return {
+        items: [],
+      }
+    }
+    const count = this.page.totalElements
+    // page.number is zero indexed
+    const zeroIndexPageNumber = this.page.number
+    const chosenPageNumber = zeroIndexPageNumber + 1
+    const pageSize = this.page.size
+    const from = zeroIndexPageNumber * pageSize + 1
+    let to = from + pageSize - 1
+    if (to > count) {
+      to = count
+    }
+    const items: MojPaginationArgs['items'] = []
+    if (totalPages <= 5) {
+      items.push(
+        ...this.constructPageItems(
+          Array.from(new Array(totalPages).keys()).map(i => i + 1),
+          chosenPageNumber
+        )
+      )
+    } else if (chosenPageNumber < 4) {
+      items.push(...this.constructPageItems([1, 2, 3, 4], chosenPageNumber))
+      items.push({ type: 'dots' })
+      items.push(...this.constructPageItems([totalPages], chosenPageNumber))
+    } else if (chosenPageNumber > totalPages - 3) {
+      const lastPages = [totalPages - 3, totalPages - 2, totalPages - 1, totalPages]
+      items.push(...this.constructPageItems([1], chosenPageNumber))
+      items.push({ type: 'dots' })
+      items.push(...this.constructPageItems(lastPages, chosenPageNumber))
+    } else {
+      const middlePages = [chosenPageNumber - 1, chosenPageNumber, chosenPageNumber + 1]
+      items.push(...this.constructPageItems([1], chosenPageNumber))
+      items.push({ type: 'dots' })
+      items.push(...this.constructPageItems(middlePages, chosenPageNumber))
+      items.push({ type: 'dots' })
+      items.push(...this.constructPageItems([totalPages], chosenPageNumber))
+    }
+    return {
+      items,
+      previous: chosenPageNumber === 1 ? undefined : { text: 'Previous', href: `?page=${chosenPageNumber - 1}` },
+      next: chosenPageNumber === totalPages ? undefined : { text: 'Next', href: `?page=${chosenPageNumber + 1}` },
+      results: { from, to, count },
+    }
+  }
+}

--- a/server/views/partials/pagination.njk
+++ b/server/views/partials/pagination.njk
@@ -1,0 +1,2 @@
+{%- from "moj/components/pagination/macro.njk" import mojPagination -%}
+{{ mojPagination(pagination) }}

--- a/testutils/factories/page.ts
+++ b/testutils/factories/page.ts
@@ -1,0 +1,26 @@
+import { Factory } from 'fishery'
+import { Page } from '../../server/models/pagination'
+
+class PageFactory<T> extends Factory<Page<T>> {
+  pageContent(content: T[]) {
+    return this.params({
+      content,
+      totalElements: 100,
+      totalPages: 10,
+      numberOfElements: content.length,
+      number: 0,
+      size: 10,
+    })
+  }
+}
+
+export default PageFactory.define(() => {
+  return {
+    content: [],
+    totalElements: 100,
+    totalPages: 10,
+    numberOfElements: 10,
+    number: 0,
+    size: 10,
+  }
+})


### PR DESCRIPTION
## What does this pull request do?

Uses the MOJ pagination component; it is quite a simple component just to display page numbers and previous/next buttons. It doesn't involve itself in the actual content for each page.
It doesn't calculate which page numbers to show, this is instead done by the new class /server/utils/pagination.ts.

No pagination is shown if all elements exist on one page.

The next button is hidden for the 1st page.

![image](https://user-images.githubusercontent.com/83066216/131997041-d819e9e5-c926-427c-a440-6da41ed2302c.png)

The previous button is hidden for the last page.

![image](https://user-images.githubusercontent.com/83066216/131997066-ca7a828f-f259-4766-8f77-5df72b9e2661.png)

The maximum number of pages to show is 5
![image](https://user-images.githubusercontent.com/83066216/131997140-fde096ea-b71b-499c-b7a3-6b042976c557.png)

If it is the first 3 pages then `...` is shown before the last element.
![image](https://user-images.githubusercontent.com/83066216/131997165-4bd40d64-1c0c-4118-b5f8-84aeb9503264.png)


If it is the last 3 pages then `...` is shown after the first element.

![image](https://user-images.githubusercontent.com/83066216/131997948-8dad4dd5-436b-4797-9d3b-151f5fd48066.png)


If it is somewhere in the middle then `...` is shown after the first element and before the last element.

![image](https://user-images.githubusercontent.com/83066216/131997965-23eb9acd-7fd2-490c-9fc1-6adc6d9a8d8a.png)

The Page interface mirrors the Pageable interface within Spring.

## What is the intent behind these changes?

Provides a framework for pagination
