### PR TITLE
43: Preserve dashboards’ sort orders

### DIFF
--- a/browser/mojSortableTable.ts
+++ b/browser/mojSortableTable.ts
@@ -1,6 +1,238 @@
+/* eslint-disable no-console */
+
+/* Extends the MOJ Frontend’s sortable table component to preserve the table’s sort order
+ * between page visits.
+ *
+ * This makes the following assumptions about the MOJ Frontend’s sortable table component (based on the code in
+ * node_modules/@ministryofjustice/frontend/moj/components/sortable-table/sortable-table.js):
+ *
+ * 1. It works by inserting buttons into the table’s 'thead th' elements. Clicking these buttons
+ *    changes the sort order.
+ *
+ * 2. Clicking on an unsorted column sorts it in ascending order. Clicking on a sorted column
+ *    causes it to alternate between descending and ascending order.
+ *
+ * 3. The sortable table component modifies the aria-sort attribute of the table’s 'thead th'
+ *    elements to reflect the current sort order.
+ *
+ * 4. The table can only be sorted by one column at a time.
+ */
+
+type ARIASort = 'none' | 'ascending' | 'descending'
+
+interface SortOrderDTO {
+  columnPersistentId: string
+  order: ARIASort
+}
+
+class PersistentSortOrder {
+  static activate(table: HTMLElement) {
+    const tablePersistentId = table.dataset.persistentId
+
+    if (tablePersistentId === undefined) {
+      console.warn('Table has no data-persistent-id attribute; cannot set up persistent sort order.')
+      return
+    }
+
+    this.observeAttributeChanges(tablePersistentId)
+
+    const sortOrder = this.fetchSortOrderDTO(tablePersistentId)
+
+    if (sortOrder !== null) {
+      this.forceSortOrder(table, sortOrder)
+    }
+  }
+
+  private static createARIASort(from: unknown): ARIASort | null {
+    if (from === 'none' || from === 'ascending' || from === 'descending') {
+      return from
+    }
+
+    return null
+  }
+
+  private static observeAttributeChanges(tablePersistentId: string) {
+    const headers = document.querySelectorAll('thead th')
+
+    headers.forEach(header => {
+      const headerAriaSortAttribute = header.getAttribute('aria-sort')
+
+      if (headerAriaSortAttribute === null) {
+        return
+      }
+
+      const observer = new MutationObserver(mutationsList =>
+        this.headingAttributesChanged(tablePersistentId, mutationsList)
+      )
+      observer.observe(header, { attributes: true })
+    })
+  }
+
+  private static headingAttributesChanged(tablePersistentId: string, mutationsList: MutationRecord[]) {
+    mutationsList.forEach(mutation => {
+      if (mutation.type === 'attributes') {
+        // All of the table’s headers receive mutation events, so
+        // we need to figure out which of these was actually clicked. We do that
+        // by finding out which of the columns is sorted (by looking at the
+        // headers’ aria-sort attributes).
+
+        const header = mutation.target as HTMLElement
+
+        const newAriaSort = this.createARIASort(header.getAttribute('aria-sort'))
+
+        if (newAriaSort === null) {
+          console.warn('Unrecognised aria-sort attribute')
+          return
+        }
+
+        const columnPersistentId = header.dataset.persistentId
+
+        if (columnPersistentId === undefined) {
+          console.warn('Column has no data-persistent-id attribute; cannot persist chosen order.')
+          return
+        }
+
+        if (['descending', 'ascending'].includes(newAriaSort)) {
+          this.persistSortOrder(tablePersistentId, columnPersistentId, newAriaSort)
+        }
+      }
+    })
+  }
+
+  private static localStorageKey(tablePersistentId: string) {
+    return `interventions:sortOrder:${tablePersistentId}`
+  }
+
+  private static persistSortOrder(tablePersistentId: string, columnPersistentId: string, order: string) {
+    const key = this.localStorageKey(tablePersistentId)
+    const object = { columnPersistentId, order }
+    window.localStorage.setItem(key, JSON.stringify(object))
+  }
+
+  private static fetchSortOrderDTO(tablePersistentId: string): SortOrderDTO | null {
+    const key = this.localStorageKey(tablePersistentId)
+    const serialized = window.localStorage.getItem(key)
+
+    if (serialized === null) {
+      return null
+    }
+
+    const deserialized = JSON.parse(serialized) as unknown
+
+    if (
+      !(
+        typeof deserialized === 'object' &&
+        deserialized !== null &&
+        'columnPersistentId' in deserialized &&
+        'order' in deserialized
+      )
+    ) {
+      return null
+    }
+
+    // I’m not sure why a cast is necessary; I’d have thought the compiler
+    // would allow us to assign directly to a variable of this type given
+    // the above check, but no…
+
+    const keyed = deserialized as {
+      columnPersistentId: unknown
+      order: unknown
+    }
+
+    if (!(typeof keyed.columnPersistentId === 'string')) {
+      return null
+    }
+
+    const withTypedValues: { columnPersistentId: string; order: ARIASort | null } = {
+      columnPersistentId: keyed.columnPersistentId,
+      order: this.createARIASort(keyed.order),
+    }
+
+    if (withTypedValues.order === null) {
+      return null
+    }
+
+    // Ditto re “not sure why a cast is necessary”
+    return withTypedValues as { columnPersistentId: string; order: ARIASort }
+  }
+
+  private static forceSortOrder(table: HTMLElement, sortOrder: SortOrderDTO) {
+    const headers = table.querySelectorAll('thead th') as NodeListOf<HTMLTableCellElement>
+
+    const header = Array.from(headers).find(aheader => aheader.dataset.persistentId === sortOrder.columnPersistentId)
+
+    if (header === undefined) {
+      console.warn("Couldn't find header with persistent ID ", sortOrder.columnPersistentId)
+      return
+    }
+
+    // Now we find the button for sorting this column, and we programatically click it.
+
+    const buttons = header.querySelectorAll('button[data-index]') as NodeListOf<HTMLButtonElement>
+
+    if (buttons.length === 0) {
+      console.warn('No buttons found in header. Not forcing sort order.')
+      return
+    }
+    if (buttons.length > 1) {
+      console.warn('Multiple buttons found in header. Not forcing sort order.')
+      return
+    }
+
+    const button = buttons[0]
+
+    const currentAriaSort = this.createARIASort(header.getAttribute('aria-sort'))
+
+    if (currentAriaSort === null) {
+      console.warn('Couldn’t parse current aria-sort attribute')
+      return
+    }
+
+    const numberOfClicks = this.clickCountToTransition({ fromAriaSort: currentAriaSort, toAriaSort: sortOrder.order })
+    for (let i = 0; i < numberOfClicks; i += 1) {
+      button.click()
+    }
+  }
+
+  private static clickCountToTransition({
+    fromAriaSort,
+    toAriaSort,
+  }: {
+    fromAriaSort: ARIASort
+    toAriaSort: ARIASort
+  }) {
+    if (fromAriaSort === toAriaSort) {
+      return 0
+    }
+
+    if (toAriaSort === 'none') {
+      console.warn('Tried to transition from sorted to unsorted, not allowed')
+      return 0
+    }
+
+    if (fromAriaSort === 'none') {
+      return ['ascending', 'descending'].indexOf(toAriaSort) + 1
+    }
+
+    return 1
+  }
+}
+
 $(() => {
+  const tables = document.getElementsByTagName('table')
+  if (tables.length === 0) {
+    console.warn('No tables found in document. Not setting up sortable table.')
+    return
+  }
+  if (tables.length > 1) {
+    console.warn('Multiple tables found in document. Not setting up sortable table.')
+    return
+  }
+
+  const table = tables[0]
+
   // eslint-disable-next-line no-new
-  new MOJFrontend.SortableTable({
-    table: $('table')[0],
-  })
+  new MOJFrontend.SortableTable({ table })
+
+  PersistentSortOrder.activate(table)
 })

--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -9,112 +9,314 @@ describe('Dashboards', () => {
   })
 
   describe('As a probation practitioner', () => {
+    const accommodationIntervention = interventionFactory.build({
+      title: 'Accommodation Services - West Midlands',
+    })
+    const womensServicesIntervention = interventionFactory.build({
+      title: "Women's Services - West Midlands",
+    })
+
+    const sentReferrals = [
+      sentReferralFactory.build({
+        sentAt: '2021-01-26T13:00:00.000000Z',
+        referenceNumber: 'ABCABCA1',
+        referral: {
+          interventionId: accommodationIntervention.id,
+          serviceUser: { firstName: 'George', lastName: 'Michael' },
+        },
+      }),
+      sentReferralFactory.build({
+        sentAt: '2020-09-13T13:00:00.000000Z',
+        assignedTo: {
+          username: 'A. Caseworker',
+          userId: '123',
+          authSource: 'auth',
+        },
+        referenceNumber: 'ABCABCA2',
+        referral: {
+          interventionId: womensServicesIntervention.id,
+          serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+          serviceProvider: { name: 'Forward Solutions' },
+        },
+      }),
+    ]
+
     beforeEach(() => {
       cy.task('stubProbationPractitionerToken')
       cy.task('stubProbationPractitionerAuthUser')
-    })
-
-    it("PP logs in and sees 'My cases' screen with list of sent referrals", () => {
-      const accommodationIntervention = interventionFactory.build({
-        title: 'Accommodation Services - West Midlands',
-      })
-      const womensServicesIntervention = interventionFactory.build({
-        title: "Women's Services - West Midlands",
-      })
-
-      const sentReferrals = [
-        sentReferralFactory.build({
-          sentAt: '2021-01-26T13:00:00.000000Z',
-          referenceNumber: 'ABCABCA1',
-          referral: {
-            interventionId: accommodationIntervention.id,
-            serviceUser: { firstName: 'George', lastName: 'Michael' },
-          },
-        }),
-        sentReferralFactory.build({
-          sentAt: '2020-09-13T13:00:00.000000Z',
-          assignedTo: {
-            username: 'A. Caseworker',
-            userId: '123',
-            authSource: 'auth',
-          },
-          referenceNumber: 'ABCABCA2',
-          referral: {
-            interventionId: womensServicesIntervention.id,
-            serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
-          },
-        }),
-      ]
 
       cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
       cy.stubGetIntervention(womensServicesIntervention.id, womensServicesIntervention)
       cy.stubGetSentReferralsForUserToken(sentReferrals)
+    })
 
-      cy.login()
+    describe('Viewing the dashboard page', () => {
+      it('shows a list of sent referrals', () => {
+        cy.login()
 
-      cy.get('h1').contains('My cases')
+        cy.get('h1').contains('My cases')
 
-      cy.get('table')
-        .getTable()
-        .should('deep.equal', [
-          {
-            'Date sent': '26 Jan 2021',
-            Referral: 'ABCABCA1',
-            'Service user': 'George Michael',
-            'Intervention type': 'Accommodation Services - West Midlands',
-            Provider: 'Harmony Living',
-            Caseworker: 'Unassigned',
-            Action: 'View',
-          },
-          {
-            'Date sent': '13 Sep 2020',
-            Referral: 'ABCABCA2',
-            'Service user': 'Jenny Jones',
-            'Intervention type': "Women's Services - West Midlands",
-            Provider: 'Harmony Living',
-            Caseworker: 'A. Caseworker',
-            Action: 'View',
-          },
-        ])
+        cy.get('table')
+          .getTable()
+          .should('deep.equal', [
+            {
+              'Date sent': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Provider: 'Harmony Living',
+              Caseworker: 'Unassigned',
+              Action: 'View',
+            },
+            {
+              'Date sent': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Provider: 'Forward Solutions',
+              Caseworker: 'A. Caseworker',
+              Action: 'View',
+            },
+          ])
+      })
+    })
+
+    describe('Sorting the table', () => {
+      const referralToSelect = sentReferrals[0]
+
+      const initialTable = [
+        {
+          'Date sent': '26 Jan 2021',
+          Referral: 'ABCABCA1',
+          'Service user': 'George Michael',
+          'Intervention type': 'Accommodation Services - West Midlands',
+          Provider: 'Harmony Living',
+          Caseworker: 'Unassigned',
+          Action: 'View',
+        },
+        {
+          'Date sent': '13 Sep 2020',
+          Referral: 'ABCABCA2',
+          'Service user': 'Jenny Jones',
+          'Intervention type': "Women's Services - West Midlands",
+          Provider: 'Forward Solutions',
+          Caseworker: 'A. Caseworker',
+          Action: 'View',
+        },
+      ]
+
+      const headersAndTables = [
+        {
+          header: 'Date sent',
+          sortedTable: [
+            {
+              'Date sent': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Provider: 'Forward Solutions',
+              Caseworker: 'A. Caseworker',
+              Action: 'View',
+            },
+            {
+              'Date sent': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Provider: 'Harmony Living',
+              Caseworker: 'Unassigned',
+              Action: 'View',
+            },
+          ],
+        },
+        {
+          header: 'Referral',
+          sortedTable: [
+            {
+              'Date sent': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Provider: 'Harmony Living',
+              Caseworker: 'Unassigned',
+              Action: 'View',
+            },
+            {
+              'Date sent': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Provider: 'Forward Solutions',
+              Caseworker: 'A. Caseworker',
+              Action: 'View',
+            },
+          ],
+        },
+        {
+          header: 'Service user',
+          sortedTable: [
+            {
+              'Date sent': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Provider: 'Harmony Living',
+              Caseworker: 'Unassigned',
+              Action: 'View',
+            },
+            {
+              'Date sent': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Provider: 'Forward Solutions',
+              Caseworker: 'A. Caseworker',
+              Action: 'View',
+            },
+          ],
+        },
+        {
+          header: 'Intervention type',
+          sortedTable: [
+            {
+              'Date sent': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Provider: 'Harmony Living',
+              Caseworker: 'Unassigned',
+              Action: 'View',
+            },
+            {
+              'Date sent': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Provider: 'Forward Solutions',
+              Caseworker: 'A. Caseworker',
+              Action: 'View',
+            },
+          ],
+        },
+        {
+          header: 'Provider',
+          sortedTable: [
+            {
+              'Date sent': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Provider: 'Forward Solutions',
+              Caseworker: 'A. Caseworker',
+              Action: 'View',
+            },
+            {
+              'Date sent': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Provider: 'Harmony Living',
+              Caseworker: 'Unassigned',
+              Action: 'View',
+            },
+          ],
+        },
+        {
+          header: 'Caseworker',
+          sortedTable: [
+            {
+              'Date sent': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Provider: 'Forward Solutions',
+              Caseworker: 'A. Caseworker',
+              Action: 'View',
+            },
+            {
+              'Date sent': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Provider: 'Harmony Living',
+              Caseworker: 'Unassigned',
+              Action: 'View',
+            },
+          ],
+        },
+      ]
+
+      headersAndTables.forEach(({ header, sortedTable }) => {
+        describe(`sorting by "${header}"`, () => {
+          it(`allows the user to sort by "${header}"`, () => {
+            cy.login()
+            cy.get('table').getTable().should('deep.equal', initialTable)
+
+            cy.get('table').within(() => cy.contains('button', header).click())
+            cy.get('table').getTable().should('deep.equal', sortedTable)
+
+            cy.get('table').within(() => cy.contains('button', header).click())
+
+            const reversedTable = [...sortedTable].reverse()
+            cy.get('table').getTable().should('deep.equal', reversedTable)
+          })
+
+          it('persists the sort order when coming back to the page', () => {
+            cy.login()
+
+            cy.get('table').within(() => cy.contains('button', header).click())
+            cy.get('table').getTable().should('deep.equal', sortedTable)
+
+            cy.stubViewReferralDetails(referralToSelect)
+
+            cy.visit(`/probation-practitioner/referrals/${referralToSelect.id}/details`)
+            cy.contains('Back').click()
+
+            // Wait for header sort button to load, as it means JS has run
+            cy.get('table').within(() => cy.contains('button', header))
+            cy.get('table').getTable().should('deep.equal', sortedTable)
+          })
+        })
+      })
     })
   })
 
   describe('As a service provider', () => {
+    const accommodationIntervention = interventionFactory.build({
+      title: 'Accommodation Services - West Midlands',
+    })
+    const womensServicesIntervention = interventionFactory.build({
+      title: "Women's Services - West Midlands",
+    })
+
+    const sentReferralSummaries = [
+      serviceProviderSentReferralSummaryFactory.build({
+        sentAt: '2021-01-26T13:00:00.000000Z',
+        referenceNumber: 'ABCABCA1',
+        interventionTitle: accommodationIntervention.title,
+        serviceUserFirstName: 'George',
+        serviceUserLastName: 'Michael',
+      }),
+      serviceProviderSentReferralSummaryFactory.build({
+        sentAt: '2020-09-13T13:00:00.000000Z',
+        referenceNumber: 'ABCABCA2',
+        interventionTitle: womensServicesIntervention.title,
+        serviceUserFirstName: 'Jenny',
+        serviceUserLastName: 'Jones',
+        assignedToUserName: 'A.Caseworker',
+      }),
+    ]
+
     beforeEach(() => {
       cy.task('stubServiceProviderToken')
       cy.task('stubServiceProviderAuthUser')
-    })
-
-    it("SP logs in and sees 'My cases' screen with list of sent referrals", () => {
-      const accommodationIntervention = interventionFactory.build({
-        title: 'Accommodation Services - West Midlands',
-      })
-      const womensServicesIntervention = interventionFactory.build({
-        title: "Women's Services - West Midlands",
-      })
-
-      const sentReferralSummaries = [
-        serviceProviderSentReferralSummaryFactory.build({
-          sentAt: '2021-01-26T13:00:00.000000Z',
-          referenceNumber: 'ABCABCA1',
-          interventionTitle: accommodationIntervention.title,
-          serviceUserFirstName: 'George',
-          serviceUserLastName: 'Michael',
-        }),
-        serviceProviderSentReferralSummaryFactory.build({
-          sentAt: '2020-09-13T13:00:00.000000Z',
-          referenceNumber: 'ABCABCA2',
-          interventionTitle: womensServicesIntervention.title,
-          serviceUserFirstName: 'Jenny',
-          serviceUserLastName: 'Jones',
-          assignedToUserName: 'A.Caseworker',
-        }),
-      ]
 
       cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
       cy.stubGetIntervention(womensServicesIntervention.id, womensServicesIntervention)
       cy.stubGetServiceProviderSentReferralsSummaryForUserToken(sentReferralSummaries)
+    })
 
+    it("SP logs in and sees 'My cases' screen with list of sent referrals", () => {
       cy.login()
 
       cy.get('h1').contains('All cases')
@@ -139,6 +341,178 @@ describe('Dashboards', () => {
             Action: 'View',
           },
         ])
+    })
+
+    describe('Sorting the table', () => {
+      const initialTable = [
+        {
+          'Date received': '26 Jan 2021',
+          Referral: 'ABCABCA1',
+          'Service user': 'George Michael',
+          'Intervention type': 'Accommodation Services - West Midlands',
+          Caseworker: '',
+          Action: 'View',
+        },
+        {
+          'Date received': '13 Sep 2020',
+          Referral: 'ABCABCA2',
+          'Service user': 'Jenny Jones',
+          'Intervention type': "Women's Services - West Midlands",
+          Caseworker: 'A.Caseworker',
+          Action: 'View',
+        },
+      ]
+
+      const headersAndTables = [
+        {
+          header: 'Date received',
+          sortedTable: [
+            {
+              'Date received': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Caseworker: 'A.Caseworker',
+              Action: 'View',
+            },
+            {
+              'Date received': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Caseworker: '',
+              Action: 'View',
+            },
+          ],
+        },
+        {
+          header: 'Referral',
+          sortedTable: [
+            {
+              'Date received': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Caseworker: '',
+              Action: 'View',
+            },
+            {
+              'Date received': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Caseworker: 'A.Caseworker',
+              Action: 'View',
+            },
+          ],
+        },
+        {
+          header: 'Service user',
+          sortedTable: [
+            {
+              'Date received': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Caseworker: 'A.Caseworker',
+              Action: 'View',
+            },
+            {
+              'Date received': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Caseworker: '',
+              Action: 'View',
+            },
+          ],
+        },
+        {
+          header: 'Intervention type',
+          sortedTable: [
+            {
+              'Date received': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Caseworker: '',
+              Action: 'View',
+            },
+            {
+              'Date received': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Caseworker: 'A.Caseworker',
+              Action: 'View',
+            },
+          ],
+        },
+        {
+          header: 'Caseworker',
+          sortedTable: [
+            {
+              'Date received': '26 Jan 2021',
+              Referral: 'ABCABCA1',
+              'Service user': 'George Michael',
+              'Intervention type': 'Accommodation Services - West Midlands',
+              Caseworker: '',
+              Action: 'View',
+            },
+            {
+              'Date received': '13 Sep 2020',
+              Referral: 'ABCABCA2',
+              'Service user': 'Jenny Jones',
+              'Intervention type': "Women's Services - West Midlands",
+              Caseworker: 'A.Caseworker',
+              Action: 'View',
+            },
+          ],
+        },
+      ]
+
+      const referralToSelect = sentReferralFactory.build({
+        sentAt: '2021-01-26T13:00:00.000000Z',
+        referenceNumber: 'ABCABCA1',
+        referral: {
+          interventionId: accommodationIntervention.id,
+          serviceUser: { firstName: 'George', lastName: 'Michael' },
+        },
+      })
+
+      headersAndTables.forEach(({ header, sortedTable }) => {
+        describe(`sorting by "${header}"`, () => {
+          it(`allows the user to sort by "${header}"`, () => {
+            cy.login()
+
+            cy.get('table').getTable().should('deep.equal', initialTable)
+
+            cy.get('table').within(() => cy.contains('button', header).click())
+            cy.get('table').getTable().should('deep.equal', sortedTable)
+
+            cy.get('table').within(() => cy.contains('button', header).click())
+
+            const reversedTable = [...sortedTable].reverse()
+            cy.get('table').getTable().should('deep.equal', reversedTable)
+          })
+
+          it('persists the sort order when coming back to the page', () => {
+            cy.login()
+
+            cy.get('table').within(() => cy.contains('button', header).click())
+            cy.get('table').getTable().should('deep.equal', sortedTable)
+
+            cy.stubViewReferralDetails(referralToSelect)
+
+            cy.visit(`/service-provider/referrals/${referralToSelect.id}/details`)
+            cy.contains('Back').click()
+
+            // Wait for header sort button to load, as it means JS has run
+            cy.get('table').within(() => cy.contains('button', header))
+            cy.get('table').getTable().should('deep.equal', sortedTable)
+          })
+        })
+      })
     })
   })
 })

--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -1,0 +1,144 @@
+import sentReferralFactory from '../../testutils/factories/sentReferral'
+import interventionFactory from '../../testutils/factories/intervention'
+import serviceProviderSentReferralSummaryFactory from '../../testutils/factories/serviceProviderSentReferralSummary'
+
+describe('Dashboards', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubLogin')
+  })
+
+  describe('As a probation practitioner', () => {
+    beforeEach(() => {
+      cy.task('stubProbationPractitionerToken')
+      cy.task('stubProbationPractitionerAuthUser')
+    })
+
+    it("PP logs in and sees 'My cases' screen with list of sent referrals", () => {
+      const accommodationIntervention = interventionFactory.build({
+        title: 'Accommodation Services - West Midlands',
+      })
+      const womensServicesIntervention = interventionFactory.build({
+        title: "Women's Services - West Midlands",
+      })
+
+      const sentReferrals = [
+        sentReferralFactory.build({
+          sentAt: '2021-01-26T13:00:00.000000Z',
+          referenceNumber: 'ABCABCA1',
+          referral: {
+            interventionId: accommodationIntervention.id,
+            serviceUser: { firstName: 'George', lastName: 'Michael' },
+          },
+        }),
+        sentReferralFactory.build({
+          sentAt: '2020-09-13T13:00:00.000000Z',
+          assignedTo: {
+            username: 'A. Caseworker',
+            userId: '123',
+            authSource: 'auth',
+          },
+          referenceNumber: 'ABCABCA2',
+          referral: {
+            interventionId: womensServicesIntervention.id,
+            serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+          },
+        }),
+      ]
+
+      cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
+      cy.stubGetIntervention(womensServicesIntervention.id, womensServicesIntervention)
+      cy.stubGetSentReferralsForUserToken(sentReferrals)
+
+      cy.login()
+
+      cy.get('h1').contains('My cases')
+
+      cy.get('table')
+        .getTable()
+        .should('deep.equal', [
+          {
+            'Date sent': '26 Jan 2021',
+            Referral: 'ABCABCA1',
+            'Service user': 'George Michael',
+            'Intervention type': 'Accommodation Services - West Midlands',
+            Provider: 'Harmony Living',
+            Caseworker: 'Unassigned',
+            Action: 'View',
+          },
+          {
+            'Date sent': '13 Sep 2020',
+            Referral: 'ABCABCA2',
+            'Service user': 'Jenny Jones',
+            'Intervention type': "Women's Services - West Midlands",
+            Provider: 'Harmony Living',
+            Caseworker: 'A. Caseworker',
+            Action: 'View',
+          },
+        ])
+    })
+  })
+
+  describe('As a service provider', () => {
+    beforeEach(() => {
+      cy.task('stubServiceProviderToken')
+      cy.task('stubServiceProviderAuthUser')
+    })
+
+    it("SP logs in and sees 'My cases' screen with list of sent referrals", () => {
+      const accommodationIntervention = interventionFactory.build({
+        title: 'Accommodation Services - West Midlands',
+      })
+      const womensServicesIntervention = interventionFactory.build({
+        title: "Women's Services - West Midlands",
+      })
+
+      const sentReferralSummaries = [
+        serviceProviderSentReferralSummaryFactory.build({
+          sentAt: '2021-01-26T13:00:00.000000Z',
+          referenceNumber: 'ABCABCA1',
+          interventionTitle: accommodationIntervention.title,
+          serviceUserFirstName: 'George',
+          serviceUserLastName: 'Michael',
+        }),
+        serviceProviderSentReferralSummaryFactory.build({
+          sentAt: '2020-09-13T13:00:00.000000Z',
+          referenceNumber: 'ABCABCA2',
+          interventionTitle: womensServicesIntervention.title,
+          serviceUserFirstName: 'Jenny',
+          serviceUserLastName: 'Jones',
+          assignedToUserName: 'A.Caseworker',
+        }),
+      ]
+
+      cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
+      cy.stubGetIntervention(womensServicesIntervention.id, womensServicesIntervention)
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken(sentReferralSummaries)
+
+      cy.login()
+
+      cy.get('h1').contains('All cases')
+
+      cy.get('table')
+        .getTable()
+        .should('deep.equal', [
+          {
+            'Date received': '26 Jan 2021',
+            Referral: 'ABCABCA1',
+            'Service user': 'George Michael',
+            'Intervention type': 'Accommodation Services - West Midlands',
+            Caseworker: '',
+            Action: 'View',
+          },
+          {
+            'Date received': '13 Sep 2020',
+            Referral: 'ABCABCA2',
+            'Service user': 'Jenny Jones',
+            'Intervention type': "Women's Services - West Midlands",
+            Caseworker: 'A.Caseworker',
+            Action: 'View',
+          },
+        ])
+    })
+  })
+})

--- a/integration_tests/support/commands.js
+++ b/integration_tests/support/commands.js
@@ -1,3 +1,9 @@
+import deliusUserFactory from '../../testutils/factories/deliusUser'
+import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
+import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
+import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
+import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
+
 Cypress.Commands.add('login', () => {
   cy.request(`/`)
   cy.task('getLoginUrl').then(cy.visit)
@@ -13,6 +19,24 @@ Cypress.Commands.add('stubGetAuthUserByUsername', (username, responseJson) => {
 
 Cypress.Commands.add('withinFieldsetThatContains', (text, action) => {
   cy.contains(text).parent('fieldset').within(action)
+})
+
+Cypress.Commands.add('stubViewReferralDetails', referralToView => {
+  const deliusUser = deliusUserFactory.build()
+  const conviction = deliusConvictionFactory.build({
+    convictionId: referralToView.referral.relevantSentenceId,
+  })
+  cy.stubGetSentReferral(referralToView.id, referralToView)
+  cy.stubGetExpandedServiceUserByCRN(referralToView.referral.serviceUser.crn, expandedDeliusServiceUserFactory.build())
+  cy.stubGetConvictionById(referralToView.referral.serviceUser.crn, conviction.convictionId, conviction)
+  cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+  cy.stubGetSupplementaryRiskInformation(
+    referralToView.supplementaryRiskId,
+    supplementaryRiskInformationFactory.build()
+  )
+  cy.stubGetResponsibleOfficerForServiceUser(referralToView.referral.serviceUser.crn, [
+    deliusOffenderManagerFactory.build(),
+  ])
 })
 
 const getTable = (subject, options = {}) => {

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
@@ -12,13 +12,13 @@ export default class MyCasesPresenter {
   readonly navItemsPresenter = new DashboardNavPresenter('My cases')
 
   readonly tableHeadings: SortableTableHeaders = [
-    { text: 'Date sent', sort: 'none' },
-    { text: 'Referral', sort: 'none' },
-    { text: 'Service user', sort: 'ascending' },
-    { text: 'Intervention type', sort: 'none' },
-    { text: 'Provider', sort: 'none' },
-    { text: 'Caseworker', sort: 'none' },
-    { text: 'Action', sort: 'none' },
+    { text: 'Date sent', sort: 'none', persistentId: 'dateSent' },
+    { text: 'Referral', sort: 'none', persistentId: 'referenceNumber' },
+    { text: 'Service user', sort: 'ascending', persistentId: 'serviceUser' },
+    { text: 'Intervention type', sort: 'none', persistentId: 'interventionType' },
+    { text: 'Provider', sort: 'none', persistentId: 'provider' },
+    { text: 'Caseworker', sort: 'none', persistentId: 'caseworker' },
+    { text: 'Action', sort: 'none', persistentId: 'action' },
   ]
 
   readonly tableRows: SortableTableRow[] = this.sentReferrals.map(referral => {

--- a/server/routes/probationPractitionerReferrals/myCasesView.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesView.ts
@@ -7,7 +7,7 @@ export default class MyCasesView {
 
   private get tableArgs(): TableArgs {
     const { tableHeadings, tableRows } = this.presenter
-    return ViewUtils.sortableTable(tableHeadings, tableRows)
+    return ViewUtils.sortableTable('probationPractitionerMyCases', tableHeadings, tableRows)
   }
 
   get renderArgs(): [string, Record<string, unknown>] {

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -9,12 +9,12 @@ export default class DashboardPresenter {
   constructor(private readonly referralsSummary: ServiceProviderSentReferralSummary[]) {}
 
   readonly tableHeadings: SortableTableHeaders = [
-    { text: 'Date received', sort: 'none' },
-    { text: 'Referral', sort: 'none' },
-    { text: 'Service user', sort: 'none' },
-    { text: 'Intervention type', sort: 'none' },
-    { text: 'Caseworker', sort: 'none' },
-    { text: 'Action', sort: 'none' },
+    { text: 'Date received', sort: 'none', persistentId: 'dateReceived' },
+    { text: 'Referral', sort: 'none', persistentId: 'referenceNumber' },
+    { text: 'Service user', sort: 'none', persistentId: 'serviceUser' },
+    { text: 'Intervention type', sort: 'none', persistentId: 'interventionType' },
+    { text: 'Caseworker', sort: 'none', persistentId: 'caseworker' },
+    { text: 'Action', sort: 'none', persistentId: 'action' },
   ]
 
   readonly navItemsPresenter = new DashboardNavPresenter('All cases')

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -7,7 +7,7 @@ export default class DashboardView {
 
   private get tableArgs(): TableArgs {
     const { tableHeadings, tableRows } = this.presenter
-    return ViewUtils.sortableTable(tableHeadings, tableRows)
+    return ViewUtils.sortableTable('serviceProviderDashboard', tableHeadings, tableRows)
   }
 
   get renderArgs(): [string, Record<string, unknown>] {

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -86,8 +86,9 @@ export default class ViewUtils {
     }
   }
 
-  static sortableTable(headers: SortableTableHeaders, rows: SortableTableRow[]): TableArgs {
+  static sortableTable(persistentId: string, headers: SortableTableHeaders, rows: SortableTableRow[]): TableArgs {
     return {
+      attributes: { 'data-persistent-id': persistentId },
       head: headers.map(heading => {
         return {
           text: heading.text,

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -3,7 +3,7 @@ import { ListStyle, SummaryListItem } from './summaryList'
 import { ErrorSummaryArgs, SummaryListArgs, TableArgs, TagArgs } from './govukFrontendTypes'
 import SessionStatusPresenter from '../routes/shared/sessionStatusPresenter'
 
-export type SortableTableHeaders = { text: string; sort: 'ascending' | 'descending' | 'none' }[]
+export type SortableTableHeaders = { text: string; sort: 'ascending' | 'descending' | 'none'; persistentId: string }[]
 export type SortableTableRow = { text: string; sortValue: string | null; href: string | null }[]
 export type PrimaryNavItem = { text: string; href: string; active: boolean }
 
@@ -93,6 +93,7 @@ export default class ViewUtils {
           text: heading.text,
           attributes: {
             'aria-sort': heading.sort,
+            'data-persistent-id': heading.persistentId,
           },
         }
       }),


### PR DESCRIPTION
I'm nearing the end of my time on the project, and I don't think I'll have much time to work on this further. So, I'm opening this as a draft, with a list of the outstanding work.

## What does this pull request do?

1. Adds a TypeScript build process for the browser-side code, and converts the existing browser-side code to TypeScript.
2. Preserves the user's chosen ordering for the sortable tables (PP and SP case lists)

## What's left to do?

- [x] Write Cypress tests to check that this behaviour works
- [ ] Test that this works across browsers (I believe that the ECMAScript version I've chosen for transpilation will work all the way down to IE11, but not sure if we'll need a polyfill / to use an older alternative for some web APIs e.g. `MutationObserver`).

## What is the intent behind these changes?

Currently, when the user sorts a sortable table, their chosen sort order is lost when they next return to that page (e.g. using the browser back button). Our user research has shown that users find this confusing, and suggested that we try preserving the sort order across page visits. That is what this change does.

## Video

https://user-images.githubusercontent.com/53756884/134332237-9ad71056-3c2d-41ac-a6d5-64b28f9c8cc2.mov


