### PR TITLE
Remove hardcoded criminogenic needs from referral details

### DIFF
--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -615,11 +615,6 @@ describe(ShowReferralPresenter, () => {
 
         expect(presenter.serviceUserNeeds).toEqual([
           {
-            key: 'Criminogenic needs',
-            lines: ['Thinking and attitudes', 'Accommodation'],
-            listStyle: ListStyle.noMarkers,
-          },
-          {
             key: 'Identify needs',
             lines: ["Alex is currently sleeping on her aunt's sofa"],
           },
@@ -703,11 +698,6 @@ describe(ShowReferralPresenter, () => {
         )
 
         expect(presenter.serviceUserNeeds).toEqual([
-          {
-            key: 'Criminogenic needs',
-            lines: ['Thinking and attitudes', 'Accommodation'],
-            listStyle: ListStyle.noMarkers,
-          },
           {
             key: 'Identify needs',
             lines: ['N/A'],

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -1,6 +1,6 @@
 import SentReferral from '../../models/sentReferral'
 import DeliusUser from '../../models/delius/deliusUser'
-import { ListStyle, SummaryListItem } from '../../utils/summaryList'
+import { SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
 import PresenterUtils from '../../utils/presenterUtils'
 import ServiceUserDetailsPresenter from '../referrals/service-user-details/serviceUserDetailsPresenter'
@@ -249,7 +249,6 @@ export default class ShowReferralPresenter {
 
   get serviceUserNeeds(): SummaryListItem[] {
     return [
-      { key: 'Criminogenic needs', lines: ['Thinking and attitudes', 'Accommodation'], listStyle: ListStyle.noMarkers },
       {
         key: 'Identify needs',
         lines: [this.sentReferral.referral.additionalNeedsInformation || 'N/A'],


### PR DESCRIPTION
## What does this pull request do?

Removes hardcoded criminogenic needs from referral details page.

## What is the intent behind these changes?

To prevent users from seeing misleading data.