### PR TITLE
Bug fix: Incorrect filtering for "Completed Cases"

### DIFF
--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -703,7 +703,7 @@ describe('Dashboards', () => {
         serviceUserFirstName: 'Jenny',
         serviceUserLastName: 'Jones',
         assignedToUserName: 'USER1',
-        hasEndOfServiceReport: false,
+        endOfServiceReportSubmitted: false,
       })
       const assignedToSelfB = serviceProviderSentReferralSummaryFactory.build({
         sentAt: '2021-01-26T13:00:00.000000Z',
@@ -712,7 +712,7 @@ describe('Dashboards', () => {
         serviceUserFirstName: 'George',
         serviceUserLastName: 'Michael',
         assignedToUserName: 'USER1',
-        hasEndOfServiceReport: false,
+        endOfServiceReportSubmitted: false,
       })
       const unassignedA = serviceProviderSentReferralSummaryFactory.build({
         sentAt: '2020-12-13T13:00:00.000000Z',
@@ -721,7 +721,7 @@ describe('Dashboards', () => {
         serviceUserFirstName: 'Jenny',
         serviceUserLastName: 'Jones',
         assignedToUserName: '',
-        hasEndOfServiceReport: false,
+        endOfServiceReportSubmitted: false,
       })
       const unassignedB = serviceProviderSentReferralSummaryFactory.build({
         sentAt: '2021-01-26T13:00:00.000000Z',
@@ -730,7 +730,7 @@ describe('Dashboards', () => {
         serviceUserFirstName: 'George',
         serviceUserLastName: 'Michael',
         assignedToUserName: '',
-        hasEndOfServiceReport: false,
+        endOfServiceReportSubmitted: false,
       })
       const completedA = serviceProviderSentReferralSummaryFactory.build({
         sentAt: '2020-12-13T13:00:00.000000Z',
@@ -739,7 +739,7 @@ describe('Dashboards', () => {
         serviceUserFirstName: 'Jenny',
         serviceUserLastName: 'Jones',
         assignedToUserName: 'USER1',
-        hasEndOfServiceReport: true,
+        endOfServiceReportSubmitted: true,
       })
       const completedB = serviceProviderSentReferralSummaryFactory.build({
         sentAt: '2021-01-26T13:00:00.000000Z',
@@ -748,7 +748,7 @@ describe('Dashboards', () => {
         serviceUserFirstName: 'George',
         serviceUserLastName: 'Michael',
         assignedToUserName: 'USER1',
-        hasEndOfServiceReport: true,
+        endOfServiceReportSubmitted: true,
       })
 
       const rowForReferralAWithNoCaseworkerColumn = {

--- a/server/models/serviceProviderSentReferralSummary.ts
+++ b/server/models/serviceProviderSentReferralSummary.ts
@@ -6,5 +6,5 @@ export default interface ServiceProviderSentReferralSummary {
   assignedToUserName?: string | null
   serviceUserFirstName: string | null
   serviceUserLastName: string | null
-  hasEndOfServiceReport?: boolean
+  endOfServiceReportSubmitted?: boolean
 }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -131,7 +131,7 @@ describe('GET /service-provider/dashboard/my-cases', () => {
     const undefinedRef = serviceProviderSentReferralSummaryFactory.build({
       referenceNumber: 'undefinedRef',
       assignedToUserName: undefined,
-      hasEndOfServiceReport: undefined,
+      endOfServiceReportSubmitted: undefined,
     })
     const assignedToSelf = serviceProviderSentReferralSummaryFactory.withAssignedUser('user1').open().build({
       referenceNumber: 'assignedToSelfRef',
@@ -162,7 +162,7 @@ describe('GET /service-provider/dashboard/all-open-cases', () => {
     const undefinedRef = serviceProviderSentReferralSummaryFactory.build({
       referenceNumber: 'undefinedRef',
       assignedToUserName: undefined,
-      hasEndOfServiceReport: undefined,
+      endOfServiceReportSubmitted: undefined,
     })
     const assignedToSelf = serviceProviderSentReferralSummaryFactory.withAssignedUser('user1').open().build({
       referenceNumber: 'assignedToSelfRef',
@@ -193,7 +193,7 @@ describe('GET /service-provider/dashboard/unassigned-cases', () => {
     const undefinedRef = serviceProviderSentReferralSummaryFactory.build({
       referenceNumber: 'undefinedRef',
       assignedToUserName: undefined,
-      hasEndOfServiceReport: undefined,
+      endOfServiceReportSubmitted: undefined,
     })
     const assignedToSelf = serviceProviderSentReferralSummaryFactory.withAssignedUser('user1').open().build({
       referenceNumber: 'assignedToSelfRef',
@@ -224,7 +224,7 @@ describe('GET /service-provider/dashboard/completed-cases', () => {
     const undefinedRef = serviceProviderSentReferralSummaryFactory.build({
       referenceNumber: 'undefinedRef',
       assignedToUserName: undefined,
-      hasEndOfServiceReport: undefined,
+      endOfServiceReportSubmitted: undefined,
     })
     const assignedToSelf = serviceProviderSentReferralSummaryFactory.withAssignedUser('user1').open().build({
       referenceNumber: 'assignedToSelfRef',

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -116,10 +116,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken
     )
     const filteredSummary = referralsSummary.filter(summary => {
-      return (
-        summary.assignedToUserName === res.locals.user.username &&
-        (summary.hasEndOfServiceReport === false || !summary.hasEndOfServiceReport)
-      )
+      return summary.assignedToUserName === res.locals.user.username && !summary.endOfServiceReportSubmitted
     })
 
     this.renderDashboard(res, filteredSummary, 'My cases')
@@ -130,7 +127,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken
     )
     const openReferrals = referralsSummary.filter(summary => {
-      return summary.hasEndOfServiceReport === false || !summary.hasEndOfServiceReport
+      return !summary.endOfServiceReportSubmitted
     })
     this.renderDashboard(res, openReferrals, 'All open cases')
   }
@@ -140,7 +137,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken
     )
     const unassignedReferrals = referralsSummary.filter(summary => {
-      return !summary.assignedToUserName && (summary.hasEndOfServiceReport === false || !summary.hasEndOfServiceReport)
+      return !summary.assignedToUserName && !summary.endOfServiceReportSubmitted
     })
     this.renderDashboard(res, unassignedReferrals, 'Unassigned cases')
   }
@@ -150,7 +147,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken
     )
     const completedReferrals = referralsSummary.filter(summary => {
-      return summary.hasEndOfServiceReport === true
+      return summary.endOfServiceReportSubmitted === true
     })
     this.renderDashboard(res, completedReferrals, 'Completed cases')
   }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1690,7 +1690,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         assignedToUserName: 'AUTH_USER',
         serviceUserFirstName: 'George',
         serviceUserLastName: 'Michael',
-        hasEndOfServiceReport: false,
+        endOfServiceReportSubmitted: false,
       }
       await provider.addInteraction({
         state:
@@ -1717,7 +1717,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(summaryResult[0].assignedToUserName).toEqual(sentReferralSummary.assignedToUserName)
       expect(summaryResult[0].serviceUserFirstName).toEqual(sentReferralSummary.serviceUserFirstName)
       expect(summaryResult[0].serviceUserLastName).toEqual(sentReferralSummary.serviceUserLastName)
-      expect(summaryResult[0].hasEndOfServiceReport).toEqual(sentReferralSummary.hasEndOfServiceReport)
+      expect(summaryResult[0].endOfServiceReportSubmitted).toEqual(sentReferralSummary.endOfServiceReportSubmitted)
     })
   })
 

--- a/testutils/factories/serviceProviderSentReferralSummary.ts
+++ b/testutils/factories/serviceProviderSentReferralSummary.ts
@@ -32,13 +32,13 @@ class ServiceProviderSentReferralSummaryFactory extends Factory<ServiceProviderS
 
   completed() {
     return this.params({
-      hasEndOfServiceReport: true,
+      endOfServiceReportSubmitted: true,
     })
   }
 
   open() {
     return this.params({
-      hasEndOfServiceReport: false,
+      endOfServiceReportSubmitted: false,
     })
   }
 }


### PR DESCRIPTION
Changed the filtering for Completed cases on SP dashboard to use endOfServiceReportSubmitted == true rather than hasEndOfServiceReport.

It is possible (although rare) for a user to start the creation of end of service report but not submit it (i.e. press back).

We should only be including referrals where the EOSR has been submitted.

