### PR TITLE
IC-1751: Add version number to table of approved Action Plans

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -565,9 +565,11 @@ describe('Probation Practitioner monitor journey', () => {
         .getTable()
         .should('deep.equal', [
           {
+            'Version number': '2',
             'Approval date': '4 Jun 2021',
           },
           {
+            'Version number': '1',
             'Approval date': '3 Jun 2021',
           },
         ])

--- a/server/routes/shared/action-plan/actionPlanPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.test.ts
@@ -204,7 +204,7 @@ describe(InterventionProgressPresenter, () => {
   })
 
   describe('actionPlanVersions', () => {
-    it('returns a list of created dates for approved action plans in descending order by date', () => {
+    it('returns a list of created dates and version numbers for approved action plans in descending order by date', () => {
       const submittedActionPlan = actionPlanFactory.submitted().build()
       const approvedActionPlanSummaries = [
         approvedActionPlanSummaryFactory.build({
@@ -223,8 +223,8 @@ describe(InterventionProgressPresenter, () => {
         approvedActionPlanSummaries
       )
       expect(submittedActionPlanPresenter.actionPlanVersions).toEqual([
-        { approvalDate: '11 Jun 2021' },
-        { approvalDate: '10 Jun 2021' },
+        { approvalDate: '11 Jun 2021', versionNumber: 2 },
+        { approvalDate: '10 Jun 2021', versionNumber: 1 },
       ])
     })
   })

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -68,10 +68,11 @@ export default class ActionPlanPresenter {
     return this.userType === 'probation-practitioner' && !this.actionPlanSummaryPresenter.actionPlanSubmitted
   }
 
-  get actionPlanVersions(): { approvalDate: string }[] {
+  get actionPlanVersions(): { approvalDate: string; versionNumber: number }[] {
     return this.approvedActionPlanSummaries
       .sort((summaryA, summaryB) => new Date(summaryB.approvedAt).getTime() - new Date(summaryA.approvedAt).getTime())
-      .map(summary => ({
+      .map((summary, index) => ({
+        versionNumber: this.approvedActionPlanSummaries.length - index,
         approvalDate: dateUtils.formattedDate(summary.approvedAt, { month: 'short' }),
       }))
   }

--- a/server/routes/shared/action-plan/actionPlanView.ts
+++ b/server/routes/shared/action-plan/actionPlanView.ts
@@ -43,8 +43,11 @@ export default class ActionPlanView {
 
   get approvedActionPlansTableArgs(): TableArgs | null {
     return {
-      head: [{ text: 'Approval date' }],
-      rows: this.presenter.actionPlanVersions.map(actionPlan => [{ text: actionPlan.approvalDate }]),
+      head: [{ text: 'Version number' }, { text: 'Approval date' }],
+      rows: this.presenter.actionPlanVersions.map(actionPlan => [
+        { text: String(actionPlan.versionNumber) },
+        { text: actionPlan.approvalDate },
+      ]),
     }
   }
 


### PR DESCRIPTION
## What does this pull request do?

Adds a version number to the table of previously-approved action plans.

## What is the intent behind these changes?

To inform the PP about which version of an action plan they are viewing.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/132228101-7d934b05-4697-4738-beec-a318c526e176.png)
