### PR TITLE
OAsys risk information - Add check box

### DIFF
--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
@@ -1,6 +1,7 @@
 import OasysRiskInformationPresenter from './oasysRiskInformationPresenter'
 import { Risk } from '../../../../../models/assessRisksAndNeeds/riskSummary'
 import RiskView from '../../../../shared/riskView'
+import { CheckboxesArgs, DetailsArgs, RadiosArgs } from '../../../../../utils/govukFrontendTypes'
 
 export default class OasysRiskInformationView {
   riskView: RiskView
@@ -77,6 +78,70 @@ export default class OasysRiskInformationView {
     }
   }
 
+  private get sensitiveInformationDetailsArgs(): DetailsArgs {
+    return {
+      summaryText: 'What is sensitive information',
+      html:
+        '<p class="govuk-body">Sensitive information can include personal information or risk-related information received directly from the person on probation or communicated by third parties.</p>' +
+        '<p class="govuk-body">It can include, but is not limited to:</p>' +
+        '<ul>' +
+        "<li>a victim's personal details</li>" +
+        '<li>personal details of other individuals</li>' +
+        '<li>police information that the person on probation cannot be made aware of</li>' +
+        "<li>safeguarding information from children's services</li>" +
+        '<li>information from mental health agencies</li>' +
+        '</ul>' +
+        '<p class="govuk-body">You should carefully consider:</p>' +
+        '<ul>' +
+        '<li>could the information cause harm or undermine the investigation of a crime if it were disclosed to the person on probation?</li>' +
+        '<li>is the information relevant to the risk management of the individual?</li>' +
+        '<li>is it necessary?</li>' +
+        '<li>can sensitive information be removed, or a safe summary provided?</li>' +
+        '</ul>',
+    }
+  }
+
+  private get confirmUnderstoodWarningCheckboxArgs(): CheckboxesArgs {
+    return {
+      idPrefix: 'confirm-understood',
+      name: 'confirm-understood[]',
+      items: [
+        {
+          value: 'understood',
+          text: 'I understand this information will be shared with the service provider',
+        },
+      ],
+      classes: 'govuk-checkboxes__inset--grey',
+    }
+  }
+
+  private editRiskConfirmationRadioButtonArgs(noEditRiskSelectionHTML: string): RadiosArgs {
+    return {
+      classes: 'govuk-radios',
+      idPrefix: 'edit-risk-confirmation',
+      name: 'relevant-sentence-id',
+      fieldset: {
+        legend: {
+          text: 'Do you want to edit this OASys risk information for the service provider?',
+          classes: 'govuk-fieldset__legend--m',
+        },
+      },
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes',
+        },
+        {
+          value: 'no',
+          text: 'No',
+          conditional: {
+            html: noEditRiskSelectionHTML,
+          },
+        },
+      ],
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'makeAReferral/riskInformationOasys',
@@ -90,6 +155,9 @@ export default class OasysRiskInformationView {
         latestAssessment: this.presenter.latestAssessment,
         roshPanelPresenter: this.presenter.riskPresenter,
         roshAnalysisTableArgs: this.riskView.roshAnalysisTableArgs.bind(this.riskView),
+        editRiskConfirmationRadioButtonArgs: this.editRiskConfirmationRadioButtonArgs.bind(this),
+        confirmUnderstoodWarningCheckboxArgs: this.confirmUnderstoodWarningCheckboxArgs,
+        sensitiveInformationDetailsArgs: this.sensitiveInformationDetailsArgs,
       },
     ]
   }

--- a/server/views/makeAReferral/riskInformationOasys.njk
+++ b/server/views/makeAReferral/riskInformationOasys.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
@@ -5,6 +6,9 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
 
 {% extends "../partials/layout.njk" %}
 
@@ -65,6 +69,25 @@
             <p class="govuk-body {{additionalRiskInformationResponse.class}}">{{ additionalRiskInformationResponse.text }}</p>
         {% endif %}
         <p class="govuk-body">{{ additionalRiskInformation | escape | nl2br }}</p>
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+          {% set noEditRiskSelectionHTML %}
+          <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-warning-text__assistive">Warning</span>
+                You have not edited any of the OASys information.
+                Selecting save and continue will share it with the service provider in its current form.
+                Make sure there are no sensitive details included.
+                You will be responsible for the information that is shared.
+                {{ govukDetails(sensitiveInformationDetailsArgs) }}
+                {{ govukCheckboxes(confirmUnderstoodWarningCheckboxArgs) }}
+            </strong>
+          </div>
+          {% endset -%}
+        {{ govukRadios(editRiskConfirmationRadioButtonArgs(noEditRiskSelectionHTML)) }}
+      </form>
     </div>
     <div class="govuk-grid-column-one-third">
       <div class="refer-and-monitor__rosh-analysis-table {{ roshPanelPresenter.overallRoshStyle }}">


### PR DESCRIPTION
Added radio selection and confirmation checkbox on view oasys risk information page.

Selecting "No" will present the user with a confirmation checkbox.

This commit just includes the component without any functionality. This is okay because risk information is hidden behind a feature flag.

## screenshot

![image](https://user-images.githubusercontent.com/83066216/140738330-3181bc04-87e5-4782-92f3-ebb10e0a6e19.png)

