### PR TITLE
Second order column

### DIFF
--- a/browser_types/moj-frontend/index.d.ts
+++ b/browser_types/moj-frontend/index.d.ts
@@ -1,6 +1,7 @@
 declare module '@ministryofjustice/frontend' {
   interface SortableTable {
     new ({ table }: { table: Node })
+    sort(rows: HTMLTableRowElement[], columnNumber: number, sortDirection: string): HTMLTableRowElement[]
   }
 }
 

--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -173,6 +173,109 @@ describe('Dashboards', () => {
     })
 
     describe('Sorting the table', () => {
+      describe('with "Date sent" as second order sort', () => {
+        it('should order by "Date sent" when first order values are identical', () => {
+          const sentReferralsWithIdenticalReferenceNumber = [
+            sentReferralFactory.build({
+              sentAt: '2021-01-27T13:00:00.000000Z',
+              referenceNumber: 'A',
+              referral: {
+                interventionId: accommodationIntervention.id,
+              },
+            }),
+            sentReferralFactory.build({
+              sentAt: '2021-01-26T13:00:00.000000Z',
+              referenceNumber: 'A',
+              referral: {
+                interventionId: accommodationIntervention.id,
+              },
+            }),
+            sentReferralFactory.build({
+              sentAt: '2021-01-28T13:00:00.000000Z',
+              referenceNumber: 'A',
+              referral: {
+                interventionId: accommodationIntervention.id,
+              },
+            }),
+            sentReferralFactory.build({
+              sentAt: '2021-01-26T13:00:00.000000Z',
+              referenceNumber: 'B',
+              referral: {
+                interventionId: accommodationIntervention.id,
+              },
+            }),
+          ]
+
+          cy.stubGetSentReferralsForUserToken(sentReferralsWithIdenticalReferenceNumber)
+          cy.login()
+
+          cy.get('table')
+            .getTable({ onlyColumns: ['Date sent', 'Referral'] })
+            .should('deep.equal', [
+              {
+                'Date sent': '27 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date sent': '26 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date sent': '28 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date sent': '26 Jan 2021',
+                Referral: 'B',
+              },
+            ])
+
+          cy.get('table').within(() => cy.contains('button', 'Referral').click())
+          cy.get('table')
+            .getTable({ onlyColumns: ['Date sent', 'Referral'] })
+            .should('deep.equal', [
+              {
+                'Date sent': '26 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date sent': '27 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date sent': '28 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date sent': '26 Jan 2021',
+                Referral: 'B',
+              },
+            ])
+
+          // Even when descending the first order column it should keep the Date sent column ordered as ascending
+          cy.get('table').within(() => cy.contains('button', 'Referral').click())
+          cy.get('table')
+            .getTable({ onlyColumns: ['Date sent', 'Referral'] })
+            .should('deep.equal', [
+              {
+                'Date sent': '26 Jan 2021',
+                Referral: 'B',
+              },
+              {
+                'Date sent': '26 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date sent': '27 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date sent': '28 Jan 2021',
+                Referral: 'A',
+              },
+            ])
+        })
+      })
       const referralToSelect = sentReferrals[0]
 
       const initialTable = [
@@ -501,6 +604,98 @@ describe('Dashboards', () => {
     })
 
     describe('Sorting the table', () => {
+      describe('with "Date received" as second order sort', () => {
+        it('should order by "Date received" when first order values are identical', () => {
+          const sentReferralsWithIdenticalReferenceNumber = [
+            serviceProviderSentReferralSummaryFactory.withAssignedUser('USER1').build({
+              sentAt: '2021-01-27T13:00:00.000000Z',
+              referenceNumber: 'A',
+            }),
+            serviceProviderSentReferralSummaryFactory.withAssignedUser('USER1').build({
+              sentAt: '2021-01-26T13:00:00.000000Z',
+              referenceNumber: 'A',
+            }),
+            serviceProviderSentReferralSummaryFactory.withAssignedUser('USER1').build({
+              sentAt: '2021-01-28T13:00:00.000000Z',
+              referenceNumber: 'A',
+            }),
+            serviceProviderSentReferralSummaryFactory.withAssignedUser('USER1').build({
+              sentAt: '2021-01-26T13:00:00.000000Z',
+              referenceNumber: 'B',
+            }),
+          ]
+
+          cy.stubGetServiceProviderSentReferralsSummaryForUserToken(sentReferralsWithIdenticalReferenceNumber)
+          cy.login()
+
+          cy.get('table')
+            .getTable({ onlyColumns: ['Date received', 'Referral'] })
+            .should('deep.equal', [
+              {
+                'Date received': '27 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date received': '28 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'B',
+              },
+            ])
+
+          cy.get('table').within(() => cy.contains('button', 'Referral').click())
+          cy.get('table')
+            .getTable({ onlyColumns: ['Date received', 'Referral'] })
+            .should('deep.equal', [
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date received': '27 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date received': '28 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'B',
+              },
+            ])
+
+          // Even when descending the first order column it should keep the Date received column ordered as ascending
+          cy.get('table').within(() => cy.contains('button', 'Referral').click())
+          cy.get('table')
+            .getTable({ onlyColumns: ['Date received', 'Referral'] })
+            .should('deep.equal', [
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'B',
+              },
+              {
+                'Date received': '26 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date received': '27 Jan 2021',
+                Referral: 'A',
+              },
+              {
+                'Date received': '28 Jan 2021',
+                Referral: 'A',
+              },
+            ])
+        })
+      })
+
       const assignedToSelfA = serviceProviderSentReferralSummaryFactory.build({
         sentAt: '2020-12-13T13:00:00.000000Z',
         referenceNumber: 'A',

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
@@ -24,8 +24,10 @@ export default class DashboardPresenter {
 
   readonly navItemsPresenter = new PrimaryNavBarPresenter('Referrals', this.loggedInUser)
 
+  private readonly secondOrderColumn = 'Date sent'
+
   readonly tableHeadings: SortableTableHeaders = [
-    { text: 'Date sent', sort: 'none', persistentId: `${this.dashboardTypePersistentId}DateSent` },
+    { text: this.secondOrderColumn, sort: 'none', persistentId: `${this.dashboardTypePersistentId}DateSent` },
     { text: 'Referral', sort: 'none', persistentId: `${this.dashboardTypePersistentId}ReferenceNumber` },
     { text: 'Service user', sort: 'ascending', persistentId: `${this.dashboardTypePersistentId}ServiceUser` },
     { text: 'Intervention type', sort: 'none', persistentId: `${this.dashboardTypePersistentId}InterventionType` },
@@ -35,6 +37,10 @@ export default class DashboardPresenter {
       : { text: 'Caseworker', sort: 'none', persistentId: `${this.dashboardTypePersistentId}Caseworker` },
     { text: 'Action', sort: 'none', persistentId: `${this.dashboardTypePersistentId}Action` },
   ].filter(row => row !== null) as SortableTableHeaders
+
+  readonly secondOrderColumnNumber: number = this.tableHeadings
+    .map(heading => heading.text)
+    .indexOf(this.secondOrderColumn)
 
   readonly tableRows: SortableTableRow[] = this.sentReferrals.map(referral => {
     const interventionForReferral = this.interventions.find(

--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -6,8 +6,10 @@ export default class DashboardView {
   constructor(private readonly presenter: DashboardPresenter) {}
 
   private get tableArgs(): TableArgs {
-    const { tableHeadings, tableRows } = this.presenter
-    return ViewUtils.sortableTable('probationPractitionerDashboard', tableHeadings, tableRows)
+    const { tableHeadings, tableRows, secondOrderColumnNumber } = this.presenter
+    return ViewUtils.sortableTable('probationPractitionerDashboard', tableHeadings, tableRows, {
+      secondOrderColumnNumber,
+    })
   }
 
   readonly subNavArgs = {

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -21,8 +21,10 @@ export default class DashboardPresenter {
 
   readonly title = this.dashboardType
 
+  private readonly secondOrderColumn = 'Date received'
+
   readonly tableHeadings: SortableTableHeaders = [
-    { text: 'Date received', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}DateReceived` },
+    { text: this.secondOrderColumn, sort: 'none', persistentId: `${this.dashBoardTypePersistentId}DateReceived` },
     { text: 'Referral', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}ReferenceNumber` },
     { text: 'Service user', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}ServiceUser` },
     { text: 'Intervention type', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}InterventionType` },
@@ -31,6 +33,10 @@ export default class DashboardPresenter {
       : { text: 'Caseworker', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}Caseworker` },
     { text: 'Action', sort: 'none', persistentId: `${this.dashBoardTypePersistentId}Action` },
   ].filter(row => row !== null) as SortableTableHeaders
+
+  readonly secondOrderColumnNumber: number = this.tableHeadings
+    .map(heading => heading.text)
+    .indexOf(this.secondOrderColumn)
 
   readonly navItemsPresenter = new PrimaryNavBarPresenter('Referrals', this.loggedInUser)
 

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -6,8 +6,8 @@ export default class DashboardView {
   constructor(private readonly presenter: DashboardPresenter) {}
 
   private get tableArgs(): TableArgs {
-    const { tableHeadings, tableRows } = this.presenter
-    return ViewUtils.sortableTable('serviceProviderDashboard', tableHeadings, tableRows)
+    const { tableHeadings, tableRows, secondOrderColumnNumber } = this.presenter
+    return ViewUtils.sortableTable('serviceProviderDashboard', tableHeadings, tableRows, { secondOrderColumnNumber })
   }
 
   readonly subNavArgs = {

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -86,9 +86,18 @@ export default class ViewUtils {
     }
   }
 
-  static sortableTable(persistentId: string, headers: SortableTableHeaders, rows: SortableTableRow[]): TableArgs {
+  static sortableTable(
+    persistentId: string,
+    headers: SortableTableHeaders,
+    rows: SortableTableRow[],
+    options?: { secondOrderColumnNumber?: number }
+  ): TableArgs {
+    const tableAttributes = { 'data-persistent-id': persistentId }
+    if (options && options.secondOrderColumnNumber !== undefined) {
+      tableAttributes['second-order-column'] = options.secondOrderColumnNumber
+    }
     return {
-      attributes: { 'data-persistent-id': persistentId },
+      attributes: tableAttributes,
       head: headers.map(heading => {
         return {
           text: heading.text,


### PR DESCRIPTION
Adds a second order column to the dashboard tables.
This performs a second ordering on "Date sent" for PP dashboards and "Date received" for SP dashboards.
It will perform a second ordering on for rows which are identical.
The second ordering is always ascending sort direction.


## Ordered by `Referral`
![image](https://user-images.githubusercontent.com/83066216/138250656-950d6403-5f7f-44f6-9b84-20646788e572.png)

## Reversed ordered by `Referral`
![image](https://user-images.githubusercontent.com/83066216/138250677-edbbc94d-5348-4cc4-a0a2-ec40c07469b2.png)
