### PR TITLE
Case note link to navigation

### DIFF
--- a/mocks.ts
+++ b/mocks.ts
@@ -14,6 +14,7 @@ import deliusConvictionFactory from './testutils/factories/deliusConviction'
 import AssessRisksAndNeedsServiceMocks from './mockApis/assessRisksAndNeedsService'
 import riskSummaryFactory from './testutils/factories/riskSummary'
 import supplementaryRiskInformationFactory from './testutils/factories/supplementaryRiskInformation'
+import deliusServiceUser from './testutils/factories/deliusServiceUser'
 
 const wiremock = new Wiremock('http://localhost:9092/__admin')
 const interventionsMocks = new InterventionsServiceMocks(wiremock, '')
@@ -158,6 +159,7 @@ export default async function setUpMocks(): Promise<void> {
       supplementaryRiskInformationFactory.build()
     ),
     communityApiMocks.stubGetActiveConvictionsByCRN('CRN24', [deliusConvictionFactory.build()]),
+    communityApiMocks.stubGetServiceUserByCRN('CRN24', deliusServiceUser.build()),
     communityApiMocks.stubGetConvictionById('CRN24', 'null', deliusConvictionFactory.build()),
     interventionsMocks.stubGetActionPlanAppointment(
       '1',

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -65,6 +65,7 @@ describe.each([
       const caseNotePage: Page<CaseNote> = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
       interventionsService.getCaseNotes.mockResolvedValue(caseNotePage)
+      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
       communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUserFactory.build())
       hmppsAuthService.getUserDetailsByUsername.mockResolvedValue(userDetailsFactory.build())
       await request(app)
@@ -83,6 +84,7 @@ describe.each([
       const caseNotePage: Page<CaseNote> = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
       interventionsService.getCaseNotes.mockResolvedValue(caseNotePage)
+      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
       hmppsAuthService.getUserDetailsByUsername.mockResolvedValue(
         userDetailsFactory.build({ name: 'firstName lastName' })
       )
@@ -104,6 +106,7 @@ describe.each([
         const caseNotePage: Page<CaseNote> = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
         interventionsService.getSentReferral.mockResolvedValue(sentReferral)
         interventionsService.getCaseNotes.mockResolvedValue(caseNotePage)
+        interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
         hmppsAuthService.getUserDetailsByUsername.mockImplementation(() => {
           return Promise.reject()
         })
@@ -127,6 +130,7 @@ describe.each([
       const caseNotePage = pageFactory.pageContent([caseNote1, caseNote2]).build() as Page<CaseNote>
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
       interventionsService.getCaseNotes.mockResolvedValue(caseNotePage)
+      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
       hmppsAuthService.getUserDetailsByUsername.mockResolvedValue(
         userDetailsFactory.build({ name: 'firstName surname' })
       )

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -39,6 +39,7 @@ export default class CaseNotesController {
     const paginationQuery = {
       page: Number(req.query.page),
       size: 5,
+      sort: ['sentAt,DESC'],
     }
     const referralId = req.params.id
     const [referral, caseNotesPage] = await Promise.all([

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -45,6 +45,7 @@ export default class CaseNotesController {
       this.interventionsService.getSentReferral(accessToken, referralId),
       this.interventionsService.getCaseNotes(accessToken, referralId, paginationQuery),
     ])
+    const intervention = await this.interventionsService.getIntervention(accessToken, referral.referral.interventionId)
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
     const uniqueUsers = new Set(caseNotesPage.content.map(caseNote => caseNote.sentBy.username))
     const userDetails: Map<string, undefined | string> = new Map(
@@ -63,7 +64,14 @@ export default class CaseNotesController {
         )
       ).map(user => [user.username, user.fullName])
     )
-    const presenter = new CaseNotesPresenter(referralId, caseNotesPage, userDetails, serviceUser, loggedInUserType)
+    const presenter = new CaseNotesPresenter(
+      referralId,
+      intervention,
+      caseNotesPage,
+      userDetails,
+      serviceUser,
+      loggedInUserType
+    )
     const view = new CaseNotesView(presenter)
     ControllerUtils.renderWithLayout(res, view, null)
   }

--- a/server/routes/caseNotes/viewAll/caseNotesPresenter.test.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesPresenter.test.ts
@@ -4,6 +4,7 @@ import CaseNotesPresenter from './caseNotesPresenter'
 import { CaseNote } from '../../../models/caseNote'
 import { Page } from '../../../models/pagination'
 import deliusServiceUserFactory from '../../../../testutils/factories/deliusServiceUser'
+import interventionFactory from '../../../../testutils/factories/intervention'
 
 describe('CaseNotesPresenter', () => {
   const referralId = 'e2e62d97-97ec-4f90-ae3d-006e42b0fc2d'
@@ -13,6 +14,7 @@ describe('CaseNotesPresenter', () => {
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
       const presenter = new CaseNotesPresenter(
         referralId,
+        interventionFactory.build(),
         page,
         new Map(),
         deliusServiceUserFactory.build(),
@@ -26,6 +28,7 @@ describe('CaseNotesPresenter', () => {
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
       const presenter = new CaseNotesPresenter(
         referralId,
+        interventionFactory.build(),
         page,
         new Map(),
         deliusServiceUserFactory.build(),
@@ -39,6 +42,7 @@ describe('CaseNotesPresenter', () => {
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
       const presenter = new CaseNotesPresenter(
         referralId,
+        interventionFactory.build(),
         page,
         new Map(),
         deliusServiceUserFactory.build(),
@@ -55,6 +59,7 @@ describe('CaseNotesPresenter', () => {
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
       let presenter = new CaseNotesPresenter(
         referralId,
+        interventionFactory.build(),
         page,
         new Map(),
         deliusServiceUserFactory.build(),
@@ -65,6 +70,7 @@ describe('CaseNotesPresenter', () => {
       )
       presenter = new CaseNotesPresenter(
         referralId,
+        interventionFactory.build(),
         page,
         new Map(),
         deliusServiceUserFactory.build(),
@@ -88,6 +94,7 @@ describe('CaseNotesPresenter', () => {
           const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
           const presenter = new CaseNotesPresenter(
             referralId,
+            interventionFactory.build(),
             page,
             new Map(),
             deliusServiceUserFactory.build(),
@@ -109,6 +116,7 @@ describe('CaseNotesPresenter', () => {
           const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
           const presenter = new CaseNotesPresenter(
             referralId,
+            interventionFactory.build(),
             page,
             new Map([['USER_1', undefined]]),
             deliusServiceUserFactory.build(),
@@ -130,6 +138,7 @@ describe('CaseNotesPresenter', () => {
           const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
           const presenter = new CaseNotesPresenter(
             referralId,
+            interventionFactory.build(),
             page,
             new Map([['USER_1', 'firstName lastName']]),
             deliusServiceUserFactory.build(),
@@ -147,6 +156,7 @@ describe('CaseNotesPresenter', () => {
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
       const presenter = new CaseNotesPresenter(
         referralId,
+        interventionFactory.build(),
         page,
         new Map(),
         deliusServiceUserFactory.build({ firstName: 'FIRSTNAME', surname: 'SURNAME' }),

--- a/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
@@ -4,6 +4,8 @@ import Pagination from '../../../utils/pagination/pagination'
 import DateUtils from '../../../utils/dateUtils'
 import utils from '../../../utils/utils'
 import DeliusServiceUser from '../../../models/delius/deliusServiceUser'
+import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from '../../shared/referralOverviewPagePresenter'
+import Intervention from '../../../models/intervention'
 
 interface CaseNotesTableRow {
   sentAtDay: string
@@ -18,15 +20,29 @@ interface CaseNotesTableRow {
 export default class CaseNotesPresenter {
   public readonly pagination: Pagination
 
+  referralOverviewPagePresenter: ReferralOverviewPagePresenter
+
   constructor(
     private referralId: string,
+    private intervention: Intervention,
     private caseNotes: Page<CaseNote>,
     private officerUserNameMapping: Map<string, undefined | string>,
     private serviceUser: DeliusServiceUser,
     public loggedInUserType: 'service-provider' | 'probation-practitioner'
   ) {
     this.pagination = new Pagination(caseNotes)
+    this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
+      ReferralOverviewPageSection.CaseNotes,
+      referralId,
+      loggedInUserType
+    )
   }
+
+  readonly text = {
+    title: `${utils.convertToTitleCase(this.intervention.contractType.name)}: case notes`,
+  }
+
+  readonly hrefBackLink = `/${this.loggedInUserType}/dashboard`
 
   readonly hrefCaseNoteStart = `/${this.loggedInUserType}/referrals/${this.referralId}/add-case-note/start`
 

--- a/server/routes/caseNotes/viewAll/caseNotesView.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesView.ts
@@ -6,6 +6,11 @@ import PresenterUtils from '../../../utils/presenterUtils'
 export default class CaseNotesView {
   constructor(private presenter: CaseNotesPresenter) {}
 
+  private readonly backLinkArgs = {
+    text: 'Back',
+    href: this.presenter.hrefBackLink,
+  }
+
   private get tableArgs(): TableArgs {
     if (this.presenter.tableRows.length === 0) {
       return { rows: [] }
@@ -40,6 +45,8 @@ export default class CaseNotesView {
       'caseNotes/caseNotes',
       {
         presenter: this.presenter,
+        backLinkArgs: this.backLinkArgs,
+        subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         pagination: this.presenter.pagination.mojPaginationArgs,
         tableArgs: this.tableArgs,
         serviceUserName: this.presenter.serviceUserName,

--- a/server/routes/shared/referralOverviewPagePresenter.ts
+++ b/server/routes/shared/referralOverviewPagePresenter.ts
@@ -23,6 +23,11 @@ export default class ReferralOverviewPagePresenter {
         href: `/${this.subNavUrlPrefix}/referrals/${this.referralId}/details`,
         active: this.section === ReferralOverviewPageSection.Details,
       },
+      {
+        text: 'Case notes',
+        href: `/${this.subNavUrlPrefix}/referrals/${this.referralId}/case-notes`,
+        active: this.section === ReferralOverviewPageSection.CaseNotes,
+      },
     ],
   }
 

--- a/server/views/caseNotes/caseNotes.njk
+++ b/server/views/caseNotes/caseNotes.njk
@@ -1,10 +1,10 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% extends "../partials/layout.njk" %}
+{% extends "../partials/referralNavigationTemplate.njk" %}
 {% set pageTitle = "Referral" %}
 {% set pageSubTitle = "Case notes" %}
 
-{% block pageContent %}
+{% block referralPageSection %}
     <form action="{{ presenter.hrefCaseNoteStart }}" method="POST">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukButton({ text: "Add case note" }) }}


### PR DESCRIPTION
## What does this pull request do?

Provide a sub navigation menu.

This will allow the user to access case notes on intervention progress screen. 

Case notes navigation will also be visible on `Progress` and `Referral details` pages. 

## What is the intent behind these changes?

Allow user to access case notes.

## Screenshot

![image](https://user-images.githubusercontent.com/83066216/132589889-7171e084-0de3-4cd0-abbc-c8a2a3aa3ed2.png)
