### PR TITLE
Ic-1833 consistent url

### DIFF
--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -139,7 +139,7 @@ describe(InterventionProgressPresenter, () => {
                 classes: 'govuk-tag--green',
               },
               link: {
-                href: `/probation-practitioner/action-plan/c59809e0-ab78-4723-bbef-bd34bc6df110/appointment/1/post-session-feedback`,
+                href: `/probation-practitioner/referrals/${referral.id}/appointment/1/post-session-feedback`,
                 text: 'View feedback form',
               },
             },
@@ -151,7 +151,7 @@ describe(InterventionProgressPresenter, () => {
                 classes: 'govuk-tag--green',
               },
               link: {
-                href: `/probation-practitioner/action-plan/c59809e0-ab78-4723-bbef-bd34bc6df110/appointment/2/post-session-feedback`,
+                href: `/probation-practitioner/referrals/${referral.id}/appointment/2/post-session-feedback`,
                 text: 'View feedback form',
               },
             },
@@ -181,7 +181,7 @@ describe(InterventionProgressPresenter, () => {
                 classes: 'govuk-tag--purple',
               },
               link: {
-                href: `/probation-practitioner/action-plan/c59809e0-ab78-4723-bbef-bd34bc6df110/appointment/1/post-session-feedback`,
+                href: `/probation-practitioner/referrals/${referral.id}/appointment/1/post-session-feedback`,
                 text: 'View feedback form',
               },
             },

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -113,7 +113,7 @@ export default class InterventionProgressPresenter {
           tagClass: presenter.tagClass,
           link: {
             text: 'View feedback form',
-            href: `/probation-practitioner/action-plan/${this.referral.actionPlanId}/appointment/${appointment.sessionNumber}/post-session-feedback`,
+            href: `/probation-practitioner/referrals/${this.referral.id}/appointment/${appointment.sessionNumber}/post-session-feedback`,
           },
         }
       case SessionStatus.completed:
@@ -122,7 +122,7 @@ export default class InterventionProgressPresenter {
           tagClass: presenter.tagClass,
           link: {
             text: 'View feedback form',
-            href: `/probation-practitioner/action-plan/${this.referral.actionPlanId}/appointment/${appointment.sessionNumber}/post-session-feedback`,
+            href: `/probation-practitioner/referrals/${this.referral.id}/appointment/${appointment.sessionNumber}/post-session-feedback`,
           },
         }
       case SessionStatus.awaitingFeedback:

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -151,7 +151,7 @@ describe('GET /probation-practitioner/referrals/:id/progress', () => {
   })
 })
 
-describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', () => {
+describe('GET /probation-practitioner/referrals/:referralId/appointment/:sessionNumber/post-session-feedback', () => {
   it('renders a page displaying feedback answers', async () => {
     const actionPlanId = '05f39e99-b5c7-4a9b-a857-bec04a28eb34'
     const referral = sentReferralFactory.assigned().build({ actionPlanId, assignedTo: { username: 'Kay.Swerker' } })
@@ -185,7 +185,7 @@ describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:ses
 
     await request(app)
       .get(
-        `/probation-practitioner/action-plan/${actionPlanId}/appointment/${appointmentWithSubmittedFeedback.sessionNumber}/post-session-feedback`
+        `/probation-practitioner/referrals/${referral.id}/appointment/${appointmentWithSubmittedFeedback.sessionNumber}/post-session-feedback`
       )
       .expect(200)
       .expect(res => {

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -186,14 +186,19 @@ export default class ProbationPractitionerReferralsController {
   async viewSubmittedPostSessionFeedback(req: Request, res: Response): Promise<void> {
     const { user } = res.locals
     const { accessToken } = user.token
-    const { actionPlanId, sessionNumber } = req.params
+    const { referralId, sessionNumber } = req.params
 
-    const actionPlan = await this.interventionsService.getActionPlan(accessToken, actionPlanId)
-    const referral = await this.interventionsService.getSentReferral(accessToken, actionPlan.referralId)
+    const referral = await this.interventionsService.getSentReferral(accessToken, referralId)
+
+    if (referral.actionPlanId === null) {
+      throw createError(500, `action plan does not exist on this referral '${req.params.id}'`, {
+        userMessage: 'No action plan exists for this referral',
+      })
+    }
 
     const currentAppointment = await this.interventionsService.getActionPlanAppointment(
       accessToken,
-      actionPlanId,
+      referral.actionPlanId,
       Number(sessionNumber)
     )
     const deliusOfficeLocation = await this.deliusOfficeLocationFilter.findOfficeByAppointment(currentAppointment)

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -21,7 +21,7 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     probationPractitionerReferralsController.showInterventionProgress(req, res)
   )
   get(router, '/referrals/:id/details', (req, res) => probationPractitionerReferralsController.showReferral(req, res))
-  get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', (req, res) =>
+  get(router, '/referrals/:referralId/appointment/:sessionNumber/post-session-feedback', (req, res) =>
     probationPractitionerReferralsController.viewSubmittedPostSessionFeedback(req, res)
   )
   get(router, '/end-of-service-report/:id', (req, res) =>


### PR DESCRIPTION
## What does this pull request do?

Updates the pp post-session-feedback url to be consistent with the others.

## What is the intent behind these changes?

All other url's are in the form `probation-practitioner/referral/:id/...` . This change is to bring the pp-post-session-feedback url in line as it was the only one not following this form.

Old: `probation-practitioner/:actionPlanId/appointment/:sessionNumber/post-session-feedback`
New: `probation-practitioner/referrals/:referralId/appointment/:sessionNumber/post-session-feedback`
