### PR TITLE
Add new case note check your answers

### DIFF
--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.test.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.test.ts
@@ -1,0 +1,57 @@
+import caseNoteFactory from '../../../../../testutils/factories/caseNote'
+import AddCaseNoteCheckAnswersPresenter from './addCaseNoteCheckAnswersPresenter'
+import userDetailsFactory from '../../../../../testutils/factories/userDetails'
+
+describe('AddCaseNoteCheckAnswersPresenter', () => {
+  const referralId = '8b588c52-91fd-48fa-89fe-6438748bceda'
+  const draftId = '1b188e6b-7ebd-42ec-8d2c-cb9af7d022d6'
+
+  describe('generated links', () => {
+    it('should show correct back link for service provider', () => {
+      const presenter = new AddCaseNoteCheckAnswersPresenter(
+        referralId,
+        draftId,
+        'service-provider',
+        userDetailsFactory.build(),
+        caseNoteFactory.build()
+      )
+      expect(presenter.backLinkHref).toEqual(
+        '/service-provider/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/add-case-note/1b188e6b-7ebd-42ec-8d2c-cb9af7d022d6/details'
+      )
+      expect(presenter.submitHref).toEqual(
+        '/service-provider/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/add-case-note/1b188e6b-7ebd-42ec-8d2c-cb9af7d022d6/submit'
+      )
+    })
+
+    it('should show correct back link for probation practitioner', () => {
+      const presenter = new AddCaseNoteCheckAnswersPresenter(
+        referralId,
+        draftId,
+        'probation-practitioner',
+        userDetailsFactory.build(),
+        caseNoteFactory.build()
+      )
+      expect(presenter.backLinkHref).toEqual(
+        '/probation-practitioner/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/add-case-note/1b188e6b-7ebd-42ec-8d2c-cb9af7d022d6/details'
+      )
+      expect(presenter.submitHref).toEqual(
+        '/probation-practitioner/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/add-case-note/1b188e6b-7ebd-42ec-8d2c-cb9af7d022d6/submit'
+      )
+    })
+  })
+
+  describe('caseNoteSummary', () => {
+    it('should display correct summary for a case note', () => {
+      const presenter = new AddCaseNoteCheckAnswersPresenter(
+        referralId,
+        draftId,
+        'service-provider',
+        userDetailsFactory.build({ name: 'firstName lastName' }),
+        caseNoteFactory.build({ subject: 'subject', body: 'body' })
+      )
+      expect(presenter.caseNoteSummary.body).toEqual('body')
+      expect(presenter.caseNoteSummary.subject).toEqual('subject')
+      expect(presenter.caseNoteSummary.from).toEqual('firstName lastName')
+    })
+  })
+})

--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.ts
@@ -1,0 +1,33 @@
+import { CaseNote } from '../../../../models/caseNote'
+import DateUtils from '../../../../utils/dateUtils'
+import UserDetails from '../../../../models/hmppsAuth/userDetails'
+
+interface CaseNotesSummary {
+  subject: string
+  date: string
+  time: string
+  from: string
+  body: string
+}
+
+export default class AddCaseNoteCheckAnswersPresenter {
+  constructor(
+    private referralId: string,
+    private draftId: string,
+    public loggedInUserType: 'service-provider' | 'probation-practitioner',
+    private loggedInUser: UserDetails,
+    private caseNote: CaseNote
+  ) {}
+
+  backLinkHref = `/${this.loggedInUserType}/referrals/${this.referralId}/add-case-note/${this.draftId}/details`
+
+  submitHref = `/${this.loggedInUserType}/referrals/${this.referralId}/add-case-note/${this.draftId}/submit`
+
+  readonly caseNoteSummary: CaseNotesSummary = {
+    subject: this.caseNote.subject,
+    date: DateUtils.formattedDate(new Date()),
+    time: DateUtils.formattedTime(new Date()),
+    from: this.loggedInUser.name,
+    body: this.caseNote.body,
+  }
+}

--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersView.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersView.ts
@@ -1,0 +1,36 @@
+import { SummaryListArgs } from '../../../../utils/govukFrontendTypes'
+import ViewUtils from '../../../../utils/viewUtils'
+import AddCaseNoteCheckAnswersPresenter from './addCaseNoteCheckAnswersPresenter'
+
+export default class AddCaseNoteCheckAnswersView {
+  constructor(private presenter: AddCaseNoteCheckAnswersPresenter) {}
+
+  private readonly backLinkArgs = {
+    text: 'Back',
+    href: this.presenter.backLinkHref,
+  }
+
+  private get caseNoteSummaryListArgs(): SummaryListArgs {
+    return ViewUtils.summaryListArgs(
+      [
+        { key: 'Subject', lines: [this.presenter.caseNoteSummary.subject] },
+        { key: 'Date', lines: [this.presenter.caseNoteSummary.date] },
+        { key: 'Time', lines: [this.presenter.caseNoteSummary.time] },
+        { key: 'From', lines: [this.presenter.caseNoteSummary.from] },
+      ],
+      { showBorders: false }
+    )
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'caseNotes/checkAnswers',
+      {
+        presenter: this.presenter,
+        backLinkArgs: this.backLinkArgs,
+        caseNoteSummaryListArgs: this.caseNoteSummaryListArgs,
+        caseNoteBody: this.presenter.caseNoteSummary.body,
+      },
+    ]
+  }
+}

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -109,6 +109,7 @@ describe.each([
         communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUserFactory.build())
         await request(app)
           .get(`/${user.userType}/referrals/${sentReferral.id}/case-notes`)
+          .expect(200)
           .expect(res => {
             expect(res.text).toContain('username')
           })

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -216,8 +216,41 @@ describe.each([
           .type('form')
           .send({ 'case-note-subject': 'subject', 'case-note-body': 'body' })
           .expect(302)
-          .expect('Location', `/${user.userType}/referrals/${sentReferral.id}/case-notes`)
+          .expect(
+            'Location',
+            `/${user.userType}/referrals/${sentReferral.id}/add-case-note/${draftCaseNote.id}/check-answers`
+          )
       })
+    })
+  })
+
+  describe(`GET /${user.userType}/referrals/:id/add-case-note/:draftCaseNoteId/check-answers`, () => {
+    it('should provide a summary of case note draft', async () => {
+      const draftCaseNote = draftCaseNoteFactory.build({
+        data: caseNoteFactory.build({ subject: 'case note subject text', body: 'case note body text' }),
+      })
+      draftsService.fetchDraft.mockResolvedValue(draftCaseNote)
+      hmppsAuthService.getUserDetails.mockResolvedValue(userDetailsFactory.build())
+      await request(app)
+        .get(`/${user.userType}/referrals/${sentReferral.id}/add-case-note/${draftCaseNote.id}/check-answers`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('case note subject text')
+          expect(res.text).toContain('case note body text')
+        })
+    })
+  })
+
+  describe(`POST /${user.userType}/referrals/:id/add-case-note/:draftCaseNoteId/submit`, () => {
+    it('should submit draft case note to interventions service', async () => {
+      const draftCaseNote = draftCaseNoteFactory.build({
+        data: caseNoteFactory.build({ subject: 'case note subject text', body: 'case note body text' }),
+      })
+      draftsService.fetchDraft.mockResolvedValue(draftCaseNote)
+      await request(app)
+        .post(`/${user.userType}/referrals/${sentReferral.id}/add-case-note/${draftCaseNote.id}/submit`)
+        .expect(302)
+        .expect('Location', `/${user.userType}/referrals/${sentReferral.id}/case-notes`)
     })
   })
 

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -92,5 +92,13 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     caseNotesController.viewCaseNote(req, res, 'probation-practitioner')
   )
 
+  get(router, '/referrals/:id/add-case-note/:draftCaseNoteId/check-answers', (req, res) =>
+    caseNotesController.checkCaseNoteAnswers(req, res, 'probation-practitioner')
+  )
+
+  post(router, '/referrals/:id/add-case-note/:draftCaseNoteId/submit', (req, res) =>
+    caseNotesController.submitCaseNote(req, res, 'probation-practitioner')
+  )
+
   return router
 }

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -195,6 +195,14 @@ export default function serviceProviderRoutes(router: Router, services: Services
 
   get(router, '/case-note/:caseNoteId', (req, res) => caseNotesController.viewCaseNote(req, res, 'service-provider'))
 
+  get(router, '/referrals/:id/add-case-note/:draftCaseNoteId/check-answers', (req, res) =>
+    caseNotesController.checkCaseNoteAnswers(req, res, 'service-provider')
+  )
+
+  post(router, '/referrals/:id/add-case-note/:draftCaseNoteId/submit', (req, res) =>
+    caseNotesController.submitCaseNote(req, res, 'service-provider')
+  )
+
   if (config.features.serviceProviderReporting.enabled) {
     get(router, '/performance-report', (req, res) => serviceProviderReferralsController.viewReporting(req, res))
     post(router, '/performance-report', (req, res) => serviceProviderReferralsController.createReport(req, res))

--- a/server/views/caseNotes/checkAnswers.njk
+++ b/server/views/caseNotes/checkAnswers.njk
@@ -1,0 +1,21 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "Referral" %}
+{% set pageSubTitle = "Review case note" %}
+
+{% block pageContent %}
+    {{ govukBackLink(backLinkArgs) }}
+    <h1 class="govuk-heading-l">Review case note</h1>
+    {{ govukSummaryList(caseNoteSummaryListArgs) }}
+    <p class="govuk-body">
+        {{ caseNoteBody | escape | nl2br }}
+    </p>
+
+    <form method="post" action="{{ presenter.submitHref }}">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+        {{ govukButton({ text: "Confirm case note" }) }}
+    </form>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a check your answers page.
The case note is not created until `Confirm case note` button is clicked; this is because the draft service is being used.

If the user clicks on `< back` they will be taken back to the `add case note` page and with the subject and case note details filled in from the draft.

## What is the intent behind these changes?

Provides a review screen for the user to double check their answers before submitting to add the new case note.

## Screenshot

![image](https://user-images.githubusercontent.com/83066216/132586782-25395b64-af0f-4232-a721-e87d0ffccc28.png)
