### PR TITLE
IC-2178: Add links to view previously approved action plans

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -517,6 +517,7 @@ describe('Probation Practitioner monitor journey', () => {
         }),
         approvedActionPlanSummaryFactory.build({
           approvedAt: '2021-06-04T00:30:00+01:00',
+          id: actionPlanId,
         }),
       ]
 
@@ -567,10 +568,12 @@ describe('Probation Practitioner monitor journey', () => {
           {
             'Version number': '2',
             'Approval date': '4 Jun 2021',
+            Action: 'This version',
           },
           {
             'Version number': '1',
             'Approval date': '3 Jun 2021',
+            Action: 'View',
           },
         ])
     })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -699,7 +699,7 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
 })
 
 describe('GET /probation-practitioner/referrals/:id/action-plan', () => {
-  it('displays information about the action plan and service user', async () => {
+  it('displays information about the latest action plan and service user', async () => {
     const sentReferral = sentReferralFactory.assigned().build()
     const serviceCategory = serviceCategoryFactory.build()
     const deliusServiceUser = deliusServiceUserFactory.build()

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -725,6 +725,32 @@ describe('GET /probation-practitioner/referrals/:id/action-plan', () => {
   })
 })
 
+describe('GET /probation-practitioner/action-plan/:actionPlanId', () => {
+  it('displays information about the specified action plan and service user', async () => {
+    const sentReferral = sentReferralFactory.assigned().build()
+    const serviceCategory = serviceCategoryFactory.build()
+    const deliusServiceUser = deliusServiceUserFactory.build()
+    const actionPlan = actionPlanFactory.approved().build()
+    const approvedActionPlanSummaries = approvedActionPlanSummaryFactory.buildList(2)
+    sentReferral.actionPlanId = actionPlan.id
+
+    interventionsService.getActionPlan.mockResolvedValue(actionPlan)
+    interventionsService.getSentReferral.mockResolvedValue(sentReferral)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getApprovedActionPlanSummaries.mockResolvedValue(approvedActionPlanSummaries)
+    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+
+    await request(app)
+      .get(`/probation-practitioner/action-plan/${actionPlan.id}`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('X123456')
+        expect(res.text).toContain('Action plan status')
+        expect(res.text).toContain('Approved')
+      })
+  })
+})
+
 describe('POST /probation-practitioner/referrals/:id/action-plan/approve', () => {
   it('calls interventions service to approve action plan', async () => {
     const sentReferral = sentReferralFactory.assigned().build({ actionPlanId: '724bf133-65cb-43d4-bff9-ca692ad1d381' })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -405,7 +405,7 @@ export default class ProbationPractitionerReferralsController {
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
-  async viewActionPlan(req: Request, res: Response): Promise<void> {
+  async viewLatestActionPlan(req: Request, res: Response): Promise<void> {
     await this.renderViewActionPlan(req, res)
   }
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -40,6 +40,8 @@ import config from '../../config'
 import AppointmentSummary from '../appointments/appointmentSummary'
 import DeliusOfficeLocationFilter from '../../services/deliusOfficeLocationFilter'
 import ReferenceDataService from '../../services/referenceDataService'
+import SentReferral from '../../models/sentReferral'
+import ActionPlan from '../../models/actionPlan'
 
 export default class ProbationPractitionerReferralsController {
   private readonly deliusOfficeLocationFilter: DeliusOfficeLocationFilter
@@ -406,10 +408,10 @@ export default class ProbationPractitionerReferralsController {
   }
 
   async viewLatestActionPlan(req: Request, res: Response): Promise<void> {
-    await this.renderViewActionPlan(req, res)
+    await this.renderLatestActionPlan(req, res)
   }
 
-  private async renderViewActionPlan(
+  private async renderLatestActionPlan(
     req: Request,
     res: Response,
     formValidationError: FormValidationError | null = null
@@ -423,13 +425,47 @@ export default class ProbationPractitionerReferralsController {
       })
     }
 
-    const [serviceCategories, actionPlan, serviceUser, actionPlanVersions] = await Promise.all([
+    const actionPlan = await this.interventionsService.getActionPlan(accessToken, sentReferral.actionPlanId)
+
+    return this.renderActionPlan(res, sentReferral, actionPlan, formValidationError)
+  }
+
+  async viewActionPlanById(req: Request, res: Response): Promise<void> {
+    const { accessToken } = res.locals.user.token
+
+    const actionPlan = await this.interventionsService.getActionPlan(accessToken, req.params.actionPlanId)
+
+    if (actionPlan === null) {
+      throw createError(500, `No action plan found with id '${req.params.actionPlanId}'`, {
+        userMessage: 'No action plan was found',
+      })
+    }
+
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, actionPlan.referralId)
+
+    if (sentReferral === null) {
+      throw createError(500, `No referral found with with id '${actionPlan.referralId}'`, {
+        userMessage: 'No action plan was found',
+      })
+    }
+
+    return this.renderActionPlan(res, sentReferral, actionPlan)
+  }
+
+  private async renderActionPlan(
+    res: Response,
+    sentReferral: SentReferral,
+    actionPlan: ActionPlan,
+    formValidationError: FormValidationError | null = null
+  ) {
+    const { accessToken } = res.locals.user.token
+
+    const [serviceCategories, serviceUser, actionPlanVersions] = await Promise.all([
       Promise.all(
         sentReferral.referral.serviceCategoryIds.map(id =>
           this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
         )
       ),
-      this.interventionsService.getActionPlan(accessToken, sentReferral.actionPlanId),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
       config.features.previouslyApprovedActionPlans
         ? this.interventionsService.getApprovedActionPlanSummaries(accessToken, sentReferral.id)
@@ -456,7 +492,7 @@ export default class ProbationPractitionerReferralsController {
       errorMessages.actionPlanApproval.notConfirmed
     ).validate()
     if (confirmApprovalResult.error) {
-      return this.renderViewActionPlan(req, res, confirmApprovalResult.error)
+      return this.renderLatestActionPlan(req, res, confirmApprovalResult.error)
     }
     const { accessToken } = res.locals.user.token
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -25,6 +25,9 @@ export default function probationPractitionerRoutes(router: Router, services: Se
   get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', (req, res) =>
     probationPractitionerReferralsController.viewSubmittedPostSessionFeedback(req, res)
   )
+  get(router, '/action-plan/:actionPlanId', (req, res) =>
+    probationPractitionerReferralsController.viewActionPlanById(req, res)
+  )
   get(router, '/end-of-service-report/:id', (req, res) =>
     probationPractitionerReferralsController.viewEndOfServiceReport(req, res)
   )

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -54,7 +54,7 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     probationPractitionerReferralsController.viewSubmittedPostAssessmentFeedback(req, res)
   )
   get(router, '/referrals/:id/action-plan', (req, res) =>
-    probationPractitionerReferralsController.viewActionPlan(req, res)
+    probationPractitionerReferralsController.viewLatestActionPlan(req, res)
   )
   post(router, '/referrals/:id/action-plan/approve', (req, res) =>
     probationPractitionerReferralsController.approveActionPlan(req, res)

--- a/server/routes/shared/action-plan/actionPlanPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.test.ts
@@ -311,4 +311,62 @@ describe(InterventionProgressPresenter, () => {
       expect(actionPlanPresenter.showActionPlanVersions).toEqual(false)
     })
   })
+
+  describe('showPreviousActionPlanNotificationBanner', () => {
+    describe('when the user is an SP', () => {
+      it("returns false, as they can't view previous revisions", () => {
+        const actionPlan = actionPlanFactory.build()
+        const approvedActionPlanSummaries = approvedActionPlanSummaryFactory.buildList(3)
+
+        const actionPlanPresenter = new ActionPlanPresenter(
+          referral,
+          actionPlan,
+          serviceCategories,
+          'service-provider',
+          null,
+          approvedActionPlanSummaries
+        )
+
+        expect(actionPlanPresenter.showPreviousActionPlanNotificationBanner).toEqual(false)
+      })
+    })
+
+    describe('when the user is a PP', () => {
+      it("returns false when the viewed action plan's ID matches the latest action plan's ID on the referral", () => {
+        const referralWithLatestActionPlan = referralFactory.assigned().build({ actionPlanId: 'latest-id' })
+        const latestActionPlan = actionPlanFactory.build({ id: 'latest-id' })
+
+        const approvedActionPlanSummaries = approvedActionPlanSummaryFactory.buildList(3)
+
+        const actionPlanPresenter = new ActionPlanPresenter(
+          referralWithLatestActionPlan,
+          latestActionPlan,
+          serviceCategories,
+          'probation-practitioner',
+          null,
+          approvedActionPlanSummaries
+        )
+
+        expect(actionPlanPresenter.showPreviousActionPlanNotificationBanner).toEqual(false)
+      })
+
+      it("returns true when the viewed action plan's ID doesn't match the latest action plan's ID on the referral", () => {
+        const referralWithNewerActionPlan = referralFactory.assigned().build({ actionPlanId: 'latest-id' })
+        const actionPlan = actionPlanFactory.build({ id: 'not-latest-id' })
+
+        const approvedActionPlanSummaries = approvedActionPlanSummaryFactory.buildList(3)
+
+        const actionPlanPresenter = new ActionPlanPresenter(
+          referralWithNewerActionPlan,
+          actionPlan,
+          serviceCategories,
+          'probation-practitioner',
+          null,
+          approvedActionPlanSummaries
+        )
+
+        expect(actionPlanPresenter.showPreviousActionPlanNotificationBanner).toEqual(true)
+      })
+    })
+  })
 })

--- a/server/routes/shared/action-plan/actionPlanPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.test.ts
@@ -204,27 +204,47 @@ describe(InterventionProgressPresenter, () => {
   })
 
   describe('actionPlanVersions', () => {
-    it('returns a list of created dates and version numbers for approved action plans in descending order by date', () => {
-      const submittedActionPlan = actionPlanFactory.submitted().build()
+    it('returns a list of created dates, version numbers, and an href for viewing the action plan (or null for the current version) for approved action plans in descending order by date', () => {
+      const viewedActionPlanId = '490cc3a9-28d6-4316-8b89-92d9ccae0e1d'
+      const otherActionPlanId = '820f2dfc-06ba-4719-b94f-673b3ef86cbe'
+      const latestActionPlanId = 'f12a3dcd-9d8a-4bb9-b65d-b0a99d227f0e'
+
+      const referralWithLatestActionPlan = referralFactory.assigned().build({ actionPlanId: latestActionPlanId })
+      const currentlyViewedActionPlan = actionPlanFactory.submitted().build({ id: viewedActionPlanId })
       const approvedActionPlanSummaries = [
         approvedActionPlanSummaryFactory.build({
+          id: viewedActionPlanId,
           approvedAt: '2021-06-10:00:00.000000Z',
         }),
         approvedActionPlanSummaryFactory.build({
+          id: otherActionPlanId,
           approvedAt: '2021-06-11:00:00.000000Z',
+        }),
+        approvedActionPlanSummaryFactory.build({
+          id: latestActionPlanId,
+          approvedAt: '2021-06-12:00:00.000000Z',
         }),
       ]
       const submittedActionPlanPresenter = new ActionPlanPresenter(
-        referral,
-        submittedActionPlan,
+        referralWithLatestActionPlan,
+        currentlyViewedActionPlan,
         serviceCategories,
         'service-provider',
         null,
         approvedActionPlanSummaries
       )
       expect(submittedActionPlanPresenter.actionPlanVersions).toEqual([
-        { approvalDate: '11 Jun 2021', versionNumber: 2 },
-        { approvalDate: '10 Jun 2021', versionNumber: 1 },
+        {
+          approvalDate: '12 Jun 2021',
+          versionNumber: 3,
+          href: `/probation-practitioner/referrals/${referralWithLatestActionPlan.id}/action-plan`,
+        },
+        {
+          approvalDate: '11 Jun 2021',
+          versionNumber: 2,
+          href: `/probation-practitioner/action-plan/${otherActionPlanId}`,
+        },
+        { approvalDate: '10 Jun 2021', versionNumber: 1, href: null },
       ])
     })
   })

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -34,6 +34,8 @@ export default class ActionPlanPresenter {
 
   readonly actionPlanEditConfirmationUrl = `/service-provider/referrals/${this.referral.id}/action-plan/edit`
 
+  readonly viewProbationPractitionerLatestActionPlanURL = `/probation-practitioner/referrals/${this.referral.id}/action-plan`
+
   readonly errorSummary = PresenterUtils.errorSummary(this.validationError)
 
   readonly fieldErrors = {
@@ -68,17 +70,33 @@ export default class ActionPlanPresenter {
     return this.userType === 'probation-practitioner' && !this.actionPlanSummaryPresenter.actionPlanSubmitted
   }
 
-  get actionPlanVersions(): { approvalDate: string; versionNumber: number }[] {
+  get actionPlanVersions(): { approvalDate: string; versionNumber: number; href: string | null }[] {
     return this.approvedActionPlanSummaries
       .sort((summaryA, summaryB) => new Date(summaryB.approvedAt).getTime() - new Date(summaryA.approvedAt).getTime())
       .map((summary, index) => ({
         versionNumber: this.approvedActionPlanSummaries.length - index,
         approvalDate: dateUtils.formattedDate(summary.approvedAt, { month: 'short' }),
+        href: this.determineActionPlanHref(summary.id),
       }))
   }
 
   get showActionPlanVersions(): boolean {
     return this.userType === 'probation-practitioner' && this.actionPlanVersions.length > 0
+  }
+
+  private determineActionPlanHref(summaryId: string): string | null {
+    const isCurrentlyViewedActionPlan = summaryId === this.actionPlan.id
+    const isLatestActionPlan = summaryId === this.referral.actionPlanId
+
+    if (isCurrentlyViewedActionPlan) {
+      return null
+    }
+
+    if (isLatestActionPlan) {
+      return this.viewProbationPractitionerLatestActionPlanURL
+    }
+
+    return `/probation-practitioner/action-plan/${summaryId}`
   }
 
   get showEditButton(): boolean {

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -99,6 +99,10 @@ export default class ActionPlanPresenter {
     return `/probation-practitioner/action-plan/${summaryId}`
   }
 
+  get showPreviousActionPlanNotificationBanner(): boolean {
+    return this.userType === 'probation-practitioner' && this.actionPlan.id !== this.referral.actionPlanId
+  }
+
   get showEditButton(): boolean {
     return this.userType === 'service-provider' && this.actionPlanSummaryPresenter.actionPlanUnderReview
   }

--- a/server/routes/shared/action-plan/actionPlanView.ts
+++ b/server/routes/shared/action-plan/actionPlanView.ts
@@ -1,5 +1,5 @@
 import ActionPlanPresenter from './actionPlanPresenter'
-import { CheckboxesArgs, InsetTextArgs, TableArgs } from '../../../utils/govukFrontendTypes'
+import { CheckboxesArgs, InsetTextArgs, NotificationBannerArgs, TableArgs } from '../../../utils/govukFrontendTypes'
 import ViewUtils from '../../../utils/viewUtils'
 import ActionPlanSummaryView from './actionPlanSummaryView'
 
@@ -54,6 +54,12 @@ export default class ActionPlanView {
     }
   }
 
+  get viewingPreviousActionPlanNotificationBannerArgs(): NotificationBannerArgs {
+    return {
+      html: `<p class="govuk-body-m">You are looking at an older version of the action plan.</p><a href="${this.presenter.viewProbationPractitionerLatestActionPlanURL}">Click here to see the current action plan.</a>`,
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'shared/actionPlan',
@@ -64,6 +70,7 @@ export default class ActionPlanView {
         actionPlanSummaryListArgs: this.actionPlanSummaryView.summaryListArgs.bind(this.actionPlanSummaryView),
         approvedActionPlansTableArgs: this.approvedActionPlansTableArgs,
         insetTextActivityArgs: this.insetTextActivityArgs.bind(this),
+        viewingPreviousActionPlanNotificationBannerArgs: this.viewingPreviousActionPlanNotificationBannerArgs,
         confirmApprovalCheckboxArgs: this.confirmApprovalCheckboxArgs,
       },
     ]

--- a/server/routes/shared/action-plan/actionPlanView.ts
+++ b/server/routes/shared/action-plan/actionPlanView.ts
@@ -43,11 +43,14 @@ export default class ActionPlanView {
 
   get approvedActionPlansTableArgs(): TableArgs | null {
     return {
-      head: [{ text: 'Version number' }, { text: 'Approval date' }],
-      rows: this.presenter.actionPlanVersions.map(actionPlan => [
-        { text: String(actionPlan.versionNumber) },
-        { text: actionPlan.approvalDate },
-      ]),
+      head: [{ text: 'Version number' }, { text: 'Approval date' }, { text: 'Action' }],
+      rows: this.presenter.actionPlanVersions.map(actionPlan => {
+        const actionRow =
+          actionPlan.href === null
+            ? { text: 'This version' }
+            : { html: `<a href="${ViewUtils.escape(actionPlan.href)}">View</a>` }
+        return [{ text: String(actionPlan.versionNumber) }, { text: actionPlan.approvalDate }, actionRow]
+      }),
     }
   }
 

--- a/server/routes/shared/action-plan/actionPlanView.ts
+++ b/server/routes/shared/action-plan/actionPlanView.ts
@@ -12,7 +12,9 @@ export default class ActionPlanView {
 
   private readonly backLinkArgs = {
     text: 'Back',
-    href: this.presenter.interventionProgressURL,
+    href: this.presenter.showPreviousActionPlanNotificationBanner
+      ? this.presenter.viewProbationPractitionerLatestActionPlanURL
+      : this.presenter.interventionProgressURL,
   }
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)

--- a/server/routes/shared/action-plan/actionPlanView.ts
+++ b/server/routes/shared/action-plan/actionPlanView.ts
@@ -43,7 +43,7 @@ export default class ActionPlanView {
     }
   }
 
-  get approvedActionPlansTableArgs(): TableArgs | null {
+  get approvedActionPlansTableArgs(): TableArgs {
     return {
       head: [{ text: 'Version number' }, { text: 'Approval date' }, { text: 'Action' }],
       rows: this.presenter.actionPlanVersions.map(actionPlan => {

--- a/server/views/shared/actionPlan.njk
+++ b/server/views/shared/actionPlan.njk
@@ -8,6 +8,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = "Action plan" %}
 {% set pageSubTitle = "View" %}
@@ -37,6 +38,10 @@
           {{ govukErrorSummary(errorSummaryArgs) }}
         {% endif %}
         <h1 class="govuk-heading-l">View action plan</h1>
+
+        {% if presenter.showPreviousActionPlanNotificationBanner %}
+          {{ govukNotificationBanner(viewingPreviousActionPlanNotificationBannerArgs) }}
+        {% endif %}
 
         {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
 


### PR DESCRIPTION
## What does this pull request do?

Adds the UI for viewing previously-approved action plans, with links to view them in the table at the bottom of the latest action plan page.

## What is the intent behind these changes?

To allow PPs to view previous revisions of an action plan

## Screenshots

### Seeing a list of previously approved action plans from the latest version

![image](https://user-images.githubusercontent.com/19826940/132371327-a2b761a1-690e-459d-be26-960eac4fe47b.png)

### Viewing an older version of the action plan

![image](https://user-images.githubusercontent.com/19826940/132371479-f908dee8-535d-4b96-ae06-44408fb2cb2a.png)

