### PR TITLE
Add new case note confirmation screen

### DIFF
--- a/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationPresenter.ts
+++ b/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationPresenter.ts
@@ -1,0 +1,41 @@
+import { SummaryListItem } from '../../../../utils/summaryList'
+import PresenterUtils from '../../../../utils/presenterUtils'
+import utils from '../../../../utils/utils'
+import SentReferral from '../../../../models/sentReferral'
+import Intervention from '../../../../models/intervention'
+
+export default class AddCaseNoteConfirmationPresenter {
+  constructor(
+    private referral: SentReferral,
+    private intervention: Intervention,
+    public loggedInUserType: 'service-provider' | 'probation-practitioner'
+  ) {}
+
+  progressHref = `/${this.loggedInUserType}/referrals/${this.referral.id}/progress`
+
+  text = {
+    whatHappensNext: `The case note will be available to view by the service user's ${this.loggedInUserTypeText}.`,
+  }
+
+  readonly serviceUserSummary: SummaryListItem[] = [
+    {
+      key: 'Name',
+      lines: [PresenterUtils.fullName(this.referral.referral.serviceUser)],
+    },
+    {
+      key: 'Referral number',
+      lines: [this.referral.referenceNumber],
+    },
+    {
+      key: 'Service type',
+      lines: [utils.convertToProperCase(this.intervention.contractType.name)],
+    },
+  ]
+
+  private get loggedInUserTypeText(): string {
+    if (this.loggedInUserType === 'service-provider') {
+      return 'service provider'
+    }
+    return 'probation practitioner'
+  }
+}

--- a/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationView.ts
+++ b/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationView.ts
@@ -1,0 +1,20 @@
+import ViewUtils from '../../../../utils/viewUtils'
+import AddCaseNoteConfirmationPresenter from './addCaseNoteConfirmationPresenter'
+
+export default class AddCaseNoteConfirmationView {
+  constructor(private presenter: AddCaseNoteConfirmationPresenter) {}
+
+  private get summaryListArgs() {
+    return ViewUtils.summaryListArgs(this.presenter.serviceUserSummary)
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'caseNotes/addNewCaseNoteConfirmation',
+      {
+        presenter: this.presenter,
+        summaryListArgs: this.summaryListArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -17,6 +17,7 @@ import deliusServiceUserFactory from '../../../testutils/factories/deliusService
 import { createDraftFactory } from '../../../testutils/factories/draft'
 import DraftsService from '../../services/draftsService'
 import { DraftCaseNote } from './caseNotesController'
+import interventionFactory from '../../../testutils/factories/intervention'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -250,7 +251,20 @@ describe.each([
       await request(app)
         .post(`/${user.userType}/referrals/${sentReferral.id}/add-case-note/${draftCaseNote.id}/submit`)
         .expect(302)
-        .expect('Location', `/${user.userType}/referrals/${sentReferral.id}/case-notes`)
+        .expect('Location', `/${user.userType}/referrals/${sentReferral.id}/add-case-note/confirmation`)
+    })
+  })
+
+  describe(`GET /${user.userType}/referrals/:id/add-case-note/confirmation`, () => {
+    it('should show confirmation of case note added', async () => {
+      interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build({}))
+      await request(app)
+        .get(`/${user.userType}/referrals/${sentReferral.id}/add-case-note/confirmation`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('New case note added')
+        })
     })
   })
 

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -17,6 +17,8 @@ import CheckAddCaseNoteAnswersView from './add/checkAnswers/addCaseNoteCheckAnsw
 import { CaseNote } from '../../models/caseNote'
 import CaseNotePresenter from './view/caseNotePresenter'
 import CaseNoteView from './view/caseNoteView'
+import AddCaseNoteConfirmationPresenter from './add/confirmation/addCaseNoteConfirmationPresenter'
+import AddCaseNoteConfirmationView from './add/confirmation/addCaseNoteConfirmationView'
 
 export type DraftCaseNote = null | CaseNote
 
@@ -184,7 +186,24 @@ export default class CaseNotesController {
     }
     await this.interventionsService.addCaseNotes(accessToken, draft.data)
     await this.draftsService.deleteDraft(draft.id, { userId: res.locals.user.userId })
-    res.redirect(`/${loggedInUserType}/referrals/${referralId}/case-notes`)
+    res.redirect(`/${loggedInUserType}/referrals/${referralId}/add-case-note/confirmation`)
+  }
+
+  async addCaseNoteConfirmation(
+    req: Request,
+    res: Response,
+    loggedInUserType: 'service-provider' | 'probation-practitioner'
+  ): Promise<void> {
+    const { accessToken } = res.locals.user.token
+    const referralId = req.params.id
+    const sentReferral = await this.interventionsService.getSentReferral(accessToken, referralId)
+    const intervention = await this.interventionsService.getIntervention(
+      accessToken,
+      sentReferral.referral.interventionId
+    )
+    const presenter = new AddCaseNoteConfirmationPresenter(sentReferral, intervention, loggedInUserType)
+    const view = new AddCaseNoteConfirmationView(presenter)
+    ControllerUtils.renderWithLayout(res, view, null)
   }
 
   private async fetchDraftCaseNoteOrRenderMessage(req: Request, res: Response) {

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -100,5 +100,9 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     caseNotesController.submitCaseNote(req, res, 'probation-practitioner')
   )
 
+  get(router, '/referrals/:id/add-case-note/confirmation', (req, res) =>
+    caseNotesController.addCaseNoteConfirmation(req, res, 'probation-practitioner')
+  )
+
   return router
 }

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -203,6 +203,10 @@ export default function serviceProviderRoutes(router: Router, services: Services
     caseNotesController.submitCaseNote(req, res, 'service-provider')
   )
 
+  get(router, '/referrals/:id/add-case-note/confirmation', (req, res) =>
+    caseNotesController.addCaseNoteConfirmation(req, res, 'service-provider')
+  )
+
   if (config.features.serviceProviderReporting.enabled) {
     get(router, '/performance-report', (req, res) => serviceProviderReferralsController.viewReporting(req, res))
     post(router, '/performance-report', (req, res) => serviceProviderReferralsController.createReport(req, res))

--- a/server/views/caseNotes/addNewCaseNoteConfirmation.njk
+++ b/server/views/caseNotes/addNewCaseNoteConfirmation.njk
@@ -1,0 +1,27 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "Referral" %}
+{% set pageSubTitle = "New case note confirmation" %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({titleText: "New case note added"}) }}
+
+      <h2 class="govuk-heading-m">Service user details</h2>
+
+      {{ govukSummaryList(summaryListArgs) }}
+
+      <h2 class="govuk-heading-m">What happens next?</h2>
+
+      <p class="govuk-body">
+        {{ presenter.text.whatHappensNext }}
+      </p>
+
+      <a href="{{ presenter.progressHref }}" class="govuk-button">Return to intervention</a>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a confirmation screen when the user has clicked `Confirm case note` on check your answers page. 
This confirmation screen differs slightly for PP and SP in the wording of the text.

There is purposefully no back link provided to prevent double submission. If the user presses back on their browser then they are presented with this screen:

![image](https://user-images.githubusercontent.com/83066216/132588445-247c855e-e533-4c74-88f7-d343d2f2fb2a.png)


## What is the intent behind these changes?

Provides a confirmation screen after the user created a new case note.

## Screenshot

![image](https://user-images.githubusercontent.com/83066216/132587959-140907d7-d415-4bdf-ac96-98165cc3ea6d.png)