### PR TITLE
IC-1833: Surface API error when reducing number of sessions

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -87,6 +87,7 @@ import AppointmentSummary from '../appointments/appointmentSummary'
 import ReferenceDataService from '../../services/referenceDataService'
 import InitialAssessmentCheckAnswersPresenter from './initialAssessmentCheckAnswersPresenter'
 import InitialAssessmentCheckAnswersView from './initialAssessmentCheckAnswersView'
+import createFormValidationErrorOrRethrow from '../../utils/interventionsFormError'
 
 export interface DraftAssignmentData {
   email: string | null
@@ -523,8 +524,13 @@ export default class ServiceProviderReferralsController {
       formError = form.error
 
       if (form.isValid) {
-        await this.interventionsService.updateDraftActionPlan(token, actionPlanId, form.paramsForUpdate)
-        return res.redirect(`/service-provider/action-plan/${actionPlanId}/review`)
+        try {
+          await this.interventionsService.updateDraftActionPlan(token, actionPlanId, form.paramsForUpdate)
+          return res.redirect(`/service-provider/action-plan/${actionPlanId}/review`)
+        } catch (e) {
+          const interventionsServiceError = e as InterventionsServiceError
+          formError = createFormValidationErrorOrRethrow(interventionsServiceError)
+        }
       }
     }
 

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -81,6 +81,7 @@ export default {
     notNumber: 'The number of sessions must be a number, like 5',
     notWholeNumber: 'The number of sessions must be a whole number, like 5',
     tooSmall: 'The number of sessions must be 1 or more',
+    cannotBeReduced: 'You cannot reduce the number of sessions for a previously-approved action plan.',
   },
   actionPlanApproval: {
     notConfirmed: 'Select the checkbox to confirm before you approve the action plan',

--- a/server/utils/interventionsServiceErrorMessages.ts
+++ b/server/utils/interventionsServiceErrorMessages.ts
@@ -4,4 +4,7 @@ export default {
   completionDeadline: {
     DATE_MUST_BE_IN_THE_FUTURE: errorMessages.completionDeadline.mustBeInFuture,
   },
+  numberOfSessions: {
+    CANNOT_BE_REDUCED: errorMessages.actionPlanNumberOfSessions.cannotBeReduced,
+  },
 }


### PR DESCRIPTION
## What does this pull request do?

Resurfaces a 400 error from the Interventions Service when trying to reduce the number of sessions for a previously-approved action plan.

## What is the intent behind these changes?

If there's already a pre-approved action plan with a set number of sessions, we can't remove any as it's unclear which ones we'd want to remove, and there's no behaviour for this written in the API.

