### PR TITLE
View all case notes

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -238,5 +238,9 @@ module.exports = on => {
     stubGenerateServiceProviderPerformanceReport: () => {
       return interventionsService.stubGenerateServiceProviderPerformanceReport()
     },
+
+    stubGetCaseNotes: arg => {
+      return interventionsService.stubGetCaseNotes(arg.referralId, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -165,3 +165,7 @@ Cypress.Commands.add('stubSubmitSupplierAssessmentAppointmentFeedback', (referra
 Cypress.Commands.add('stubGenerateServiceProviderPerformanceReport', () => {
   cy.task('stubGenerateServiceProviderPerformanceReport', {})
 })
+
+Cypress.Commands.add('stubGetCaseNotes', (referralId, responseJson) => {
+  cy.task('stubGetCaseNotes', { referralId, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -690,4 +690,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubGetCaseNotes = async (referralId: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/sent-referral/${referralId}/case-notes`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/models/caseNote.ts
+++ b/server/models/caseNote.ts
@@ -1,0 +1,10 @@
+import User from './hmppsAuth/user'
+
+export interface CaseNote {
+  id: string
+  referralId: string
+  subject: string
+  body: string
+  sentBy: User
+  sentAt: string
+}

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -1,0 +1,52 @@
+import { Express } from 'express'
+import request from 'supertest'
+import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
+import InterventionsService from '../../services/interventionsService'
+import apiConfig from '../../config'
+import caseNoteFactory from '../../../testutils/factories/caseNote'
+import pageFactory from '../../../testutils/factories/page'
+import { CaseNote } from '../../models/caseNote'
+import { Page } from '../../models/pagination'
+import sentReferralFactory from '../../../testutils/factories/sentReferral'
+
+jest.mock('../../services/interventionsService')
+
+const interventionsService = new InterventionsService(
+  apiConfig.apis.interventionsService
+) as jest.Mocked<InterventionsService>
+
+let app: Express
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe.each([
+  { userType: 'service-provider', source: AppSetupUserType.serviceProvider },
+  { userType: 'probation-practitioner', source: AppSetupUserType.serviceProvider },
+])('as a %s user', user => {
+  beforeEach(() => {
+    app = appWithAllRoutes({
+      overrides: {
+        interventionsService,
+      },
+      userType: user.source,
+    })
+  })
+
+  describe(`GET /${user.userType}/referrals/:id/case-notes`, () => {
+    it('displays all case notes', async () => {
+      const sentReferral = sentReferralFactory.build()
+      const caseNote = caseNoteFactory.build({ subject: 'case note 1 subject', body: 'case note 1 body text' })
+      const caseNotePage: Page<CaseNote> = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+      interventionsService.getCaseNotes.mockResolvedValue(caseNotePage)
+      await request(app)
+        .get(`/${user.userType}/referrals/${sentReferral.id}/case-notes`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('case note 1 subject')
+          expect(res.text).toContain('case note 1 body text')
+        })
+    })
+  })
+})

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -8,12 +8,18 @@ import pageFactory from '../../../testutils/factories/page'
 import { CaseNote } from '../../models/caseNote'
 import { Page } from '../../models/pagination'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
+import MockedHmppsAuthService from '../../services/testutils/hmppsAuthServiceSetup'
+import HmppsAuthService from '../../services/hmppsAuthService'
+import userDetailsFactory from '../../../testutils/factories/userDetails'
 
 jest.mock('../../services/interventionsService')
+jest.mock('../../services/communityApiService')
+jest.mock('../../services/hmppsAuthService')
 
 const interventionsService = new InterventionsService(
   apiConfig.apis.interventionsService
 ) as jest.Mocked<InterventionsService>
+const hmppsAuthService = new MockedHmppsAuthService() as jest.Mocked<HmppsAuthService>
 
 let app: Express
 
@@ -29,17 +35,19 @@ describe.each([
     app = appWithAllRoutes({
       overrides: {
         interventionsService,
+        hmppsAuthService,
       },
       userType: user.source,
     })
   })
+  const sentReferral = sentReferralFactory.build()
 
   describe(`GET /${user.userType}/referrals/:id/case-notes`, () => {
     it('displays all case notes', async () => {
-      const sentReferral = sentReferralFactory.build()
       const caseNote = caseNoteFactory.build({ subject: 'case note 1 subject', body: 'case note 1 body text' })
       const caseNotePage: Page<CaseNote> = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
       interventionsService.getCaseNotes.mockResolvedValue(caseNotePage)
+      hmppsAuthService.getUserDetailsByUsername.mockResolvedValue(userDetailsFactory.build())
       await request(app)
         .get(`/${user.userType}/referrals/${sentReferral.id}/case-notes`)
         .expect(200)
@@ -48,5 +56,59 @@ describe.each([
           expect(res.text).toContain('case note 1 body text')
         })
     })
+
+    it('should call hmpss auth', async () => {
+      const caseNote = caseNoteFactory.build({
+        sentBy: { authSource: 'auth' },
+      })
+      const caseNotePage: Page<CaseNote> = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+      interventionsService.getCaseNotes.mockResolvedValue(caseNotePage)
+      hmppsAuthService.getUserDetailsByUsername.mockResolvedValue(
+        userDetailsFactory.build({ name: 'firstName lastName' })
+      )
+      await request(app)
+        .get(`/${user.userType}/referrals/${sentReferral.id}/case-notes`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('firstName lastName')
+        })
+    })
+
+    describe('and there is a failure to call hmpps auth', () => {
+      it('should display username instead', async () => {
+        const caseNote = caseNoteFactory.build({
+          sentBy: { username: 'username', authSource: 'auth' },
+        })
+        const caseNotePage: Page<CaseNote> = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+        interventionsService.getCaseNotes.mockResolvedValue(caseNotePage)
+        hmppsAuthService.getUserDetailsByUsername.mockImplementation(() => {
+          return Promise.reject()
+        })
+        await request(app)
+          .get(`/${user.userType}/referrals/${sentReferral.id}/case-notes`)
+          .expect(res => {
+            expect(res.text).toContain('username')
+          })
+      })
+    })
+  })
+
+  it('should combine the same users into a single call', async () => {
+    const caseNote1 = caseNoteFactory.build({
+      sentBy: { userId: '1', username: 'username', authSource: 'delius' },
+    })
+    const caseNote2 = caseNoteFactory.build({
+      sentBy: { userId: '1', username: 'username', authSource: 'delius' },
+    })
+    const caseNotePage: Page<CaseNote> = pageFactory.pageContent([caseNote1, caseNote2]).build() as Page<CaseNote>
+    interventionsService.getCaseNotes.mockResolvedValue(caseNotePage)
+    hmppsAuthService.getUserDetailsByUsername.mockResolvedValue(userDetailsFactory.build({ name: 'firstName surname' }))
+    await request(app)
+      .get(`/${user.userType}/referrals/${sentReferral.id}/case-notes`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('firstName surname')
+      })
+    expect(hmppsAuthService.getUserDetailsByUsername).toHaveBeenCalledTimes(1)
   })
 })

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -3,9 +3,13 @@ import InterventionsService from '../../services/interventionsService'
 import CaseNotesPresenter from './caseNotesPresenter'
 import CaseNotesView from './caseNotesView'
 import ControllerUtils from '../../utils/controllerUtils'
+import HmppsAuthService from '../../services/hmppsAuthService'
 
 export default class CaseNotesController {
-  constructor(private readonly interventionsService: InterventionsService) {}
+  constructor(
+    private readonly interventionsService: InterventionsService,
+    private readonly hmppsAuthService: HmppsAuthService
+  ) {}
 
   async showCaseNotes(req: Request, res: Response): Promise<void> {
     const { accessToken } = res.locals.user.token
@@ -14,7 +18,24 @@ export default class CaseNotesController {
       size: 5,
     }
     const caseNotesPage = await this.interventionsService.getCaseNotes(accessToken, req.params.id, paginationQuery)
-    const presenter = new CaseNotesPresenter(caseNotesPage)
+    const uniqueUsers = new Set(caseNotesPage.content.map(caseNote => caseNote.sentBy.username))
+    const userDetails: Map<string, undefined | string> = new Map(
+      (
+        await Promise.all(
+          [...uniqueUsers].map(username => {
+            return this.hmppsAuthService
+              .getUserDetailsByUsername(accessToken, username)
+              .then(userDetail => {
+                return { username, fullName: userDetail.name }
+              })
+              .catch(error => {
+                return { username, fullName: undefined }
+              })
+          })
+        )
+      ).map(user => [user.username, user.fullName])
+    )
+    const presenter = new CaseNotesPresenter(caseNotesPage, userDetails)
     const view = new CaseNotesView(presenter)
     ControllerUtils.renderWithLayout(res, view, null)
   }

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express'
+import InterventionsService from '../../services/interventionsService'
+import CaseNotesPresenter from './caseNotesPresenter'
+import CaseNotesView from './caseNotesView'
+import ControllerUtils from '../../utils/controllerUtils'
+
+export default class CaseNotesController {
+  constructor(private readonly interventionsService: InterventionsService) {}
+
+  async showCaseNotes(req: Request, res: Response): Promise<void> {
+    const { accessToken } = res.locals.user.token
+    const paginationQuery = {
+      page: Number(req.query.page),
+      size: 5,
+    }
+    const caseNotesPage = await this.interventionsService.getCaseNotes(accessToken, req.params.id, paginationQuery)
+    const presenter = new CaseNotesPresenter(caseNotesPage)
+    const view = new CaseNotesView(presenter)
+    ControllerUtils.renderWithLayout(res, view, null)
+  }
+}

--- a/server/routes/caseNotes/caseNotesPresenter.test.ts
+++ b/server/routes/caseNotes/caseNotesPresenter.test.ts
@@ -1,0 +1,30 @@
+import caseNoteFactory from '../../../testutils/factories/caseNote'
+import pageFactory from '../../../testutils/factories/page'
+import CaseNotesPresenter from './caseNotesPresenter'
+import { CaseNote } from '../../models/caseNote'
+import { Page } from '../../models/pagination'
+
+describe('CaseNotesPresenter', () => {
+  describe('tableRows', () => {
+    it('should format sent day correctly', () => {
+      const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
+      const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+      const presenter = new CaseNotesPresenter(page)
+      expect(presenter.tableRows[0].sentAtDay).toEqual('Friday')
+    })
+
+    it('should format sent date correctly', () => {
+      const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
+      const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+      const presenter = new CaseNotesPresenter(page)
+      expect(presenter.tableRows[0].sentAtDate).toEqual('1 January 2021')
+    })
+
+    it('should format sent time correctly', () => {
+      const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
+      const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+      const presenter = new CaseNotesPresenter(page)
+      expect(presenter.tableRows[0].sentAtTime).toEqual('9:45am')
+    })
+  })
+})

--- a/server/routes/caseNotes/caseNotesPresenter.test.ts
+++ b/server/routes/caseNotes/caseNotesPresenter.test.ts
@@ -9,22 +9,69 @@ describe('CaseNotesPresenter', () => {
     it('should format sent day correctly', () => {
       const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-      const presenter = new CaseNotesPresenter(page)
+      const presenter = new CaseNotesPresenter(page, new Map())
       expect(presenter.tableRows[0].sentAtDay).toEqual('Friday')
     })
 
     it('should format sent date correctly', () => {
       const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-      const presenter = new CaseNotesPresenter(page)
+      const presenter = new CaseNotesPresenter(page, new Map())
       expect(presenter.tableRows[0].sentAtDate).toEqual('1 January 2021')
     })
 
     it('should format sent time correctly', () => {
       const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-      const presenter = new CaseNotesPresenter(page)
+      const presenter = new CaseNotesPresenter(page, new Map())
       expect(presenter.tableRows[0].sentAtTime).toEqual('9:45am')
+    })
+
+    describe('when displaying officer names', () => {
+      describe("if the officer details don't exist", () => {
+        it('should display the username', () => {
+          const caseNote = caseNoteFactory.build({
+            sentBy: {
+              username: 'USER_1',
+              userId: '1',
+              authSource: 'delius',
+            },
+          })
+          const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+          const presenter = new CaseNotesPresenter(page, new Map())
+          expect(presenter.tableRows[0].sentBy).toEqual('USER_1')
+        })
+      })
+
+      describe("if the officer details couldn't be obtained", () => {
+        it('should display the username', () => {
+          const caseNote = caseNoteFactory.build({
+            sentBy: {
+              username: 'USER_1',
+              userId: '1',
+              authSource: 'delius',
+            },
+          })
+          const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+          const presenter = new CaseNotesPresenter(page, new Map([['USER_1', undefined]]))
+          expect(presenter.tableRows[0].sentBy).toEqual('USER_1')
+        })
+      })
+
+      describe('if the officer details exist', () => {
+        it('should display the name', () => {
+          const caseNote = caseNoteFactory.build({
+            sentBy: {
+              username: 'USER_1',
+              userId: '1',
+              authSource: 'delius',
+            },
+          })
+          const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+          const presenter = new CaseNotesPresenter(page, new Map([['USER_1', 'firstName lastName']]))
+          expect(presenter.tableRows[0].sentBy).toEqual('firstName lastName')
+        })
+      })
     })
   })
 })

--- a/server/routes/caseNotes/caseNotesPresenter.test.ts
+++ b/server/routes/caseNotes/caseNotesPresenter.test.ts
@@ -3,27 +3,28 @@ import pageFactory from '../../../testutils/factories/page'
 import CaseNotesPresenter from './caseNotesPresenter'
 import { CaseNote } from '../../models/caseNote'
 import { Page } from '../../models/pagination'
+import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
 
 describe('CaseNotesPresenter', () => {
   describe('tableRows', () => {
     it('should format sent day correctly', () => {
       const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-      const presenter = new CaseNotesPresenter(page, new Map())
+      const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build())
       expect(presenter.tableRows[0].sentAtDay).toEqual('Friday')
     })
 
     it('should format sent date correctly', () => {
       const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-      const presenter = new CaseNotesPresenter(page, new Map())
+      const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build())
       expect(presenter.tableRows[0].sentAtDate).toEqual('1 January 2021')
     })
 
     it('should format sent time correctly', () => {
       const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-      const presenter = new CaseNotesPresenter(page, new Map())
+      const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build())
       expect(presenter.tableRows[0].sentAtTime).toEqual('9:45am')
     })
 
@@ -38,7 +39,7 @@ describe('CaseNotesPresenter', () => {
             },
           })
           const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-          const presenter = new CaseNotesPresenter(page, new Map())
+          const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build())
           expect(presenter.tableRows[0].sentBy).toEqual('USER_1')
         })
       })
@@ -53,7 +54,11 @@ describe('CaseNotesPresenter', () => {
             },
           })
           const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-          const presenter = new CaseNotesPresenter(page, new Map([['USER_1', undefined]]))
+          const presenter = new CaseNotesPresenter(
+            page,
+            new Map([['USER_1', undefined]]),
+            deliusServiceUserFactory.build()
+          )
           expect(presenter.tableRows[0].sentBy).toEqual('USER_1')
         })
       })
@@ -68,10 +73,27 @@ describe('CaseNotesPresenter', () => {
             },
           })
           const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-          const presenter = new CaseNotesPresenter(page, new Map([['USER_1', 'firstName lastName']]))
+          const presenter = new CaseNotesPresenter(
+            page,
+            new Map([['USER_1', 'firstName lastName']]),
+            deliusServiceUserFactory.build()
+          )
           expect(presenter.tableRows[0].sentBy).toEqual('firstName lastName')
         })
       })
+    })
+  })
+
+  describe('serviceUserName', () => {
+    it('should format the name correctly', () => {
+      const caseNote = caseNoteFactory.build()
+      const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+      const presenter = new CaseNotesPresenter(
+        page,
+        new Map(),
+        deliusServiceUserFactory.build({ firstName: 'FIRSTNAME', surname: 'SURNAME' })
+      )
+      expect(presenter.serviceUserName).toEqual('Firstname Surname')
     })
   })
 })

--- a/server/routes/caseNotes/caseNotesPresenter.ts
+++ b/server/routes/caseNotes/caseNotesPresenter.ts
@@ -2,6 +2,8 @@ import { Page } from '../../models/pagination'
 import { CaseNote } from '../../models/caseNote'
 import Pagination from '../../utils/pagination/pagination'
 import DateUtils from '../../utils/dateUtils'
+import utils from '../../utils/utils'
+import DeliusServiceUser from '../../models/delius/deliusServiceUser'
 
 interface CaseNotesTableRow {
   sentAtDay: string
@@ -15,9 +17,15 @@ interface CaseNotesTableRow {
 export default class CaseNotesPresenter {
   public readonly pagination: Pagination
 
-  constructor(private caseNotes: Page<CaseNote>, private officerUserNameMapping: Map<string, undefined | string>) {
+  constructor(
+    private caseNotes: Page<CaseNote>,
+    private officerUserNameMapping: Map<string, undefined | string>,
+    private serviceUser: DeliusServiceUser
+  ) {
     this.pagination = new Pagination(caseNotes)
   }
+
+  readonly serviceUserName = utils.convertToTitleCase(`${this.serviceUser.firstName} ${this.serviceUser.surname}`)
 
   readonly tableHeadings: string[] = ['Details', 'Case notes']
 

--- a/server/routes/caseNotes/caseNotesPresenter.ts
+++ b/server/routes/caseNotes/caseNotesPresenter.ts
@@ -15,18 +15,23 @@ interface CaseNotesTableRow {
 export default class CaseNotesPresenter {
   public readonly pagination: Pagination
 
-  constructor(private caseNotes: Page<CaseNote>) {
+  constructor(private caseNotes: Page<CaseNote>, private officerUserNameMapping: Map<string, undefined | string>) {
     this.pagination = new Pagination(caseNotes)
   }
 
   readonly tableHeadings: string[] = ['Details', 'Case notes']
 
   readonly tableRows: CaseNotesTableRow[] = this.caseNotes.content.map(caseNote => {
+    const matchedOfficer = this.officerUserNameMapping.get(caseNote.sentBy.username)
+    let officerName = caseNote.sentBy.username
+    if (matchedOfficer) {
+      officerName = matchedOfficer
+    }
     return {
       sentAtDay: DateUtils.formattedDayOfWeek(caseNote.sentAt),
       sentAtDate: DateUtils.formattedDate(caseNote.sentAt),
       sentAtTime: DateUtils.formattedTime(caseNote.sentAt),
-      sentBy: caseNote.sentBy.username,
+      sentBy: officerName,
       subject: caseNote.subject,
       body: caseNote.body,
     }

--- a/server/routes/caseNotes/caseNotesPresenter.ts
+++ b/server/routes/caseNotes/caseNotesPresenter.ts
@@ -1,0 +1,34 @@
+import { Page } from '../../models/pagination'
+import { CaseNote } from '../../models/caseNote'
+import Pagination from '../../utils/pagination/pagination'
+import DateUtils from '../../utils/dateUtils'
+
+interface CaseNotesTableRow {
+  sentAtDay: string
+  sentAtDate: string
+  sentAtTime: string
+  sentBy: string
+  subject: string
+  body: string
+}
+
+export default class CaseNotesPresenter {
+  public readonly pagination: Pagination
+
+  constructor(private caseNotes: Page<CaseNote>) {
+    this.pagination = new Pagination(caseNotes)
+  }
+
+  readonly tableHeadings: string[] = ['Details', 'Case notes']
+
+  readonly tableRows: CaseNotesTableRow[] = this.caseNotes.content.map(caseNote => {
+    return {
+      sentAtDay: DateUtils.formattedDayOfWeek(caseNote.sentAt),
+      sentAtDate: DateUtils.formattedDate(caseNote.sentAt),
+      sentAtTime: DateUtils.formattedTime(caseNote.sentAt),
+      sentBy: caseNote.sentBy.username,
+      subject: caseNote.subject,
+      body: caseNote.body,
+    }
+  })
+}

--- a/server/routes/caseNotes/caseNotesView.ts
+++ b/server/routes/caseNotes/caseNotesView.ts
@@ -6,6 +6,10 @@ export default class CaseNotesView {
   constructor(private presenter: CaseNotesPresenter) {}
 
   private get tableArgs(): TableArgs {
+    if (this.presenter.tableRows.length === 0) {
+      return { rows: [] }
+    }
+
     return {
       head: [
         { text: 'Details', classes: 'govuk-!-width-one-quarter' },

--- a/server/routes/caseNotes/caseNotesView.ts
+++ b/server/routes/caseNotes/caseNotesView.ts
@@ -1,0 +1,38 @@
+import { TableArgs } from '../../utils/govukFrontendTypes'
+import CaseNotesPresenter from './caseNotesPresenter'
+import ViewUtils from '../../utils/viewUtils'
+
+export default class CaseNotesView {
+  constructor(private presenter: CaseNotesPresenter) {}
+
+  private get tableArgs(): TableArgs {
+    return {
+      head: [
+        { text: 'Details', classes: 'govuk-!-width-one-quarter' },
+        { text: 'Case notes', classes: 'govuk-!-width-three-quarters' },
+      ],
+      rows: this.presenter.tableRows.map(row => {
+        return [
+          {
+            html: `<p class="govuk-body">${row.sentAtDay}<br>${row.sentAtDate}<br>${row.sentAtTime}<br>${row.sentBy}</p>`,
+          },
+          {
+            html: `<p class="govuk-body">
+                    <b>${ViewUtils.escape(row.subject)}</b>
+                    <br><br>${ViewUtils.nl2br(ViewUtils.escape(row.body))}</p>`,
+          },
+        ]
+      }),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'caseNotes/caseNotes',
+      {
+        pagination: this.presenter.pagination.mojPaginationArgs,
+        tableArgs: this.tableArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/caseNotes/caseNotesView.ts
+++ b/server/routes/caseNotes/caseNotesView.ts
@@ -36,6 +36,7 @@ export default class CaseNotesView {
       {
         pagination: this.presenter.pagination.mojPaginationArgs,
         tableArgs: this.tableArgs,
+        serviceUserName: this.presenter.serviceUserName,
       },
     ]
   }

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -63,7 +63,11 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     probationPractitionerReferralsController.actionPlanApproved(req, res)
   )
 
-  const caseNotesController = new CaseNotesController(services.interventionsService, services.hmppsAuthService)
+  const caseNotesController = new CaseNotesController(
+    services.interventionsService,
+    services.communityApiService,
+    services.hmppsAuthService
+  )
   get(router, '/referrals/:id/case-notes', (req, res) => caseNotesController.showCaseNotes(req, res))
 
   return router

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -63,7 +63,7 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     probationPractitionerReferralsController.actionPlanApproved(req, res)
   )
 
-  const caseNotesController = new CaseNotesController(services.interventionsService)
+  const caseNotesController = new CaseNotesController(services.interventionsService, services.hmppsAuthService)
   get(router, '/referrals/:id/case-notes', (req, res) => caseNotesController.showCaseNotes(req, res))
 
   return router

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { Services, get, post } from './index'
 import ProbationPractitionerReferralsController from './probationPractitionerReferrals/probationPractitionerReferralsController'
+import CaseNotesController from './caseNotes/caseNotesController'
 
 export const probationPractitionerUrlPrefix = '/probation-practitioner'
 
@@ -61,6 +62,9 @@ export default function probationPractitionerRoutes(router: Router, services: Se
   get(router, '/referrals/:id/action-plan/approved', (req, res) =>
     probationPractitionerReferralsController.actionPlanApproved(req, res)
   )
+
+  const caseNotesController = new CaseNotesController(services.interventionsService)
+  get(router, '/referrals/:id/case-notes', (req, res) => caseNotesController.showCaseNotes(req, res))
 
   return router
 }

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -171,7 +171,7 @@ export default function serviceProviderRoutes(router: Router, services: Services
     serviceProviderReferralsController.createNewDraftActionPlan(req, res)
   )
 
-  const caseNotesController = new CaseNotesController(services.interventionsService)
+  const caseNotesController = new CaseNotesController(services.interventionsService, services.hmppsAuthService)
   get(router, '/referrals/:id/case-notes', (req, res) => caseNotesController.showCaseNotes(req, res))
 
   if (config.features.serviceProviderReporting.enabled) {

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import { Services, get, post } from './index'
 import ServiceProviderReferralsController from './serviceProviderReferrals/serviceProviderReferralsController'
 import config from '../config'
+import CaseNotesController from './caseNotes/caseNotesController'
 
 export const serviceProviderUrlPrefix = '/service-provider'
 
@@ -169,6 +170,9 @@ export default function serviceProviderRoutes(router: Router, services: Services
   post(router, '/referrals/:id/action-plan/edit', (req, res) =>
     serviceProviderReferralsController.createNewDraftActionPlan(req, res)
   )
+
+  const caseNotesController = new CaseNotesController(services.interventionsService)
+  get(router, '/referrals/:id/case-notes', (req, res) => caseNotesController.showCaseNotes(req, res))
 
   if (config.features.serviceProviderReporting.enabled) {
     get(router, '/performance-report', (req, res) => serviceProviderReferralsController.viewReporting(req, res))

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -171,7 +171,11 @@ export default function serviceProviderRoutes(router: Router, services: Services
     serviceProviderReferralsController.createNewDraftActionPlan(req, res)
   )
 
-  const caseNotesController = new CaseNotesController(services.interventionsService, services.hmppsAuthService)
+  const caseNotesController = new CaseNotesController(
+    services.interventionsService,
+    services.communityApiService,
+    services.hmppsAuthService
+  )
   get(router, '/referrals/:id/case-notes', (req, res) => caseNotesController.showCaseNotes(req, res))
 
   if (config.features.serviceProviderReporting.enabled) {

--- a/server/services/hmppsAuthService.test.ts
+++ b/server/services/hmppsAuthService.test.ts
@@ -54,6 +54,21 @@ describe('hmppsAuthService', () => {
     })
   })
 
+  describe('getUserDetailsByUsername', () => {
+    it('should return user details from api', async () => {
+      const response = { username: 'user_1' }
+      const username = 'user_1'
+
+      fakeHmppsAuthApi
+        .get('/api/user/user_1')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(200, response)
+
+      const output = await hmppsAuthService.getUserDetailsByUsername(token.access_token, username)
+      expect(output).toEqual(response)
+    })
+  })
+
   describe('getSPUserByEmailAddress', () => {
     describe('when a matching user is found with the requested email address', () => {
       it('should return the first active and verified user from the API response', async () => {

--- a/server/services/hmppsAuthService.ts
+++ b/server/services/hmppsAuthService.ts
@@ -38,6 +38,11 @@ export default class HmppsAuthService {
     return (await this.restClient(userToken).get({ path: '/api/user/me' })) as UserDetails
   }
 
+  async getUserDetailsByUsername(userToken: string, username: string): Promise<UserDetails> {
+    logger.info(`Getting user details: calling HMPPS Auth`)
+    return (await this.restClient(userToken).get({ path: `/api/user/${username}` })) as UserDetails
+  }
+
   async getUserOrganizations(token: string, user: User): Promise<Array<ServiceProviderOrganization>> {
     return user.authSource === 'auth'
       ? (await this.getAuthUserGroups(token, user.username))

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -48,6 +48,65 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     serviceProviderToken = oauth2TokenFactory.serviceProviderToken().build()
   })
 
+  describe('get case notes', () => {
+    it('returns a list of case notes', async () => {
+      await provider.addInteraction({
+        state:
+          'There is an existing sent referral with ID of 7197d9b1-ca8b-475c-9f44-1fed47778c23, and it has 20 case notes',
+        uponReceiving: 'a request for 2 case notes and the 2nd page',
+        withRequest: {
+          method: 'GET',
+          path: '/sent-referral/7197d9b1-ca8b-475c-9f44-1fed47778c23/case-notes',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+          query: {
+            page: '2',
+            size: '2',
+            sort: 'sentBy,DESC',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like({
+            content: [
+              {
+                referralId: '03bf1369-00d3-4b7f-88b2-da3cc8cc35b9',
+                subject: 'subject for case note 3 of 20',
+                body: 'body for case note 3 of 20',
+                sentBy: {
+                  userId: '608955ae-52ed-44cc-884c-011597a77949',
+                  username: 'AUTH_USER',
+                  authSource: 'auth',
+                },
+              },
+              {
+                referralId: '03bf1369-00d3-4b7f-88b2-da3cc8cc35b9',
+                subject: 'subject for case note 4 of 20',
+                body: 'body for case note 4 of 20',
+                sentBy: {
+                  userId: '608955ae-52ed-44cc-884c-011597a77949',
+                  username: 'AUTH_USER',
+                  authSource: 'auth',
+                },
+              },
+            ],
+            totalElements: 20,
+            totalPages: 10,
+            numberOfElements: 2,
+            number: 1,
+            size: 2,
+          }),
+          headers: { 'Content-Type': 'application/json' },
+        },
+      })
+
+      await interventionsService.getCaseNotes(probationPractitionerToken, '7197d9b1-ca8b-475c-9f44-1fed47778c23', {
+        page: 2,
+        size: 2,
+        sort: ['sentBy,DESC'],
+      })
+    })
+  })
+
   describe('getDraftReferral', () => {
     it('returns a referral for the given ID', async () => {
       await provider.addInteraction({

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -25,6 +25,8 @@ import {
   InitialAssessmentAppointment,
 } from '../models/appointment'
 import ApprovedActionPlanSummary from '../models/approvedActionPlanSummary'
+import { Page } from '../models/pagination'
+import { CaseNote } from '../models/caseNote'
 
 export interface InterventionsServiceValidationError {
   field: string
@@ -586,5 +588,15 @@ export default class InterventionsService {
       path: '/reports/service-provider/performance',
       data: InterventionsService.createReportDatesDTO(reportDates),
     })
+  }
+
+  async getCaseNotes(token: string, referralId: string, paginationParams: PaginationParams): Promise<Page<CaseNote>> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.get({
+      path: `/sent-referral/${referralId}/case-notes`,
+      headers: { Accept: 'application/json' },
+      query: { ...paginationParams },
+    })) as Page<CaseNote>
   }
 }

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -3,6 +3,22 @@ import CalendarDay from './calendarDay'
 import ClockTime from './clockTime'
 
 describe('DateUtils', () => {
+  describe('formattedDayOfWeek', () => {
+    it('returns a formatted string with local timezone offset for a valid ISO8601 datetime input', () => {
+      expect(DateUtils.formattedDayOfWeek('2021-02-01T13:00:00Z')).toEqual('Monday')
+      // BST should display as GMT during winter if before 1am
+      expect(DateUtils.formattedDayOfWeek('2021-02-02T00:59:00+01:00')).toEqual('Monday')
+      expect(DateUtils.formattedDayOfWeek('2021-02-02T01:00:00+01:00')).toEqual('Tuesday')
+      // GMT
+      expect(DateUtils.formattedDayOfWeek('2021-02-01T23:30:00+00:00')).toEqual('Monday')
+      // BST should display as BST
+      expect(DateUtils.formattedDayOfWeek('2021-06-02T00:30:00+01:00')).toEqual('Wednesday')
+      // GMT should transform to BST during summer if after 11pm
+      expect(DateUtils.formattedDayOfWeek('2021-06-01T22:59:00+00:00')).toEqual('Tuesday')
+      expect(DateUtils.formattedDayOfWeek('2021-06-01T23:00:00+00:00')).toEqual('Wednesday')
+    })
+  })
+
   describe('formattedDateTime', () => {
     it('returns a formatted string with local timezone offset for a valid ISO8601 datetime input', () => {
       expect(DateUtils.formattedDateTime('2021-02-01T13:00:00Z')).toEqual('1:00pm on 1 February 2021')

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -3,6 +3,16 @@ import CalendarDay from './calendarDay'
 
 type casing = 'lowercase' | 'capitalized'
 export default class DateUtils {
+  static formattedDayOfWeek(inputDate: Date | string): string {
+    let date: Date
+    if (inputDate instanceof Date) {
+      date = inputDate
+    } else {
+      date = new Date(inputDate)
+    }
+    return date.toLocaleDateString('en-GB', { weekday: 'long', timeZone: 'Europe/London' })
+  }
+
   // example output: 1:00pm on 12 April 2021
   static formattedDateTime(
     dateTime: Date | string,

--- a/server/views/caseNotes/caseNotes.njk
+++ b/server/views/caseNotes/caseNotes.njk
@@ -4,6 +4,7 @@
 {% set pageSubTitle = "Case notes" %}
 
 {% block pageContent %}
+    <p class="govuk-body">See all case notes about {{ serviceUserName }}</p>
     {{ govukTable(tableArgs) }}
     {% include "../partials/pagination.njk" %}
 {% endblock %}

--- a/server/views/caseNotes/caseNotes.njk
+++ b/server/views/caseNotes/caseNotes.njk
@@ -1,0 +1,9 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% extends "../partials/layout.njk" %}
+{% set pageTitle = "Referral" %}
+{% set pageSubTitle = "Case notes" %}
+
+{% block pageContent %}
+    {{ govukTable(tableArgs) }}
+    {% include "../partials/pagination.njk" %}
+{% endblock %}

--- a/testutils/factories/caseNote.ts
+++ b/testutils/factories/caseNote.ts
@@ -1,0 +1,16 @@
+import { Factory } from 'fishery'
+import { CaseNote } from '../../server/models/caseNote'
+import sentReferralFactory from './sentReferral'
+
+export default Factory.define<CaseNote>(({ sequence }) => ({
+  id: sequence.toString(),
+  referralId: sentReferralFactory.build().id,
+  subject: 'Case note subject',
+  body: 'Case note body text',
+  sentBy: {
+    username: 'BERNARD.BEAKS',
+    userId: sequence.toString(),
+    authSource: 'delius',
+  },
+  sentAt: '2021-01-01T09:45:21.986389Z',
+}))

--- a/testutils/factories/userDetails.ts
+++ b/testutils/factories/userDetails.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery'
+import UserDetails from '../../server/models/hmppsAuth/userDetails'
+
+export default Factory.define<UserDetails>(() => ({
+  name: 'john smith',
+  active: true,
+  username: 'user1',
+  authSource: 'delius',
+  userId: '123',
+  uuid: '123',
+  organizations: [],
+}))


### PR DESCRIPTION
Please review this PR first: https://github.com/ministryofjustice/hmpps-interventions-ui/pull/770

This PR branches from it.

## What does this pull request do?

Show all case notes for SP and PP user.
    
This shows a paginated view of all case notes; defaulted to 5 notes per page, and ordered by sentAt in descending order.
    
When displaying the case note content the full case note is visible, there will be a future change to restrict this to 250 characters. This requires having a page to display the full case note - since this has not been implemented yet, it's best to show the full case note until that has been done.

## What is the intent behind these changes?

Allow both SP and PP users to view case notes for a referral.


## Example

![image](https://user-images.githubusercontent.com/83066216/132204231-64c58f38-500b-410b-8125-ee1621256d21.png)


## Note 

The page won't be navigable for the user (unless they type it in the URL). This is because it doesn't make sense to show case notes without the ability to add a case note.

Eventually the page will be navigable by the navigation tabs:

![image](https://user-images.githubusercontent.com/83066216/132204413-1a985eb2-adae-4e28-b69d-765180bac9df.png)

This will be added in the `add case note` PR.

## Latest

latest changes to date presentation now look like:

![image](https://user-images.githubusercontent.com/83066216/132370301-063aca55-9fd8-42e4-bef2-6abcd8b4888c.png)
