### PR TITLE
change all references to an incorrect css class 'govuk-grid-column-full-width' to 'govuk-grid-column-full'

### DIFF
--- a/server/views/probationPractitionerReferrals/myCases.njk
+++ b/server/views/probationPractitionerReferrals/myCases.njk
@@ -12,7 +12,7 @@
 
 {% block pageContent %}
   <div class="govuk-grid-row refer-and-monitor__main-grid-row">
-    <div class="govuk-grid-column-full-width">
+    <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">My cases</h1>
 
       {{ govukTable(tableArgs) }}

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -7,7 +7,7 @@
 
 {% block pageContent %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full-width">
+    <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <p class="govuk-body-m govuk-!-margin-bottom-8">{{ presenter.text.confirmationQuestion }}</p>
     </div>

--- a/server/views/probationPractitionerReferrals/referralCancellationReason.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationReason.njk
@@ -10,7 +10,7 @@
 
 {% block pageContent %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full-width">
+    <div class="govuk-grid-column-full">
       {% if errorSummaryArgs !== null %}
         {{ govukErrorSummary(errorSummaryArgs) }}
       {% endif %}

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -10,7 +10,7 @@
 
 {% block pageContent %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full-width">
+    <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
 
         {{ mojSubNavigation(subNavArgs) }}

--- a/server/views/staticContent/index.njk
+++ b/server/views/staticContent/index.njk
@@ -4,7 +4,7 @@
 
 {% block pageContent %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full-width">
+    <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">Static pages</h1>
 
       <p class="govuk-body">These are the static pages which are either:</p>


### PR DESCRIPTION
## What does this pull request do?

change all references to an incorrect css class 'govuk-grid-column-full-width' to 'govuk-grid-column-full'

## What is the intent behind these changes?

'govuk-grid-column-full-width' doesn't exist, causing some layout issues in the views where it was used.

see https://design-system.service.gov.uk/styles/layout/ for more details on these layout classes.