### PR TITLE
44: Add Referral date to My Cases table

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -88,6 +88,7 @@ describe('Probation practitioner referrals dashboard', () => {
       .getTable()
       .should('deep.equal', [
         {
+          'Date sent': '26 Jan 2021',
           Referral: 'ABCABCA1',
           'Service user': 'George Michael',
           'Intervention type': 'Accommodation Services - West Midlands',
@@ -96,6 +97,7 @@ describe('Probation practitioner referrals dashboard', () => {
           Action: 'View',
         },
         {
+          'Date sent': '13 Sep 2020',
           Referral: 'ABCABCA2',
           'Service user': 'Jenny Jones',
           'Intervention type': "Women's Services - West Midlands",

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.test.ts
@@ -9,6 +9,9 @@ describe('MyCasesPresenter', () => {
   ]
   const referrals = [
     SentReferralFactory.assigned().build({
+      id: '1',
+      sentAt: '2021-01-26T13:00:00.000000Z',
+      referenceNumber: 'ABCABCA1',
       referral: {
         interventionId: '1',
         serviceUser: {
@@ -18,6 +21,9 @@ describe('MyCasesPresenter', () => {
       },
     }),
     SentReferralFactory.unassigned().build({
+      id: '2',
+      sentAt: '2020-10-14T13:00:00.000000Z',
+      referenceNumber: 'ABCABCA2',
       referral: {
         interventionId: '2',
         serviceUser: {
@@ -27,6 +33,9 @@ describe('MyCasesPresenter', () => {
       },
     }),
     SentReferralFactory.assigned().build({
+      id: '3',
+      sentAt: '2020-10-13T13:00:00.000000Z',
+      referenceNumber: 'ABCABCA3',
       referral: {
         interventionId: '1',
         serviceUser: {
@@ -42,29 +51,53 @@ describe('MyCasesPresenter', () => {
       const presenter = new MyCasesPresenter(referrals, interventions)
 
       expect(presenter.tableRows).toEqual([
-        expect.arrayContaining([
+        [
+          { text: '26 Jan 2021', sortValue: '2021-01-26', href: null },
+          { text: 'ABCABCA1', sortValue: 'ABCABCA1', href: null },
           { text: 'Rob Shah-Brookes', sortValue: 'shah-brookes, rob', href: null },
-          { text: 'UserABC', sortValue: 'AUserABC', href: null },
           {
             text: 'Accommodation Services - West Midlands',
             sortValue: null,
             href: null,
           },
-        ]),
-        expect.arrayContaining([
+          { text: 'Harmony Living', sortValue: 'Harmony Living', href: null },
+          { text: 'UserABC', sortValue: 'AUserABC', href: null },
+          {
+            text: 'View',
+            sortValue: null,
+            href: '/probation-practitioner/referrals/1/progress',
+          },
+        ],
+        [
+          { text: '14 Oct 2020', sortValue: '2020-10-14', href: null },
+          { text: 'ABCABCA2', sortValue: 'ABCABCA2', href: null },
           { text: 'Hardip Fraiser', sortValue: 'fraiser, hardip', href: null },
-          { text: 'Unassigned', sortValue: 'Unassigned', href: null },
           { text: "Women's Services - West Midlands", sortValue: null, href: null },
-        ]),
-        expect.arrayContaining([
+          { text: 'Harmony Living', sortValue: 'Harmony Living', href: null },
+          { text: 'Unassigned', sortValue: 'Unassigned', href: null },
+          {
+            text: 'View',
+            sortValue: null,
+            href: '/probation-practitioner/referrals/2/progress',
+          },
+        ],
+        [
+          { text: '13 Oct 2020', sortValue: '2020-10-13', href: null },
+          { text: 'ABCABCA3', sortValue: 'ABCABCA3', href: null },
           { text: 'Jenny Catherine', sortValue: 'catherine, jenny', href: null },
-          { text: 'UserABC', sortValue: 'AUserABC', href: null },
           {
             text: 'Accommodation Services - West Midlands',
             sortValue: null,
             href: null,
           },
-        ]),
+          { text: 'Harmony Living', sortValue: 'Harmony Living', href: null },
+          { text: 'UserABC', sortValue: 'AUserABC', href: null },
+          {
+            text: 'View',
+            sortValue: null,
+            href: '/probation-practitioner/referrals/3/progress',
+          },
+        ],
       ])
     })
   })

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
@@ -1,5 +1,7 @@
 import Intervention from '../../models/intervention'
 import SentReferral from '../../models/sentReferral'
+import CalendarDay from '../../utils/calendarDay'
+import DateUtils from '../../utils/dateUtils'
 import PresenterUtils from '../../utils/presenterUtils'
 import { SortableTableHeaders, SortableTableRow } from '../../utils/viewUtils'
 import DashboardNavPresenter from './dashboardNavPresenter'
@@ -10,6 +12,7 @@ export default class MyCasesPresenter {
   readonly navItemsPresenter = new DashboardNavPresenter('My cases')
 
   readonly tableHeadings: SortableTableHeaders = [
+    { text: 'Date sent', sort: 'none' },
     { text: 'Referral', sort: 'none' },
     { text: 'Service user', sort: 'ascending' },
     { text: 'Intervention type', sort: 'none' },
@@ -28,8 +31,14 @@ export default class MyCasesPresenter {
 
     // i really want the actual names here, but that's an API call for each row - how can we improve this?
     const assignee = referral.assignedTo?.username || 'Unassigned'
+    const sentAtDay = CalendarDay.britishDayForDate(new Date(referral.sentAt))
 
     return [
+      {
+        text: DateUtils.formattedDate(sentAtDay, { month: 'short' }),
+        sortValue: sentAtDay.iso8601,
+        href: null,
+      },
       {
         text: referral.referenceNumber,
         sortValue: referral.referenceNumber,


### PR DESCRIPTION
## What does this pull request do?

Adds the date of a referral to the PP My Cases table.

I initially tried to do a bit of a refactor to remove one of the two dashboard tables, as i'd really like to be able to use one table for both SPs and PPs, but due to the different fields required (and while we're using the `Summary`-type component for the SP view), it's been a bit of a pain building a one-size-fits-all approach, as some of the fields we need aren't on the Summary component yet.

We should revisit this once we've introduced pagination to the table, when we will possibly no longer have a need for the summary component, meaning we'll have access to all the fields on the referral.

## What is the intent behind these changes?

In the first two rounds of research on the live service, PP participants have consistently told us that they would find Referral date more useful in My Cases than the Referral number, which is currently displayed in the left-hand column. 

They would regularly sort by this column as a way of monitoring which referrals need to be chased up.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/133444829-51c2f2e4-6d9c-499e-b697-e20088229bb6.png)

