### PR TITLE
Remove singular service category reference

### DIFF
--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -144,7 +144,6 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   completionDeadline: null,
   serviceProvider: null,
   interventionId: interventionFactory.build().id,
-  serviceCategoryId: null,
   serviceCategoryIds: [],
   complexityLevelId: null,
   complexityLevels: null,


### PR DESCRIPTION
Remove singular service category reference. This was from before we had the concept of cohort referrals. 

This is a removal of the serviceCategoryId field in the DraftReferralFactory; removing it has no effect since we don't use the field any where.