### PR TITLE
50: Simplify feature flagging logic and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ git-lfs may conflict with any local git hooks you may have configured, so if you
 
 See https://git-lfs.github.com/ for more information.
 
+### Feature flags
+
+Any features or behaviour that isn't ready to be interacted with by users should be placed behind a config-based feature flag, configured in `server/config.ts`, e.g. as below:
+```
+features: {
+  previouslyApprovedActionPlans: get('FEATURE_PREVIOUSLY_APPROVED_ACTION_PLANS', 'false') === 'true',
+}
+```
+
+You can then set whether the feature should be enabled in the config for each environment in the respective `helm_deploy/values-[ENVIRONMENT].yaml` file.
+
 ## Dependencies
 
 - hmpps-auth - for authentication

--- a/doc/architecture/decisions/0012-use-feature-flags-for-in-progress-features.md
+++ b/doc/architecture/decisions/0012-use-feature-flags-for-in-progress-features.md
@@ -1,0 +1,43 @@
+# 12. Use feature flags for in-progress features
+
+Date: 2021-09-13
+
+## Status
+
+Accepted
+
+## Context
+
+There are a few reasons we might not want to put a new feature in front of users as soon as it's been merged into the `main` branch:
+
+- The API might not be up-to-date with the latest version of the UI (and vice versa) - because we're building the UI and API side of the service independently, there are times when the two may be out of sync: an endpoint may not yet be providing all the data we need; the backend functionality may not be finished at the time of writing the UI code.
+- We want to satisfy the Pact contracts between the two sides of the service but not use the new data structure until the UI has been updated.
+- The new functionality may need to be further tested (either with users by developers) and iterated upon before release.
+- We want to keep Pull Requests as small as possible so they're quick to review and it's easy to make changes - this means we'd want to merge smaller chunks of work at a time, which might not be ready for users.
+- We want to test interactions between systems (e.g. the Community API) on the Development environment but not release these changes to the public.
+
+## Decision
+
+Any features or behaviour that isn't ready to be interacted with by users will be placed behind a config-based feature flag, configured in `server/config.ts`, e.g. as below:
+```
+features: {
+  previouslyApprovedActionPlans: get('FEATURE_PREVIOUSLY_APPROVED_ACTION_PLANS', 'false') === 'true',
+}
+```
+
+This can then be turned on for each environment by adding the environment variable (e.g. `FEATURE_PREVIOUSLY_APPROVED_ACTION_PLANS`) to the intended environment.
+
+We'll usually want to enable this for the development environment and test environment, possibly the user research and pre-prod environments but not the production environment.
+
+Before deploying the changes to the production environment, it's a good idea to double check the configuration is as expected e.g. by checking it's hidden in the user research environment.
+
+Once the feature is ready to be interacted with by users, we'll remove the feature flag from the UI configuration.
+
+## Consequences
+
+- Pull requests can be kept small and self-contained, as we don't need to release a whole feature at once, and there's no risk of it being visible to users.
+- We can test functionality on the development environment without these changes being deployed to production.
+- We can release changes to the contracts between the UI and API but keep existing functionality working until both are in sync.
+- We can test functionality in User Research sessions without it being on the production environment.
+
+There's a small overhead involved in setting up the config and testing it's visible or not on the desired environment.

--- a/server/config.ts
+++ b/server/config.ts
@@ -43,9 +43,6 @@ export default {
   deploymentEnvironment: get('DEPLOYMENT_ENV', 'local', requiredInProduction),
   googleAnalyticsTrackingId: get('GA_ID', '', requiredInProduction),
   features: {
-    npsOfficeLocationSelection: {
-      enabled: get('FEATURE_NPS_OFFICE_LOCATION_SELECTION_ENABLED', 'true') === 'true',
-    },
     serviceProviderReporting: {
       enabled: get('FEATURE_SP_REPORTING_ENABLED', 'false') === 'true',
     },

--- a/server/config.ts
+++ b/server/config.ts
@@ -43,12 +43,8 @@ export default {
   deploymentEnvironment: get('DEPLOYMENT_ENV', 'local', requiredInProduction),
   googleAnalyticsTrackingId: get('GA_ID', '', requiredInProduction),
   features: {
-    serviceProviderReporting: {
-      enabled: get('FEATURE_SP_REPORTING_ENABLED', 'false') === 'true',
-    },
-    previouslyApprovedActionPlans: {
-      enabled: get('FEATURE_PREVIOUSLY_APPROVED_ACTION_PLANS', 'false') === 'true',
-    },
+    serviceProviderReporting: get('FEATURE_SP_REPORTING_ENABLED', 'false') === 'true',
+    previouslyApprovedActionPlans: get('FEATURE_PREVIOUSLY_APPROVED_ACTION_PLANS', 'false') === 'true',
   },
   s3: {
     service: {

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -467,7 +467,7 @@ export default class ProbationPractitionerReferralsController {
         )
       ),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
-      config.features.previouslyApprovedActionPlans.enabled
+      config.features.previouslyApprovedActionPlans
         ? this.interventionsService.getApprovedActionPlanSummaries(accessToken, sentReferral.id)
         : [],
     ])

--- a/server/routes/serviceProviderReferrals/dashboardNavPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardNavPresenter.ts
@@ -13,7 +13,7 @@ export default class DashboardNavPresenter {
       },
     ]
 
-    if (config.features.serviceProviderReporting.enabled) {
+    if (config.features.serviceProviderReporting) {
       // TODO: do we need to restrict this to only SP managers?
       items.push({
         text: 'Reporting',

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -10,7 +10,6 @@ import SentReferral from '../../models/sentReferral'
 import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
 import AppointmentSummary from '../appointments/appointmentSummary'
 import { SummaryListItem } from '../../utils/summaryList'
-import config from '../../config'
 
 export default class ScheduleAppointmentPresenter {
   constructor(
@@ -70,10 +69,6 @@ export default class ScheduleAppointmentPresenter {
         selected: this.fields.deliusOfficeLocation.value === officeLocation.deliusCRSLocationId,
       }
     })
-  }
-
-  get deliusOfficeLocationSelectionEnabled(): boolean {
-    return config.features.npsOfficeLocationSelection.enabled
   }
 
   get allowSessionTypeSelection(): boolean {

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentView.ts
@@ -210,17 +210,15 @@ export default class ScheduleAppointmentView {
       text: 'Video call',
       checked: this.presenter.fields.meetingMethod.value === 'VIDEO_CALL',
     })
-    if (this.presenter.deliusOfficeLocationSelectionEnabled) {
-      items.push({
-        id: 'meeting-method-meeting-probation-office',
-        value: 'IN_PERSON_MEETING_PROBATION_OFFICE',
-        text: 'In-person meeting - NPS offices',
-        checked: this.presenter.fields.meetingMethod.value === 'IN_PERSON_MEETING_PROBATION_OFFICE',
-        conditional: {
-          html: deliusOfficeLocationHTML,
-        },
-      })
-    }
+    items.push({
+      id: 'meeting-method-meeting-probation-office',
+      value: 'IN_PERSON_MEETING_PROBATION_OFFICE',
+      text: 'In-person meeting - NPS offices',
+      checked: this.presenter.fields.meetingMethod.value === 'IN_PERSON_MEETING_PROBATION_OFFICE',
+      conditional: {
+        html: deliusOfficeLocationHTML,
+      },
+    })
     items.push({
       id: 'meeting-method-meeting-other',
       value: 'IN_PERSON_MEETING_OTHER',

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -207,7 +207,7 @@ export default function serviceProviderRoutes(router: Router, services: Services
     caseNotesController.addCaseNoteConfirmation(req, res, 'service-provider')
   )
 
-  if (config.features.serviceProviderReporting.enabled) {
+  if (config.features.serviceProviderReporting) {
     get(router, '/performance-report', (req, res) => serviceProviderReferralsController.viewReporting(req, res))
     post(router, '/performance-report', (req, res) => serviceProviderReferralsController.createReport(req, res))
     get(router, '/performance-report/confirmation', (req, res) =>

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -108,7 +108,7 @@ export default class ActionPlanPresenter {
   }
 
   get showCreateNewActionPlanVersionButton(): boolean {
-    if (config.features.previouslyApprovedActionPlans.enabled) {
+    if (config.features.previouslyApprovedActionPlans) {
       return this.userType === 'service-provider' && this.actionPlanSummaryPresenter.actionPlanApproved
     }
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -61,7 +61,7 @@ function appSetup(
   app.use(createErrorHandler(production))
 
   config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = true
-  config.features.serviceProviderReporting.enabled = true
+  config.features.serviceProviderReporting = true
 
   return app
 }


### PR DESCRIPTION
## What does this pull request do?

- Removes the now unused feature flag for Selecting an NPS office in the referral journey (it's visible in all environments)
- Makes the logic for feature flags a bit more user friendly by removing the nested `enabled` object, as this was missed by people writing code and reviewing code.
- Adds an ADR for why we use feature flags
- Updates README with instructions for how to add a feature flag

## What is the intent behind these changes?

We had an unfinished feature slip through onto Production without us knowing - the changes to the config and instructions in the README should hopefully make it harder for that to happen again.
