### PR TITLE
fix layouts of pp pages which were broken in 226e2bcd6a2574939a0e6de3eca3b4425ac92c54

### DIFF
--- a/server/views/probationPractitionerReferrals/myCases.njk
+++ b/server/views/probationPractitionerReferrals/myCases.njk
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block pageContent %}
-  <div class="govuk-grid-row refer-and-monitor__main-grid-row">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">My cases</h1>
 

--- a/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationCheckAnswers.njk
@@ -10,11 +10,11 @@
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <p class="govuk-body-m govuk-!-margin-bottom-8">{{ presenter.text.confirmationQuestion }}</p>
-    </div>
-    <form method="post" action="{{ presenter.confirmCancellationHref }}">
-      <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      <form method="post" action="{{ presenter.confirmCancellationHref }}">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
-      {{ govukButton({ text: "Cancel referral", preventDoubleClick: true }) }}
-    </form>
+        {{ govukButton({ text: "Cancel referral", preventDoubleClick: true }) }}
+      </form>
+    </div>
   </div>
 {% endblock %}

--- a/server/views/probationPractitionerReferrals/referralCancellationReason.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationReason.njk
@@ -17,14 +17,15 @@
 
       <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <p class="govuk-body-m govuk-!-margin-bottom-8">{{ presenter.text.information }}</p>
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {{ govukRadios(referralCancellationRadiosArgs) }}
+        {{ govukTextarea(additionalCommentsTextareaArgs) }}
+
+        {{ govukButton({ text: "Continue" }) }}
+      </form>
     </div>
-    <form method="post">
-      <input type="hidden" name="_csrf" value="{{csrfToken}}">
-
-      {{ govukRadios(referralCancellationRadiosArgs) }}
-      {{ govukTextarea(additionalCommentsTextareaArgs) }}
-
-      {{ govukButton({ text: "Continue" }) }}
-    </form>
   </div>
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?
it fixes a few broken layouts that were caused by the fix in 226e2bcd6a2574939a0e6de3eca3b4425ac92c54.

i guess since the incorrect grid class wasn't getting the layout right, these pages had made their own tweaks to get the page looking correct. 

## What is the intent behind these changes?

get the pages all lined up again.
