### PR TITLE
[MFA9IGgc] Remove old Action Plan session scheduling routes

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -882,7 +882,7 @@ describe('Service provider referrals dashboard', () => {
     describe('with valid inputs', () => {
       describe('when booking for an In-Person Meeting - Other Location', () => {
         it('should present no errors and display scheduled appointment', () => {
-          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type('24')
           cy.get('#date-month').type('3')
           cy.get('#date-year').type('2021')
@@ -932,7 +932,7 @@ describe('Service provider referrals dashboard', () => {
 
           cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
 
-          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
 
           cy.get('#date-day').should('have.value', '24')
           cy.get('#date-month').should('have.value', '3')
@@ -953,7 +953,7 @@ describe('Service provider referrals dashboard', () => {
 
         describe('and their chosen date causes a clash of appointments', () => {
           it('the user is able to amend their chosen date and re-submit', () => {
-            cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+            cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
             cy.get('#date-day').type('24')
             cy.get('#date-month').type('3')
             cy.get('#date-year').type('2021')
@@ -1035,7 +1035,7 @@ describe('Service provider referrals dashboard', () => {
 
       describe('when booking for an In-Person Meeting - NPS Location', () => {
         it('should present no errors and display scheduled appointment', () => {
-          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type('24')
           cy.get('#date-month').type('3')
           cy.get('#date-year').type('2021')
@@ -1072,7 +1072,7 @@ describe('Service provider referrals dashboard', () => {
           cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
           // TODO: Add checks for NPS Office address on this page
 
-          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
 
           cy.get('#date-day').should('have.value', '24')
           cy.get('#date-month').should('have.value', '3')
@@ -1095,7 +1095,7 @@ describe('Service provider referrals dashboard', () => {
     describe('with invalid inputs', () => {
       describe("when the user doesn't select a session type", () => {
         it('should show an error', () => {
-          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type('24')
           cy.get('#date-month').type('3')
           cy.get('#date-year').type('2021')
@@ -1112,7 +1112,7 @@ describe('Service provider referrals dashboard', () => {
 
       describe("when the user doesn't select meeting method", () => {
         it('should show an error', () => {
-          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type('24')
           cy.get('#date-month').type('3')
           cy.get('#date-year').type('2021')
@@ -1129,7 +1129,7 @@ describe('Service provider referrals dashboard', () => {
 
       describe("when the user doesn't enter an address", () => {
         it('should show an error', () => {
-          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
+          cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type('24')
           cy.get('#date-month').type('3')
           cy.get('#date-year').type('2021')

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1021,20 +1021,6 @@ describe('GET /service-provider/action-plan/:actionPlanId/confirmation', () => {
   })
 })
 
-describe('GET /service-provider/action-plan/:id/sessions/:sessionNumber/edit', () => {
-  it('creates a draft session update and redirects to the details page', async () => {
-    const booking = draftAppointmentBookingFactory.build()
-    draftsService.createDraft.mockResolvedValue(booking)
-
-    await request(app)
-      .get(`/service-provider/action-plan/1/sessions/1/edit`)
-      .expect(302)
-      .expect('Location', `/service-provider/action-plan/1/sessions/1/edit/${booking.id}/details`)
-
-    expect(draftsService.createDraft).toHaveBeenCalledWith('actionPlanSessionUpdate', null, { userId: '123' })
-  })
-})
-
 describe('GET /service-provider/action-plan/:id/sessions/:sessionNumber/edit/start', () => {
   it('creates a draft session update and redirects to the details page', async () => {
     const booking = draftAppointmentBookingFactory.build()
@@ -1067,97 +1053,6 @@ describe('GET /service-provider/action-plan/:id/sessions/:sessionNumber/edit/:dr
       .expect(res => {
         expect(res.text).toContain('Add session 1 details')
       })
-  })
-})
-
-describe('POST /service-provider/action-plan/:id/sessions/:sessionNumber/edit', () => {
-  describe('with valid data', () => {
-    it('creates a draft session update, updates it with the submitted data, and redirects to the check-answers page', async () => {
-      const actionPlan = actionPlanFactory.build()
-
-      const draftBooking = draftAppointmentBookingFactory.build()
-      draftsService.createDraft.mockResolvedValue(draftBooking)
-      draftsService.updateDraft.mockResolvedValue()
-
-      interventionsService.getActionPlan.mockResolvedValue(actionPlan)
-      interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
-      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
-
-      await request(app)
-        .post(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit`)
-        .type('form')
-        .send({
-          'date-day': '24',
-          'date-month': '3',
-          'date-year': '2021',
-          'time-hour': '9',
-          'time-minute': '02',
-          'time-part-of-day': 'am',
-          'duration-hours': '1',
-          'duration-minutes': '15',
-          'session-type': 'ONE_TO_ONE',
-          'meeting-method': 'PHONE_CALL',
-        })
-        .expect(302)
-        .expect(
-          'Location',
-          `/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/${draftBooking.id}/check-answers`
-        )
-
-      expect(draftsService.createDraft).toHaveBeenCalledWith('actionPlanSessionUpdate', null, { userId: '123' })
-
-      expect(draftsService.updateDraft).toHaveBeenCalledWith(
-        draftBooking.id,
-        {
-          appointmentDeliveryAddress: null,
-          appointmentTime: '2021-03-24T09:02:00.000Z',
-          durationInMinutes: 75,
-          npsOfficeCode: null,
-          appointmentDeliveryType: 'PHONE_CALL',
-          sessionType: 'ONE_TO_ONE',
-        },
-        { userId: '123' }
-      )
-    })
-  })
-
-  describe('with invalid data', () => {
-    it('creates a draft booking but does not update it, and renders an error message', async () => {
-      const draftBooking = draftAppointmentBookingFactory.build()
-      draftsService.createDraft.mockResolvedValue(draftBooking)
-
-      const actionPlan = actionPlanFactory.build()
-      const appointment = actionPlanAppointmentFactory.build()
-
-      interventionsService.getActionPlan.mockResolvedValue(actionPlan)
-      interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
-      interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
-      interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
-
-      await request(app)
-        .post(`/service-provider/action-plan/1/sessions/1/edit`)
-        .type('form')
-        .send({
-          'date-day': '32',
-          'date-month': '3',
-          'date-year': '2021',
-          'time-hour': '9',
-          'time-minute': '02',
-          'time-part-of-day': 'am',
-          'duration-hours': '1',
-          'duration-minutes': '15',
-          'session-type': 'ONE_TO_ONE',
-          'meeting-method': 'PHONE_CALL',
-        })
-        .expect(400)
-        .expect(res => {
-          expect(res.text).toContain('The session date must be a real date')
-        })
-
-      expect(draftsService.createDraft).toHaveBeenCalledWith('actionPlanSessionUpdate', null, { userId: '123' })
-
-      expect(draftsService.updateDraft).not.toHaveBeenCalled()
-    })
   })
 })
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -612,14 +612,6 @@ export default class ServiceProviderReferralsController {
     )
   }
 
-  async backwardsCompatibilityEditActionPlanSession(req: Request, res: Response): Promise<void> {
-    const draft = await this.draftsService.createDraft('actionPlanSessionUpdate', null, {
-      userId: res.locals.user.userId,
-    })
-
-    await this.editActionPlanSessionUsingDraft(draft, req, res)
-  }
-
   async editActionPlanSession(req: Request, res: Response): Promise<void> {
     const fetchResult = await this.fetchDraftBookingOrRenderMessage(req, res)
     if (fetchResult.rendered) {

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -68,18 +68,8 @@ export default function serviceProviderRoutes(router: Router, services: Services
   post(router, '/action-plan/:id/number-of-sessions', (req, res) =>
     serviceProviderReferralsController.addNumberOfSessionsToActionPlan(req, res)
   )
-  // This keeps the Edit button on pre-drafts versions of the intervention
-  // progress page working
-  get(router, '/action-plan/:id/sessions/:sessionNumber/edit', (req, res) =>
-    serviceProviderReferralsController.startEditingActionPlanSession(req, res)
-  )
   get(router, '/action-plan/:id/sessions/:sessionNumber/edit/start', (req, res) =>
     serviceProviderReferralsController.startEditingActionPlanSession(req, res)
-  )
-  // This keeps the submit button on pre-drafts versions of the action plan
-  // appointment scheduling page working
-  post(router, '/action-plan/:id/sessions/:sessionNumber/edit', (req, res) =>
-    serviceProviderReferralsController.backwardsCompatibilityEditActionPlanSession(req, res)
   )
   get(router, '/action-plan/:id/sessions/:sessionNumber/edit/:draftBookingId/details', (req, res) =>
     serviceProviderReferralsController.editActionPlanSession(req, res)


### PR DESCRIPTION
## What does this pull request do?

Removes the old `/service-provider/action-plan/:id/sessions/:sessionNumber/edit` Action Plan session scheduling routes, as they are no longer needed.

## What is the intent behind these changes?

These were left in when the new `/action-plan/:id/sessions/:sessionNumber/edit/:draftBookingId/details` routes were added to keep the deployment backwards compatible - that is, if a user was still in the old journey and trying to schedule a session, we didn't want to remove any of the `POST` endpoints and break their session.

After some digging in Kibana, this should be safe to deploy now as the last event on that route was on 28/09/2021 (7 days after these new routes were deployed to production). There's been no traffic on the old routes since then, only on the new ones.
