### PR TITLE
Remove coreruleset HTTP Request Smuggling rule 921110

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6,setvar:tx.outbound_anomaly_score_threshold=4"
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
+      SecRuleRemoveById 921110
     {{- else }}
     kubernetes.io/ingress.class: "nginx"
     {{- end }}


### PR DESCRIPTION
## What does this pull request do?

Allows more requests to go through by removing the request smuggling rule from the web application firewall.

## What is the intent behind these changes?

> **HTTP Request Smuggling**
> This rule looks for a HTTP / WEBDAV method name in combination with
> the word http/\d or a CR/LF character.

This rule has been blocking appointment behaviour submissions, eg.

`Matched Data: get comfortable.\r found within REQUEST_BODY`

We have quite a lot of these forms, so let's try without this rule.