### PR TITLE
Added new SP dashboards

### DIFF
--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -289,61 +289,148 @@ describe('Dashboards', () => {
       title: "Women's Services - West Midlands",
     })
 
-    const sentReferralSummaries = [
-      serviceProviderSentReferralSummaryFactory.build({
-        sentAt: '2021-01-26T13:00:00.000000Z',
-        referenceNumber: 'ABCABCA1',
-        interventionTitle: accommodationIntervention.title,
-        serviceUserFirstName: 'George',
-        serviceUserLastName: 'Michael',
-      }),
-      serviceProviderSentReferralSummaryFactory.build({
-        sentAt: '2020-12-13T13:00:00.000000Z',
-        referenceNumber: 'ABCABCA2',
-        interventionTitle: womensServicesIntervention.title,
-        serviceUserFirstName: 'Jenny',
-        serviceUserLastName: 'Jones',
-        assignedToUserName: 'A.Caseworker',
-      }),
-    ]
-
     beforeEach(() => {
       cy.task('stubServiceProviderToken')
       cy.task('stubServiceProviderAuthUser')
 
       cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
       cy.stubGetIntervention(womensServicesIntervention.id, womensServicesIntervention)
-      cy.stubGetServiceProviderSentReferralsSummaryForUserToken(sentReferralSummaries)
     })
 
-    it("SP logs in and sees 'My cases' screen with list of sent referrals", () => {
-      cy.login()
-
-      cy.get('h1').contains('All cases')
-
-      cy.get('table')
-        .getTable()
-        .should('deep.equal', [
-          {
-            'Date received': '26 Jan 2021',
-            Referral: 'ABCABCA1',
-            'Service user': 'George Michael',
-            'Intervention type': 'Accommodation Services - West Midlands',
-            Caseworker: '',
-            Action: 'View',
-          },
-          {
-            'Date received': '13 Dec 2020',
-            Referral: 'ABCABCA2',
-            'Service user': 'Jenny Jones',
-            'Intervention type': "Women's Services - West Midlands",
-            Caseworker: 'A.Caseworker',
-            Action: 'View',
-          },
+    describe('SP logs in and accesses "My cases"', () => {
+      beforeEach(() => {
+        const assignedToSelf = serviceProviderSentReferralSummaryFactory
+          .withAssignedUser('USER1')
+          .build({ referenceNumber: 'ASSIGNED_TO_SELF' })
+        const unassigned = serviceProviderSentReferralSummaryFactory
+          .unassigned()
+          .build({ referenceNumber: 'UNASSIGNED' })
+        const assignedToOther = serviceProviderSentReferralSummaryFactory
+          .withAssignedUser('other')
+          .build({ referenceNumber: 'ASSIGNED_TO_OTHER' })
+        const completed = serviceProviderSentReferralSummaryFactory.completed().build({ referenceNumber: 'COMPLETED' })
+        cy.stubGetServiceProviderSentReferralsSummaryForUserToken([
+          assignedToSelf,
+          unassigned,
+          assignedToOther,
+          completed,
         ])
+        cy.login()
+      })
+
+      it('should see "My cases" and cases that are assigned to themselves only', () => {
+        cy.get('h1').contains('My cases')
+        cy.get('table')
+          .getTable()
+          .should('deep.equal', [
+            {
+              'Date received': '26 Jan 2021',
+              Referral: 'ASSIGNED_TO_SELF',
+              'Service user': 'Jenny Jones',
+              'Intervention type': 'Social Inclusion - West Midlands',
+              Action: 'View',
+            },
+          ])
+      })
+
+      describe('Selecting "All open cases"', () => {
+        it('should see "All open cases" and cases that are not concluded', () => {
+          cy.get('h1').contains('My cases')
+          cy.contains('All open cases').click()
+          cy.get('h1').contains('All open cases')
+          cy.get('table')
+            .getTable()
+            .should('deep.equal', [
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'ASSIGNED_TO_SELF',
+                'Service user': 'Jenny Jones',
+                'Intervention type': 'Social Inclusion - West Midlands',
+                Caseworker: 'USER1',
+                Action: 'View',
+              },
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'UNASSIGNED',
+                'Service user': 'Jenny Jones',
+                'Intervention type': 'Social Inclusion - West Midlands',
+                Caseworker: '',
+                Action: 'View',
+              },
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'ASSIGNED_TO_OTHER',
+                'Service user': 'Jenny Jones',
+                'Intervention type': 'Social Inclusion - West Midlands',
+                Caseworker: 'other',
+                Action: 'View',
+              },
+            ])
+        })
+      })
+
+      describe('Selecting "Unassigned cases"', () => {
+        it('should see "Unassigned cases" and cases that are not assigned', () => {
+          cy.get('h1').contains('My cases')
+          cy.contains('Unassigned cases').click()
+          cy.get('h1').contains('Unassigned cases')
+          cy.get('table')
+            .getTable()
+            .should('deep.equal', [
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'UNASSIGNED',
+                'Service user': 'Jenny Jones',
+                'Intervention type': 'Social Inclusion - West Midlands',
+                Action: 'View',
+              },
+            ])
+        })
+      })
+
+      describe('Selecting "Completed cases"', () => {
+        it('should see "Completed cases" and cases that are concluded', () => {
+          cy.get('h1').contains('My cases')
+          cy.contains('Completed cases').click()
+          cy.get('h1').contains('Completed cases')
+          cy.get('table')
+            .getTable()
+            .should('deep.equal', [
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'COMPLETED',
+                'Service user': 'Jenny Jones',
+                'Intervention type': 'Social Inclusion - West Midlands',
+                Caseworker: '',
+                Action: 'View',
+              },
+            ])
+        })
+      })
     })
 
     describe('Sorting the table', () => {
+      beforeEach(() => {
+        const sentReferralSummaries = [
+          serviceProviderSentReferralSummaryFactory.build({
+            sentAt: '2021-01-26T13:00:00.000000Z',
+            referenceNumber: 'ABCABCA1',
+            interventionTitle: accommodationIntervention.title,
+            serviceUserFirstName: 'George',
+            serviceUserLastName: 'Michael',
+          }),
+          serviceProviderSentReferralSummaryFactory.build({
+            sentAt: '2020-12-13T13:00:00.000000Z',
+            referenceNumber: 'ABCABCA2',
+            interventionTitle: womensServicesIntervention.title,
+            serviceUserFirstName: 'Jenny',
+            serviceUserLastName: 'Jones',
+            assignedToUserName: 'A.Caseworker',
+          }),
+        ]
+        cy.stubGetServiceProviderSentReferralsSummaryForUserToken(sentReferralSummaries)
+      })
+
       const initialTable = [
         {
           'Date received': '26 Jan 2021',

--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -410,192 +410,171 @@ describe('Dashboards', () => {
     })
 
     describe('Sorting the table', () => {
-      beforeEach(() => {
-        const sentReferralSummaries = [
-          serviceProviderSentReferralSummaryFactory.build({
-            sentAt: '2021-01-26T13:00:00.000000Z',
-            referenceNumber: 'ABCABCA1',
-            interventionTitle: accommodationIntervention.title,
-            serviceUserFirstName: 'George',
-            serviceUserLastName: 'Michael',
-          }),
-          serviceProviderSentReferralSummaryFactory.build({
-            sentAt: '2020-12-13T13:00:00.000000Z',
-            referenceNumber: 'ABCABCA2',
-            interventionTitle: womensServicesIntervention.title,
-            serviceUserFirstName: 'Jenny',
-            serviceUserLastName: 'Jones',
-            assignedToUserName: 'A.Caseworker',
-          }),
-        ]
-        cy.stubGetServiceProviderSentReferralsSummaryForUserToken(sentReferralSummaries)
+      const assignedToSelfA = serviceProviderSentReferralSummaryFactory.build({
+        sentAt: '2020-12-13T13:00:00.000000Z',
+        referenceNumber: 'A',
+        interventionTitle: accommodationIntervention.title,
+        serviceUserFirstName: 'Jenny',
+        serviceUserLastName: 'Jones',
+        assignedToUserName: 'USER1',
+        hasEndOfServiceReport: false,
+      })
+      const assignedToSelfB = serviceProviderSentReferralSummaryFactory.build({
+        sentAt: '2021-01-26T13:00:00.000000Z',
+        referenceNumber: 'B',
+        interventionTitle: womensServicesIntervention.title,
+        serviceUserFirstName: 'George',
+        serviceUserLastName: 'Michael',
+        assignedToUserName: 'USER1',
+        hasEndOfServiceReport: false,
+      })
+      const unassignedA = serviceProviderSentReferralSummaryFactory.build({
+        sentAt: '2020-12-13T13:00:00.000000Z',
+        referenceNumber: 'A',
+        interventionTitle: accommodationIntervention.title,
+        serviceUserFirstName: 'Jenny',
+        serviceUserLastName: 'Jones',
+        assignedToUserName: '',
+        hasEndOfServiceReport: false,
+      })
+      const unassignedB = serviceProviderSentReferralSummaryFactory.build({
+        sentAt: '2021-01-26T13:00:00.000000Z',
+        referenceNumber: 'B',
+        interventionTitle: womensServicesIntervention.title,
+        serviceUserFirstName: 'George',
+        serviceUserLastName: 'Michael',
+        assignedToUserName: '',
+        hasEndOfServiceReport: false,
+      })
+      const completedA = serviceProviderSentReferralSummaryFactory.build({
+        sentAt: '2020-12-13T13:00:00.000000Z',
+        referenceNumber: 'A',
+        interventionTitle: accommodationIntervention.title,
+        serviceUserFirstName: 'Jenny',
+        serviceUserLastName: 'Jones',
+        assignedToUserName: 'USER1',
+        hasEndOfServiceReport: true,
+      })
+      const completedB = serviceProviderSentReferralSummaryFactory.build({
+        sentAt: '2021-01-26T13:00:00.000000Z',
+        referenceNumber: 'B',
+        interventionTitle: womensServicesIntervention.title,
+        serviceUserFirstName: 'George',
+        serviceUserLastName: 'Michael',
+        assignedToUserName: 'USER1',
+        hasEndOfServiceReport: true,
       })
 
-      const initialTable = [
-        {
-          'Date received': '26 Jan 2021',
-          Referral: 'ABCABCA1',
-          'Service user': 'George Michael',
-          'Intervention type': 'Accommodation Services - West Midlands',
-          Caseworker: '',
-          Action: 'View',
-        },
-        {
-          'Date received': '13 Dec 2020',
-          Referral: 'ABCABCA2',
-          'Service user': 'Jenny Jones',
-          'Intervention type': "Women's Services - West Midlands",
-          Caseworker: 'A.Caseworker',
-          Action: 'View',
-        },
-      ]
+      const rowForReferralAWithNoCaseworkerColumn = {
+        'Date received': '13 Dec 2020',
+        Referral: 'A',
+        'Service user': 'Jenny Jones',
+        'Intervention type': 'Accommodation Services - West Midlands',
+        Action: 'View',
+      }
+      const rowForReferralBWithNoCaseworkerColumn = {
+        'Date received': '26 Jan 2021',
+        Referral: 'B',
+        'Service user': 'George Michael',
+        'Intervention type': "Women's Services - West Midlands",
+        Action: 'View',
+      }
 
-      const headersAndTables = [
+      const rowForReferralAWithCaseworker = {
+        'Date received': '13 Dec 2020',
+        Referral: 'A',
+        'Service user': 'Jenny Jones',
+        'Intervention type': 'Accommodation Services - West Midlands',
+        Caseworker: 'USER1',
+        Action: 'View',
+      }
+
+      const rowForReferralBWithCaseworker = {
+        'Date received': '26 Jan 2021',
+        Referral: 'B',
+        'Service user': 'George Michael',
+        'Intervention type': "Women's Services - West Midlands",
+        Caseworker: 'USER1',
+        Action: 'View',
+      }
+
+      const dashBoardTables = [
         {
-          header: 'Date received',
-          sortedTable: [
+          dashboardType: 'My cases',
+          referrals: [assignedToSelfA, assignedToSelfB],
+          initialTable: [rowForReferralAWithNoCaseworkerColumn, rowForReferralBWithNoCaseworkerColumn],
+          sortedTable: [rowForReferralAWithNoCaseworkerColumn, rowForReferralBWithNoCaseworkerColumn],
+          sortedTables: [
             {
-              'Date received': '13 Dec 2020',
-              Referral: 'ABCABCA2',
-              'Service user': 'Jenny Jones',
-              'Intervention type': "Women's Services - West Midlands",
-              Caseworker: 'A.Caseworker',
-              Action: 'View',
-            },
-            {
-              'Date received': '26 Jan 2021',
-              Referral: 'ABCABCA1',
-              'Service user': 'George Michael',
-              'Intervention type': 'Accommodation Services - West Midlands',
-              Caseworker: '',
-              Action: 'View',
+              header: 'Date received',
             },
           ],
         },
         {
-          header: 'Referral',
-          sortedTable: [
-            {
-              'Date received': '26 Jan 2021',
-              Referral: 'ABCABCA1',
-              'Service user': 'George Michael',
-              'Intervention type': 'Accommodation Services - West Midlands',
-              Caseworker: '',
-              Action: 'View',
-            },
-            {
-              'Date received': '13 Dec 2020',
-              Referral: 'ABCABCA2',
-              'Service user': 'Jenny Jones',
-              'Intervention type': "Women's Services - West Midlands",
-              Caseworker: 'A.Caseworker',
-              Action: 'View',
-            },
-          ],
+          dashboardType: 'All open cases',
+          referrals: [assignedToSelfA, assignedToSelfB],
+          initialTable: [rowForReferralAWithCaseworker, rowForReferralBWithCaseworker],
+          sortedTable: [rowForReferralAWithCaseworker, rowForReferralBWithCaseworker],
         },
         {
-          header: 'Service user',
-          sortedTable: [
-            {
-              'Date received': '13 Dec 2020',
-              Referral: 'ABCABCA2',
-              'Service user': 'Jenny Jones',
-              'Intervention type': "Women's Services - West Midlands",
-              Caseworker: 'A.Caseworker',
-              Action: 'View',
-            },
-            {
-              'Date received': '26 Jan 2021',
-              Referral: 'ABCABCA1',
-              'Service user': 'George Michael',
-              'Intervention type': 'Accommodation Services - West Midlands',
-              Caseworker: '',
-              Action: 'View',
-            },
-          ],
+          dashboardType: 'Unassigned cases',
+          referrals: [unassignedA, unassignedB],
+          initialTable: [rowForReferralAWithNoCaseworkerColumn, rowForReferralBWithNoCaseworkerColumn],
+          sortedTable: [rowForReferralAWithNoCaseworkerColumn, rowForReferralBWithNoCaseworkerColumn],
         },
         {
-          header: 'Intervention type',
-          sortedTable: [
-            {
-              'Date received': '26 Jan 2021',
-              Referral: 'ABCABCA1',
-              'Service user': 'George Michael',
-              'Intervention type': 'Accommodation Services - West Midlands',
-              Caseworker: '',
-              Action: 'View',
-            },
-            {
-              'Date received': '13 Dec 2020',
-              Referral: 'ABCABCA2',
-              'Service user': 'Jenny Jones',
-              'Intervention type': "Women's Services - West Midlands",
-              Caseworker: 'A.Caseworker',
-              Action: 'View',
-            },
-          ],
-        },
-        {
-          header: 'Caseworker',
-          sortedTable: [
-            {
-              'Date received': '26 Jan 2021',
-              Referral: 'ABCABCA1',
-              'Service user': 'George Michael',
-              'Intervention type': 'Accommodation Services - West Midlands',
-              Caseworker: '',
-              Action: 'View',
-            },
-            {
-              'Date received': '13 Dec 2020',
-              Referral: 'ABCABCA2',
-              'Service user': 'Jenny Jones',
-              'Intervention type': "Women's Services - West Midlands",
-              Caseworker: 'A.Caseworker',
-              Action: 'View',
-            },
-          ],
+          dashboardType: 'Completed cases',
+          referrals: [completedA, completedB],
+          initialTable: [rowForReferralAWithCaseworker, rowForReferralBWithCaseworker],
+          sortedTable: [rowForReferralAWithCaseworker, rowForReferralBWithCaseworker],
         },
       ]
 
       const referralToSelect = sentReferralFactory.build({
         sentAt: '2021-01-26T13:00:00.000000Z',
-        referenceNumber: 'ABCABCA1',
+        referenceNumber: 'B',
         referral: {
           interventionId: accommodationIntervention.id,
           serviceUser: { firstName: 'George', lastName: 'Michael' },
         },
       })
 
-      headersAndTables.forEach(({ header, sortedTable }) => {
-        describe(`sorting by "${header}"`, () => {
-          it(`allows the user to sort by "${header}"`, () => {
+      dashBoardTables.forEach(({ dashboardType, referrals, initialTable, sortedTable }) => {
+        describe(`sorting by "Date received" for dashboard "${dashboardType}"`, () => {
+          beforeEach(() => {
+            cy.stubGetServiceProviderSentReferralsSummaryForUserToken(referrals)
+          })
+
+          it(`allows the user to sort by "Date received" for dashboard "${dashboardType}"`, () => {
             cy.login()
+            cy.contains(dashboardType).click()
 
             cy.get('table').getTable().should('deep.equal', initialTable)
 
-            cy.get('table').within(() => cy.contains('button', header).click())
+            cy.get('table').within(() => cy.contains('button', 'Date received').click())
             cy.get('table').getTable().should('deep.equal', sortedTable)
 
-            cy.get('table').within(() => cy.contains('button', header).click())
+            cy.get('table').within(() => cy.contains('button', 'Date received').click())
 
             const reversedTable = [...sortedTable].reverse()
             cy.get('table').getTable().should('deep.equal', reversedTable)
           })
 
-          it('persists the sort order when coming back to the page', () => {
+          it(`persists the sort order when coming back to the page for dashboard "${dashboardType}"`, () => {
             cy.login()
+            cy.contains(dashboardType).click()
 
-            cy.get('table').within(() => cy.contains('button', header).click())
+            cy.get('table').within(() => cy.contains('button', 'Date received').click())
             cy.get('table').getTable().should('deep.equal', sortedTable)
 
             cy.stubViewReferralDetails(referralToSelect)
 
             cy.visit(`/service-provider/referrals/${referralToSelect.id}/details`)
             cy.contains('Back').click()
+            cy.contains(dashboardType).click()
 
             // Wait for header sort button to load, as it means JS has run
-            cy.get('table').within(() => cy.contains('button', header))
+            cy.get('table').within(() => cy.contains('button', 'Date received'))
             cy.get('table').getTable().should('deep.equal', sortedTable)
           })
         })

--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -26,7 +26,7 @@ describe('Dashboards', () => {
         },
       }),
       sentReferralFactory.build({
-        sentAt: '2020-09-13T13:00:00.000000Z',
+        sentAt: '2020-12-13T13:00:00.000000Z',
         assignedTo: {
           username: 'A. Caseworker',
           userId: '123',
@@ -69,7 +69,7 @@ describe('Dashboards', () => {
               Action: 'View',
             },
             {
-              'Date sent': '13 Sep 2020',
+              'Date sent': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -95,7 +95,7 @@ describe('Dashboards', () => {
           Action: 'View',
         },
         {
-          'Date sent': '13 Sep 2020',
+          'Date sent': '13 Dec 2020',
           Referral: 'ABCABCA2',
           'Service user': 'Jenny Jones',
           'Intervention type': "Women's Services - West Midlands",
@@ -110,7 +110,7 @@ describe('Dashboards', () => {
           header: 'Date sent',
           sortedTable: [
             {
-              'Date sent': '13 Sep 2020',
+              'Date sent': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -142,7 +142,7 @@ describe('Dashboards', () => {
               Action: 'View',
             },
             {
-              'Date sent': '13 Sep 2020',
+              'Date sent': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -165,7 +165,7 @@ describe('Dashboards', () => {
               Action: 'View',
             },
             {
-              'Date sent': '13 Sep 2020',
+              'Date sent': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -188,7 +188,7 @@ describe('Dashboards', () => {
               Action: 'View',
             },
             {
-              'Date sent': '13 Sep 2020',
+              'Date sent': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -202,7 +202,7 @@ describe('Dashboards', () => {
           header: 'Provider',
           sortedTable: [
             {
-              'Date sent': '13 Sep 2020',
+              'Date sent': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -225,7 +225,7 @@ describe('Dashboards', () => {
           header: 'Caseworker',
           sortedTable: [
             {
-              'Date sent': '13 Sep 2020',
+              'Date sent': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -298,7 +298,7 @@ describe('Dashboards', () => {
         serviceUserLastName: 'Michael',
       }),
       serviceProviderSentReferralSummaryFactory.build({
-        sentAt: '2020-09-13T13:00:00.000000Z',
+        sentAt: '2020-12-13T13:00:00.000000Z',
         referenceNumber: 'ABCABCA2',
         interventionTitle: womensServicesIntervention.title,
         serviceUserFirstName: 'Jenny',
@@ -333,7 +333,7 @@ describe('Dashboards', () => {
             Action: 'View',
           },
           {
-            'Date received': '13 Sep 2020',
+            'Date received': '13 Dec 2020',
             Referral: 'ABCABCA2',
             'Service user': 'Jenny Jones',
             'Intervention type': "Women's Services - West Midlands",
@@ -354,7 +354,7 @@ describe('Dashboards', () => {
           Action: 'View',
         },
         {
-          'Date received': '13 Sep 2020',
+          'Date received': '13 Dec 2020',
           Referral: 'ABCABCA2',
           'Service user': 'Jenny Jones',
           'Intervention type': "Women's Services - West Midlands",
@@ -368,7 +368,7 @@ describe('Dashboards', () => {
           header: 'Date received',
           sortedTable: [
             {
-              'Date received': '13 Sep 2020',
+              'Date received': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -397,7 +397,7 @@ describe('Dashboards', () => {
               Action: 'View',
             },
             {
-              'Date received': '13 Sep 2020',
+              'Date received': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -410,7 +410,7 @@ describe('Dashboards', () => {
           header: 'Service user',
           sortedTable: [
             {
-              'Date received': '13 Sep 2020',
+              'Date received': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -439,7 +439,7 @@ describe('Dashboards', () => {
               Action: 'View',
             },
             {
-              'Date received': '13 Sep 2020',
+              'Date received': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",
@@ -460,7 +460,7 @@ describe('Dashboards', () => {
               Action: 'View',
             },
             {
-              'Date received': '13 Sep 2020',
+              'Date received': '13 Dec 2020',
               Referral: 'ABCABCA2',
               'Service user': 'Jenny Jones',
               'Intervention type': "Women's Services - West Midlands",

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -52,7 +52,7 @@ describe('Probation practitioner referrals dashboard', () => {
         },
       }),
       sentReferralFactory.build({
-        sentAt: '2020-09-13T13:00:00.000000Z',
+        sentAt: '2020-12-13T13:00:00.000000Z',
         assignedTo: {
           username: 'A. Caseworker',
           userId: '123',
@@ -97,7 +97,7 @@ describe('Probation practitioner referrals dashboard', () => {
           Action: 'View',
         },
         {
-          'Date sent': '13 Sep 2020',
+          'Date sent': '13 Dec 2020',
           Referral: 'ABCABCA2',
           'Service user': 'Jenny Jones',
           'Intervention type': "Women's Services - West Midlands",
@@ -345,7 +345,7 @@ describe('Probation practitioner referrals dashboard', () => {
     })
 
     const referral = sentReferralFactory.build({
-      sentAt: '2020-09-13T13:00:00.000000Z',
+      sentAt: '2020-12-13T13:00:00.000000Z',
       referenceNumber: 'ABCABCA2',
       referral: {
         interventionId: personalWellbeingIntervention.id,

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -195,8 +195,8 @@ describe('Service provider referrals dashboard', () => {
 
     cy.login()
 
-    cy.get('h1').contains('All cases')
-
+    cy.get('h1').contains('My cases')
+    cy.contains('All open cases').click()
     cy.get('table')
       .getTable()
       .should('deep.equal', [
@@ -354,6 +354,7 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('Return to dashboard').click()
 
       cy.location('pathname').should('equal', `/service-provider/dashboard`)
+      cy.contains('All open cases').click()
       cy.contains('john.smith')
 
       cy.visit(`/service-provider/referrals/${referral.id}/details`)

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -66,7 +66,7 @@ describe('Service provider referrals dashboard', () => {
         },
       }),
       sentReferralFactory.build({
-        sentAt: '2020-09-13T13:00:00.000000Z',
+        sentAt: '2020-12-13T13:00:00.000000Z',
         referenceNumber: 'ABCABCA2',
         referral: {
           interventionId: personalWellbeingIntervention.id,
@@ -209,7 +209,7 @@ describe('Service provider referrals dashboard', () => {
           Action: 'View',
         },
         {
-          'Date received': '13 Sep 2020',
+          'Date received': '13 Dec 2020',
           'Intervention type': 'Personal Wellbeing - West Midlands',
           Referral: 'ABCABCA2',
           'Service user': 'Jenny Jones',

--- a/server/models/serviceProviderSentReferralSummary.ts
+++ b/server/models/serviceProviderSentReferralSummary.ts
@@ -6,4 +6,5 @@ export default interface ServiceProviderSentReferralSummary {
   assignedToUserName?: string | null
   serviceUserFirstName: string | null
   serviceUserLastName: string | null
+  hasEndOfServiceReport?: boolean
 }

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -2,6 +2,19 @@ import DashboardPresenter, { DashboardType } from './dashboardPresenter'
 import ServiceProviderSentReferralSummary from '../../models/serviceProviderSentReferralSummary'
 
 describe(DashboardPresenter, () => {
+  describe('tableHeadings', () => {
+    it('incorporates dashboard type name into persistent id', () => {
+      const presenter = new DashboardPresenter([], 'My cases')
+      expect(presenter.tableHeadings.map(headers => headers.persistentId)).toEqual([
+        'MycasesDateReceived',
+        'MycasesReferenceNumber',
+        'MycasesServiceUser',
+        'MycasesInterventionType',
+        'MycasesAction',
+      ])
+    })
+  })
+
   describe('tableRows', () => {
     const displayCaseworkerDashboardTypes: DashboardType[] = ['All open cases', 'Completed cases']
     describe.each(displayCaseworkerDashboardTypes)('with %s dashboard type', dashboardType => {

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -1,74 +1,56 @@
-import DashboardPresenter from './dashboardPresenter'
+import DashboardPresenter, { DashboardType } from './dashboardPresenter'
 import ServiceProviderSentReferralSummary from '../../models/serviceProviderSentReferralSummary'
 
 describe(DashboardPresenter, () => {
   describe('tableRows', () => {
-    it('returns the table’s rows', () => {
-      const referralsSummary: ServiceProviderSentReferralSummary[] = [
-        {
-          referralId: '1',
-          sentAt: '2021-01-26T13:00:00.000000Z',
-          referenceNumber: 'ABCABCA1',
-          interventionTitle: 'Accommodation Services - West Midlands',
-          assignedToUserName: null,
-          serviceUserFirstName: 'George',
-          serviceUserLastName: 'Michael',
-        },
-        {
-          referralId: '2',
-          sentAt: '2020-10-13T13:00:00.000000Z',
-          referenceNumber: 'ABCABCA2',
-          interventionTitle: "Women's Services - West Midlands",
-          assignedToUserName: null,
-          serviceUserFirstName: 'Jenny',
-          serviceUserLastName: 'Jones',
-        },
-      ]
-
-      const presenter = new DashboardPresenter(referralsSummary)
-
-      expect(presenter.tableRows).toEqual([
-        [
-          { text: '26 Jan 2021', sortValue: '2021-01-26', href: null },
-          { text: 'ABCABCA1', sortValue: null, href: null },
-          { text: 'George Michael', sortValue: 'michael, george', href: null },
-          { text: 'Accommodation Services - West Midlands', sortValue: null, href: null },
-          { text: '', sortValue: null, href: null },
-          { text: 'View', sortValue: null, href: `/service-provider/referrals/1/details` },
-        ],
-        [
-          { text: '13 Oct 2020', sortValue: '2020-10-13', href: null },
-          { text: 'ABCABCA2', sortValue: null, href: null },
-          { text: 'Jenny Jones', sortValue: 'jones, jenny', href: null },
-          { text: "Women's Services - West Midlands", sortValue: null, href: null },
-          { text: '', sortValue: null, href: null },
-          { text: 'View', sortValue: null, href: `/service-provider/referrals/2/details` },
-        ],
-      ])
-    })
-
-    describe('when a referral has been assigned to a caseworker', () => {
-      it('includes the caseworker’s username', () => {
+    const displayCaseworkerDashboardTypes: DashboardType[] = ['All open cases', 'Completed cases']
+    describe.each(displayCaseworkerDashboardTypes)('with %s dashboard type', dashboardType => {
+      it('returns the table’s rows', () => {
         const referralsSummary: ServiceProviderSentReferralSummary[] = [
           {
             referralId: '1',
             sentAt: '2021-01-26T13:00:00.000000Z',
             referenceNumber: 'ABCABCA1',
             interventionTitle: 'Accommodation Services - West Midlands',
-            assignedToUserName: 'john.smith',
+            assignedToUserName: null,
             serviceUserFirstName: 'George',
             serviceUserLastName: 'Michael',
           },
+          {
+            referralId: '2',
+            sentAt: '2020-10-13T13:00:00.000000Z',
+            referenceNumber: 'ABCABCA2',
+            interventionTitle: "Women's Services - West Midlands",
+            assignedToUserName: null,
+            serviceUserFirstName: 'Jenny',
+            serviceUserLastName: 'Jones',
+          },
         ]
-        const presenter = new DashboardPresenter(referralsSummary)
 
-        expect(presenter.tableRows[0][4]).toMatchObject({ text: 'john.smith' })
+        const presenter = new DashboardPresenter(referralsSummary, dashboardType)
+
+        expect(presenter.tableRows).toEqual([
+          [
+            { text: '26 Jan 2021', sortValue: '2021-01-26', href: null },
+            { text: 'ABCABCA1', sortValue: null, href: null },
+            { text: 'George Michael', sortValue: 'michael, george', href: null },
+            { text: 'Accommodation Services - West Midlands', sortValue: null, href: null },
+            { text: '', sortValue: null, href: null },
+            { text: 'View', sortValue: null, href: `/service-provider/referrals/1/details` },
+          ],
+          [
+            { text: '13 Oct 2020', sortValue: '2020-10-13', href: null },
+            { text: 'ABCABCA2', sortValue: null, href: null },
+            { text: 'Jenny Jones', sortValue: 'jones, jenny', href: null },
+            { text: "Women's Services - West Midlands", sortValue: null, href: null },
+            { text: '', sortValue: null, href: null },
+            { text: 'View', sortValue: null, href: `/service-provider/referrals/2/details` },
+          ],
+        ])
       })
-    })
 
-    describe('the View link', () => {
       describe('when a referral has been assigned to a caseworker', () => {
-        it('links to the intervention progress page', () => {
+        it('includes the caseworker’s username', () => {
           const referralsSummary: ServiceProviderSentReferralSummary[] = [
             {
               referralId: '1',
@@ -80,11 +62,60 @@ describe(DashboardPresenter, () => {
               serviceUserLastName: 'Michael',
             },
           ]
-          const presenter = new DashboardPresenter(referralsSummary)
+          const presenter = new DashboardPresenter(referralsSummary, dashboardType)
 
-          expect(presenter.tableRows[0][5]).toMatchObject({
-            href: `/service-provider/referrals/1/progress`,
-          })
+          expect(presenter.tableRows[0][4]).toMatchObject({ text: 'john.smith' })
+        })
+      })
+    })
+
+    const dontDisplayCaseworkerDashboardTypes: DashboardType[] = ['My cases', 'Unassigned cases']
+    describe.each(dontDisplayCaseworkerDashboardTypes)('with %s dashboard type', dashboardType => {
+      it('does not display the case worker column', () => {
+        const referralsSummary: ServiceProviderSentReferralSummary[] = [
+          {
+            referralId: '1',
+            sentAt: '2021-01-26T13:00:00.000000Z',
+            referenceNumber: 'ABCABCA1',
+            interventionTitle: 'Accommodation Services - West Midlands',
+            assignedToUserName: 'john.smith',
+            serviceUserFirstName: 'George',
+            serviceUserLastName: 'Michael',
+          },
+        ]
+        const presenter = new DashboardPresenter(referralsSummary, dashboardType)
+
+        expect(presenter.tableRows).toEqual([
+          [
+            { text: '26 Jan 2021', sortValue: '2021-01-26', href: null },
+            { text: 'ABCABCA1', sortValue: null, href: null },
+            { text: 'George Michael', sortValue: 'michael, george', href: null },
+            { text: 'Accommodation Services - West Midlands', sortValue: null, href: null },
+            { text: 'View', sortValue: null, href: `/service-provider/referrals/1/progress` },
+          ],
+        ])
+      })
+    })
+  })
+
+  describe('the View link', () => {
+    describe('when a referral has been assigned to a caseworker', () => {
+      it('links to the intervention progress page', () => {
+        const referralsSummary: ServiceProviderSentReferralSummary[] = [
+          {
+            referralId: '1',
+            sentAt: '2021-01-26T13:00:00.000000Z',
+            referenceNumber: 'ABCABCA1',
+            interventionTitle: 'Accommodation Services - West Midlands',
+            assignedToUserName: 'john.smith',
+            serviceUserFirstName: 'George',
+            serviceUserLastName: 'Michael',
+          },
+        ]
+        const presenter = new DashboardPresenter(referralsSummary, 'All open cases')
+
+        expect(presenter.tableRows[0][5]).toMatchObject({
+          href: `/service-provider/referrals/1/progress`,
         })
       })
     })

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -15,6 +15,8 @@ export default class DashboardPresenter {
   private readonly showAssignedCaseworkerColumn =
     this.dashboardType === 'My cases' || this.dashboardType === 'Unassigned cases'
 
+  readonly title = this.dashboardType
+
   readonly tableHeadings: SortableTableHeaders = [
     { text: 'Date received', sort: 'none', persistentId: 'dateReceived' },
     { text: 'Referral', sort: 'none', persistentId: 'referenceNumber' },

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -15,15 +15,19 @@ export default class DashboardPresenter {
   private readonly showAssignedCaseworkerColumn =
     this.dashboardType === 'My cases' || this.dashboardType === 'Unassigned cases'
 
+  private readonly dashBoardTypePersistentId = this.dashboardType.replace(/\s/g, '')
+
   readonly title = this.dashboardType
 
   readonly tableHeadings: SortableTableHeaders = [
-    { text: 'Date received', sort: 'none', persistentId: 'dateReceived' },
-    { text: 'Referral', sort: 'none', persistentId: 'referenceNumber' },
-    { text: 'Service user', sort: 'none', persistentId: 'serviceUser' },
-    { text: 'Intervention type', sort: 'none', persistentId: 'interventionType' },
-    this.showAssignedCaseworkerColumn ? null : { text: 'Caseworker', sort: 'none', persistentId: 'caseworker' },
-    { text: 'Action', sort: 'none', persistentId: 'action' },
+    { text: 'Date received', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}DateReceived` },
+    { text: 'Referral', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}ReferenceNumber` },
+    { text: 'Service user', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}ServiceUser` },
+    { text: 'Intervention type', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}InterventionType` },
+    this.showAssignedCaseworkerColumn
+      ? null
+      : { text: 'Caseworker', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}Caseworker` },
+    { text: 'Action', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}Action` },
   ].filter(row => row !== null) as SortableTableHeaders
 
   readonly navItemsPresenter = new DashboardNavPresenter('All cases')

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -5,17 +5,24 @@ import ServiceProviderSentReferralSummary from '../../models/serviceProviderSent
 import utils from '../../utils/utils'
 import DateUtils from '../../utils/dateUtils'
 
+export type DashboardType = 'My cases' | 'All open cases' | 'Unassigned cases' | 'Completed cases'
 export default class DashboardPresenter {
-  constructor(private readonly referralsSummary: ServiceProviderSentReferralSummary[]) {}
+  constructor(
+    private readonly referralsSummary: ServiceProviderSentReferralSummary[],
+    private readonly dashboardType: DashboardType
+  ) {}
+
+  private readonly showAssignedCaseworkerColumn =
+    this.dashboardType === 'My cases' || this.dashboardType === 'Unassigned cases'
 
   readonly tableHeadings: SortableTableHeaders = [
     { text: 'Date received', sort: 'none', persistentId: 'dateReceived' },
     { text: 'Referral', sort: 'none', persistentId: 'referenceNumber' },
     { text: 'Service user', sort: 'none', persistentId: 'serviceUser' },
     { text: 'Intervention type', sort: 'none', persistentId: 'interventionType' },
-    { text: 'Caseworker', sort: 'none', persistentId: 'caseworker' },
+    this.showAssignedCaseworkerColumn ? null : { text: 'Caseworker', sort: 'none', persistentId: 'caseworker' },
     { text: 'Action', sort: 'none', persistentId: 'action' },
-  ]
+  ].filter(row => row !== null) as SortableTableHeaders
 
   readonly navItemsPresenter = new DashboardNavPresenter('All cases')
 
@@ -38,9 +45,11 @@ export default class DashboardPresenter {
         href: null,
       },
       { text: referralSummary.interventionTitle, sortValue: null, href: null },
-      { text: referralSummary.assignedToUserName ?? '', sortValue: null, href: null },
+      this.showAssignedCaseworkerColumn
+        ? null
+        : { text: referralSummary.assignedToUserName ?? '', sortValue: null, href: null },
       { text: 'View', sortValue: null, href: DashboardPresenter.hrefForViewing(referralSummary) },
-    ]
+    ].filter(row => row !== null) as SortableTableRow
   })
 
   private static hrefForViewing(referralSummary: ServiceProviderSentReferralSummary): string {

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -9,7 +9,7 @@ export type DashboardType = 'My cases' | 'All open cases' | 'Unassigned cases' |
 export default class DashboardPresenter {
   constructor(
     private readonly referralsSummary: ServiceProviderSentReferralSummary[],
-    private readonly dashboardType: DashboardType
+    readonly dashboardType: DashboardType
   ) {}
 
   private readonly showAssignedCaseworkerColumn =

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -13,7 +13,11 @@ export default class DashboardView {
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/dashboard',
-      { tableArgs: this.tableArgs, primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items) },
+      {
+        presenter: this.presenter,
+        tableArgs: this.tableArgs,
+        primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items),
+      },
     ]
   }
 }

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -10,6 +10,31 @@ export default class DashboardView {
     return ViewUtils.sortableTable('serviceProviderDashboard', tableHeadings, tableRows)
   }
 
+  readonly subNavArgs = {
+    items: [
+      {
+        text: 'My cases',
+        href: `/service-provider/dashboard/my-cases`,
+        active: this.presenter.dashboardType === 'My cases',
+      },
+      {
+        text: 'All open cases',
+        href: `/service-provider/dashboard/all-open-cases`,
+        active: this.presenter.dashboardType === 'All open cases',
+      },
+      {
+        text: 'Unassigned cases',
+        href: `/service-provider/dashboard/unassigned-cases`,
+        active: this.presenter.dashboardType === 'Unassigned cases',
+      },
+      {
+        text: 'Completed cases',
+        href: `/service-provider/dashboard/completed-cases`,
+        active: this.presenter.dashboardType === 'Completed cases',
+      },
+    ],
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/dashboard',
@@ -17,6 +42,7 @@ export default class DashboardView {
         presenter: this.presenter,
         tableArgs: this.tableArgs,
         primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items),
+        subNavArgs: this.subNavArgs,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -111,7 +111,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken
     )
 
-    const presenter = new DashboardPresenter(referralsSummary)
+    const presenter = new DashboardPresenter(referralsSummary, 'All open cases')
     const view = new DashboardView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, null)

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -17,7 +17,18 @@ export default function serviceProviderRoutes(router: Router, services: Services
     services.referenceDataService
   )
 
-  get(router, '/dashboard', (req, res) => serviceProviderReferralsController.showDashboard(req, res))
+  get(router, '/dashboard', (req, res) => serviceProviderReferralsController.showMyCasesDashboard(req, res))
+  get(router, '/dashboard/my-cases', (req, res) => serviceProviderReferralsController.showMyCasesDashboard(req, res))
+  get(router, '/dashboard/all-open-cases', (req, res) =>
+    serviceProviderReferralsController.showAllOpenCasesDashboard(req, res)
+  )
+  get(router, '/dashboard/unassigned-cases', (req, res) =>
+    serviceProviderReferralsController.showUnassignedCasesDashboard(req, res)
+  )
+  get(router, '/dashboard/completed-cases', (req, res) =>
+    serviceProviderReferralsController.showCompletedCasesDashboard(req, res)
+  )
+
   get(router, '/referrals/:id/details', (req, res) => serviceProviderReferralsController.showReferral(req, res))
   get(router, '/referrals/:id/progress', (req, res) =>
     serviceProviderReferralsController.showInterventionProgress(req, res)

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1673,6 +1673,54 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('getServiceProviderSentReferralsSummaryForUserToken', () => {
+    it('returns a list of sent referrals', async () => {
+      const spUserWithAccess = oauth2TokenFactory
+        .transient({
+          authSource: 'auth',
+          userID: '608955ae-52ed-44cc-884c-011597a77949',
+          username: 'AUTH_USER',
+          roles: ['ROLE_CRS_PROVIDER', 'INT_SP_HARMONY_LIVING'],
+        })
+        .build()
+      const sentReferralSummary = {
+        referralId: '4afb07a0-e50b-490c-a8c1-c858d5a1e912',
+        referenceNumber: 'JS18726AC',
+        interventionTitle: 'Accommodation Services - West Midlands',
+        assignedToUserName: 'AUTH_USER',
+        serviceUserFirstName: 'George',
+        serviceUserLastName: 'Michael',
+        hasEndOfServiceReport: false,
+      }
+      await provider.addInteraction({
+        state:
+          'There is an existing sent referral with ID of 2f4e91bf-5f73-4ca8-ad84-afee3f12ed8e, and it has a caseworker assigned',
+        uponReceiving: 'a request for all sent referral summaries',
+        withRequest: {
+          method: 'GET',
+          path: '/sent-referrals/summary/service-provider',
+          headers: { Accept: 'application/json', Authorization: `Bearer ${spUserWithAccess}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like([sentReferralSummary]),
+          headers: { 'Content-Type': 'application/json' },
+        },
+      })
+      const summaryResult = await interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
+        spUserWithAccess
+      )
+      expect(summaryResult.length).toEqual(1)
+      expect(summaryResult[0].referralId).toEqual(sentReferralSummary.referralId)
+      expect(summaryResult[0].referenceNumber).toEqual(sentReferralSummary.referenceNumber)
+      expect(summaryResult[0].interventionTitle).toEqual(sentReferralSummary.interventionTitle)
+      expect(summaryResult[0].assignedToUserName).toEqual(sentReferralSummary.assignedToUserName)
+      expect(summaryResult[0].serviceUserFirstName).toEqual(sentReferralSummary.serviceUserFirstName)
+      expect(summaryResult[0].serviceUserLastName).toEqual(sentReferralSummary.serviceUserLastName)
+      expect(summaryResult[0].hasEndOfServiceReport).toEqual(sentReferralSummary.hasEndOfServiceReport)
+    })
+  })
+
   describe('getReferralsForUserToken', () => {
     it('returns a list of sent referrals', async () => {
       await provider.addInteraction({

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -11,9 +12,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
-      <p>See all interventions below.</p>
 
-      {{ govukTable(tableArgs) }}
+        {{ mojSubNavigation(subNavArgs) }}
+        {{ govukTable(tableArgs) }}
 
       <script src="/assets/mojSortableTable.js">
       </script>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -10,7 +10,7 @@
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
-      <h1 class="govuk-heading-xl">All cases</h1>
+      <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
       <p>See all interventions below.</p>
 
       {{ govukTable(tableArgs) }}

--- a/testutils/factories/serviceProviderSentReferralSummary.ts
+++ b/testutils/factories/serviceProviderSentReferralSummary.ts
@@ -23,8 +23,26 @@ class ServiceProviderSentReferralSummaryFactory extends Factory<ServiceProviderS
       assignedToUserName: username,
     })
   }
+
+  unassigned() {
+    return this.params({
+      assignedToUserName: null,
+    })
+  }
+
+  completed() {
+    return this.params({
+      hasEndOfServiceReport: true,
+    })
+  }
+
+  open() {
+    return this.params({
+      hasEndOfServiceReport: false,
+    })
+  }
 }
-export default ServiceProviderSentReferralSummaryFactory.define<ServiceProviderSentReferralSummary>(({ sequence }) => ({
+export default ServiceProviderSentReferralSummaryFactory.define(({ sequence }) => ({
   referralId: sequence.toString(),
   sentAt: '2021-01-26T13:00:00.000000Z',
   referenceNumber: 'ABCABCA2',


### PR DESCRIPTION
## What does this pull request do?

Adds 4 dashboard types for logged in SPs.

These are:

1. My cases : Cases which are only assigned for the current logged in user
2. All open cases: Cases which are not completed and within the scope of the logged in user.
3. Unassinged cases: Cases which are not completed, within the scope of the logged in user and do not have an assigned user.
4. Completed cases: Cases which are completed and within the scope of the logged in user.


## What is the intent behind these changes?

Makes it easier for SPs to locate the referral that they want.

## Notes:
 Count display for each dashboard and 2nd order filtering on `received at` will be in the next PRs.

## Screenshot
![image](https://user-images.githubusercontent.com/83066216/134899171-5d2bfef8-8056-4d60-8a54-66ad53d26819.png)
