### PR TITLE
8: Only show "Create End of service report" button when we should

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1586,15 +1586,18 @@ describe('Service provider referrals dashboard', () => {
     })
 
     it('User fills in, reviews, changes, and submits an end of service report', () => {
-      const draftEndOfServiceReport = endOfServiceReportFactory.justCreated().build({ referralId: referral.id })
+      const referralNeedingEndOfServiceReport = { ...referral, endOfServiceReportCreationRequired: true }
+      const draftEndOfServiceReport = endOfServiceReportFactory
+        .justCreated()
+        .build({ referralId: referralNeedingEndOfServiceReport.id })
 
       cy.stubCreateDraftEndOfServiceReport(draftEndOfServiceReport)
       cy.stubGetEndOfServiceReport(draftEndOfServiceReport.id, draftEndOfServiceReport)
-      cy.stubGetSentReferral(referral.id, referral)
+      cy.stubGetSentReferral(referralNeedingEndOfServiceReport.id, referralNeedingEndOfServiceReport)
 
       cy.login()
 
-      cy.visit(`/service-provider/referrals/${referral.id}/progress`)
+      cy.visit(`/service-provider/referrals/${referralNeedingEndOfServiceReport.id}/progress`)
       cy.contains('Create end of service report').click()
 
       cy.location('pathname').should(
@@ -1707,7 +1710,10 @@ describe('Service provider referrals dashboard', () => {
         submittedAt: new Date().toISOString(),
       }
 
-      cy.stubGetSentReferral(referral.id, { ...referral, endOfServiceReport: submittedEndOfServiceReport })
+      cy.stubGetSentReferral(referral.id, {
+        ...referralNeedingEndOfServiceReport,
+        endOfServiceReport: submittedEndOfServiceReport,
+      })
       cy.stubSubmitEndOfServiceReport(submittedEndOfServiceReport.id, submittedEndOfServiceReport)
 
       cy.contains('Submit the report').click()

--- a/server/models/sentReferral.ts
+++ b/server/models/sentReferral.ts
@@ -15,5 +15,6 @@ export default interface SentReferral {
   endRequestedReason: string | null
   endRequestedComments: string | null
   endOfServiceReport: EndOfServiceReport | null
+  endOfServiceReportCreationRequired: boolean
   concludedAt: string | null
 }

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -404,61 +404,24 @@ describe(InterventionProgressPresenter, () => {
   })
 
   describe('canSubmitEndOfServiceReport', () => {
-    describe('when the referral has been assigned', () => {
-      describe('when there is no end of service report', () => {
-        it('returns true', () => {
-          const referral = sentReferralFactory.assigned().build({ endOfServiceReport: null })
-          const intervention = interventionFactory.build()
-          const presenter = new InterventionProgressPresenter(
-            referral,
-            intervention,
-            null,
-            [],
-            supplierAssessmentFactory.build()
-          )
+    describe('when the end of service report creation is required', () => {
+      it('returns true', () => {
+        const referral = sentReferralFactory.build({ endOfServiceReportCreationRequired: true })
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          null,
+          [],
+          supplierAssessmentFactory.build()
+        )
 
-          expect(presenter.canSubmitEndOfServiceReport).toEqual(true)
-        })
-      })
-
-      describe('when there is an end of service report but it has not been submitted', () => {
-        it('returns true', () => {
-          const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
-          const referral = sentReferralFactory.assigned().build({ endOfServiceReport })
-          const intervention = interventionFactory.build()
-          const presenter = new InterventionProgressPresenter(
-            referral,
-            intervention,
-            null,
-            [],
-            supplierAssessmentFactory.build()
-          )
-
-          expect(presenter.canSubmitEndOfServiceReport).toEqual(true)
-        })
-      })
-
-      describe('when there is an end of service report and it has been submitted', () => {
-        it('returns false', () => {
-          const endOfServiceReport = endOfServiceReportFactory.submitted().build()
-          const referral = sentReferralFactory.assigned().build({ endOfServiceReport })
-          const intervention = interventionFactory.build()
-          const presenter = new InterventionProgressPresenter(
-            referral,
-            intervention,
-            null,
-            [],
-            supplierAssessmentFactory.build()
-          )
-
-          expect(presenter.canSubmitEndOfServiceReport).toEqual(false)
-        })
+        expect(presenter.canSubmitEndOfServiceReport).toEqual(true)
       })
     })
-
-    describe('when the referral has not been assigned', () => {
+    describe('when the end of service report creation is not yet required', () => {
       it('returns false', () => {
-        const referral = sentReferralFactory.build()
+        const referral = sentReferralFactory.build({ endOfServiceReportCreationRequired: false })
         const intervention = interventionFactory.build()
         const presenter = new InterventionProgressPresenter(
           referral,

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -169,7 +169,7 @@ export default class InterventionProgressPresenter {
   }
 
   get canSubmitEndOfServiceReport(): boolean {
-    return this.referralAssigned && !this.endOfServiceReportSubmitted
+    return this.referral.endOfServiceReportCreationRequired
   }
 
   private get endOfServiceReportStarted(): boolean {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1469,6 +1469,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     endRequestedAt: null,
     endRequestedReason: null,
     endRequestedComments: null,
+    endOfServiceReportCreationRequired: false,
     concludedAt: null,
     endOfServiceReport: null,
     referenceNumber: 'HDJ2123F',

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -110,5 +110,6 @@ export default SentReferralFactory.define(({ sequence }) => ({
   endRequestedReason: null,
   endRequestedComments: null,
   endOfServiceReport: null,
+  endOfServiceReportCreationRequired: false,
   concludedAt: null,
 }))


### PR DESCRIPTION
## What does this pull request do?

Uses the `endOfServiceReportCreationRequired`, now a field on the `SentReferral` object to determine whether or not we should show the `Create End of Service Report` button.

## What is the intent behind these changes?

We were showing the button when we shouldn't have been. Now the backend is taking care of this logic for us, meaning we only need to have the logic for when an EOSR can be created in one place.

## Note

It's worth testing this out a fair bit on dev as I'm not 100% convinced it worked every time, but this may be due to incomplete / inconsistent data on the local environment.
