### PR TITLE
Include some cancelled referrals for Completed cases dashboard

### DIFF
--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -502,12 +502,12 @@ describe('Dashboards', () => {
         const assignedToOther = serviceProviderSentReferralSummaryFactory
           .withAssignedUser('other')
           .build({ referenceNumber: 'ASSIGNED_TO_OTHER' })
-        const completed = serviceProviderSentReferralSummaryFactory.completed().build({ referenceNumber: 'COMPLETED' })
+        const concluded = serviceProviderSentReferralSummaryFactory.concluded().build({ referenceNumber: 'COMPLETED' })
         cy.stubGetServiceProviderSentReferralsSummaryForUserToken([
           assignedToSelf,
           unassigned,
           assignedToOther,
-          completed,
+          concluded,
         ])
         cy.login()
       })

--- a/server/models/serviceProviderSentReferralSummary.ts
+++ b/server/models/serviceProviderSentReferralSummary.ts
@@ -7,4 +7,5 @@ export default interface ServiceProviderSentReferralSummary {
   serviceUserFirstName: string | null
   serviceUserLastName: string | null
   endOfServiceReportSubmitted?: boolean
+  concluded: boolean
 }

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -31,6 +31,7 @@ describe(DashboardPresenter, () => {
             assignedToUserName: null,
             serviceUserFirstName: 'George',
             serviceUserLastName: 'Michael',
+            concluded: false,
           },
           {
             referralId: '2',
@@ -40,6 +41,7 @@ describe(DashboardPresenter, () => {
             assignedToUserName: null,
             serviceUserFirstName: 'Jenny',
             serviceUserLastName: 'Jones',
+            concluded: false,
           },
         ]
 
@@ -76,6 +78,7 @@ describe(DashboardPresenter, () => {
               assignedToUserName: 'john.smith',
               serviceUserFirstName: 'George',
               serviceUserLastName: 'Michael',
+              concluded: false,
             },
           ]
           const presenter = new DashboardPresenter(referralsSummary, dashboardType, loggedInUser)
@@ -97,6 +100,7 @@ describe(DashboardPresenter, () => {
             assignedToUserName: 'john.smith',
             serviceUserFirstName: 'George',
             serviceUserLastName: 'Michael',
+            concluded: false,
           },
         ]
         const presenter = new DashboardPresenter(referralsSummary, dashboardType, loggedInUser)
@@ -126,6 +130,7 @@ describe(DashboardPresenter, () => {
             assignedToUserName: 'john.smith',
             serviceUserFirstName: 'George',
             serviceUserLastName: 'Michael',
+            concluded: false,
           },
         ]
         const presenter = new DashboardPresenter(referralsSummary, 'All open cases', loggedInUser)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -98,6 +98,7 @@ describe('GET /service-provider/dashboard', () => {
         assignedToUserName: 'user1',
         serviceUserFirstName: 'George',
         serviceUserLastName: 'Michael',
+        concluded: false,
       },
       {
         referralId: '2',
@@ -107,6 +108,7 @@ describe('GET /service-provider/dashboard', () => {
         assignedToUserName: 'user1',
         serviceUserFirstName: 'Jenny',
         serviceUserLastName: 'Jones',
+        concluded: false,
       },
     ]
 
@@ -138,10 +140,10 @@ describe('GET /service-provider/dashboard/my-cases', () => {
     const unassigned = serviceProviderSentReferralSummaryFactory.unassigned().open().build({
       referenceNumber: 'unassignedRef',
     })
-    const completed = serviceProviderSentReferralSummaryFactory.completed().build({
-      referenceNumber: 'completedRef',
+    const concluded = serviceProviderSentReferralSummaryFactory.concluded().build({
+      referenceNumber: 'concludedRef',
     })
-    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, completed]
+    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, concluded]
     interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue(referralsSummary)
     await request(app)
       .get('/service-provider/dashboard')
@@ -151,7 +153,7 @@ describe('GET /service-provider/dashboard/my-cases', () => {
         expect(res.text).toContain('assignedToSelfRef')
         expect(res.text).not.toContain('undefinedRef')
         expect(res.text).not.toContain('unassignedRef')
-        expect(res.text).not.toContain('completedRef')
+        expect(res.text).not.toContain('concludedRef')
       })
   })
 })
@@ -169,10 +171,10 @@ describe('GET /service-provider/dashboard/all-open-cases', () => {
     const unassigned = serviceProviderSentReferralSummaryFactory.unassigned().open().build({
       referenceNumber: 'unassignedRef',
     })
-    const completed = serviceProviderSentReferralSummaryFactory.completed().build({
-      referenceNumber: 'completedRef',
+    const concluded = serviceProviderSentReferralSummaryFactory.concluded().build({
+      referenceNumber: 'concludedRef',
     })
-    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, completed]
+    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, concluded]
     interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue(referralsSummary)
     await request(app)
       .get('/service-provider/dashboard/all-open-cases')
@@ -182,7 +184,7 @@ describe('GET /service-provider/dashboard/all-open-cases', () => {
         expect(res.text).toContain('assignedToSelfRef')
         expect(res.text).toContain('undefinedRef')
         expect(res.text).toContain('unassignedRef')
-        expect(res.text).not.toContain('completedRef')
+        expect(res.text).not.toContain('concludedRef')
       })
   })
 })
@@ -200,10 +202,10 @@ describe('GET /service-provider/dashboard/unassigned-cases', () => {
     const unassigned = serviceProviderSentReferralSummaryFactory.unassigned().open().build({
       referenceNumber: 'unassignedRef',
     })
-    const completed = serviceProviderSentReferralSummaryFactory.completed().build({
-      referenceNumber: 'completedRef',
+    const concluded = serviceProviderSentReferralSummaryFactory.concluded().build({
+      referenceNumber: 'concludedRef',
     })
-    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, completed]
+    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, concluded]
     interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue(referralsSummary)
     await request(app)
       .get('/service-provider/dashboard/unassigned-cases')
@@ -213,13 +215,13 @@ describe('GET /service-provider/dashboard/unassigned-cases', () => {
         expect(res.text).not.toContain('assignedToSelfRef')
         expect(res.text).toContain('undefinedRef')
         expect(res.text).toContain('unassignedRef')
-        expect(res.text).not.toContain('completedRef')
+        expect(res.text).not.toContain('concludedRef')
       })
   })
 })
 
 describe('GET /service-provider/dashboard/completed-cases', () => {
-  it('displays a list of my cases', async () => {
+  it('displays a list of concluded cases', async () => {
     const undefinedRef = serviceProviderSentReferralSummaryFactory.build({
       referenceNumber: 'undefinedRef',
       assignedToUserName: undefined,
@@ -231,10 +233,10 @@ describe('GET /service-provider/dashboard/completed-cases', () => {
     const unassigned = serviceProviderSentReferralSummaryFactory.unassigned().open().build({
       referenceNumber: 'unassignedRef',
     })
-    const completed = serviceProviderSentReferralSummaryFactory.completed().build({
-      referenceNumber: 'completedRef',
+    const concluded = serviceProviderSentReferralSummaryFactory.concluded().build({
+      referenceNumber: 'concludedRef',
     })
-    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, completed]
+    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, concluded]
     interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue(referralsSummary)
     await request(app)
       .get('/service-provider/dashboard/completed-cases')
@@ -244,7 +246,7 @@ describe('GET /service-provider/dashboard/completed-cases', () => {
         expect(res.text).not.toContain('assignedToSelfRef')
         expect(res.text).not.toContain('undefinedRef')
         expect(res.text).not.toContain('unassignedRef')
-        expect(res.text).toContain('completedRef')
+        expect(res.text).toContain('concludedRef')
       })
   })
 })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -102,7 +102,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken
     )
     const filteredSummary = referralsSummary.filter(summary => {
-      return summary.assignedToUserName === res.locals.user.username && !summary.endOfServiceReportSubmitted
+      return summary.assignedToUserName === res.locals.user.username && !summary.concluded
     })
 
     this.renderDashboard(res, filteredSummary, 'My cases')
@@ -113,7 +113,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken
     )
     const openReferrals = referralsSummary.filter(summary => {
-      return !summary.endOfServiceReportSubmitted
+      return !summary.concluded
     })
     this.renderDashboard(res, openReferrals, 'All open cases')
   }
@@ -123,7 +123,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken
     )
     const unassignedReferrals = referralsSummary.filter(summary => {
-      return !summary.assignedToUserName && !summary.endOfServiceReportSubmitted
+      return !summary.assignedToUserName && !summary.concluded
     })
     this.renderDashboard(res, unassignedReferrals, 'Unassigned cases')
   }
@@ -133,7 +133,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken
     )
     const completedReferrals = referralsSummary.filter(summary => {
-      return summary.endOfServiceReportSubmitted === true
+      return summary.concluded === true
     })
     this.renderDashboard(res, completedReferrals, 'Completed cases')
   }

--- a/testutils/factories/serviceProviderSentReferralSummary.ts
+++ b/testutils/factories/serviceProviderSentReferralSummary.ts
@@ -30,15 +30,15 @@ class ServiceProviderSentReferralSummaryFactory extends Factory<ServiceProviderS
     })
   }
 
-  completed() {
+  concluded() {
     return this.params({
-      endOfServiceReportSubmitted: true,
+      concluded: true,
     })
   }
 
   open() {
     return this.params({
-      endOfServiceReportSubmitted: false,
+      concluded: false,
     })
   }
 }
@@ -49,4 +49,5 @@ export default ServiceProviderSentReferralSummaryFactory.define(({ sequence }) =
   interventionTitle: 'Social Inclusion - West Midlands',
   serviceUserFirstName: 'Jenny',
   serviceUserLastName: 'Jones',
+  concluded: false,
 }))


### PR DESCRIPTION
Intervention-Service returns a concluded boolean flag for /sent-referrals/summary/service-provider to indicate if a referral has been concluded.

This flag should be used instead of endOfServiceReportSubmitted as we now want to include unfiltered cancelled referrals in the "Completed cases" dashboard. These referrals will not have an end of service report.

## Notes:
This is based on a conversation with Leigh where he provided the following table:
![image](https://user-images.githubusercontent.com/83066216/139669955-6c189f6a-eaf6-43f2-a5c6-c2258ba5b361.png)

This shows that we should be including some cancelled referrals in the Completed cases. intervention service does the filtering so only the correct cancelled referrals will be returned.
