### PR TITLE
rrVyeXa1 add new router for service editing functionality

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -30,6 +30,7 @@ import broadcastMessageConfig from './broadcast-message-config.json'
 import probationPractitionerRoutes, { probationPractitionerUrlPrefix } from './routes/probationPractitionerRoutes'
 import DraftsService from './services/draftsService'
 import ReferenceDataService from './services/referenceDataService'
+import serviceEditorRoutes, { serviceEditorUrlPrefix } from './routes/serviceEditorRoutes'
 
 const RedisStore = connectRedis(session)
 
@@ -217,6 +218,7 @@ export default function createApp(
   app.use('/', indexRoutes(standardRouter(), services))
   app.use(serviceProviderUrlPrefix, serviceProviderRoutes(standardRouter(['ROLE_CRS_PROVIDER']), services))
   app.use(probationPractitionerUrlPrefix, probationPractitionerRoutes(standardRouter(['ROLE_PROBATION']), services))
+  app.use(serviceEditorUrlPrefix, serviceEditorRoutes(standardRouter(['ROLE_INTERVENTIONS_SERVICE_EDITOR']), services))
 
   // final regular middleware is for handling 404s
   app.use((req, res, next) => {

--- a/server/routes/serviceEditor/serviceEditorController.ts
+++ b/server/routes/serviceEditor/serviceEditorController.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from 'express'
+import ControllerUtils from '../../utils/controllerUtils'
+
+export default class ServiceEditorController {
+  async dashboard(req: Request, res: Response): Promise<void> {
+    ControllerUtils.renderWithLayout(res, { renderArgs: ['serviceEditor/dashboard', {}] }, null)
+  }
+}

--- a/server/routes/serviceEditorRoutes.ts
+++ b/server/routes/serviceEditorRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express'
+import { Services, get } from './index'
+import ServiceEditorController from './serviceEditor/serviceEditorController'
+
+export const serviceEditorUrlPrefix = '/service-editor'
+
+export default function serviceEditorRoutes(router: Router, _: Services): Router {
+  const serviceEditorController = new ServiceEditorController()
+
+  get(router, '/dashboard', (req, res) => serviceEditorController.dashboard(req, res))
+
+  return router
+}

--- a/server/views/serviceEditor/dashboard.njk
+++ b/server/views/serviceEditor/dashboard.njk
@@ -1,0 +1,1 @@
+{% extends "../partials/layout.njk" %}


### PR DESCRIPTION
## What does this pull request do?

adds the super basic code required to be able to add pages that are only accessible to users with role "ROLE_INTERVENTIONS_SERVICE_EDITOR".

## What is the intent behind these changes?

allow 'self-service' pages to be added in the future
