### PR TITLE
FIX: Use correct feature flag attribute

### DIFF
--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -467,7 +467,7 @@ export default class ProbationPractitionerReferralsController {
         )
       ),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
-      config.features.previouslyApprovedActionPlans
+      config.features.previouslyApprovedActionPlans.enabled
         ? this.interventionsService.getApprovedActionPlanSummaries(accessToken, sentReferral.id)
         : [],
     ])

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -108,7 +108,7 @@ export default class ActionPlanPresenter {
   }
 
   get showCreateNewActionPlanVersionButton(): boolean {
-    if (config.features.previouslyApprovedActionPlans) {
+    if (config.features.previouslyApprovedActionPlans.enabled) {
       return this.userType === 'service-provider' && this.actionPlanSummaryPresenter.actionPlanApproved
     }
 


### PR DESCRIPTION
## What does this pull request do?

Accesses the correct value of the config var for the new versions of action plans.

## What is the intent behind these changes?

This was returning true and the feature was turned on for all
environments.
