### PR TITLE
Bug fix commit - reword this

### DIFF
--- a/browser/mojSortableTable.ts
+++ b/browser/mojSortableTable.ts
@@ -247,7 +247,8 @@ class MOJFrontendTableSecondOrderSorter {
     const tableSecondOrderColumnAttr = this.table.getAttribute('second-order-column')
     if (tableSecondOrderColumnAttr !== null) {
       const parsedColumnNumber = parseInt(tableSecondOrderColumnAttr, 10)
-      if (!Number.isNaN(parsedColumnNumber)) {
+      // eslint-disable-next-line no-restricted-globals
+      if (!isNaN(parsedColumnNumber)) {
         this.secondOrderColumnNumber = parsedColumnNumber
       }
     }


### PR DESCRIPTION
Fixes IE11 bug with Number.isNaN not being supported.

Rather than Number.isNaN() we can use NaN()