### PR TITLE
PP Case lists

### DIFF
--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -79,6 +79,97 @@ describe('Dashboards', () => {
             },
           ])
       })
+
+      describe('Selecting "Unassigned cases"', () => {
+        it('should see "Unassigned cases"', () => {
+          cy.login()
+          cy.get('h1').contains('Open cases')
+          cy.contains('Unassigned cases').click()
+          cy.get('h1').contains('Unassigned cases')
+          cy.get('table')
+            .getTable()
+            .should('deep.equal', [
+              {
+                'Date sent': '26 Jan 2021',
+                Referral: 'ABCABCA1',
+                'Service user': 'George Michael',
+                'Intervention type': 'Accommodation Services - West Midlands',
+                Provider: 'Harmony Living',
+                Action: 'View',
+              },
+              {
+                'Date sent': '13 Dec 2020',
+                Referral: 'ABCABCA2',
+                'Service user': 'Jenny Jones',
+                'Intervention type': "Women's Services - West Midlands",
+                Provider: 'Forward Solutions',
+                Action: 'View',
+              },
+            ])
+        })
+      })
+
+      describe('Selecting "Completed cases"', () => {
+        it('should see "Completed cases"', () => {
+          cy.login()
+          cy.get('h1').contains('Open cases')
+          cy.contains('Completed cases').click()
+          cy.get('h1').contains('Completed cases')
+          cy.get('table')
+            .getTable()
+            .should('deep.equal', [
+              {
+                'Date sent': '26 Jan 2021',
+                Referral: 'ABCABCA1',
+                'Service user': 'George Michael',
+                'Intervention type': 'Accommodation Services - West Midlands',
+                Provider: 'Harmony Living',
+                Caseworker: 'Unassigned',
+                Action: 'View',
+              },
+              {
+                'Date sent': '13 Dec 2020',
+                Referral: 'ABCABCA2',
+                'Service user': 'Jenny Jones',
+                'Intervention type': "Women's Services - West Midlands",
+                Provider: 'Forward Solutions',
+                Caseworker: 'A. Caseworker',
+                Action: 'View',
+              },
+            ])
+        })
+      })
+
+      describe('Selecting "Cancelled cases"', () => {
+        it('should see "Cancelled cases"', () => {
+          cy.login()
+          cy.get('h1').contains('Open cases')
+          cy.contains('Cancelled cases').click()
+          cy.get('h1').contains('Cancelled cases')
+          cy.get('table')
+            .getTable()
+            .should('deep.equal', [
+              {
+                'Date sent': '26 Jan 2021',
+                Referral: 'ABCABCA1',
+                'Service user': 'George Michael',
+                'Intervention type': 'Accommodation Services - West Midlands',
+                Provider: 'Harmony Living',
+                Caseworker: 'Unassigned',
+                Action: 'View',
+              },
+              {
+                'Date sent': '13 Dec 2020',
+                Referral: 'ABCABCA2',
+                'Service user': 'Jenny Jones',
+                'Intervention type': "Women's Services - West Midlands",
+                Provider: 'Forward Solutions',
+                Caseworker: 'A. Caseworker',
+                Action: 'View',
+              },
+            ])
+        })
+      })
     })
 
     describe('Sorting the table', () => {

--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -54,7 +54,7 @@ describe('Dashboards', () => {
       it('shows a list of sent referrals', () => {
         cy.login()
 
-        cy.get('h1').contains('My cases')
+        cy.get('h1').contains('Open cases')
 
         cy.get('table')
           .getTable()

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -20,7 +20,7 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.task('stubProbationPractitionerAuthUser')
   })
 
-  it("user logs in and sees 'My cases' screen with list of sent referrals", () => {
+  it("user logs in and sees 'Open cases' screen with list of sent referrals", () => {
     const serviceCategory = serviceCategoryFactory.build()
     const accommodationIntervention = interventionFactory.build({
       contractType: { name: 'accommodation' },
@@ -82,7 +82,7 @@ describe('Probation practitioner referrals dashboard', () => {
 
     cy.login()
 
-    cy.get('h1').contains('My cases')
+    cy.get('h1').contains('Open cases')
 
     cy.get('table')
       .getTable()

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -158,7 +158,7 @@ export default class InterventionsServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPathPattern: `${this.mockPrefix}/sent-referrals`,
+        urlPattern: `${this.mockPrefix}/sent-referrals\\?.*`,
       },
       response: {
         status: 200,

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.test.ts
@@ -1,9 +1,9 @@
 import interventionFactory from '../../../testutils/factories/intervention'
 import SentReferralFactory from '../../../testutils/factories/sentReferral'
-import MyCasesPresenter from './myCasesPresenter'
+import DashboardPresenter from './dashboardPresenter'
 import loggedInUserFactory from '../../../testutils/factories/loggedInUser'
 
-describe('MyCasesPresenter', () => {
+describe('DashboardPresenter', () => {
   const interventions = [
     interventionFactory.build({ id: '1', title: 'Accommodation Services - West Midlands' }),
     interventionFactory.build({ id: '2', title: "Women's Services - West Midlands" }),
@@ -51,7 +51,7 @@ describe('MyCasesPresenter', () => {
 
   describe('tableRows', () => {
     it('returns a list of table rows with appropriate sort values', () => {
-      const presenter = new MyCasesPresenter(referrals, interventions, loggedInUser)
+      const presenter = new DashboardPresenter(referrals, interventions, loggedInUser)
 
       expect(presenter.tableRows).toEqual([
         [

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.test.ts
@@ -51,7 +51,7 @@ describe('DashboardPresenter', () => {
 
   describe('tableRows', () => {
     it('returns a list of table rows with appropriate sort values', () => {
-      const presenter = new DashboardPresenter(referrals, interventions, loggedInUser)
+      const presenter = new DashboardPresenter(referrals, interventions, loggedInUser, 'Open cases')
 
       expect(presenter.tableRows).toEqual([
         [

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
@@ -7,12 +7,14 @@ import { SortableTableHeaders, SortableTableRow } from '../../utils/viewUtils'
 import PrimaryNavBarPresenter from '../shared/primaryNavBar/primaryNavBarPresenter'
 import LoggedInUser from '../../models/loggedInUser'
 
-export default class MyCasesPresenter {
+export default class DashboardPresenter {
   constructor(
     private readonly sentReferrals: SentReferral[],
     private readonly interventions: Intervention[],
     private readonly loggedInUser: LoggedInUser
   ) {}
+
+  readonly title = 'Open cases'
 
   readonly navItemsPresenter = new PrimaryNavBarPresenter('Referrals', this.loggedInUser)
 

--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -10,6 +10,31 @@ export default class DashboardView {
     return ViewUtils.sortableTable('probationPractitionerDashboard', tableHeadings, tableRows)
   }
 
+  readonly subNavArgs = {
+    items: [
+      {
+        text: 'Open cases',
+        href: `/probation-practitioner/dashboard/open-cases`,
+        active: this.presenter.dashboardType === 'Open cases',
+      },
+      {
+        text: 'Unassigned cases',
+        href: `/probation-practitioner/dashboard/unassigned-cases`,
+        active: this.presenter.dashboardType === 'Unassigned cases',
+      },
+      {
+        text: 'Completed cases',
+        href: `/probation-practitioner/dashboard/completed-cases`,
+        active: this.presenter.dashboardType === 'Completed cases',
+      },
+      {
+        text: 'Cancelled cases',
+        href: `/probation-practitioner/dashboard/cancelled-cases`,
+        active: this.presenter.dashboardType === 'Cancelled cases',
+      },
+    ],
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'probationPractitionerReferrals/dashboard',
@@ -17,6 +42,7 @@ export default class DashboardView {
         presenter: this.presenter,
         tableArgs: this.tableArgs,
         primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items),
+        subNavArgs: this.subNavArgs,
       },
     ]
   }

--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -1,18 +1,18 @@
 import { TableArgs } from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
-import MyCasesPresenter from './myCasesPresenter'
+import DashboardPresenter from './dashboardPresenter'
 
-export default class MyCasesView {
-  constructor(private readonly presenter: MyCasesPresenter) {}
+export default class DashboardView {
+  constructor(private readonly presenter: DashboardPresenter) {}
 
   private get tableArgs(): TableArgs {
     const { tableHeadings, tableRows } = this.presenter
-    return ViewUtils.sortableTable('probationPractitionerMyCases', tableHeadings, tableRows)
+    return ViewUtils.sortableTable('probationPractitionerDashboard', tableHeadings, tableRows)
   }
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [
-      'probationPractitionerReferrals/myCases',
+      'probationPractitionerReferrals/dashboard',
       {
         presenter: this.presenter,
         tableArgs: this.tableArgs,

--- a/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/myCasesPresenter.ts
@@ -14,7 +14,7 @@ export default class MyCasesPresenter {
     private readonly loggedInUser: LoggedInUser
   ) {}
 
-  readonly navItemsPresenter = new PrimaryNavBarPresenter('My cases', this.loggedInUser)
+  readonly navItemsPresenter = new PrimaryNavBarPresenter('Referrals', this.loggedInUser)
 
   readonly tableHeadings: SortableTableHeaders = [
     { text: 'Date sent', sort: 'none', persistentId: 'dateSent' },

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -58,7 +58,7 @@ export default class ProbationPractitionerReferralsController {
   }
 
   async showOpenCases(req: Request, res: Response): Promise<void> {
-    const cases = await this.interventionsService.getSentReferralsForUserToken(res.locals.user.token.accessToken)
+    const cases = await this.interventionsService.getSentReferralsForUserToken(res.locals.user.token.accessToken, {})
 
     const dedupedInterventionIds = Array.from(new Set(cases.map(referral => referral.referral.interventionId)))
     const interventions = await Promise.all(

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -6,8 +6,8 @@ import { ActionPlanAppointment } from '../../models/appointment'
 import InterventionProgressPresenter from './interventionProgressPresenter'
 import InterventionProgressView from './interventionProgressView'
 import FindStartPresenter from './findStartPresenter'
-import MyCasesView from './myCasesView'
-import MyCasesPresenter from './myCasesPresenter'
+import DashboardView from './dashboardView'
+import DashboardPresenter from './dashboardPresenter'
 import FindStartView from './findStartView'
 import SubmittedFeedbackPresenter from '../shared/appointment/feedback/submittedFeedbackPresenter'
 import SubmittedFeedbackView from '../shared/appointment/feedback/submittedFeedbackView'
@@ -57,7 +57,7 @@ export default class ProbationPractitionerReferralsController {
     this.deliusOfficeLocationFilter = new DeliusOfficeLocationFilter(referenceDataService)
   }
 
-  async showMyCases(req: Request, res: Response): Promise<void> {
+  async showOpenCases(req: Request, res: Response): Promise<void> {
     const cases = await this.interventionsService.getSentReferralsForUserToken(res.locals.user.token.accessToken)
 
     const dedupedInterventionIds = Array.from(new Set(cases.map(referral => referral.referral.interventionId)))
@@ -65,8 +65,8 @@ export default class ProbationPractitionerReferralsController {
       dedupedInterventionIds.map(id => this.interventionsService.getIntervention(res.locals.user.token.accessToken, id))
     )
 
-    const presenter = new MyCasesPresenter(cases, interventions, res.locals.user)
-    const view = new MyCasesView(presenter)
+    const presenter = new DashboardPresenter(cases, interventions, res.locals.user)
+    const view = new DashboardView(presenter)
     ControllerUtils.renderWithLayout(res, view, null)
   }
 

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -15,7 +15,7 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     services.referenceDataService
   )
 
-  get(router, '/dashboard', (req, res) => probationPractitionerReferralsController.showMyCases(req, res))
+  get(router, '/dashboard', (req, res) => probationPractitionerReferralsController.showOpenCases(req, res))
   get(router, '/find', (req, res) => probationPractitionerReferralsController.showFindStartPage(req, res))
 
   get(router, '/referrals/:id/progress', (req, res) =>

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -16,6 +16,17 @@ export default function probationPractitionerRoutes(router: Router, services: Se
   )
 
   get(router, '/dashboard', (req, res) => probationPractitionerReferralsController.showOpenCases(req, res))
+  get(router, '/dashboard/open-cases', (req, res) => probationPractitionerReferralsController.showOpenCases(req, res))
+  get(router, '/dashboard/unassigned-cases', (req, res) =>
+    probationPractitionerReferralsController.showUnassignedCases(req, res)
+  )
+  get(router, '/dashboard/completed-cases', (req, res) =>
+    probationPractitionerReferralsController.showCompletedCases(req, res)
+  )
+  get(router, '/dashboard/cancelled-cases', (req, res) =>
+    probationPractitionerReferralsController.showCancelledCases(req, res)
+  )
+
   get(router, '/find', (req, res) => probationPractitionerReferralsController.showFindStartPage(req, res))
 
   get(router, '/referrals/:id/progress', (req, res) =>

--- a/server/routes/shared/primaryNavBar/primaryNavBarPresenter.ts
+++ b/server/routes/shared/primaryNavBar/primaryNavBarPresenter.ts
@@ -1,7 +1,7 @@
 import config from '../../../config'
 import LoggedInUser from '../../../models/loggedInUser'
 
-export type PrimaryNavBarHeading = 'Referrals' | 'Reporting' | 'My cases' | 'Find interventions' | 'My services'
+export type PrimaryNavBarHeading = 'Referrals' | 'Reporting' | 'Find interventions' | 'My services'
 export type PrimaryNavBarItem = { text: PrimaryNavBarHeading; href: string; active: boolean }
 
 export default class PrimaryNavBarPresenter {
@@ -30,9 +30,9 @@ export default class PrimaryNavBarPresenter {
 
     if (this.loggedInUser.token.roles.includes('ROLE_PROBATION')) {
       items.push({
-        text: 'My cases',
+        text: 'Referrals',
         href: '/probation-practitioner/dashboard',
-        active: this.active === 'My cases',
+        active: this.active === 'Referrals',
       })
       items.push({
         text: 'Find interventions',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1743,6 +1743,118 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         sentReferral,
       ])
     })
+
+    describe('with "concluded" option', () => {
+      it('returns concluded sent referrals', async () => {
+        await provider.addInteraction({
+          state: 'There are some sent referrals in various states of completion for probation practitioner user',
+          uponReceiving: 'a request for sent referrals which are concluded',
+          withRequest: {
+            method: 'GET',
+            path: '/sent-referrals',
+            query: { concluded: 'true' },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like([
+              { id: 'eb25cf36-4956-4924-a887-989fe3d6638d' },
+              { id: 'bfabb659-1200-4479-bae7-8927e1e87a0d' },
+            ]),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        const sentReferrals = await interventionsService.getSentReferralsForUserToken(probationPractitionerToken, {
+          concluded: true,
+        })
+        expect(sentReferrals.length).toEqual(2)
+        const sentReferralIds = sentReferrals.map(referral => referral.id)
+        expect(sentReferralIds).toContain('eb25cf36-4956-4924-a887-989fe3d6638d')
+        expect(sentReferralIds).toContain('bfabb659-1200-4479-bae7-8927e1e87a0d')
+      })
+    })
+
+    describe('with "cancelled" option', () => {
+      it('returns cancelled sent referrals', async () => {
+        await provider.addInteraction({
+          state: 'There are some sent referrals in various states of completion for probation practitioner user',
+          uponReceiving: 'a request for sent referrals which are cancelled',
+          withRequest: {
+            method: 'GET',
+            path: '/sent-referrals',
+            query: { cancelled: 'true' },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like([{ id: 'bfabb659-1200-4479-bae7-8927e1e87a0d' }]),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        const sentReferrals = await interventionsService.getSentReferralsForUserToken(probationPractitionerToken, {
+          cancelled: true,
+        })
+        expect(sentReferrals.length).toEqual(1)
+        const sentReferralIds = sentReferrals.map(referral => referral.id)
+        expect(sentReferralIds).toContain('bfabb659-1200-4479-bae7-8927e1e87a0d')
+      })
+    })
+
+    describe('with "unassigned" option', () => {
+      it('returns unassigned sent referrals', async () => {
+        await provider.addInteraction({
+          state: 'There are some sent referrals in various states of completion for probation practitioner user',
+          uponReceiving: 'a request for sent referrals which are unassigned',
+          withRequest: {
+            method: 'GET',
+            path: '/sent-referrals',
+            query: { unassigned: 'true' },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like([{ id: '995b30f5-182d-4409-aed9-0f3f4ae56802' }]),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        const sentReferrals = await interventionsService.getSentReferralsForUserToken(probationPractitionerToken, {
+          unassigned: true,
+        })
+        expect(sentReferrals.length).toEqual(1)
+        const sentReferralIds = sentReferrals.map(referral => referral.id)
+        expect(sentReferralIds).toContain('995b30f5-182d-4409-aed9-0f3f4ae56802')
+      })
+    })
+
+    describe('with "assigned" option', () => {
+      it('returns assigned sent referrals', async () => {
+        await provider.addInteraction({
+          state: 'There are some sent referrals in various states of completion for probation practitioner user',
+          uponReceiving: 'a request for sent referrals which are assigned',
+          withRequest: {
+            method: 'GET',
+            path: '/sent-referrals',
+            query: { assignedTo: 'AUTH_USER' },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+          },
+          willRespondWith: {
+            status: 200,
+            body: Matchers.like([{ id: '4b56a623-2f85-4670-87a7-68d458378646' }]),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        })
+
+        const sentReferrals = await interventionsService.getSentReferralsForUserToken(probationPractitionerToken, {
+          assignedTo: 'AUTH_USER',
+        })
+        expect(sentReferrals.length).toEqual(1)
+        const sentReferralIds = sentReferrals.map(referral => referral.id)
+        expect(sentReferralIds).toContain('4b56a623-2f85-4670-87a7-68d458378646')
+      })
+    })
   })
 
   describe('assignSentReferral', () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1738,7 +1738,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      expect(await interventionsService.getSentReferralsForUserToken(probationPractitionerToken)).toEqual([
+      expect(await interventionsService.getSentReferralsForUserToken(probationPractitionerToken, {})).toEqual([
         sentReferral,
         sentReferral,
       ])

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -76,6 +76,13 @@ export interface PaginationParams {
   sort?: string[]
 }
 
+export interface GetSentReferralsFilterParams {
+  concluded?: boolean
+  cancelled?: boolean
+  unassigned?: boolean
+  assignedTo?: string
+}
+
 export type InterventionsServiceError = RestClientError
 
 export interface CreateCaseNoteParams {
@@ -217,12 +224,16 @@ export default class InterventionsService {
     })) as SentReferral
   }
 
-  async getSentReferralsForUserToken(token: string): Promise<SentReferral[]> {
+  async getSentReferralsForUserToken(
+    token: string,
+    filterParams: GetSentReferralsFilterParams
+  ): Promise<SentReferral[]> {
     const restClient = this.createRestClient(token)
 
     return (await restClient.get({
       path: `/sent-referrals`,
       headers: { Accept: 'application/json' },
+      query: { ...filterParams },
     })) as SentReferral[]
   }
 

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -13,7 +13,7 @@
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">My cases</h1>
+      <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
 
       {{ govukTable(tableArgs) }}
       <script src="/assets/mojSortableTable.js">

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -15,7 +16,9 @@
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
 
-      {{ govukTable(tableArgs) }}
+        {{ mojSubNavigation(subNavArgs) }}
+        {{ govukTable(tableArgs) }}
+
       <script src="/assets/mojSortableTable.js">
       </script>
     </div>

--- a/server/views/probationPractitionerReferrals/myCases.njk
+++ b/server/views/probationPractitionerReferrals/myCases.njk
@@ -4,7 +4,7 @@
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = "Referral" %}
-{% set pageSubTitle = "My cases" %}
+{% set pageSubTitle = "Referrals" %}
 
 {% block primaryNav %}
   {{ mojPrimaryNavigation(primaryNavArgs) }}


### PR DESCRIPTION
Adds the following dashboards for PP when they login:

- Open cases - Anything that is not concluded
- Unassigned cases - Anything that is not concluded and unassigned
- Completed cases - Anything that is concluded but not cancelled
- Cancelled cases - Anything that is cancelled

The filtering is done by the back-end by passing in filtering parameters.

The new dashboard looks like:

![image](https://user-images.githubusercontent.com/83066216/137732150-0740a250-5402-47cd-818f-731a34311c80.png)
