### PR TITLE
[CnVfA8tT] Add functions and contracts for appointments linked to referrals, not action plans

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -147,6 +147,15 @@ module.exports = on => {
       return interventionsService.stubSubmitActionPlan(arg.id, arg.responseJson)
     },
 
+    stubRecordDeliverySessionAppointmentAttendance: arg => {
+      return interventionsService.stubRecordDeliverySessionAppointmentAttendance(
+        arg.referralId,
+        arg.appointmentId,
+        arg.responseJson
+      )
+    },
+
+    // Deprecated
     stubRecordActionPlanAppointmentAttendance: arg => {
       return interventionsService.stubRecordActionPlanAppointmentAttendance(
         arg.actionPlanId,
@@ -155,6 +164,15 @@ module.exports = on => {
       )
     },
 
+    stubRecordDeliverySessionAppointmentBehaviour: arg => {
+      return interventionsService.stubRecordDeliverySessionAppointmentBehaviour(
+        arg.referralId,
+        arg.appointmentId,
+        arg.responseJson
+      )
+    },
+
+    // Deprecated
     stubRecordActionPlanAppointmentBehavior: arg => {
       return interventionsService.stubRecordActionPlanAppointmentBehavior(
         arg.actionPlanId,
@@ -163,22 +181,51 @@ module.exports = on => {
       )
     },
 
+    stubGetDeliverySessionAppointments: arg => {
+      return interventionsService.stubGetDeliverySessionAppointments(arg.id, arg.responseJson)
+    },
+
+    // Deprecated
     stubGetActionPlanAppointments: arg => {
       return interventionsService.stubGetActionPlanAppointments(arg.id, arg.responseJson)
     },
 
+    stubGetDeliverySessionAppointment: arg => {
+      return interventionsService.stubGetDeliverySessionAppointment(arg.referralId, arg.appointmentId, arg.responseJson)
+    },
+
+    // Deprecated
     stubGetActionPlanAppointment: arg => {
       return interventionsService.stubGetActionPlanAppointment(arg.id, arg.session, arg.responseJson)
     },
 
+    stubUpdateDeliverySessionAppointment: arg => {
+      return interventionsService.stubUpdateDeliverySessionAppointment(
+        arg.referralId,
+        arg.appointmentId,
+        arg.responseJson
+      )
+    },
+
+    // Deprecated
     stubUpdateActionPlanAppointment: arg => {
       return interventionsService.stubUpdateActionPlanAppointment(arg.id, arg.session, arg.responseJson)
     },
 
+    stubUpdateDeliverySessionAppointmentClash: arg => {
+      return interventionsService.stubUpdateDeliverySessionAppointmentClash(arg.referralId, arg.appointmentId)
+    },
+
+    // Deprecated
     stubUpdateActionPlanAppointmentClash: arg => {
       return interventionsService.stubUpdateActionPlanAppointmentClash(arg.actionPlanId, arg.sessionNumber)
     },
 
+    stubSubmitDeliverySessionFeedback: arg => {
+      return interventionsService.stubSubmitDeliverySessionFeedback(arg.referralId, arg.appointmentId, arg.responseJson)
+    },
+
+    // Deprecated
     stubSubmitActionPlanSessionFeedback: arg => {
       return interventionsService.stubSubmitActionPlanSessionFeedback(arg.actionPlanId, arg.session, arg.responseJson)
     },

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -90,6 +90,34 @@ Cypress.Commands.add('stubSubmitActionPlan', (id, responseJson) => {
   cy.task('stubSubmitActionPlan', { id, responseJson })
 })
 
+Cypress.Commands.add('stubRecordDeliverySessionAppointmentAttendance', (referralId, appointmentId, responseJson) => {
+  cy.task('stubRecordDeliverySessionAppointmentAttendance', { referralId, appointmentId, responseJson })
+})
+
+Cypress.Commands.add('stubRecordDeliverySessionAppointmentBehaviour', (referralId, appointmentId, responseJson) => {
+  cy.task('stubRecordDeliverySessionAppointmentBehaviour', { referralId, appointmentId, responseJson })
+})
+
+Cypress.Commands.add('stubGetDeliverySessionAppointments', (id, responseJson) => {
+  cy.task('stubGetDeliverySessionAppointments', { id, responseJson })
+})
+
+Cypress.Commands.add('stubGetDeliverySessionAppointment', (referralId, appointmentId, responseJson) => {
+  cy.task('stubGetDeliverySessionAppointment', { referralId, appointmentId, responseJson })
+})
+
+Cypress.Commands.add('stubUpdateDeliverySessionAppointment', (referralId, appointmentId, responseJson) => {
+  cy.task('stubUpdateDeliverySessionAppointment', { referralId, appointmentId, responseJson })
+})
+
+Cypress.Commands.add('stubUpdateDeliverySessionAppointmentClash', (referralId, appointmentId) => {
+  cy.task('stubUpdateDeliverySessionAppointmentClash', { referralId, appointmentId })
+})
+
+Cypress.Commands.add('stubSubmitDeliverySessionFeedback', (referralId, appointmentId, responseJson) => {
+  cy.task('stubSubmitDeliverySessionFeedback', { referralId, appointmentId, responseJson })
+})
+
 Cypress.Commands.add('stubRecordActionPlanAppointmentAttendance', (actionPlanId, sessionNumber, responseJson) => {
   cy.task('stubRecordActionPlanAppointmentAttendance', { actionPlanId, sessionNumber, responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -367,6 +367,27 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubRecordDeliverySessionAppointmentAttendance = async (
+    referralId: string,
+    appointmentId: string,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}/record-attendance`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubRecordActionPlanAppointmentAttendance = async (
     actionPlanId: string,
     sessionNumber: string,
@@ -387,6 +408,27 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubRecordDeliverySessionAppointmentBehaviour = async (
+    referralId: string,
+    appointmentId: string,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}/record-behaviour`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubRecordActionPlanAppointmentBehavior = async (
     actionPlanId: string,
     sessionNumber: string,
@@ -407,6 +449,23 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubGetDeliverySessionAppointments = async (id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/referral/${id}/appointments`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubGetActionPlanAppointments = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
@@ -423,6 +482,27 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubGetDeliverySessionAppointment = async (
+    referralId: string,
+    appointmentId: number,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubGetActionPlanAppointment = async (id: string, session: number, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
@@ -439,6 +519,27 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubUpdateDeliverySessionAppointment = async (
+    referralId: string,
+    appointmentId: number,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubUpdateActionPlanAppointment = async (id: string, session: number, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
@@ -455,6 +556,23 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubUpdateDeliverySessionAppointmentClash = async (referralId: string, appointmentId: number): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      },
+      response: {
+        status: 409,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: {},
+      },
+    })
+  }
+
+  // Deprecated
   stubUpdateActionPlanAppointmentClash = async (actionPlanId: string, sessionNumber: number): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
@@ -471,6 +589,27 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubSubmitDeliverySessionFeedback = async (
+    referralId: string,
+    appointmentId: string,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}/submit`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubSubmitActionPlanSessionFeedback = async (
     actionPlanId: string,
     session: number,

--- a/server/models/appointment.ts
+++ b/server/models/appointment.ts
@@ -8,6 +8,7 @@ export interface InitialAssessmentAppointment extends Appointment {
 }
 
 export interface ActionPlanAppointment extends Appointment {
+  id: string
   sessionNumber: number
 }
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2727,6 +2727,53 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('getDeliverySessionAppointment', () => {
+    const deliverySessionAppointment = actionPlanAppointmentFactory.build({
+      id: '915fd66f-9d74-4e22-8b85-38972b36f6cf',
+      sessionNumber: 1,
+      appointmentTime: '2021-05-13T12:30:00Z',
+      durationInMinutes: 120,
+      sessionType: 'ONE_TO_ONE',
+      appointmentDeliveryType: 'PHONE_CALL',
+    })
+
+    const referralId = '8d107952-9bde-4854-ad1e-dee09daab992'
+
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: `a referral with ID ${referralId} exists and it has an appointment with ID ${deliverySessionAppointment.id}`,
+        uponReceiving: `a GET request for the appointment the appointment with ID ${deliverySessionAppointment.id}`,
+        withRequest: {
+          method: 'GET',
+          path: `/referral/${referralId}/delivery-session-appointment/${deliverySessionAppointment.id}`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(deliverySessionAppointment),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns the requested action plan appointment', async () => {
+      const appointment = await interventionsService.getDeliverySessionAppointment(
+        probationPractitionerToken,
+        referralId,
+        deliverySessionAppointment.id
+      )
+      expect(appointment.id).toEqual('915fd66f-9d74-4e22-8b85-38972b36f6cf')
+      expect(appointment.sessionNumber).toEqual(1)
+      expect(appointment.appointmentTime).toEqual('2021-05-13T12:30:00Z')
+      expect(appointment.durationInMinutes).toEqual(120)
+      expect(appointment.sessionType).toEqual('ONE_TO_ONE')
+      expect(appointment.appointmentDeliveryType).toEqual('PHONE_CALL')
+    })
+  })
+
+  // Deprecated
   describe('getActionPlanAppointment', () => {
     const actionPlanAppointment = actionPlanAppointmentFactory.build({
       sessionNumber: 1,

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2862,6 +2862,84 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('updateDeliverySessionAppointment', () => {
+    const referralId = '8d107952-9bde-4854-ad1e-dee09daab992'
+
+    describe('with non-null values', () => {
+      it('returns an updated delivery session appointment', async () => {
+        const deliverySessionAppointment = actionPlanAppointmentFactory.build({
+          sessionNumber: 2,
+          appointmentTime: '2021-05-13T12:30:00Z',
+          durationInMinutes: 60,
+          sessionType: 'ONE_TO_ONE',
+          appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+          appointmentDeliveryAddress: {
+            firstAddressLine: 'Harmony Living Office, Room 4',
+            secondAddressLine: '44 Bouverie Road',
+            townOrCity: 'Blackpool',
+            county: 'Lancashire',
+            postCode: 'SY40RE',
+          },
+        })
+
+        await provider.addInteraction({
+          state: `a referral exists with ID ${referralId} exists and has 2 2-hour appointments already`,
+          uponReceiving: `a PATCH request to update the appointment for session 2 to change the duration to an hour on action plan with ID ${referralId}`,
+          withRequest: {
+            method: 'PATCH',
+            path: `/referral/${referralId}/delivery-session-appointment/${deliverySessionAppointment.id}`,
+            body: {
+              appointmentTime: '2021-05-13T12:30:00Z',
+              durationInMinutes: 60,
+              sessionType: 'ONE_TO_ONE',
+              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+              appointmentDeliveryAddress: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '44 Bouverie Road',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY40RE',
+              },
+              npsOfficeCode: null,
+            },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+          },
+          // note - this is an exact match
+          willRespondWith: {
+            status: 200,
+            body: deliverySessionAppointment,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        })
+
+        expect(
+          await interventionsService.updateDeliverySessionAppointment(
+            probationPractitionerToken,
+            referralId,
+            deliverySessionAppointment.id,
+            {
+              appointmentTime: '2021-05-13T12:30:00Z',
+              durationInMinutes: 60,
+              sessionType: 'ONE_TO_ONE',
+              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+              appointmentDeliveryAddress: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '44 Bouverie Road',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY40RE',
+              },
+              npsOfficeCode: null,
+            }
+          )
+        ).toMatchObject(deliverySessionAppointment)
+      })
+    })
+  })
+
+  // Deprecated
   describe('updateActionPlanAppointment', () => {
     describe('with non-null values', () => {
       it('returns an updated action plan appointment', async () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2939,6 +2939,73 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('recordDeliverySessionAppointmentAttendance', () => {
+    const referralId = '8d107952-9bde-4854-ad1e-dee09daab992'
+
+    const deliverySessionAppointment = actionPlanAppointmentFactory.build({
+      sessionNumber: 2,
+      appointmentTime: '2021-05-13T12:30:00Z',
+      durationInMinutes: 60,
+      sessionType: 'GROUP',
+      appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+      appointmentDeliveryAddress: {
+        firstAddressLine: 'Harmony Living Office, Room 4',
+        secondAddressLine: '44 Bouverie Road',
+        townOrCity: 'Blackpool',
+        county: 'Lancashire',
+        postCode: 'SY40RE',
+      },
+      sessionFeedback: {
+        attendance: {
+          attended: 'late',
+          additionalAttendanceInformation: 'Alex missed the bus',
+        },
+        behaviour: {
+          behaviourDescription: null,
+          notifyProbationPractitioner: null,
+        },
+        submitted: false,
+        submittedBy: null,
+      },
+    })
+
+    it('returns an updated delivery session appointment with the service user‘s attendance', async () => {
+      await provider.addInteraction({
+        state: `a referral with ID ${referralId} exists with appointment with ID ${deliverySessionAppointment.id} for which no session feedback has been recorded`,
+        uponReceiving: 'a POST request to record attendance for for that appointment',
+        withRequest: {
+          method: 'POST',
+          path: `/referral/${referralId}/delivery-session-appointment/${deliverySessionAppointment.id}/record-attendance`,
+          body: {
+            attended: 'late',
+            additionalAttendanceInformation: 'Alex missed the bus',
+          },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(deliverySessionAppointment),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const appointment = await interventionsService.recordDeliverySessionAppointmentAttendance(
+        probationPractitionerToken,
+        referralId,
+        deliverySessionAppointment.id,
+        {
+          attended: 'late',
+          additionalAttendanceInformation: 'Alex missed the bus',
+        }
+      )
+      expect(appointment.sessionFeedback!.attendance!.attended).toEqual('late')
+      expect(appointment.sessionFeedback!.attendance!.additionalAttendanceInformation).toEqual('Alex missed the bus')
+    })
+  })
+
+  // Deprecated
   describe('recordActionPlanAppointmentAttendance', () => {
     it('returns an updated action plan appointment with the service user‘s attendance', async () => {
       await provider.addInteraction({

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2616,6 +2616,63 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('getDeliverySessionAppointments', () => {
+    const deliverySessionAppointments = [
+      actionPlanAppointmentFactory.build({
+        id: '915fd66f-9d74-4e22-8b85-38972b36f6cf',
+        sessionNumber: 1,
+        appointmentTime: '2021-05-13T12:30:00Z',
+        durationInMinutes: 120,
+        sessionType: 'GROUP',
+        appointmentDeliveryType: 'PHONE_CALL',
+      }),
+      actionPlanAppointmentFactory.build({
+        id: 'e3b59b74-fe85-4dac-bd1b-42de02c26267',
+        sessionNumber: 2,
+        appointmentTime: '2021-05-20T12:30:00Z',
+        durationInMinutes: 120,
+        sessionType: 'ONE_TO_ONE',
+        appointmentDeliveryType: 'PHONE_CALL',
+      }),
+      actionPlanAppointmentFactory.build({
+        id: '840488d1-0619-412e-a32c-89a84c4ca4f8',
+        sessionNumber: 3,
+        appointmentTime: '2021-05-27T12:30:00Z',
+        durationInMinutes: 120,
+        sessionType: 'GROUP',
+        appointmentDeliveryType: 'PHONE_CALL',
+      }),
+    ]
+
+    const referralId = '8d107952-9bde-4854-ad1e-dee09daab992'
+
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: `a referral with ID ${referralId} exists and it has 3 scheduled appointments`,
+        uponReceiving: 'a GET request for the delivery session appointments on the referral',
+        withRequest: {
+          method: 'GET',
+          path: `/referral/${referralId}/delivery-session-appointments`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(deliverySessionAppointments),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns delivery session appointments', async () => {
+      expect(
+        await interventionsService.getDeliverySessionAppointments(probationPractitionerToken, referralId)
+      ).toMatchObject(deliverySessionAppointments)
+    })
+  })
+
+  // Deprecated
   describe('getActionPlanAppointments', () => {
     const actionPlanAppointments = [
       actionPlanAppointmentFactory.build({

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -3192,6 +3192,68 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('submitDeliverySessionFeedback', () => {
+    const referralId = '8d107952-9bde-4854-ad1e-dee09daab992'
+
+    const deliverySessionAppointment = actionPlanAppointmentFactory.build({
+      sessionNumber: 1,
+      appointmentTime: '2021-05-13T12:30:00Z',
+      durationInMinutes: 60,
+      sessionType: 'GROUP',
+      appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+      appointmentDeliveryAddress: {
+        firstAddressLine: 'Harmony Living Office, Room 4',
+        secondAddressLine: '44 Bouverie Road',
+        townOrCity: 'Blackpool',
+        county: 'Lancashire',
+        postCode: 'SY40RE',
+      },
+      sessionFeedback: {
+        attendance: {
+          attended: 'late',
+          additionalAttendanceInformation: 'Alex missed the bus',
+        },
+        behaviour: {
+          behaviourDescription: 'Alex was well behaved',
+          notifyProbationPractitioner: false,
+        },
+        submitted: true,
+        submittedBy: {
+          authSource: 'delius',
+          userId: '2500128586',
+          username: 'joe.smith',
+        },
+      },
+    })
+
+    it('submits attendance and behaviour feedback to the PP', async () => {
+      await provider.addInteraction({
+        state: `a referral exists with ID ${referralId} exists with 1 appointment with ID ${deliverySessionAppointment.id} with recorded attendance and behaviour`,
+        uponReceiving: `a POST request to submit the feedback for appointment 1 on the referral with ID ${referralId}`,
+        withRequest: {
+          method: 'POST',
+          path: `/referral/${referralId}/delivery-session-appointment/${deliverySessionAppointment.id}/submit`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(deliverySessionAppointment),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const appointment = await interventionsService.submitDeliverySessionAppointmentFeedback(
+        probationPractitionerToken,
+        referralId,
+        deliverySessionAppointment.id
+      )
+      expect(appointment.sessionFeedback!.submitted).toEqual(true)
+    })
+  })
+
+  // Deprecated
   describe('submitActionPlanSessionFeedback', () => {
     it('submits attendance and behaviour feedback to the PP', async () => {
       await provider.addInteraction({

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -383,6 +383,15 @@ export default class InterventionsService {
     })) as ApprovedActionPlanSummary[]
   }
 
+  async getDeliverySessionAppointments(token: string, referralId: string): Promise<ActionPlanAppointment[]> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.get({
+      path: `/referral/${referralId}/delivery-session-appointments`,
+      headers: { Accept: 'application/json' },
+    })) as ActionPlanAppointment[]
+  }
+
+  // Deprecated in favour of `getDeliverySessionAppointments`
   async getActionPlanAppointments(token: string, actionPlanId: string): Promise<ActionPlanAppointment[]> {
     const restClient = this.createRestClient(token)
     return (await restClient.get({

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -485,6 +485,22 @@ export default class InterventionsService {
     })) as ActionPlanAppointment
   }
 
+  async recordDeliverySessionAppointmentBehaviour(
+    token: string,
+    referralId: string,
+    appointmentId: string,
+    appointmentBehaviourUpdate: Partial<AppointmentBehaviour>
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}/record-behaviour`,
+      headers: { Accept: 'application/json' },
+      data: appointmentBehaviourUpdate,
+    })) as ActionPlanAppointment
+  }
+
+  // Deprecated in favour of recordDeliverySessionAppointmentBehaviour
   async recordActionPlanAppointmentBehavior(
     token: string,
     actionPlanId: string,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -516,6 +516,20 @@ export default class InterventionsService {
     })) as ActionPlanAppointment
   }
 
+  async submitDeliverySessionAppointmentFeedback(
+    token: string,
+    referralId: string,
+    appointmentId: string
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}/submit`,
+      headers: { Accept: 'application/json' },
+    })) as ActionPlanAppointment
+  }
+
+  // Deprecated in favour of submitDeliverySessionAppointmentFeedback
   async submitActionPlanSessionFeedback(
     token: string,
     actionPlanId: string,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -391,6 +391,18 @@ export default class InterventionsService {
     })) as ActionPlanAppointment[]
   }
 
+  async getDeliverySessionAppointment(
+    token: string,
+    referralId: string,
+    appointmentId: string
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.get({
+      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      headers: { Accept: 'application/json' },
+    })) as ActionPlanAppointment
+  }
+
   // Deprecated in favour of `getDeliverySessionAppointments`
   async getActionPlanAppointments(token: string, actionPlanId: string): Promise<ActionPlanAppointment[]> {
     const restClient = this.createRestClient(token)
@@ -400,6 +412,7 @@ export default class InterventionsService {
     })) as ActionPlanAppointment[]
   }
 
+  // Deprecated in favour of `getDeliverySessionAppointment`
   async getActionPlanAppointment(token: string, actionPlanId: string, session: number): Promise<ActionPlanAppointment> {
     const restClient = this.createRestClient(token)
     return (await restClient.get({

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -454,6 +454,22 @@ export default class InterventionsService {
     })) as ActionPlanAppointment
   }
 
+  async recordDeliverySessionAppointmentAttendance(
+    token: string,
+    referralId: string,
+    appointmentId: string,
+    appointmentAttendanceUpdate: Partial<AppointmentAttendance>
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}/record-attendance`,
+      headers: { Accept: 'application/json' },
+      data: appointmentAttendanceUpdate,
+    })) as ActionPlanAppointment
+  }
+
+  // Deprecated in favour of `recordDeliverySessionAppointmentAttendance`
   async recordActionPlanAppointmentAttendance(
     token: string,
     actionPlanId: string,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -440,6 +440,21 @@ export default class InterventionsService {
     )) as ActionPlanAppointment
   }
 
+  async updateDeliverySessionAppointment(
+    token: string,
+    referralId: string,
+    appointmentId: string,
+    appointmentUpdate: AppointmentSchedulingDetails
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.patch({
+      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      headers: { Accept: 'application/json' },
+      data: { ...appointmentUpdate },
+    })) as ActionPlanAppointment
+  }
+
+  // Deprecated in favour of updateDeliverySessionAppointment
   async updateActionPlanAppointment(
     token: string,
     actionPlanId: string,

--- a/testutils/factories/actionPlanAppointment.ts
+++ b/testutils/factories/actionPlanAppointment.ts
@@ -21,7 +21,8 @@ class ActionPlanAppointmentFactory extends Factory<ActionPlanAppointment> {
   }
 }
 
-export default ActionPlanAppointmentFactory.define(() => ({
+export default ActionPlanAppointmentFactory.define(({ sequence }) => ({
+  id: sequence.toString(),
   sessionNumber: 1,
   appointmentTime: null,
   durationInMinutes: null,


### PR DESCRIPTION
## Note: do not merge this until the backend has been updated to add in these new endpoints.

## What does this pull request do?

Adds new `/referral/:id/delivery-session-appointment/:id`-consuming functions to reflect the fact that Delivery Session appointments are no longer closely linked to an Action Plan. These no longer refer to an appointment by `sessionNumber` but by an `appointmentId`, now added to the `Appointment` interface.

Adds mocks for these to be used in Cypress tests.

This does not use the new functions or remove the old ones, it's merely to drive the API behaviour via consumer-driven contracts.

## What is the intent behind these changes?

- Delivery sessions (what we used to call Action Plan sessions, renamed in the new functions) are no longer tied to an Action Plan, but are linked to a Referral.
- We're going to be displaying multiple appointments against a single session when the person on probation fails to attend an appointment, to allow SPs to reschedule appointments. This means we can no longer rely on the `sessionNumber` to represent an appointment, as we were previously doing. This change will allow us to fetch all appointments for a session and render them on the Intervention Progress page.
