### PR TITLE
Get supplementary risk information for crn

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -8,6 +8,7 @@ import interventionFactory from '../../testutils/factories/intervention'
 import ReferralSectionVerifier from './make_a_referral/referralSectionVerifier'
 import riskSummaryFactory from '../../testutils/factories/riskSummary'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
+import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 
 describe('Referral form', () => {
   const deliusServiceUser = deliusServiceUserFactory.build({
@@ -143,6 +144,10 @@ describe('Referral form', () => {
       cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
       cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
       cy.stubGetRiskSummary(draftReferral.serviceUser.crn, riskSummaryFactory.build())
+      cy.stubGetSupplementaryRiskInformationForCrn(
+        draftReferral.serviceUser.crn,
+        supplementaryRiskInformationFactory.build()
+      )
 
       cy.login()
 
@@ -575,6 +580,10 @@ describe('Referral form', () => {
       cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
       cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
       cy.stubGetRiskSummary(draftReferral.serviceUser.crn, riskSummaryFactory.build())
+      cy.stubGetSupplementaryRiskInformationForCrn(
+        draftReferral.serviceUser.crn,
+        supplementaryRiskInformationFactory.build()
+      )
 
       cy.login()
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -211,6 +211,10 @@ module.exports = on => {
       return assessRisksAndNeedsService.stubGetSupplementaryRiskInformation(arg.riskId, arg.responseJson)
     },
 
+    stubGetSupplementaryRiskInformationForCrn: arg => {
+      return assessRisksAndNeedsService.stubGetSupplementaryRiskInformationForCrn(arg.crn, arg.responseJson)
+    },
+
     stubGetRiskSummary: arg => {
       return assessRisksAndNeedsService.stubGetRiskSummary(arg.crn, arg.responseJson)
     },

--- a/integration_tests/support/assessRisksAndNeedsServiceStubs.js
+++ b/integration_tests/support/assessRisksAndNeedsServiceStubs.js
@@ -2,6 +2,10 @@ Cypress.Commands.add('stubGetSupplementaryRiskInformation', (riskId, responseJso
   cy.task('stubGetSupplementaryRiskInformation', { riskId, responseJson })
 })
 
+Cypress.Commands.add('stubGetSupplementaryRiskInformationForCrn', (crn, responseJson) => {
+  cy.task('stubGetSupplementaryRiskInformationForCrn', { crn, responseJson })
+})
+
 Cypress.Commands.add('stubGetRiskSummary', (crn, responseJson) => {
   cy.task('stubGetRiskSummary', { crn, responseJson })
 })

--- a/mockApis/assessRisksAndNeedsService.ts
+++ b/mockApis/assessRisksAndNeedsService.ts
@@ -19,6 +19,22 @@ export default class AssessRisksAndNeedsServiceMocks {
     })
   }
 
+  stubGetSupplementaryRiskInformationForCrn = async (crn: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/risks/supplementary/crn/${crn}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
   stubGetRiskSummary = async (crn: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/routes/referrals/risk-information/oasys/view/oasysRiskInformationPresenter.test.ts
+++ b/server/routes/referrals/risk-information/oasys/view/oasysRiskInformationPresenter.test.ts
@@ -1,13 +1,12 @@
 import OasysRiskInformationPresenter from './oasysRiskInformationPresenter'
-import draftReferralFactory from '../../../../../../testutils/factories/draftReferral'
 import riskSummaryFactory from '../../../../../../testutils/factories/riskSummary'
+import supplementaryRiskInformationFactory from '../../../../../../testutils/factories/supplementaryRiskInformation'
 
 describe('OasysRiskInformationPresenter', () => {
   describe('latestAssessment', () => {
     it('returns the correctly formatted date', () => {
-      const referral = draftReferralFactory.build()
       const riskSummary = riskSummaryFactory.build({ assessedOn: '2021-09-20T09:31:45.062Z' })
-      const presenter = new OasysRiskInformationPresenter(referral, riskSummary)
+      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformationFactory.build(), riskSummary)
 
       expect(presenter.latestAssessment).toEqual('20 September 2021')
     })

--- a/server/routes/referrals/risk-information/oasys/view/oasysRiskInformationPresenter.ts
+++ b/server/routes/referrals/risk-information/oasys/view/oasysRiskInformationPresenter.ts
@@ -1,11 +1,12 @@
-import DraftReferral from '../../../../../models/draftReferral'
 import RiskSummary from '../../../../../models/assessRisksAndNeeds/riskSummary'
 import DateUtils from '../../../../../utils/dateUtils'
+import { SupplementaryRiskInformation } from '../../../../../models/assessRisksAndNeeds/supplementaryRiskInformation'
 
 export default class OasysRiskInformationPresenter {
-  constructor(private readonly referral: DraftReferral, readonly riskSummary: RiskSummary) {}
-
-  readonly additionalInformation = this.referral.additionalRiskInformation
+  constructor(
+    readonly supplementaryRiskInformation: SupplementaryRiskInformation | null,
+    readonly riskSummary: RiskSummary
+  ) {}
 
   get latestAssessment(): string {
     return DateUtils.formattedDate(this.riskSummary.assessedOn)

--- a/server/routes/referrals/risk-information/oasys/view/oasysRiskInformationView.test.ts
+++ b/server/routes/referrals/risk-information/oasys/view/oasysRiskInformationView.test.ts
@@ -1,15 +1,14 @@
 import OasysRiskInformationPresenter from './oasysRiskInformationPresenter'
-import draftReferralFactory from '../../../../../../testutils/factories/draftReferral'
 import riskSummaryFactory from '../../../../../../testutils/factories/riskSummary'
 import OasysRiskInformationView from './oasysRiskInformationView'
 import { Risk } from '../../../../../models/assessRisksAndNeeds/riskSummary'
+import supplementaryRiskInformationFactory from '../../../../../../testutils/factories/supplementaryRiskInformation'
 
 describe('OasysRiskInformationView', () => {
   describe('additionalRiskInformationResponse', () => {
     it('returns special content to display if no additional risk information has been provided', () => {
-      const referral = draftReferralFactory.build({ additionalRiskInformation: null })
       const riskSummary = riskSummaryFactory.build()
-      const presenter = new OasysRiskInformationPresenter(referral, riskSummary)
+      const presenter = new OasysRiskInformationPresenter(null, riskSummary)
       const view = new OasysRiskInformationView(presenter)
       expect(view.renderArgs[1].additionalRiskInformationResponse).toHaveProperty('text', 'None')
     })
@@ -17,11 +16,11 @@ describe('OasysRiskInformationView', () => {
 
   describe('riskSummaryResponse', () => {
     it('returns correct response text when no null values provided ', () => {
-      const referral = draftReferralFactory.build({ additionalRiskInformation: null })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const riskSummary = riskSummaryFactory.build({
         summary: { whoIsAtRisk: null, natureOfRisk: null, riskImminence: null },
       })
-      const presenter = new OasysRiskInformationPresenter(referral, riskSummary)
+      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
       const view = new OasysRiskInformationView(presenter)
       expect(view.renderArgs[1].riskSummaryResponse).toEqual({
         whoIsAtRisk: expect.objectContaining({
@@ -37,11 +36,11 @@ describe('OasysRiskInformationView', () => {
     })
 
     it('returns correct response text when no values provided ', () => {
-      const referral = draftReferralFactory.build({ additionalRiskInformation: null })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const riskSummary = riskSummaryFactory.build({
         summary: { whoIsAtRisk: undefined, natureOfRisk: undefined, riskImminence: undefined },
       })
-      const presenter = new OasysRiskInformationPresenter(referral, riskSummary)
+      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
       const view = new OasysRiskInformationView(presenter)
       expect(view.renderArgs[1].riskSummaryResponse).toEqual({
         whoIsAtRisk: expect.objectContaining({
@@ -57,11 +56,11 @@ describe('OasysRiskInformationView', () => {
     })
 
     it('returns undefined when values are provided ', () => {
-      const referral = draftReferralFactory.build({ additionalRiskInformation: null })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const riskSummary = riskSummaryFactory.build({
         summary: { whoIsAtRisk: 'whoIsAtRisk', natureOfRisk: 'natureOfRisk', riskImminence: 'riskImminence' },
       })
-      const presenter = new OasysRiskInformationPresenter(referral, riskSummary)
+      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
       const view = new OasysRiskInformationView(presenter)
       expect(view.renderArgs[1].riskSummaryResponse).toEqual({
         whoIsAtRisk: undefined,
@@ -73,7 +72,7 @@ describe('OasysRiskInformationView', () => {
 
   describe('riskToSelfResponse', () => {
     it('returns correct response text when null values provided ', () => {
-      const referral = draftReferralFactory.build({ additionalRiskInformation: null })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const riskSummary = riskSummaryFactory.build({
         riskToSelf: {
           suicide: null,
@@ -82,7 +81,7 @@ describe('OasysRiskInformationView', () => {
           vulnerability: null,
         },
       })
-      const presenter = new OasysRiskInformationPresenter(referral, riskSummary)
+      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
       const view = new OasysRiskInformationView(presenter)
       expect(view.renderArgs[1].riskToSelfResponse).toEqual({
         suicide: expect.objectContaining({
@@ -101,7 +100,7 @@ describe('OasysRiskInformationView', () => {
     })
 
     it('returns correct response text when no values provided ', () => {
-      const referral = draftReferralFactory.build({ additionalRiskInformation: null })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const riskSummary = riskSummaryFactory.build({
         riskToSelf: {
           suicide: undefined,
@@ -110,7 +109,7 @@ describe('OasysRiskInformationView', () => {
           vulnerability: undefined,
         },
       })
-      const presenter = new OasysRiskInformationPresenter(referral, riskSummary)
+      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
       const view = new OasysRiskInformationView(presenter)
       expect(view.renderArgs[1].riskToSelfResponse).toEqual({
         suicide: expect.objectContaining({
@@ -129,14 +128,14 @@ describe('OasysRiskInformationView', () => {
     })
 
     it("returns correct response when 'YES' values are provided", () => {
-      const referral = draftReferralFactory.build({ additionalRiskInformation: null })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const yesRisk: Risk = {
         risk: null,
         current: 'YES',
         currentConcernsText: null,
       }
       const presenter = new OasysRiskInformationPresenter(
-        referral,
+        supplementaryRiskInformation,
         riskSummaryFactory.build({
           riskToSelf: {
             suicide: yesRisk,
@@ -164,14 +163,14 @@ describe('OasysRiskInformationView', () => {
     })
 
     it("returns correct response when 'NO' values are provided", () => {
-      const referral = draftReferralFactory.build({ additionalRiskInformation: null })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const noRisk: Risk = {
         risk: null,
         current: 'NO',
         currentConcernsText: null,
       }
       const presenter = new OasysRiskInformationPresenter(
-        referral,
+        supplementaryRiskInformation,
         riskSummaryFactory.build({
           riskToSelf: {
             suicide: noRisk,
@@ -199,14 +198,14 @@ describe('OasysRiskInformationView', () => {
     })
 
     it("returns correct response when 'DK' values are provided", () => {
-      const referral = draftReferralFactory.build({ additionalRiskInformation: null })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const dkRisk: Risk = {
         risk: null,
         current: 'DK',
         currentConcernsText: null,
       }
       const presenter = new OasysRiskInformationPresenter(
-        referral,
+        supplementaryRiskInformation,
         riskSummaryFactory.build({
           riskToSelf: {
             suicide: dkRisk,
@@ -234,14 +233,14 @@ describe('OasysRiskInformationView', () => {
     })
 
     it('returns correct response when no values for current are provided', () => {
-      const referral = draftReferralFactory.build({ additionalRiskInformation: null })
+      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
       const nullRisk: Risk = {
         risk: null,
         current: null,
         currentConcernsText: null,
       }
       const presenter = new OasysRiskInformationPresenter(
-        referral,
+        supplementaryRiskInformation,
         riskSummaryFactory.build({
           riskToSelf: {
             suicide: nullRisk,

--- a/server/routes/referrals/risk-information/oasys/view/oasysRiskInformationView.ts
+++ b/server/routes/referrals/risk-information/oasys/view/oasysRiskInformationView.ts
@@ -5,7 +5,7 @@ export default class OasysRiskInformationView {
   constructor(private readonly presenter: OasysRiskInformationPresenter) {}
 
   private get additionalRiskInformationResponse(): { class: string; text: string } | undefined {
-    if (this.presenter.additionalInformation) {
+    if (this.presenter.supplementaryRiskInformation != null) {
       return undefined
     }
     return {
@@ -80,7 +80,7 @@ export default class OasysRiskInformationView {
         riskSummaryResponse: this.riskSummaryResponse,
         riskToSelf: this.presenter.riskSummary.riskToSelf,
         riskToSelfResponse: this.riskToSelfResponse,
-        additionalRiskInformation: this.presenter.additionalInformation,
+        additionalRiskInformation: this.presenter.supplementaryRiskInformation?.riskSummaryComments,
         additionalRiskInformationResponse: this.additionalRiskInformationResponse,
         latestAssessment: this.presenter.latestAssessment,
       },

--- a/server/services/assessRisksAndNeedsService.test.ts
+++ b/server/services/assessRisksAndNeedsService.test.ts
@@ -25,6 +25,21 @@ describe(AssessRisksAndNeedsService, () => {
     })
   })
 
+  describe('getSupplementaryRiskInformationForCrn', () => {
+    const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
+
+    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(restClientMock, true)
+
+    const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+
+    it('makes a request to the Assess Risks and Needs API', async () => {
+      restClientMock.get.mockResolvedValue(supplementaryRiskInformation)
+      await assessRisksAndNeedsService.getSupplementaryRiskInformationForCrn('crn', 'token')
+
+      expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/supplementary/crn/crn`, token: 'token' })
+    })
+  })
+
   describe('getRiskSummary', () => {
     const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
 

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -17,6 +17,14 @@ export default class AssessRisksAndNeedsService {
     })) as SupplementaryRiskInformation
   }
 
+  async getSupplementaryRiskInformationForCrn(crn: string, token: string): Promise<SupplementaryRiskInformation> {
+    logger.info({ crn }, 'getting supplementary risk information for crn')
+    return (await this.restClient.get({
+      path: `/risks/supplementary/crn/${crn}`,
+      token,
+    })) as SupplementaryRiskInformation
+  }
+
   async getRiskSummary(crn: string, token: string): Promise<RiskSummary | null> {
     if (!this.riskSummaryEnabled) {
       logger.info('not getting risk summary information; disabled')


### PR DESCRIPTION
## What does this pull request do?

For Oasys risk information page the additional information is now populated from the ARN supplementary info call rather than populated from our own additional information data source.
This was an invalid assumption made regarding the source of the data.

## What is the intent behind these changes?

Ensure that PP see's supplementary risk information before editing.

Note: Changes are behind a feature flag so this page would not be rendered until all the risk work is finished.