### PR TITLE
45: Sort Find filter regions alphabetically

### DIFF
--- a/server/routes/findInterventions/searchResultsPresenter.test.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.test.ts
@@ -41,14 +41,19 @@ describe(SearchResultsPresenter, () => {
   })
 
   describe('pccRegionFilters', () => {
-    const pccRegions = [pccRegionFactory.build({ name: 'Cheshire' }), pccRegionFactory.build({ name: 'Lancashire' })]
+    const lancashire = pccRegionFactory.build({ name: 'Lancashire' })
+    const norfolk = pccRegionFactory.build({ name: 'Norfolk' })
+    const cheshire = pccRegionFactory.build({ name: 'Cheshire' })
 
-    it('has the correct name and value', () => {
+    const pccRegions = [lancashire, norfolk, cheshire]
+
+    it('has the correct name and value in alphabetical order', () => {
       const presenter = new SearchResultsPresenter([], new InterventionsFilter(), pccRegions)
 
       expect(presenter.pccRegionFilters).toMatchObject([
-        { value: pccRegions[0].id, text: 'Cheshire' },
-        { value: pccRegions[1].id, text: 'Lancashire' },
+        { value: cheshire.id, text: 'Cheshire' },
+        { value: lancashire.id, text: 'Lancashire' },
+        { value: norfolk.id, text: 'Norfolk' },
       ])
     })
 
@@ -57,17 +62,17 @@ describe(SearchResultsPresenter, () => {
         it('is false for all regions', () => {
           const presenter = new SearchResultsPresenter([], new InterventionsFilter(), pccRegions)
 
-          expect(presenter.pccRegionFilters).toMatchObject([{ checked: false }, { checked: false }])
+          expect(presenter.pccRegionFilters).toMatchObject([{ checked: false }, { checked: false }, { checked: false }])
         })
       })
 
       describe('when filter specifies PCC region IDs', () => {
         it('returns true for a region listed in the filter and false for a region not listed in the filter', () => {
           const filter = new InterventionsFilter()
-          filter.pccRegionIds = [pccRegions[0].id]
+          filter.pccRegionIds = [cheshire.id]
           const presenter = new SearchResultsPresenter([], filter, pccRegions)
 
-          expect(presenter.pccRegionFilters).toMatchObject([{ checked: true }, { checked: false }])
+          expect(presenter.pccRegionFilters).toMatchObject([{ checked: true }, { checked: false }, { checked: false }])
         })
       })
     })

--- a/server/routes/findInterventions/searchResultsPresenter.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.ts
@@ -15,11 +15,13 @@ export default class SearchResultsPresenter {
     value: string
     text: string
     checked: boolean
-  }[] = this.pccRegions.map(region => ({
-    value: region.id,
-    text: region.name,
-    checked: this.filter.pccRegionIds?.includes(region.id) ?? false,
-  }))
+  }[] = this.pccRegions
+    .map(region => ({
+      value: region.id,
+      text: region.name,
+      checked: this.filter.pccRegionIds?.includes(region.id) ?? false,
+    }))
+    .sort((a, b) => a.text.localeCompare(b.text))
 
   readonly genderFilters: {
     value: string


### PR DESCRIPTION
## What does this pull request do?

Sorts PCC regions alphabetically in the Find an interventions journey filtering component

## What is the intent behind these changes?

For some reason, all filters seemed to be in the correct order in the API response except "London (Metropolitan Area)". This always appeared last in the list and was confusing users.

## Screenshots

### Before 

![image](https://user-images.githubusercontent.com/19826940/133112909-7f50161f-023b-4724-b32a-7b49c83ac6d6.png)

### After

![image](https://user-images.githubusercontent.com/19826940/133112965-3a356af5-791c-476e-acfd-5929d2ad6939.png)
