### PR TITLE
[PHFYyvs4g] Add on-screen guidance for case notes

### DIFF
--- a/server/routes/caseNotes/add/addCaseNoteView.ts
+++ b/server/routes/caseNotes/add/addCaseNoteView.ts
@@ -1,5 +1,5 @@
 import AddCaseNotePresenter from './addCaseNotePresenter'
-import { InputArgs } from '../../../utils/govukFrontendTypes'
+import { DetailsArgs, InputArgs } from '../../../utils/govukFrontendTypes'
 import AddNewCaseNoteForm from './AddNewCaseNoteForm'
 import ViewUtils from '../../../utils/viewUtils'
 
@@ -37,6 +37,15 @@ export default class AddCaseNoteView {
     }
   }
 
+  private get detailsArgs(): DetailsArgs {
+    return {
+      summaryText: 'What should go in a case note',
+      html: `<p class="govuk-body">Case notes are for anything outside of scheduled sessions, such as phone calls or unplanned appointments.</p>
+        <p class="govuk-body">If the person is moving between prisons or being released, add which prison, where they’ll be released to and when.</p>
+        <p class="govuk-body">Anything urgent or important needs to be followed up between the service provider and probation practitioner.</p>`,
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'caseNotes/addNewCaseNote',
@@ -45,6 +54,7 @@ export default class AddCaseNoteView {
         backLinkArgs: this.backLinkArgs,
         subjectInputArgs: this.subjectInputArgs,
         bodyInputArgs: this.bodyInputArgs,
+        detailsArgs: this.detailsArgs,
       },
     ]
   }

--- a/server/views/caseNotes/addNewCaseNote.njk
+++ b/server/views/caseNotes/addNewCaseNote.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -14,8 +15,13 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Add case note</h1>
       <p class="govuk-body">
-        Add any notes you've made about the case. Case notes will be shared with the relevant probation practitioner and service provider.
+        Case notes are for the probation practitioner and service provider to record and share information about the intervention.
       </p>
+      <p class="govuk-body">
+        What you add cannot be viewed on any other service.
+      </p>
+
+      {{ govukDetails(detailsArgs) }}
       <form method="post" novalidate="novalidate">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukInput(subjectInputArgs) }}


### PR DESCRIPTION
## What does this pull request do?

- Adds on screen guidance for case notes.
- Tweaks Add Case Note styles & layout a little to make them closer to the mockups.
- Adds a "details" section to the case notes page.

## What is the intent behind these changes?

Users are putting anything and everything in case notes - in some cases urgent info that should not be communicated in a case note; in other cases irrelevant information.

Case notes are not intended to be a messaging system, but a _record_ of stuff related to the delivery of the intervention.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/19826940/138303240-2dbb8e55-2945-428c-b311-c54637954d95.png)

### After

![image](https://user-images.githubusercontent.com/19826940/138303155-84663ca7-2240-4ac7-b8f9-b67dc51efa33.png)

