### PR TITLE
Case note badge for user type

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -9,6 +9,7 @@ $path: "/assets/images/"
 @import './components/header-bar'
 @import './components/inset-text'
 @import './components/intervention-summary-list'
+@import './components/moj_badge'
 @import './components/notification-banner'
 @import './components/primary-navigation'
 @import './components/service-user-banner'

--- a/assets/sass/components/_moj_badge.scss
+++ b/assets/sass/components/_moj_badge.scss
@@ -1,0 +1,3 @@
+.moj-badge--single-line {
+  white-space: nowrap;
+}

--- a/integration_tests/integration/case-notes.spec.js
+++ b/integration_tests/integration/case-notes.spec.js
@@ -1,0 +1,74 @@
+import sentReferralFactory from '../../testutils/factories/sentReferral'
+import interventionFactory from '../../testutils/factories/intervention'
+import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
+import caseNoteFactory from '../../testutils/factories/caseNote'
+import pageFactory from '../../testutils/factories/page'
+
+context('Case notes', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubLogin')
+    cy.task('stubServiceProviderToken')
+    cy.task('stubServiceProviderAuthUser')
+  })
+
+  describe('when viewing case notes for a referral', () => {
+    describe('when there is a case note made by a PP', () => {
+      it('should display "Probation Practitioner" as the user type', () => {
+        const sentReferral = sentReferralFactory.build()
+        cy.stubGetSentReferralsForUserToken([])
+        cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
+        cy.login()
+
+        const ppCaseNote = caseNoteFactory.build({
+          sentBy: {
+            username: 'BERNARD.BEAKS',
+            userId: 'userId',
+            authSource: 'delius',
+          },
+        })
+
+        cy.stubGetSentReferral(sentReferral.id, sentReferral)
+        cy.stubGetIntervention(sentReferral.referral.interventionId, interventionFactory.build())
+        cy.stubGetServiceUserByCRN(sentReferral.referral.serviceUser.crn, deliusServiceUserFactory.build())
+        cy.stubGetCaseNotes(sentReferral.id, pageFactory.build({ content: [ppCaseNote] }))
+        cy.visit(`/service-provider/referrals/${sentReferral.id}/case-notes`)
+
+        cy.get('table')
+          .getTable()
+          .should(tableData => {
+            expect(tableData[0].Details).to.contain('probation practitioner')
+          })
+      })
+    })
+
+    describe('when there is a case note made by a PP', () => {
+      it('should display "Service Provider" as the user type', () => {
+        const sentReferral = sentReferralFactory.build()
+        cy.stubGetSentReferralsForUserToken([])
+        cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
+        cy.login()
+
+        const ppCaseNote = caseNoteFactory.build({
+          sentBy: {
+            username: 'BERNARD.BEAKS',
+            userId: 'userId',
+            authSource: 'auth',
+          },
+        })
+
+        cy.stubGetSentReferral(sentReferral.id, sentReferral)
+        cy.stubGetIntervention(sentReferral.referral.interventionId, interventionFactory.build())
+        cy.stubGetServiceUserByCRN(sentReferral.referral.serviceUser.crn, deliusServiceUserFactory.build())
+        cy.stubGetCaseNotes(sentReferral.id, pageFactory.build({ content: [ppCaseNote] }))
+        cy.visit(`/service-provider/referrals/${sentReferral.id}/case-notes`)
+
+        cy.get('table')
+          .getTable()
+          .should(tableData => {
+            expect(tableData[0].Details).to.contain('service provider')
+          })
+      })
+    })
+  })
+})

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -256,7 +256,7 @@ module.exports = on => {
     },
 
     stubGetCaseNote: arg => {
-      return interventionsService.stubGetCaseNotes(arg.caseNoteId, arg.responseJson)
+      return interventionsService.stubGetCaseNote(arg.caseNoteId, arg.responseJson)
     },
   })
 }

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -711,7 +711,7 @@ export default class InterventionsServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `${this.mockPrefix}/sent-referral/${referralId}/case-notes`,
+        urlPattern: `${this.mockPrefix}/sent-referral/${referralId}/case-notes\\?.*`,
       },
       response: {
         status: 200,

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -36,8 +36,9 @@ export default class CaseNotesController {
     loggedInUserType: 'service-provider' | 'probation-practitioner'
   ): Promise<void> {
     const { accessToken } = res.locals.user.token
+    const pageNumber = req.query.page
     const paginationQuery = {
-      page: Number(req.query.page),
+      page: pageNumber ? Number(pageNumber) : undefined,
       size: 5,
       sort: ['sentAt,DESC'],
     }

--- a/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
@@ -12,6 +12,7 @@ interface CaseNotesTableRow {
   sentAtDate: string
   sentAtTime: string
   sentBy: string
+  sentByUserType: 'probation practitioner' | 'service provider'
   subject: string
   body: string
   caseNoteLink: string
@@ -61,6 +62,7 @@ export default class CaseNotesPresenter {
       sentAtDate: DateUtils.formattedDate(caseNote.sentAt),
       sentAtTime: DateUtils.formattedTime(caseNote.sentAt),
       sentBy: officerName,
+      sentByUserType: caseNote.sentBy.authSource === 'delius' ? 'probation practitioner' : 'service provider',
       subject: caseNote.subject,
       body: caseNote.body,
       caseNoteLink: `/${this.loggedInUserType}/case-note/${caseNote.id}`,

--- a/server/routes/caseNotes/viewAll/caseNotesView.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesView.ts
@@ -11,7 +11,7 @@ export default class CaseNotesView {
     href: this.presenter.hrefBackLink,
   }
 
-  private get tableArgs(): TableArgs {
+  private tableArgs(mojBadgeMacro: (args: { text: string; classes: string }) => string): TableArgs {
     if (this.presenter.tableRows.length === 0) {
       return { rows: [] }
     }
@@ -24,7 +24,18 @@ export default class CaseNotesView {
       rows: this.presenter.tableRows.map(row => {
         return [
           {
-            html: `<p class="govuk-body">${row.sentAtDay}<br>${row.sentAtDate}<br>${row.sentAtTime}<br>${row.sentBy}</p>`,
+            html: `<p class="govuk-body">
+          ${row.sentAtDay}
+          <br>${row.sentAtDate}
+          <br>${row.sentAtTime}
+          <br>${row.sentBy}
+          <br><br>${mojBadgeMacro({
+            text: row.sentByUserType,
+            classes: `moj-badge--single-line ${
+              row.sentByUserType === 'probation practitioner' ? 'moj-badge--grey' : 'moj-badge--purple'
+            }`,
+          })}
+        </p>`,
           },
           {
             html: `<p class="govuk-body">
@@ -48,7 +59,7 @@ export default class CaseNotesView {
         backLinkArgs: this.backLinkArgs,
         subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         pagination: this.presenter.pagination.mojPaginationArgs,
-        tableArgs: this.tableArgs,
+        tableArgs: this.tableArgs.bind(this),
         serviceUserName: this.presenter.serviceUserName,
       },
     ]

--- a/server/views/caseNotes/caseNotes.njk
+++ b/server/views/caseNotes/caseNotes.njk
@@ -1,5 +1,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{%- from "moj/components/badge/macro.njk" import mojBadge -%}
+
 {% extends "../partials/referralNavigationTemplate.njk" %}
 {% set pageTitle = "Referral" %}
 {% set pageSubTitle = "Case notes" %}
@@ -11,6 +13,6 @@
     </form>
 
     <p class="govuk-body">See all case notes about {{ serviceUserName }}</p>
-    {{ govukTable(tableArgs) }}
+    {{ govukTable(tableArgs(mojBadge)) }}
     {% include "../partials/pagination.njk" %}
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds a user type badge to inform the reader if the case note creator was a probation practitioner or service provider.
The logic is based on authSource === 'delius' then the user is a PP. 

## What is the intent behind these changes?

Provides further details to users the type of user who made the case note.


![image](https://user-images.githubusercontent.com/83066216/136007715-b7b091f1-75e4-473f-8cb4-3678650fdcee.png)

