### PR TITLE
Tweak coreruleset 942100 for case note params

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
@@ -22,6 +22,7 @@ metadata:
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleRemoveById 921110
+      SecRule REQUEST_URI "@contains /add-case-note" "phase:1,nolog,pass,id:10000,ctl:ruleRemoveTargetById=942100;ARGS:case-note-body,ctl:ruleRemoveTargetById=942100;ARGS:case-note-subject"
     {{- else }}
     kubernetes.io/ingress.class: "nginx"
     {{- end }}


### PR DESCRIPTION
## What does this pull request do?

Ignores `case-note-subject` and `case-note-body` params for LibInjection (SQL injection) checks:

> -=[ LibInjection Check ]=-
>
> There is a stricter sibling of this rule at 941101. It covers
> REQUEST_BASENAME.
>
> Ref: https://libinjection.client9.com/

## What is the intent behind these changes?

We're seeing requests blocked due to the parameter names `case-note-subject` and `case-note-body`, I believe due to the fact that they include the SQL term `case` so they're being blocked. This should hopefully whitelist those params and allow users to submit case notes.
