### PR TITLE
View single case note

### DIFF
--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -219,4 +219,27 @@ describe.each([
       })
     })
   })
+
+  describe(`GET /${user.userType}/case-note/:caseNoteId`, () => {
+    it('should provide a summary of case note', async () => {
+      const caseNote = caseNoteFactory.build({
+        subject: 'case note subject text',
+        body: 'case note body text',
+        sentAt: '2021-01-01T09:45:21.986389Z',
+      })
+      const userDetails = userDetailsFactory.build({ name: 'firstName lastName' })
+      interventionsService.getCaseNote.mockResolvedValue(caseNote)
+      hmppsAuthService.getUserDetailsByUsername.mockResolvedValue(userDetails)
+      await request(app)
+        .get(`/${user.userType}/case-note/${caseNote.id}`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('case note subject text')
+          expect(res.text).toContain('case note body text')
+          expect(res.text).toContain('1 January 2021')
+          expect(res.text).toContain('9:45am')
+          expect(res.text).toContain('firstName lastName')
+        })
+    })
+  })
 })

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -12,6 +12,8 @@ import { FormValidationError } from '../../utils/formValidationError'
 import createFormValidationErrorOrRethrow from '../../utils/interventionsFormError'
 import DraftsService from '../../services/draftsService'
 import { CaseNote } from '../../models/caseNote'
+import CaseNotePresenter from './view/caseNotePresenter'
+import CaseNoteView from './view/caseNoteView'
 
 export type DraftCaseNote = null | CaseNote
 
@@ -102,6 +104,24 @@ export default class CaseNotesController {
 
     const presenter = new AddCaseNotePresenter(referralId, loggedInUserType, draftCaseNote.data, error, userInputData)
     const view = new AddCaseNoteView(presenter)
+    ControllerUtils.renderWithLayout(res, view, null)
+  }
+
+  async viewCaseNote(
+    req: Request,
+    res: Response,
+    loggedInUserType: 'service-provider' | 'probation-practitioner'
+  ): Promise<void> {
+    const { accessToken } = res.locals.user.token
+    const { caseNoteId } = req.params
+    const caseNote = await this.interventionsService.getCaseNote(accessToken, caseNoteId)
+    const sentByUserDetails = await this.hmppsAuthService.getUserDetailsByUsername(
+      accessToken,
+      caseNote.sentBy.username
+    )
+    const sentByUserName = sentByUserDetails.name
+    const presenter = new CaseNotePresenter(caseNote, sentByUserName, loggedInUserType)
+    const view = new CaseNoteView(presenter)
     ControllerUtils.renderWithLayout(res, view, null)
   }
 

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -25,7 +25,11 @@ export default class CaseNotesController {
     private readonly draftsService: DraftsService
   ) {}
 
-  async showCaseNotes(req: Request, res: Response): Promise<void> {
+  async showCaseNotes(
+    req: Request,
+    res: Response,
+    loggedInUserType: 'service-provider' | 'probation-practitioner'
+  ): Promise<void> {
     const { accessToken } = res.locals.user.token
     const paginationQuery = {
       page: Number(req.query.page),
@@ -54,7 +58,7 @@ export default class CaseNotesController {
         )
       ).map(user => [user.username, user.fullName])
     )
-    const presenter = new CaseNotesPresenter(caseNotesPage, userDetails, serviceUser)
+    const presenter = new CaseNotesPresenter(caseNotesPage, userDetails, serviceUser, loggedInUserType)
     const view = new CaseNotesView(presenter)
     ControllerUtils.renderWithLayout(res, view, null)
   }

--- a/server/routes/caseNotes/view/caseNotePresenter.test.ts
+++ b/server/routes/caseNotes/view/caseNotePresenter.test.ts
@@ -1,0 +1,47 @@
+import caseNoteFactory from '../../../../testutils/factories/caseNote'
+import CaseNotePresenter from './caseNotePresenter'
+
+describe('CaseNotePresenter', () => {
+  describe('generated links', () => {
+    it('should show correct back link for service provider', () => {
+      const presenter = new CaseNotePresenter(
+        caseNoteFactory.build({ referralId: '8b588c52-91fd-48fa-89fe-6438748bceda' }),
+        'firstName lastName',
+        'service-provider'
+      )
+      expect(presenter.backLinkHref).toEqual(
+        '/service-provider/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/case-notes'
+      )
+    })
+
+    it('should show correct back link for probation practitioner', () => {
+      const presenter = new CaseNotePresenter(
+        caseNoteFactory.build({ referralId: '8b588c52-91fd-48fa-89fe-6438748bceda' }),
+        'firstName lastName',
+        'probation-practitioner'
+      )
+      expect(presenter.backLinkHref).toEqual(
+        '/probation-practitioner/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/case-notes'
+      )
+    })
+  })
+
+  describe('caseNoteSummary', () => {
+    it('should display correct summary for a case note', () => {
+      const presenter = new CaseNotePresenter(
+        caseNoteFactory.build({
+          subject: 'Case note subject',
+          body: 'Case note body text',
+          sentAt: '2021-01-01T09:45:21.986389Z',
+        }),
+        'firstName lastName',
+        'probation-practitioner'
+      )
+      expect(presenter.caseNoteSummary.subject).toEqual('Case note subject')
+      expect(presenter.caseNoteSummary.body).toEqual('Case note body text')
+      expect(presenter.caseNoteSummary.date).toEqual('1 January 2021')
+      expect(presenter.caseNoteSummary.time).toEqual('9:45am')
+      expect(presenter.caseNoteSummary.from).toEqual('firstName lastName')
+    })
+  })
+})

--- a/server/routes/caseNotes/view/caseNotePresenter.ts
+++ b/server/routes/caseNotes/view/caseNotePresenter.ts
@@ -1,0 +1,28 @@
+import { CaseNote } from '../../../models/caseNote'
+import DateUtils from '../../../utils/dateUtils'
+
+interface CaseNoteSummary {
+  subject: string
+  date: string
+  time: string
+  from: string
+  body: string
+}
+
+export default class CaseNotePresenter {
+  constructor(
+    private caseNote: CaseNote,
+    private sentByUserName: string,
+    public loggedInUserType: 'service-provider' | 'probation-practitioner'
+  ) {}
+
+  backLinkHref = `/${this.loggedInUserType}/referrals/${this.caseNote.referralId}/case-notes`
+
+  readonly caseNoteSummary: CaseNoteSummary = {
+    subject: this.caseNote.subject,
+    date: DateUtils.formattedDate(this.caseNote.sentAt),
+    time: DateUtils.formattedTime(this.caseNote.sentAt),
+    from: this.sentByUserName,
+    body: this.caseNote.body,
+  }
+}

--- a/server/routes/caseNotes/view/caseNoteView.ts
+++ b/server/routes/caseNotes/view/caseNoteView.ts
@@ -1,0 +1,36 @@
+import { SummaryListArgs } from '../../../utils/govukFrontendTypes'
+import ViewUtils from '../../../utils/viewUtils'
+import CaseNotePresenter from './caseNotePresenter'
+
+export default class CaseNoteView {
+  constructor(private presenter: CaseNotePresenter) {}
+
+  private readonly backLinkArgs = {
+    text: 'Back',
+    href: this.presenter.backLinkHref,
+  }
+
+  private get caseNoteSummaryListArgs(): SummaryListArgs {
+    return ViewUtils.summaryListArgs(
+      [
+        { key: 'Date', lines: [this.presenter.caseNoteSummary.date] },
+        { key: 'Time', lines: [this.presenter.caseNoteSummary.time] },
+        { key: 'From', lines: [this.presenter.caseNoteSummary.from] },
+      ],
+      { showBorders: false }
+    )
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'caseNotes/caseNote',
+      {
+        presenter: this.presenter,
+        caseNoteSubject: this.presenter.caseNoteSummary.subject,
+        backLinkArgs: this.backLinkArgs,
+        caseNoteSummaryListArgs: this.caseNoteSummaryListArgs,
+        caseNoteBody: this.presenter.caseNoteSummary.body,
+      },
+    ]
+  }
+}

--- a/server/routes/caseNotes/viewAll/caseNotesPresenter.test.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesPresenter.test.ts
@@ -10,22 +10,38 @@ describe('CaseNotesPresenter', () => {
     it('should format sent day correctly', () => {
       const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-      const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build())
+      const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build(), 'service-provider')
       expect(presenter.tableRows[0].sentAtDay).toEqual('Friday')
     })
 
     it('should format sent date correctly', () => {
       const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-      const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build())
+      const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build(), 'service-provider')
       expect(presenter.tableRows[0].sentAtDate).toEqual('1 January 2021')
     })
 
     it('should format sent time correctly', () => {
       const caseNote = caseNoteFactory.build({ sentAt: '2021-01-01T09:45:21.986389Z' })
       const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-      const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build())
+      const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build(), 'service-provider')
       expect(presenter.tableRows[0].sentAtTime).toEqual('9:45am')
+    })
+
+    it('should format the case note links correctly for the relevant logged in user', () => {
+      const caseNote = caseNoteFactory.build({
+        id: '025a807d-a631-4559-be74-664ba62db279',
+        sentAt: '2021-01-01T09:45:21.986389Z',
+      })
+      const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+      let presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build(), 'service-provider')
+      expect(presenter.tableRows[0].caseNoteLink).toEqual(
+        '/service-provider/case-note/025a807d-a631-4559-be74-664ba62db279'
+      )
+      presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build(), 'probation-practitioner')
+      expect(presenter.tableRows[0].caseNoteLink).toEqual(
+        '/probation-practitioner/case-note/025a807d-a631-4559-be74-664ba62db279'
+      )
     })
 
     describe('when displaying officer names', () => {
@@ -39,7 +55,12 @@ describe('CaseNotesPresenter', () => {
             },
           })
           const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
-          const presenter = new CaseNotesPresenter(page, new Map(), deliusServiceUserFactory.build())
+          const presenter = new CaseNotesPresenter(
+            page,
+            new Map(),
+            deliusServiceUserFactory.build(),
+            'service-provider'
+          )
           expect(presenter.tableRows[0].sentBy).toEqual('USER_1')
         })
       })
@@ -57,7 +78,8 @@ describe('CaseNotesPresenter', () => {
           const presenter = new CaseNotesPresenter(
             page,
             new Map([['USER_1', undefined]]),
-            deliusServiceUserFactory.build()
+            deliusServiceUserFactory.build(),
+            'service-provider'
           )
           expect(presenter.tableRows[0].sentBy).toEqual('USER_1')
         })
@@ -76,7 +98,8 @@ describe('CaseNotesPresenter', () => {
           const presenter = new CaseNotesPresenter(
             page,
             new Map([['USER_1', 'firstName lastName']]),
-            deliusServiceUserFactory.build()
+            deliusServiceUserFactory.build(),
+            'service-provider'
           )
           expect(presenter.tableRows[0].sentBy).toEqual('firstName lastName')
         })
@@ -91,7 +114,8 @@ describe('CaseNotesPresenter', () => {
       const presenter = new CaseNotesPresenter(
         page,
         new Map(),
-        deliusServiceUserFactory.build({ firstName: 'FIRSTNAME', surname: 'SURNAME' })
+        deliusServiceUserFactory.build({ firstName: 'FIRSTNAME', surname: 'SURNAME' }),
+        'service-provider'
       )
       expect(presenter.serviceUserName).toEqual('Firstname Surname')
     })

--- a/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
@@ -12,6 +12,7 @@ interface CaseNotesTableRow {
   sentBy: string
   subject: string
   body: string
+  caseNoteLink: string
 }
 
 export default class CaseNotesPresenter {
@@ -20,7 +21,8 @@ export default class CaseNotesPresenter {
   constructor(
     private caseNotes: Page<CaseNote>,
     private officerUserNameMapping: Map<string, undefined | string>,
-    private serviceUser: DeliusServiceUser
+    private serviceUser: DeliusServiceUser,
+    public loggedInUserType: 'service-provider' | 'probation-practitioner'
   ) {
     this.pagination = new Pagination(caseNotes)
   }
@@ -42,6 +44,7 @@ export default class CaseNotesPresenter {
       sentBy: officerName,
       subject: caseNote.subject,
       body: caseNote.body,
+      caseNoteLink: `/${this.loggedInUserType}/case-note/${caseNote.id}`,
     }
   })
 }

--- a/server/routes/caseNotes/viewAll/caseNotesView.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesView.ts
@@ -1,6 +1,7 @@
 import { TableArgs } from '../../../utils/govukFrontendTypes'
 import CaseNotesPresenter from './caseNotesPresenter'
 import ViewUtils from '../../../utils/viewUtils'
+import PresenterUtils from '../../../utils/presenterUtils'
 
 export default class CaseNotesView {
   constructor(private presenter: CaseNotesPresenter) {}
@@ -23,7 +24,11 @@ export default class CaseNotesView {
           {
             html: `<p class="govuk-body">
                     <b>${ViewUtils.escape(row.subject)}</b>
-                    <br><br>${ViewUtils.nl2br(ViewUtils.escape(row.body))}</p>`,
+                    <br><br>${ViewUtils.nl2br(
+                      ViewUtils.escape(PresenterUtils.truncateCharacters(row.body, 250, { addEllipsis: true }))
+                    )}
+                    <p/><a href="${row.caseNoteLink}" class="govuk-link">Read More</a>
+                    </p>`,
           },
         ]
       }),

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -86,5 +86,9 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     caseNotesController.addCaseNote(req, res, 'probation-practitioner')
   )
 
+  get(router, '/case-note/:caseNoteId', (req, res) =>
+    caseNotesController.viewCaseNote(req, res, 'probation-practitioner')
+  )
+
   return router
 }

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -72,7 +72,9 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     services.hmppsAuthService,
     services.draftsService
   )
-  get(router, '/referrals/:id/case-notes', (req, res) => caseNotesController.showCaseNotes(req, res))
+  get(router, '/referrals/:id/case-notes', (req, res) =>
+    caseNotesController.showCaseNotes(req, res, 'probation-practitioner')
+  )
 
   post(router, '/referrals/:id/add-case-note/start', (req, res) =>
     caseNotesController.startAddCaseNote(req, res, 'probation-practitioner')

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -191,6 +191,8 @@ export default function serviceProviderRoutes(router: Router, services: Services
     caseNotesController.addCaseNote(req, res, 'service-provider')
   )
 
+  get(router, '/case-note/:caseNoteId', (req, res) => caseNotesController.viewCaseNote(req, res, 'service-provider'))
+
   if (config.features.serviceProviderReporting.enabled) {
     get(router, '/performance-report', (req, res) => serviceProviderReferralsController.viewReporting(req, res))
     post(router, '/performance-report', (req, res) => serviceProviderReferralsController.createReport(req, res))

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -177,7 +177,9 @@ export default function serviceProviderRoutes(router: Router, services: Services
     services.hmppsAuthService,
     services.draftsService
   )
-  get(router, '/referrals/:id/case-notes', (req, res) => caseNotesController.showCaseNotes(req, res))
+  get(router, '/referrals/:id/case-notes', (req, res) =>
+    caseNotesController.showCaseNotes(req, res, 'service-provider')
+  )
 
   post(router, '/referrals/:id/add-case-note/start', (req, res) =>
     caseNotesController.startAddCaseNote(req, res, 'service-provider')

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -906,4 +906,32 @@ describe(PresenterUtils, () => {
       })
     })
   })
+
+  describe('truncateCharacters', () => {
+    describe('when the character count is equal to the truncate amount', () => {
+      it('no truncation should occur', () => {
+        expect(PresenterUtils.truncateCharacters('12345', 5)).toEqual('12345')
+      })
+    })
+
+    describe('when the character count is greater than truncate amount', () => {
+      it('no truncation should occur', () => {
+        expect(PresenterUtils.truncateCharacters('123456', 5)).toEqual('12345')
+      })
+    })
+
+    describe('with addEllipsis option', () => {
+      describe('when the character count is less then truncate amount', () => {
+        it('it should not add ellipsis', () => {
+          expect(PresenterUtils.truncateCharacters('12345', 5, { addEllipsis: true })).toEqual('12345')
+        })
+      })
+
+      describe('when the character count is greater than truncate amount', () => {
+        it('it should add ellipsis', () => {
+          expect(PresenterUtils.truncateCharacters('123456', 5, { addEllipsis: true })).toEqual('12345...')
+        })
+      })
+    })
+  })
 })

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -387,4 +387,16 @@ export default class PresenterUtils {
   static isNonNullAndDefined<T>(arg: T | undefined | null): arg is T {
     return arg !== null && arg !== undefined
   }
+
+  static truncateCharacters(
+    text: string,
+    truncateToLength: number,
+    options: { addEllipsis: boolean } = { addEllipsis: false }
+  ): string {
+    const truncatedCharacters = text.slice(0, truncateToLength)
+    if (options.addEllipsis && text.length > truncateToLength) {
+      return `${truncatedCharacters}...`
+    }
+    return truncatedCharacters
+  }
 }

--- a/server/utils/viewUtils.test.ts
+++ b/server/utils/viewUtils.test.ts
@@ -93,6 +93,7 @@ describe('ViewUtils', () => {
           { key: 'Address', lines: ['Flat 2', '27 Test Walk', 'SY16 1AQ'] },
         ])
       ).toEqual({
+        classes: undefined,
         rows: [
           {
             key: {
@@ -147,6 +148,17 @@ describe('ViewUtils', () => {
             actions: null,
           },
         ],
+      })
+    })
+
+    describe('with provided options', () => {
+      describe('when show borders is set to false', () => {
+        it('should add a hide borders class', () => {
+          expect(ViewUtils.summaryListArgs([], { showBorders: false })).toEqual({
+            classes: 'govuk-summary-list--no-border',
+            rows: [],
+          })
+        })
       })
     })
   })

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -43,8 +43,12 @@ export default class ViewUtils {
     }
   }
 
-  static summaryListArgs(summaryListItems: SummaryListItem[]): SummaryListArgs {
+  static summaryListArgs(
+    summaryListItems: SummaryListItem[],
+    options: { showBorders: boolean } = { showBorders: true }
+  ): SummaryListArgs {
     return {
+      classes: options.showBorders ? undefined : 'govuk-summary-list--no-border',
       rows: summaryListItems.map(item => {
         return {
           key: {

--- a/server/views/caseNotes/caseNote.njk
+++ b/server/views/caseNotes/caseNote.njk
@@ -1,0 +1,21 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "Referral" %}
+{% set pageSubTitle = "View case note" %}
+
+{% block pageContent %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukBackLink(backLinkArgs) }}
+            <h1 class="govuk-heading-l">Subject: {{ caseNoteSubject | escape }}</h1>
+            {{ govukSummaryList(caseNoteSummaryListArgs) }}
+            <p class="govuk-body">
+                {{ caseNoteBody | escape | nl2br }}
+            </p>
+        </div>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

`bc88cc903704a15e1cccf73d82f6cc4dec3a29ad`
Added option to remove borders (horizontal lines) for summary list.

`8aecf9126fff5b7a69762895fe63cec052cc4b2c`
Add a new page to view a single case note detail for SP or PP.
    
The url to access this page matches what is sent to the user by email when the case note was created.

`cb405e43d616af99139a424051d1e781d70b99fc`
Added a link to case notes list to view single case note details as a 'Read More' link.
    
The body of the case note in the paginated table is restricted to 250 characters.
    
The `Read more` link is shown even if the body is less than 250 characters based on the comments in the ticket (IC-728).


## What is the intent behind these changes?

Allow users to view case note details.

## Note

The back link for the case-note goes back to the first page for view all case note.

There will be a future commit which returns them to the correct page.

## Screen shot

**View all case notes with character < 250**
![image](https://user-images.githubusercontent.com/83066216/132857912-31bcdca7-6191-472c-b6af-954bf7477031.png)

**View all case notes with character > 250**
![image](https://user-images.githubusercontent.com/83066216/132856357-4dc6e5f2-a3dc-4b58-b10d-93fb12e47449.png)


**View single case note**

![image](https://user-images.githubusercontent.com/83066216/132856554-d5b9873a-520b-460a-a5b2-0ae9667f9676.png)
