### PR TITLE
add nav bar item for 'My services' for users with valid role

### DIFF
--- a/server/routes/serviceEditor/dashboardView.ts
+++ b/server/routes/serviceEditor/dashboardView.ts
@@ -1,0 +1,18 @@
+import ViewUtils from '../../utils/viewUtils'
+import PrimaryNavBarPresenter from '../shared/primaryNavBar/primaryNavBarPresenter'
+import LoggedInUser from '../../models/loggedInUser'
+
+export default class DashboardView {
+  constructor(private readonly loggedInUser: LoggedInUser) {}
+
+  private primaryNavBarPresenter = new PrimaryNavBarPresenter('My services', this.loggedInUser)
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'serviceEditor/dashboard',
+      {
+        primaryNavArgs: ViewUtils.primaryNav(this.primaryNavBarPresenter.items),
+      },
+    ]
+  }
+}

--- a/server/routes/serviceEditor/serviceEditorController.ts
+++ b/server/routes/serviceEditor/serviceEditorController.ts
@@ -1,8 +1,10 @@
 import { Request, Response } from 'express'
 import ControllerUtils from '../../utils/controllerUtils'
+import DashboardView from './dashboardView'
 
 export default class ServiceEditorController {
   async dashboard(req: Request, res: Response): Promise<void> {
-    ControllerUtils.renderWithLayout(res, { renderArgs: ['serviceEditor/dashboard', {}] }, null)
+    const view = new DashboardView(res.locals.user)
+    ControllerUtils.renderWithLayout(res, view, null)
   }
 }

--- a/server/routes/shared/primaryNavBar/primaryNavBarPresenter.ts
+++ b/server/routes/shared/primaryNavBar/primaryNavBarPresenter.ts
@@ -1,7 +1,7 @@
 import config from '../../../config'
 import LoggedInUser from '../../../models/loggedInUser'
 
-export type PrimaryNavBarHeading = 'Referrals' | 'Reporting' | 'My cases' | 'Find interventions'
+export type PrimaryNavBarHeading = 'Referrals' | 'Reporting' | 'My cases' | 'Find interventions' | 'My services'
 export type PrimaryNavBarItem = { text: PrimaryNavBarHeading; href: string; active: boolean }
 
 export default class PrimaryNavBarPresenter {
@@ -38,6 +38,14 @@ export default class PrimaryNavBarPresenter {
         text: 'Find interventions',
         href: '/probation-practitioner/find',
         active: this.active === 'Find interventions',
+      })
+    }
+
+    if (this.loggedInUser.token.roles.includes('ROLE_INTERVENTIONS_SERVICE_EDITOR')) {
+      items.push({
+        text: 'My services',
+        href: '/service-editor/dashboard',
+        active: this.active === 'My services',
       })
     }
 

--- a/server/views/serviceEditor/dashboard.njk
+++ b/server/views/serviceEditor/dashboard.njk
@@ -1,1 +1,7 @@
+{% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
+
 {% extends "../partials/layout.njk" %}
+
+{% block primaryNav %}
+    {{ mojPrimaryNavigation(primaryNavArgs) }}
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

add nav bar item for 'My services' for users with role `ROLE_INTERVENTIONS_SERVICE_EDITOR`

## What is the intent behind these changes?

allow service editors to navigate to the 'My services' dashboard
