### PR TITLE
FIX: Use cypress selector to click on correct element

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -2154,7 +2154,7 @@ describe('Service provider referrals dashboard', () => {
             `/service-provider/referrals/${sentReferral.id}/supplier-assessment/post-assessment-feedback/attendance`
           )
 
-          cy.contains('No').click()
+          cy.get('[data-cy=supplier-assessment-attendance-radios]').contains('No').click()
           cy.contains("Add additional information about Alex's attendance").type('Alex did not attend the session')
 
           const appointmentWithAttendanceFeedback = initialAssessmentAppointmentFactory.build({

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackView.ts
@@ -12,6 +12,7 @@ export default class AttendanceFeedbackView {
       classes: 'govuk-radios',
       idPrefix: 'attended',
       name: 'attended',
+      attributes: { 'data-cy': 'supplier-assessment-attendance-radios' },
       fieldset: {
         legend: {
           text: this.presenter.text.attendanceQuestion,


### PR DESCRIPTION
## What does this pull request do?

Adds a `data-cy` element to the attendance feedback list of radio buttons to ensure we're clicking on the correct element in the cypress tests.

## What is the intent behind these changes?

This was failing due to our tests creating an object with the current date, using November as the month and trying to click on "No" and actually clicking on the month, rather than the "No" radio button.
