### PR TITLE
IC-1833: Update PP post session feedback url to be more consistent with other routes

### DIFF
--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -139,7 +139,7 @@ describe(InterventionProgressPresenter, () => {
                 classes: 'govuk-tag--green',
               },
               link: {
-                href: `/probation-practitioner/action-plan/c59809e0-ab78-4723-bbef-bd34bc6df110/appointment/1/post-session-feedback`,
+                href: `/probation-practitioner/referrals/${referral.id}/appointment/1/post-session-feedback`,
                 text: 'View feedback form',
               },
             },
@@ -151,7 +151,7 @@ describe(InterventionProgressPresenter, () => {
                 classes: 'govuk-tag--green',
               },
               link: {
-                href: `/probation-practitioner/action-plan/c59809e0-ab78-4723-bbef-bd34bc6df110/appointment/2/post-session-feedback`,
+                href: `/probation-practitioner/referrals/${referral.id}/appointment/2/post-session-feedback`,
                 text: 'View feedback form',
               },
             },
@@ -181,7 +181,7 @@ describe(InterventionProgressPresenter, () => {
                 classes: 'govuk-tag--purple',
               },
               link: {
-                href: `/probation-practitioner/action-plan/c59809e0-ab78-4723-bbef-bd34bc6df110/appointment/1/post-session-feedback`,
+                href: `/probation-practitioner/referrals/${referral.id}/appointment/1/post-session-feedback`,
                 text: 'View feedback form',
               },
             },

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -113,7 +113,7 @@ export default class InterventionProgressPresenter {
           tagClass: presenter.tagClass,
           link: {
             text: 'View feedback form',
-            href: `/probation-practitioner/action-plan/${this.referral.actionPlanId}/appointment/${appointment.sessionNumber}/post-session-feedback`,
+            href: `/probation-practitioner/referrals/${this.referral.id}/appointment/${appointment.sessionNumber}/post-session-feedback`,
           },
         }
       case SessionStatus.completed:
@@ -122,7 +122,7 @@ export default class InterventionProgressPresenter {
           tagClass: presenter.tagClass,
           link: {
             text: 'View feedback form',
-            href: `/probation-practitioner/action-plan/${this.referral.actionPlanId}/appointment/${appointment.sessionNumber}/post-session-feedback`,
+            href: `/probation-practitioner/referrals/${this.referral.id}/appointment/${appointment.sessionNumber}/post-session-feedback`,
           },
         }
       case SessionStatus.awaitingFeedback:

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -151,6 +151,54 @@ describe('GET /probation-practitioner/referrals/:id/progress', () => {
   })
 })
 
+describe('GET /probation-practitioner/referrals/:referralId/appointment/:sessionNumber/post-session-feedback', () => {
+  it('renders a page displaying feedback answers', async () => {
+    const actionPlanId = '05f39e99-b5c7-4a9b-a857-bec04a28eb34'
+    const referral = sentReferralFactory.assigned().build({ actionPlanId, assignedTo: { username: 'Kay.Swerker' } })
+    const submittedActionPlan = actionPlanFactory
+      .submitted()
+      .build({ id: actionPlanId, referralId: referral.id, numberOfSessions: 1 })
+    const serviceUser = deliusServiceUserFactory.build()
+
+    const appointmentWithSubmittedFeedback = actionPlanAppointmentFactory.build({
+      appointmentTime: '2021-02-01T13:00:00Z',
+      durationInMinutes: 60,
+      appointmentDeliveryType: 'PHONE_CALL',
+      sessionNumber: 1,
+      sessionFeedback: {
+        attendance: {
+          attended: 'yes',
+          additionalAttendanceInformation: 'They were early to the session',
+        },
+        behaviour: {
+          behaviourDescription: 'Alex was well-behaved',
+          notifyProbationPractitioner: false,
+        },
+        submitted: true,
+      },
+    })
+
+    communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+    interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
+
+    await request(app)
+      .get(
+        `/probation-practitioner/referrals/${referral.id}/appointment/${appointmentWithSubmittedFeedback.sessionNumber}/post-session-feedback`
+      )
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('View feedback')
+        expect(res.text).toContain('Kay.Swerker')
+        expect(res.text).toContain('They were early to the session')
+        expect(res.text).toContain('Yes, they were on time')
+        expect(res.text).toContain('Alex was well-behaved')
+        expect(res.text).toContain('No')
+      })
+  })
+})
+
 describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', () => {
   it('renders a page displaying feedback answers', async () => {
     const actionPlanId = '05f39e99-b5c7-4a9b-a857-bec04a28eb34'

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -245,70 +245,70 @@ describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:ses
         expect(res.text).toContain('No')
       })
   })
+})
 
-  describe('GET /probation-practitioner/end-of-service-report/:id', () => {
-    it('renders a page with the contents of the end of service report', async () => {
-      const serviceCategory = serviceCategoryFactory.build()
-      const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
-      const referral = sentReferralFactory.build({
-        referral: {
-          serviceCategoryIds: [serviceCategory.id],
-          desiredOutcomes: [
-            { serviceCategoryId: serviceCategory.id, desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id] },
-          ],
-        },
-      })
-      const endOfServiceReport = endOfServiceReportFactory.build({
-        outcomes: [
-          {
-            desiredOutcome: serviceCategory.desiredOutcomes[0],
-            achievementLevel: 'ACHIEVED',
-            progressionComments: 'Some progression comments',
-            additionalTaskComments: 'Some task comments',
-          },
+describe('GET /probation-practitioner/end-of-service-report/:id', () => {
+  it('renders a page with the contents of the end of service report', async () => {
+    const serviceCategory = serviceCategoryFactory.build()
+    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
+    const referral = sentReferralFactory.build({
+      referral: {
+        serviceCategoryIds: [serviceCategory.id],
+        desiredOutcomes: [
+          { serviceCategoryId: serviceCategory.id, desiredOutcomesIds: [serviceCategory.desiredOutcomes[0].id] },
         ],
-        furtherInformation: 'Some further information',
-      })
-      const deliusServiceUser = deliusServiceUserFactory.build()
-
-      interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
-      interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getIntervention.mockResolvedValue(intervention)
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-
-      await request(app)
-        .get(`/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`)
-        .expect(200)
-        .expect(res => {
-          expect(res.text).toContain('Achieved')
-          expect(res.text).toContain(serviceCategory.desiredOutcomes[0].description)
-          expect(res.text).toContain('Some progression comments')
-          expect(res.text).toContain('Some task comments')
-          expect(res.text).toContain('Some further information')
-        })
+      },
     })
-
-    it('throws error if not all service categories were obtainable', async () => {
-      const serviceCategory = serviceCategoryFactory.build()
-      const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
-      const referral = sentReferralFactory.build({
-        referral: {
-          serviceCategoryIds: [serviceCategory.id, 'someOtherId'],
+    const endOfServiceReport = endOfServiceReportFactory.build({
+      outcomes: [
+        {
+          desiredOutcome: serviceCategory.desiredOutcomes[0],
+          achievementLevel: 'ACHIEVED',
+          progressionComments: 'Some progression comments',
+          additionalTaskComments: 'Some task comments',
         },
-      })
-      const endOfServiceReport = endOfServiceReportFactory.build()
-      const deliusServiceUser = deliusServiceUserFactory.build()
-      interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
-      interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getIntervention.mockResolvedValue(intervention)
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-      await request(app)
-        .get(`/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`)
-        .expect(500)
-        .expect(res => {
-          expect(res.text).toContain('Expected service categories are missing in intervention')
-        })
+      ],
+      furtherInformation: 'Some further information',
     })
+    const deliusServiceUser = deliusServiceUserFactory.build()
+
+    interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
+    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+
+    await request(app)
+      .get(`/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Achieved')
+        expect(res.text).toContain(serviceCategory.desiredOutcomes[0].description)
+        expect(res.text).toContain('Some progression comments')
+        expect(res.text).toContain('Some task comments')
+        expect(res.text).toContain('Some further information')
+      })
+  })
+
+  it('throws error if not all service categories were obtainable', async () => {
+    const serviceCategory = serviceCategoryFactory.build()
+    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
+    const referral = sentReferralFactory.build({
+      referral: {
+        serviceCategoryIds: [serviceCategory.id, 'someOtherId'],
+      },
+    })
+    const endOfServiceReport = endOfServiceReportFactory.build()
+    const deliusServiceUser = deliusServiceUserFactory.build()
+    interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getIntervention.mockResolvedValue(intervention)
+    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+    await request(app)
+      .get(`/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`)
+      .expect(500)
+      .expect(res => {
+        expect(res.text).toContain('Expected service categories are missing in intervention')
+      })
   })
 })
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -188,11 +188,50 @@ export default class ProbationPractitionerReferralsController {
   async viewSubmittedPostSessionFeedback(req: Request, res: Response): Promise<void> {
     const { user } = res.locals
     const { accessToken } = user.token
+    const { referralId, sessionNumber } = req.params
+
+    const referral = await this.interventionsService.getSentReferral(accessToken, referralId)
+
+    if (referral.actionPlanId === null) {
+      throw createError(500, `action plan does not exist on this referral '${req.params.id}'`, {
+        userMessage: 'No action plan exists for this referral',
+      })
+    }
+
+    const currentAppointment = await this.interventionsService.getActionPlanAppointment(
+      accessToken,
+      referral.actionPlanId,
+      Number(sessionNumber)
+    )
+    const deliusOfficeLocation = await this.deliusOfficeLocationFilter.findOfficeByAppointment(currentAppointment)
+
+    const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
+
+    if (!referral.assignedTo) {
+      throw new Error('Referral has not yet been assigned to a caseworker')
+    }
+
+    const presenter = new SubmittedFeedbackPresenter(
+      currentAppointment,
+      new AppointmentSummary(currentAppointment, referral.assignedTo, deliusOfficeLocation),
+      serviceUser,
+      'probation-practitioner',
+      referral.id,
+      null
+    )
+    const view = new SubmittedFeedbackView(presenter)
+
+    return ControllerUtils.renderWithLayout(res, view, serviceUser)
+  }
+
+  // This is left to keep links in old emails still working - we'll monitor the endpoint and remove it when usage drops off.
+  async viewLegacySubmittedPostSessionFeedback(req: Request, res: Response): Promise<void> {
+    const { user } = res.locals
+    const { accessToken } = user.token
     const { actionPlanId, sessionNumber } = req.params
 
     const actionPlan = await this.interventionsService.getActionPlan(accessToken, actionPlanId)
     const referral = await this.interventionsService.getSentReferral(accessToken, actionPlan.referralId)
-
     const currentAppointment = await this.interventionsService.getActionPlanAppointment(
       accessToken,
       actionPlanId,

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -22,7 +22,11 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     probationPractitionerReferralsController.showInterventionProgress(req, res)
   )
   get(router, '/referrals/:id/details', (req, res) => probationPractitionerReferralsController.showReferral(req, res))
+  // Legacy route to keep links in old emails still working. We'll monitor and remove once traffic drops off
   get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', (req, res) =>
+    probationPractitionerReferralsController.viewLegacySubmittedPostSessionFeedback(req, res)
+  )
+  get(router, '/referrals/:referralId/appointment/:sessionNumber/post-session-feedback', (req, res) =>
     probationPractitionerReferralsController.viewSubmittedPostSessionFeedback(req, res)
   )
   get(router, '/action-plan/:actionPlanId', (req, res) =>


### PR DESCRIPTION
## What does this pull request do?

 Make PP Post Session Feedback URL consistent with other PP routes.

We're leaving the old URL and route in there for now, as we want to ensure that links in older emails to view Post Session Feedback still function and don't take users to a now 404ing page. We're going to monitor the old `/probation-practitioner/action-plan/:id/appointment/:id/post-session-feedback` URL and remove this duplicate route once traffic drops off.

## What is the intent behind these changes?

All other URLs are in the form `probation-practitioner/referral/:id/...` This was the only one not following this form.

This replaces https://github.com/ministryofjustice/hmpps-interventions-ui/pull/798 as that didn't take into account that we needed to keep old links working.


