### PR TITLE
Re-enable pact broker SSL verification.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
     environment:
       PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
       PACT_BROKER_USERNAME: "interventions"
-      PACT_BROKER_DISABLE_SSL_VERIFICATION: "true"
     executor:
       name: hmpps/node
       tag: 14.16.0-browsers
@@ -49,7 +48,6 @@ jobs:
     environment:
       PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
       PACT_BROKER_USERNAME: "interventions"
-      PACT_BROKER_DISABLE_SSL_VERIFICATION: "true"
     executor: hmpps/node
     parameters:
       tag:


### PR DESCRIPTION
This was originally disabled to get around LetsEncrypt CA expiry for cloud platform services.