### PR TITLE
41: Fetch main address for Service Users if set in nDelius

### DIFF
--- a/server/decorators/expandedDeliusServiceUserDecorator.test.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.test.ts
@@ -4,239 +4,300 @@ import ExpandedDeliusServiceUserDecorator from './expandedDeliusServiceUserDecor
 describe(ExpandedDeliusServiceUserDecorator, () => {
   describe('address', () => {
     describe('selecting the current address', () => {
-      describe('when there is only one address returned from nDelius', () => {
-        it('uses that address as the current address', () => {
-          const serviceUser = new ExpandedDeliusServiceUserDecorator(
-            expandedDeliusServiceUserFactory.build({
-              contactDetails: {
-                addresses: [
-                  {
-                    addressNumber: 'Flat 2',
-                    buildingName: null,
-                    streetName: 'Test Walk',
-                    postcode: 'SW16 1AQ',
-                    town: 'London',
-                    district: 'City of London',
-                    county: 'Greater London',
-                    from: '2019-01-01',
-                    to: null,
-                    noFixedAbode: false,
+      describe('when there is a "Main" address in nDelius', () => {
+        const serviceUser = new ExpandedDeliusServiceUserDecorator(
+          expandedDeliusServiceUserFactory.build({
+            contactDetails: {
+              addresses: [
+                {
+                  addressNumber: 'Flat 2',
+                  buildingName: null,
+                  streetName: 'Test Walk',
+                  postcode: 'SW16 1AQ',
+                  town: 'London',
+                  district: 'City of London',
+                  county: 'Greater London',
+                  from: '2019-01-01',
+                  to: null,
+                  noFixedAbode: false,
+                  status: {
+                    code: 'M',
                   },
-                ],
-              },
-            })
-          )
+                },
+                {
+                  addressNumber: 'Flat 10',
+                  buildingName: null,
+                  streetName: 'Test Walk',
+                  postcode: 'SW16 1AQ',
+                  town: 'London',
+                  district: 'City of London',
+                  county: 'Greater London',
+                  from: '2021-01-01',
+                  to: null,
+                  noFixedAbode: false,
+                  status: undefined,
+                },
+              ],
+            },
+          })
+        )
 
-          expect(serviceUser.address).toEqual([
-            'Flat 2 Test Walk',
-            'London',
-            'City of London',
-            'Greater London',
-            'SW16 1AQ',
-          ])
-        })
+        expect(serviceUser.address).toEqual([
+          'Flat 2 Test Walk',
+          'London',
+          'City of London',
+          'Greater London',
+          'SW16 1AQ',
+        ])
       })
 
-      describe('when there are multiple addresses returned from nDelius', () => {
-        describe('when all addresses have a non-null "from" field', () => {
-          it('uses the address with the most recent "from" date but no elapsed "to" date', () => {
-            const oldAddressWithNullToDate = {
-              addressNumber: 'Flat 2',
-              buildingName: null,
-              streetName: 'Test Walk',
-              postcode: 'SW16 1AQ',
-              town: 'London',
-              district: 'City of London',
-              county: 'Greater London',
-              from: '2018-01-01',
-              to: null,
-              noFixedAbode: false,
-            }
-
-            const mostRecentButNoLongerCurrentAddress = {
-              addressNumber: 'Flat 3',
-              buildingName: null,
-              streetName: 'Test Walk',
-              postcode: 'SW16 1AQ',
-              town: 'London',
-              district: 'City of London',
-              county: 'Greater London',
-              from: '2021-02-01',
-              to: '2019-02-03',
-              noFixedAbode: false,
-            }
-
-            const olderButCurrentAddress = {
-              addressNumber: 'Flat 10',
-              buildingName: null,
-              streetName: 'Test Walk',
-              postcode: 'SW16 1AQ',
-              town: 'London',
-              district: 'City of London',
-              county: 'Greater London',
-              from: '2021-01-01',
-              to: null,
-              noFixedAbode: false,
-            }
-
-            const serviceUser = new ExpandedDeliusServiceUserDecorator(
-              expandedDeliusServiceUserFactory.build({
-                contactDetails: {
-                  addresses: [oldAddressWithNullToDate, mostRecentButNoLongerCurrentAddress, olderButCurrentAddress],
-                },
-              })
-            )
-
-            expect(serviceUser.address).toEqual([
-              'Flat 10 Test Walk',
-              'London',
-              'City of London',
-              'Greater London',
-              'SW16 1AQ',
-            ])
-          })
-        })
-
-        describe('when one address has a null "from" field', () => {
-          it('returns the address with the most recent "from" field, ignoring the null value', () => {
-            const oldAddress = {
-              addressNumber: 'Flat 10',
-              buildingName: null,
-              streetName: 'Test Walk',
-              postcode: 'SW16 1AQ',
-              town: 'London',
-              district: 'City of London',
-              county: 'Greater London',
-              from: '2020-01-01',
-              to: null,
-              noFixedAbode: false,
-            }
-            const newAddress = {
-              addressNumber: 'Flat 10',
-              buildingName: null,
-              streetName: 'Test Walk',
-              postcode: 'SW16 1AQ',
-              town: 'London',
-              district: 'City of London',
-              county: 'Greater London',
-              from: '2021-01-01',
-              to: null,
-              noFixedAbode: false,
-            }
-            const addressWithNullFromValue = {
-              addressNumber: 'Flat 10',
-              buildingName: null,
-              streetName: 'Test Walk',
-              postcode: 'SW16 1AQ',
-              town: 'London',
-              district: 'City of London',
-              county: 'Greater London',
-              from: null,
-              to: null,
-              noFixedAbode: false,
-            }
-
-            const serviceUser = new ExpandedDeliusServiceUserDecorator(
-              expandedDeliusServiceUserFactory.build({
-                contactDetails: {
-                  addresses: [oldAddress, newAddress, addressWithNullFromValue],
-                },
-              })
-            )
-
-            expect(serviceUser.address).toEqual([
-              'Flat 10 Test Walk',
-              'London',
-              'City of London',
-              'Greater London',
-              'SW16 1AQ',
-            ])
-          })
-        })
-
-        describe('when all addresses have a null or undefined "from" field', () => {
-          it('returns "null" as we are unable to determine the most recent', () => {
-            const firstAddressNullFromDate = {
-              addressNumber: 'Flat 10',
-              buildingName: null,
-              streetName: 'Test Walk',
-              postcode: 'SW16 1AQ',
-              town: 'London',
-              district: 'City of London',
-              county: 'Greater London',
-              from: null,
-              to: null,
-              noFixedAbode: false,
-            }
-            const secondAddressUndefinedFromDate = {
-              addressNumber: 'Flat 10',
-              buildingName: null,
-              streetName: 'Test Walk',
-              postcode: 'SW16 1AQ',
-              town: 'London',
-              district: 'City of London',
-              county: 'Greater London',
-              to: null,
-              noFixedAbode: false,
-            }
-
-            const serviceUser = new ExpandedDeliusServiceUserDecorator(
-              expandedDeliusServiceUserFactory.build({
-                contactDetails: {
-                  addresses: [firstAddressNullFromDate, secondAddressUndefinedFromDate],
-                },
-              })
-            )
-
-            expect(serviceUser.address).toBeNull()
-          })
-        })
-
-        describe('when there is no current address added for the service user', () => {
-          it('should return null', () => {
+      describe('when there is no "Main" address in nDelius', () => {
+        describe('when there is only one address returned from nDelius', () => {
+          it('uses that address as the current address', () => {
             const serviceUser = new ExpandedDeliusServiceUserDecorator(
               expandedDeliusServiceUserFactory.build({
                 contactDetails: {
                   addresses: [
                     {
-                      from: '2021-04-09',
-                      to: '2021-04-30',
-                      noFixedAbode: true,
-                      postcode: 'xxx',
-                    },
-                    {
-                      from: '2020-06-29',
-                      to: '2021-04-09',
+                      addressNumber: 'Flat 2',
+                      buildingName: null,
+                      streetName: 'Test Walk',
+                      postcode: 'SW16 1AQ',
+                      town: 'London',
+                      district: 'City of London',
+                      county: 'Greater London',
+                      from: '2019-01-01',
+                      to: null,
                       noFixedAbode: false,
-                      addressNumber: 'xxx',
-                      streetName: 'xxx',
-                      district: 'xxx',
-                      postcode: 'xxx',
+                      status: undefined,
                     },
                   ],
                 },
               })
             )
 
+            expect(serviceUser.address).toEqual([
+              'Flat 2 Test Walk',
+              'London',
+              'City of London',
+              'Greater London',
+              'SW16 1AQ',
+            ])
+          })
+        })
+
+        describe('when there are multiple addresses returned from nDelius', () => {
+          describe('when all addresses have a non-null "from" field', () => {
+            it('uses the address with the most recent "from" date but no elapsed "to" date', () => {
+              const oldAddressWithNullToDate = {
+                addressNumber: 'Flat 2',
+                buildingName: null,
+                streetName: 'Test Walk',
+                postcode: 'SW16 1AQ',
+                town: 'London',
+                district: 'City of London',
+                county: 'Greater London',
+                from: '2018-01-01',
+                to: null,
+                noFixedAbode: false,
+                status: undefined,
+              }
+
+              const mostRecentButNoLongerCurrentAddress = {
+                addressNumber: 'Flat 3',
+                buildingName: null,
+                streetName: 'Test Walk',
+                postcode: 'SW16 1AQ',
+                town: 'London',
+                district: 'City of London',
+                county: 'Greater London',
+                from: '2021-02-01',
+                to: '2019-02-03',
+                noFixedAbode: false,
+                status: undefined,
+              }
+
+              const olderButCurrentAddress = {
+                addressNumber: 'Flat 10',
+                buildingName: null,
+                streetName: 'Test Walk',
+                postcode: 'SW16 1AQ',
+                town: 'London',
+                district: 'City of London',
+                county: 'Greater London',
+                from: '2021-01-01',
+                to: null,
+                noFixedAbode: false,
+                status: undefined,
+              }
+
+              const serviceUser = new ExpandedDeliusServiceUserDecorator(
+                expandedDeliusServiceUserFactory.build({
+                  contactDetails: {
+                    addresses: [oldAddressWithNullToDate, mostRecentButNoLongerCurrentAddress, olderButCurrentAddress],
+                  },
+                })
+              )
+
+              expect(serviceUser.address).toEqual([
+                'Flat 10 Test Walk',
+                'London',
+                'City of London',
+                'Greater London',
+                'SW16 1AQ',
+              ])
+            })
+          })
+
+          describe('when one address has a null "from" field', () => {
+            it('returns the address with the most recent "from" field, ignoring the null value', () => {
+              const oldAddress = {
+                addressNumber: 'Flat 10',
+                buildingName: null,
+                streetName: 'Test Walk',
+                postcode: 'SW16 1AQ',
+                town: 'London',
+                district: 'City of London',
+                county: 'Greater London',
+                from: '2020-01-01',
+                to: null,
+                noFixedAbode: false,
+                status: undefined,
+              }
+              const newAddress = {
+                addressNumber: 'Flat 10',
+                buildingName: null,
+                streetName: 'Test Walk',
+                postcode: 'SW16 1AQ',
+                town: 'London',
+                district: 'City of London',
+                county: 'Greater London',
+                from: '2021-01-01',
+                to: null,
+                noFixedAbode: false,
+                status: undefined,
+              }
+              const addressWithNullFromValue = {
+                addressNumber: 'Flat 10',
+                buildingName: null,
+                streetName: 'Test Walk',
+                postcode: 'SW16 1AQ',
+                town: 'London',
+                district: 'City of London',
+                county: 'Greater London',
+                from: null,
+                to: null,
+                noFixedAbode: false,
+                status: undefined,
+              }
+
+              const serviceUser = new ExpandedDeliusServiceUserDecorator(
+                expandedDeliusServiceUserFactory.build({
+                  contactDetails: {
+                    addresses: [oldAddress, newAddress, addressWithNullFromValue],
+                  },
+                })
+              )
+
+              expect(serviceUser.address).toEqual([
+                'Flat 10 Test Walk',
+                'London',
+                'City of London',
+                'Greater London',
+                'SW16 1AQ',
+              ])
+            })
+          })
+
+          describe('when all addresses have a null or undefined "from" field', () => {
+            it('returns "null" as we are unable to determine the most recent', () => {
+              const firstAddressNullFromDate = {
+                addressNumber: 'Flat 10',
+                buildingName: null,
+                streetName: 'Test Walk',
+                postcode: 'SW16 1AQ',
+                town: 'London',
+                district: 'City of London',
+                county: 'Greater London',
+                from: null,
+                to: null,
+                noFixedAbode: false,
+                status: undefined,
+              }
+              const secondAddressUndefinedFromDate = {
+                addressNumber: 'Flat 10',
+                buildingName: null,
+                streetName: 'Test Walk',
+                postcode: 'SW16 1AQ',
+                town: 'London',
+                district: 'City of London',
+                county: 'Greater London',
+                to: null,
+                noFixedAbode: false,
+                status: undefined,
+              }
+
+              const serviceUser = new ExpandedDeliusServiceUserDecorator(
+                expandedDeliusServiceUserFactory.build({
+                  contactDetails: {
+                    addresses: [firstAddressNullFromDate, secondAddressUndefinedFromDate],
+                  },
+                })
+              )
+
+              expect(serviceUser.address).toBeNull()
+            })
+          })
+
+          describe('when there is no current address added for the service user', () => {
+            it('should return null', () => {
+              const serviceUser = new ExpandedDeliusServiceUserDecorator(
+                expandedDeliusServiceUserFactory.build({
+                  contactDetails: {
+                    addresses: [
+                      {
+                        from: '2021-04-09',
+                        to: '2021-04-30',
+                        noFixedAbode: true,
+                        postcode: 'xxx',
+                      },
+                      {
+                        from: '2020-06-29',
+                        to: '2021-04-09',
+                        noFixedAbode: false,
+                        status: undefined,
+
+                        addressNumber: 'xxx',
+                        streetName: 'xxx',
+                        district: 'xxx',
+                        postcode: 'xxx',
+                      },
+                    ],
+                  },
+                })
+              )
+
+              expect(serviceUser.address).toBeNull()
+            })
+          })
+        })
+
+        describe('when there is no address returned from nDelius', () => {
+          it('returns null', () => {
+            const serviceUser = new ExpandedDeliusServiceUserDecorator(
+              expandedDeliusServiceUserFactory.build({
+                contactDetails: {
+                  addresses: [],
+                },
+              })
+            )
+
             expect(serviceUser.address).toBeNull()
           })
         })
       })
-
-      describe('when there is no address returned from nDelius', () => {
-        it('returns null', () => {
-          const serviceUser = new ExpandedDeliusServiceUserDecorator(
-            expandedDeliusServiceUserFactory.build({
-              contactDetails: {
-                addresses: [],
-              },
-            })
-          )
-
-          expect(serviceUser.address).toBeNull()
-        })
-      })
     })
+
     describe('formatting', () => {
       describe('when there is an address number but no building name', () => {
         it('returns an array of the address fields with address number prefixed to street name', () => {
@@ -254,6 +315,7 @@ describe(ExpandedDeliusServiceUserDecorator, () => {
                   from: '2019-01-01',
                   to: null,
                   noFixedAbode: false,
+                  status: undefined,
                 },
               ],
             },
@@ -285,6 +347,7 @@ describe(ExpandedDeliusServiceUserDecorator, () => {
                   from: '2019-01-01',
                   to: null,
                   noFixedAbode: false,
+                  status: undefined,
                 },
               ],
             },
@@ -316,6 +379,7 @@ describe(ExpandedDeliusServiceUserDecorator, () => {
                   from: '2019-01-01',
                   to: null,
                   noFixedAbode: false,
+                  status: undefined,
                 },
               ],
             },

--- a/server/decorators/expandedDeliusServiceUserDecorator.ts
+++ b/server/decorators/expandedDeliusServiceUserDecorator.ts
@@ -20,6 +20,12 @@ export default class ExpandedDeliusServiceUserDecorator {
       return this.deliusAddressToArray(addresses[0])
     }
 
+    const nDeliusMainAddress = addresses.find(address => address.status?.code === 'M')
+
+    if (nDeliusMainAddress) {
+      return this.deliusAddressToArray(nDeliusMainAddress)
+    }
+
     // If we have no "from" date, how do we know which is the most recent?
     if (addresses.every(address => address.from === null || address.from === undefined)) {
       logger.error({ err: `No 'from' value in addresses for user ${this.deliusServiceUser.otherIds.crn}.` })

--- a/server/models/delius/deliusServiceUser.ts
+++ b/server/models/delius/deliusServiceUser.ts
@@ -22,6 +22,11 @@ export interface Address {
   from?: string | null
   to?: string | null
   noFixedAbode?: boolean | null
+  status?: AddressStatus | null
+}
+
+interface AddressStatus {
+  code?: string
 }
 
 interface ContactDetails {

--- a/testutils/factories/expandedDeliusServiceUser.ts
+++ b/testutils/factories/expandedDeliusServiceUser.ts
@@ -40,6 +40,9 @@ export default Factory.define<ExpandedDeliusServiceUser>(() => ({
         from: '2019-01-01',
         to: null,
         noFixedAbode: false,
+        status: {
+          code: 'M',
+        },
       },
     ],
     emailAddresses: ['alex.river@example.com'],


### PR DESCRIPTION
## What does this pull request do?

Fetches the main address specified in nDelius (`status: { code: "M" }`), falling back to the previous logic to fetch the address with the most recent `from` date` with a `to` date that hasn't elapsed if the status isn't present in the response.

## What is the intent behind these changes?

To make it easier for users to correct the address in Delius without having to follow complex logic like to/from dates.
