### PR TITLE
[UOl5bHUM] Don't show `cancel` button for ended referrals

### DIFF
--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -295,6 +295,59 @@ describe(InterventionProgressPresenter, () => {
     })
   })
 
+  describe('canCancelReferral', () => {
+    describe('when the referral is still in progress', () => {
+      it('returns true', () => {
+        const inProgressReferral = sentReferralFactory.build({ endRequestedAt: null, concludedAt: null })
+
+        const presenter = new InterventionProgressPresenter(
+          inProgressReferral,
+          interventionFactory.build(),
+          [],
+          null,
+          supplierAssessmentFactory.build(),
+          null
+        )
+
+        expect(presenter.canCancelReferral).toEqual(true)
+      })
+    })
+
+    describe('when the PP has requested an end to the referral', () => {
+      it('returns false', () => {
+        const endRequestedReferral = sentReferralFactory.build({ endRequestedAt: '2020-12-07T12:00:00.000000Z' })
+
+        const presenter = new InterventionProgressPresenter(
+          endRequestedReferral,
+          interventionFactory.build(),
+          [],
+          null,
+          supplierAssessmentFactory.build(),
+          null
+        )
+
+        expect(presenter.canCancelReferral).toEqual(false)
+      })
+    })
+
+    describe('when the referral has already been concluded', () => {
+      it('returns false', () => {
+        const concludedReferral = sentReferralFactory.build({ concludedAt: '2020-12-07T12:00:00.000000Z' })
+
+        const presenter = new InterventionProgressPresenter(
+          concludedReferral,
+          interventionFactory.build(),
+          [],
+          null,
+          supplierAssessmentFactory.build(),
+          null
+        )
+
+        expect(presenter.canCancelReferral).toEqual(false)
+      })
+    })
+  })
+
   describe('hasEndOfServiceReport', () => {
     describe('when the referral has no end of service report', () => {
       it('returns false', () => {

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -61,6 +61,12 @@ export default class InterventionProgressPresenter {
     return this.referral.endRequestedAt !== null
   }
 
+  get canCancelReferral(): boolean {
+    return !this.referralEndRequested && !this.referralConcluded
+  }
+
+  private readonly referralConcluded = this.referral.concludedAt !== null
+
   get referralEndRequestedText(): string {
     if (!this.referral.endRequestedAt) {
       return ''

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -54,9 +54,9 @@
     <p>Below you will be able to find the end of service report created by the service provider. Once submitted, you will be able to read and download it.</p>
   {% endif %}
 
-  {% if presenter.referralEndRequested %}
-    <p class="govuk-body">{{ presenter.referralEndRequestedText }}</p>
-  {% else %}
+  {% if presenter.canCancelReferral %}
     <a href='{{ presenter.referralCancellationHref }}'>Cancel this referral</a>
+  {% elseif presenter.referralEndRequested %}
+    <p class="govuk-body">{{ presenter.referralEndRequestedText }}</p>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Uses a referral's `concludedAt` and `endRequestedAt` fields to determine whether the PP should be able to cancel a referral.

## What is the intent behind these changes?

We were previously showing the "cancel" button for referrals that had a submitted End of Service report.

The link that says "Cancel this referral" should not be visible as soon as:

- PP has prematurely ended an intervention OR
- The SP has submitted an EOSR after a complete intervention

