### PR TITLE
Show EOSR creation button when a report exists but has not yet been submitted.

### DIFF
--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -514,7 +514,7 @@ describe(InterventionProgressPresenter, () => {
   })
 
   describe('canSubmitEndOfServiceReport', () => {
-    describe('when the end of service report creation is required', () => {
+    describe('when the end of service report creation flag is true on the referral', () => {
       it('returns true', () => {
         const referral = sentReferralFactory.build({ endOfServiceReportCreationRequired: true })
         const intervention = interventionFactory.build()
@@ -530,20 +530,62 @@ describe(InterventionProgressPresenter, () => {
         expect(presenter.canSubmitEndOfServiceReport).toEqual(true)
       })
     })
-    describe('when the end of service report creation is not yet required', () => {
-      it('returns false', () => {
-        const referral = sentReferralFactory.build({ endOfServiceReportCreationRequired: false })
-        const intervention = interventionFactory.build()
-        const presenter = new InterventionProgressPresenter(
-          referral,
-          intervention,
-          null,
-          [],
-          supplierAssessmentFactory.build(),
-          null
-        )
 
-        expect(presenter.canSubmitEndOfServiceReport).toEqual(false)
+    describe('when the end of service report creation flag is false on the referral', () => {
+      describe('when there is an end of service report but it has not been submitted', () => {
+        it('returns true', () => {
+          const endOfServiceReport = endOfServiceReportFactory.notSubmitted().build()
+          const referral = sentReferralFactory.build({ endOfServiceReport, endOfServiceReportCreationRequired: false })
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(
+            referral,
+            intervention,
+            null,
+            [],
+            supplierAssessmentFactory.build(),
+            null
+          )
+
+          expect(presenter.canSubmitEndOfServiceReport).toEqual(true)
+        })
+      })
+
+      describe('when there is an end of service report and it has been submitted', () => {
+        it('returns false', () => {
+          const endOfServiceReport = endOfServiceReportFactory.submitted().build()
+          const referral = sentReferralFactory.build({ endOfServiceReport, endOfServiceReportCreationRequired: false })
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(
+            referral,
+            intervention,
+            null,
+            [],
+            supplierAssessmentFactory.build(),
+            null
+          )
+
+          expect(presenter.canSubmitEndOfServiceReport).toEqual(false)
+        })
+      })
+
+      describe('when there is no end of service report', () => {
+        it('returns false', () => {
+          const referral = sentReferralFactory.build({
+            endOfServiceReport: null,
+            endOfServiceReportCreationRequired: false,
+          })
+          const intervention = interventionFactory.build()
+          const presenter = new InterventionProgressPresenter(
+            referral,
+            intervention,
+            null,
+            [],
+            supplierAssessmentFactory.build(),
+            null
+          )
+
+          expect(presenter.canSubmitEndOfServiceReport).toEqual(false)
+        })
       })
     })
   })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -179,7 +179,7 @@ export default class InterventionProgressPresenter {
   }
 
   get canSubmitEndOfServiceReport(): boolean {
-    return this.referral.endOfServiceReportCreationRequired
+    return this.referral.endOfServiceReportCreationRequired || this.endOfServiceReportStarted
   }
 
   private get endOfServiceReportStarted(): boolean {


### PR DESCRIPTION
## What does this pull request do?

Checks if an EOSR has been started but not finished to determine whether or not to display the button to allow a user to submit an EOSR.

## What is the intent behind these changes?

Before this change, if a user clicked "back" after creating an end of service report, they wouldn't be shown the button and would have no way to get back to finishing it off.
