### PR TITLE
Revert "Switch to local network access to the service"

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,7 +19,7 @@ env:
   DEPLOYMENT_ENV: dev
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
-  INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
+  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
   ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
   ASSESS_RISKS_AND_NEEDS_API_RISK_SUMMARY_ENABLED: true
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -19,7 +19,7 @@ env:
   DEPLOYMENT_ENV: preprod
   HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io
-  INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
+  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
   ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,7 +17,7 @@ env:
   DEPLOYMENT_ENV: prod
   HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.probation.service.justice.gov.uk
-  INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
+  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk
   ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs.hmpps.service.justice.gov.uk
   TOKEN_VERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
   TOKEN_VERIFICATION_ENABLED: true

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -16,7 +16,7 @@ env:
   DEPLOYMENT_ENV: research
   HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
-  INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service
+  INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-research.apps.live-1.cloud-platform.service.justice.gov.uk
   ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
   ASSESS_RISKS_AND_NEEDS_API_RISK_SUMMARY_ENABLED: true
   TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk


### PR DESCRIPTION

## What does this pull request do?

This reverts commit c6a556c3492f847ec00fda54d709fa134f5c929b.



## What is the intent behind these changes?

We are going to need to use the ingress to support splitting API pods by
pathname _and_ support zero-downtime deployments on the service

So this PR also solves the `ECONNREFUSED` errors reported by Sentry

<img width="343" alt="image" src="https://user-images.githubusercontent.com/1526295/138885247-f24210f0-1c07-4e23-87e7-c40d86a6b859.png">
