### PR TITLE
Create script to ensure stable dependency boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You'll also need to add the following line to your `/etc/hosts` file:
 ### Running the app
 
 ```
-docker-compose up -d
+bin/start-dependencies
 npm run start:dev
 ```
 

--- a/bin/start-dependencies
+++ b/bin/start-dependencies
@@ -1,0 +1,25 @@
+#!/bin/sh -e
+compose_network="hmpps-interventions-ui_hmpps"
+
+echo
+docker compose up -d community-api
+docker run --rm --network="$compose_network" jwilder/dockerize \
+  -wait tcp://community-api:8080 \
+  -wait-retry-interval 5s \
+  -timeout 360s
+
+echo
+docker compose up -d hmpps-auth
+docker run --rm --network="$compose_network" jwilder/dockerize \
+  -wait tcp://hmpps-auth:8090 \
+  -wait-retry-interval 5s \
+  -timeout 360s
+
+echo
+docker compose up -d
+docker run --rm --network="$compose_network" jwilder/dockerize \
+  -wait tcp://interventions-service:8080 \
+  -wait tcp://assess-risks-and-needs:8080 \
+  -wait tcp://offender-assessments-api:8080 \
+  -wait-retry-interval 5s \
+  -timeout 360s


### PR DESCRIPTION
## What does this pull request do?

Creates a script that boots the dependencies in predictable, stable order.

## What is the intent behind these changes?

TL;DR: Booting community-api first, then hmpps-auth, then the rest will ensure a stable boot order without excessive restarts and CPU load.

Without this, all services will boot up, and then randomly restart until the right startup order is achieved. This works, but  the laptop fans find it strenuous  :)

---

Every application is dependent on `hmpps-auth` being responsive;
otherwise, they end up with

```
org.springframework.web.client.ResourceAccessException: ⏎
  I/O error on GET request for ⏎
  "http://hmpps-auth:8090/auth/issuer/.well-known/openid-configuration"
```

In turn, `hmpps-auth` requires `community-api` to be responsive during
boot, resulting in
```
reactor.core.Exceptions$ReactiveException: ⏎
  java.net.UnknownHostException: failed to resolve 'community-api' after 2 queries
```

This forces the boot order described in the script.

## How does it look like?

<img width="969" alt="image" src="https://user-images.githubusercontent.com/1526295/134368776-585b185c-80b4-4a0c-ace1-187135646858.png">
