### PR TITLE
fix wording bug with case notes

### DIFF
--- a/server/views/caseNotes/addNewCaseNote.njk
+++ b/server/views/caseNotes/addNewCaseNote.njk
@@ -12,7 +12,7 @@
     {{ govukBackLink(backLinkArgs) }}
     <h1 class="govuk-heading-l">Add case note</h1>
     <p class="govuk-body">
-        Add any notes you've made about the case. Case notes will be shared with the relevant probation practitioner and service user.
+        Add any notes you've made about the case. Case notes will be shared with the relevant probation practitioner and service provider.
     </p>
     <form method="post" novalidate>
         <input type="hidden" name="_csrf" value="{{csrfToken}}">


### PR DESCRIPTION
The wording when presenting to the user for adding case notes should read:

"Case notes will be shared with the relevant probation practitioner and service provider."

instead of:

"Case notes will be shared with the relevant probation practitioner and service user."

