### PR TITLE
disable libinjection testing on request args

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
@@ -22,6 +22,7 @@ metadata:
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleRemoveById 921110
+      SecRuleUpdateTargetById 942100 "!ARGS"  # disable libinjection testing on request args. to disable all SQLi testing, modify rules in the range 942100-942999
     {{- else }}
     kubernetes.io/ingress.class: "nginx"
     {{- end }}


### PR DESCRIPTION
## What does this pull request do?

disable libinjection testing on request args.

## What is the intent behind these changes?

we suspect this rule is responsible for many blocked requests. one such example of the value of an argument which is blocked by this rule is:

```
Phone call received from X
```

This matches libinjection fingerprint `nTnkn`. 