### PR TITLE
OAsys risk information - refactor

### DIFF
--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.test.ts
@@ -1,269 +1,212 @@
 import OasysRiskInformationPresenter from './oasysRiskInformationPresenter'
 import riskSummaryFactory from '../../../../../../testutils/factories/riskSummary'
-import OasysRiskInformationView from './oasysRiskInformationView'
+import OasysRiskInformationView, { RiskInformationArgs } from './oasysRiskInformationView'
 import { Risk } from '../../../../../models/assessRisksAndNeeds/riskSummary'
 import supplementaryRiskInformationFactory from '../../../../../../testutils/factories/supplementaryRiskInformation'
 
 describe('OasysRiskInformationView', () => {
-  describe('additionalRiskInformationResponse', () => {
-    it('returns special content to display if no additional risk information has been provided', () => {
-      const riskSummary = riskSummaryFactory.build()
-      const presenter = new OasysRiskInformationPresenter(null, riskSummary)
-      const view = new OasysRiskInformationView(presenter)
-      expect(view.renderArgs[1].additionalRiskInformationResponse).toHaveProperty('text', 'None')
-    })
-  })
+  describe('riskInformation', () => {
+    describe('additionalRiskInformation', () => {
+      it('returns special content to display if no additional risk information has been provided', () => {
+        const riskSummary = riskSummaryFactory.build()
+        const presenter = new OasysRiskInformationPresenter(null, riskSummary)
+        const view = new OasysRiskInformationView(presenter)
+        const riskInformation = view.renderArgs[1].riskInformation as RiskInformationArgs
+        expect(riskInformation.additionalRiskInformation.label).toHaveProperty('text', 'None')
+      })
 
-  describe('riskSummaryResponse', () => {
-    it('returns correct response text when no null values provided ', () => {
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const riskSummary = riskSummaryFactory.build({
-        summary: { whoIsAtRisk: null, natureOfRisk: null, riskImminence: null },
-      })
-      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
-      const view = new OasysRiskInformationView(presenter)
-      expect(view.renderArgs[1].riskSummaryResponse).toEqual({
-        whoIsAtRisk: expect.objectContaining({
-          text: 'No information provided',
-        }),
-        natureOfRisk: expect.objectContaining({
-          text: 'No information provided',
-        }),
-        riskImminence: expect.objectContaining({
-          text: 'No information provided',
-        }),
-      })
-    })
-
-    it('returns correct response text when no values provided ', () => {
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const riskSummary = riskSummaryFactory.build({
-        summary: { whoIsAtRisk: undefined, natureOfRisk: undefined, riskImminence: undefined },
-      })
-      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
-      const view = new OasysRiskInformationView(presenter)
-      expect(view.renderArgs[1].riskSummaryResponse).toEqual({
-        whoIsAtRisk: expect.objectContaining({
-          text: 'No information provided',
-        }),
-        natureOfRisk: expect.objectContaining({
-          text: 'No information provided',
-        }),
-        riskImminence: expect.objectContaining({
-          text: 'No information provided',
-        }),
-      })
-    })
-
-    it('returns undefined when values are provided ', () => {
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const riskSummary = riskSummaryFactory.build({
-        summary: { whoIsAtRisk: 'whoIsAtRisk', natureOfRisk: 'natureOfRisk', riskImminence: 'riskImminence' },
-      })
-      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
-      const view = new OasysRiskInformationView(presenter)
-      expect(view.renderArgs[1].riskSummaryResponse).toEqual({
-        whoIsAtRisk: undefined,
-        natureOfRisk: undefined,
-        riskImminence: undefined,
-      })
-    })
-  })
-
-  describe('riskToSelfResponse', () => {
-    it('returns correct response text when null values provided ', () => {
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const riskSummary = riskSummaryFactory.build({
-        riskToSelf: {
-          suicide: null,
-          selfHarm: null,
-          hostelSetting: null,
-          vulnerability: null,
-        },
-      })
-      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
-      const view = new OasysRiskInformationView(presenter)
-      expect(view.renderArgs[1].riskToSelfResponse).toEqual({
-        suicide: expect.objectContaining({
-          text: "Don't know",
-        }),
-        selfHarm: expect.objectContaining({
-          text: "Don't know",
-        }),
-        hostelSetting: expect.objectContaining({
-          text: "Don't know",
-        }),
-        vulnerability: expect.objectContaining({
-          text: "Don't know",
-        }),
-      })
-    })
-
-    it('returns correct response text when no values provided ', () => {
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const riskSummary = riskSummaryFactory.build({
-        riskToSelf: {
-          suicide: undefined,
-          selfHarm: undefined,
-          hostelSetting: undefined,
-          vulnerability: undefined,
-        },
-      })
-      const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
-      const view = new OasysRiskInformationView(presenter)
-      expect(view.renderArgs[1].riskToSelfResponse).toEqual({
-        suicide: expect.objectContaining({
-          text: "Don't know",
-        }),
-        selfHarm: expect.objectContaining({
-          text: "Don't know",
-        }),
-        hostelSetting: expect.objectContaining({
-          text: "Don't know",
-        }),
-        vulnerability: expect.objectContaining({
-          text: "Don't know",
-        }),
-      })
-    })
-
-    it("returns correct response when 'YES' values are provided", () => {
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const yesRisk: Risk = {
-        risk: null,
-        current: 'YES',
-        currentConcernsText: null,
-      }
-      const presenter = new OasysRiskInformationPresenter(
-        supplementaryRiskInformation,
-        riskSummaryFactory.build({
-          riskToSelf: {
-            suicide: yesRisk,
-            selfHarm: yesRisk,
-            hostelSetting: yesRisk,
-            vulnerability: yesRisk,
-          },
+      describe('summary', () => {
+        it('returns null text and label when null summary values provided ', () => {
+          const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+          const riskSummary = riskSummaryFactory.build({
+            summary: { whoIsAtRisk: null, natureOfRisk: null, riskImminence: null },
+          })
+          const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
+          const view = new OasysRiskInformationView(presenter)
+          const riskInformation = view.renderArgs[1].riskInformation as RiskInformationArgs
+          expect(riskInformation.summary.whoIsAtRisk.text).toBeNull()
+          expect(riskInformation.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
+          expect(riskInformation.summary.natureOfRisk.text).toBeNull()
+          expect(riskInformation.summary.natureOfRisk.label?.text).toEqual('No information provided')
+          expect(riskInformation.summary.riskImminence.text).toBeNull()
+          expect(riskInformation.summary.riskImminence.label?.text).toEqual('No information provided')
         })
-      )
-      const view = new OasysRiskInformationView(presenter)
-      expect(view.renderArgs[1].riskToSelfResponse).toEqual({
-        suicide: expect.objectContaining({
-          text: 'Yes',
-        }),
-        selfHarm: expect.objectContaining({
-          text: 'Yes',
-        }),
-        hostelSetting: expect.objectContaining({
-          text: 'Yes',
-        }),
-        vulnerability: expect.objectContaining({
-          text: 'Yes',
-        }),
-      })
-    })
 
-    it("returns correct response when 'NO' values are provided", () => {
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const noRisk: Risk = {
-        risk: null,
-        current: 'NO',
-        currentConcernsText: null,
-      }
-      const presenter = new OasysRiskInformationPresenter(
-        supplementaryRiskInformation,
-        riskSummaryFactory.build({
-          riskToSelf: {
-            suicide: noRisk,
-            selfHarm: noRisk,
-            hostelSetting: noRisk,
-            vulnerability: noRisk,
-          },
+        it('returns null text and label when no summary values provided ', () => {
+          const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+          const riskSummary = riskSummaryFactory.build({
+            summary: { whoIsAtRisk: undefined, natureOfRisk: undefined, riskImminence: undefined },
+          })
+          const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
+          const view = new OasysRiskInformationView(presenter)
+          const riskInformation = view.renderArgs[1].riskInformation as RiskInformationArgs
+          expect(riskInformation.summary.whoIsAtRisk.text).toBeNull()
+          expect(riskInformation.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
+          expect(riskInformation.summary.natureOfRisk.text).toBeNull()
+          expect(riskInformation.summary.natureOfRisk.label?.text).toEqual('No information provided')
+          expect(riskInformation.summary.riskImminence.text).toBeNull()
+          expect(riskInformation.summary.riskImminence.label?.text).toEqual('No information provided')
         })
-      )
-      const view = new OasysRiskInformationView(presenter)
-      expect(view.renderArgs[1].riskToSelfResponse).toEqual({
-        suicide: expect.objectContaining({
-          text: 'No',
-        }),
-        selfHarm: expect.objectContaining({
-          text: 'No',
-        }),
-        hostelSetting: expect.objectContaining({
-          text: 'No',
-        }),
-        vulnerability: expect.objectContaining({
-          text: 'No',
-        }),
-      })
-    })
 
-    it("returns correct response when 'DK' values are provided", () => {
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const dkRisk: Risk = {
-        risk: null,
-        current: 'DK',
-        currentConcernsText: null,
-      }
-      const presenter = new OasysRiskInformationPresenter(
-        supplementaryRiskInformation,
-        riskSummaryFactory.build({
-          riskToSelf: {
-            suicide: dkRisk,
-            selfHarm: dkRisk,
-            hostelSetting: dkRisk,
-            vulnerability: dkRisk,
-          },
+        it('returns text and no label when summary values are provided ', () => {
+          const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+          const riskSummary = riskSummaryFactory.build({
+            summary: { whoIsAtRisk: 'whoIsAtRisk', natureOfRisk: 'natureOfRisk', riskImminence: 'riskImminence' },
+          })
+          const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
+          const view = new OasysRiskInformationView(presenter)
+          const riskInformation = view.renderArgs[1].riskInformation as RiskInformationArgs
+          expect(riskInformation.summary.whoIsAtRisk.text).toEqual('whoIsAtRisk')
+          expect(riskInformation.summary.whoIsAtRisk.label).toBeUndefined()
+          expect(riskInformation.summary.natureOfRisk.text).toEqual('natureOfRisk')
+          expect(riskInformation.summary.natureOfRisk.label).toBeUndefined()
+          expect(riskInformation.summary.riskImminence.text).toEqual('riskImminence')
+          expect(riskInformation.summary.riskImminence.label).toBeUndefined()
         })
-      )
-      const view = new OasysRiskInformationView(presenter)
-      expect(view.renderArgs[1].riskToSelfResponse).toEqual({
-        suicide: expect.objectContaining({
-          text: "Don't know",
-        }),
-        selfHarm: expect.objectContaining({
-          text: "Don't know",
-        }),
-        hostelSetting: expect.objectContaining({
-          text: "Don't know",
-        }),
-        vulnerability: expect.objectContaining({
-          text: "Don't know",
-        }),
       })
-    })
 
-    it('returns correct response when no values for current are provided', () => {
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-      const nullRisk: Risk = {
-        risk: null,
-        current: null,
-        currentConcernsText: null,
-      }
-      const presenter = new OasysRiskInformationPresenter(
-        supplementaryRiskInformation,
-        riskSummaryFactory.build({
-          riskToSelf: {
-            suicide: nullRisk,
-            selfHarm: nullRisk,
-            hostelSetting: nullRisk,
-            vulnerability: nullRisk,
-          },
+      describe('riskToSelf', () => {
+        it('returns "Don\'t know" label text when null riskToSelf values provided ', () => {
+          const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+          const riskSummary = riskSummaryFactory.build({
+            riskToSelf: {
+              suicide: null,
+              selfHarm: null,
+              hostelSetting: null,
+              vulnerability: null,
+            },
+          })
+          const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
+          const view = new OasysRiskInformationView(presenter)
+          const riskInformation = view.renderArgs[1].riskInformation as RiskInformationArgs
+          expect(riskInformation.riskToSelf.suicide.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.vulnerability.label.text).toEqual("Don't know")
         })
-      )
-      const view = new OasysRiskInformationView(presenter)
-      expect(view.renderArgs[1].riskToSelfResponse).toEqual({
-        suicide: expect.objectContaining({
-          text: "Don't know",
-        }),
-        selfHarm: expect.objectContaining({
-          text: "Don't know",
-        }),
-        hostelSetting: expect.objectContaining({
-          text: "Don't know",
-        }),
-        vulnerability: expect.objectContaining({
-          text: "Don't know",
-        }),
+
+        it('returns "Don\'t know" label text when no values provided ', () => {
+          const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+          const riskSummary = riskSummaryFactory.build({
+            riskToSelf: {
+              suicide: undefined,
+              selfHarm: undefined,
+              hostelSetting: undefined,
+              vulnerability: undefined,
+            },
+          })
+          const presenter = new OasysRiskInformationPresenter(supplementaryRiskInformation, riskSummary)
+          const view = new OasysRiskInformationView(presenter)
+          const riskInformation = view.renderArgs[1].riskInformation as RiskInformationArgs
+          expect(riskInformation.riskToSelf.suicide.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+        })
+
+        it('returns "Yes" label text when \'YES\' RiskResponse is provided', () => {
+          const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+          const yesRisk: Risk = {
+            risk: null,
+            current: 'YES',
+            currentConcernsText: null,
+          }
+          const presenter = new OasysRiskInformationPresenter(
+            supplementaryRiskInformation,
+            riskSummaryFactory.build({
+              riskToSelf: {
+                suicide: yesRisk,
+                selfHarm: yesRisk,
+                hostelSetting: yesRisk,
+                vulnerability: yesRisk,
+              },
+            })
+          )
+          const view = new OasysRiskInformationView(presenter)
+          const riskInformation = view.renderArgs[1].riskInformation as RiskInformationArgs
+          expect(riskInformation.riskToSelf.suicide.label.text).toEqual('Yes')
+          expect(riskInformation.riskToSelf.selfHarm.label.text).toEqual('Yes')
+          expect(riskInformation.riskToSelf.hostelSetting.label.text).toEqual('Yes')
+          expect(riskInformation.riskToSelf.vulnerability.label.text).toEqual('Yes')
+        })
+
+        it('returns "No" label text when \'NO\' RiskResponse is provided', () => {
+          const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+          const noRisk: Risk = {
+            risk: null,
+            current: 'NO',
+            currentConcernsText: null,
+          }
+          const presenter = new OasysRiskInformationPresenter(
+            supplementaryRiskInformation,
+            riskSummaryFactory.build({
+              riskToSelf: {
+                suicide: noRisk,
+                selfHarm: noRisk,
+                hostelSetting: noRisk,
+                vulnerability: noRisk,
+              },
+            })
+          )
+          const view = new OasysRiskInformationView(presenter)
+          const riskInformation = view.renderArgs[1].riskInformation as RiskInformationArgs
+          expect(riskInformation.riskToSelf.suicide.label.text).toEqual('No')
+          expect(riskInformation.riskToSelf.selfHarm.label.text).toEqual('No')
+          expect(riskInformation.riskToSelf.hostelSetting.label.text).toEqual('No')
+          expect(riskInformation.riskToSelf.vulnerability.label.text).toEqual('No')
+        })
+
+        it("returns \"Don't know\" label text when 'DK' RiskResponse is provided", () => {
+          const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+          const dkRisk: Risk = {
+            risk: null,
+            current: 'DK',
+            currentConcernsText: null,
+          }
+          const presenter = new OasysRiskInformationPresenter(
+            supplementaryRiskInformation,
+            riskSummaryFactory.build({
+              riskToSelf: {
+                suicide: dkRisk,
+                selfHarm: dkRisk,
+                hostelSetting: dkRisk,
+                vulnerability: dkRisk,
+              },
+            })
+          )
+          const view = new OasysRiskInformationView(presenter)
+          const riskInformation = view.renderArgs[1].riskInformation as RiskInformationArgs
+          expect(riskInformation.riskToSelf.suicide.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+        })
+
+        it('returns "Don\'t know" label text when no values for current are provided', () => {
+          const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+          const nullRisk: Risk = {
+            risk: null,
+            current: null,
+            currentConcernsText: null,
+          }
+          const presenter = new OasysRiskInformationPresenter(
+            supplementaryRiskInformation,
+            riskSummaryFactory.build({
+              riskToSelf: {
+                suicide: nullRisk,
+                selfHarm: nullRisk,
+                hostelSetting: nullRisk,
+                vulnerability: nullRisk,
+              },
+            })
+          )
+          const view = new OasysRiskInformationView(presenter)
+          const riskInformation = view.renderArgs[1].riskInformation as RiskInformationArgs
+          expect(riskInformation.riskToSelf.suicide.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+          expect(riskInformation.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+        })
       })
     })
   })

--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
@@ -3,6 +3,53 @@ import { Risk } from '../../../../../models/assessRisksAndNeeds/riskSummary'
 import RiskView from '../../../../shared/riskView'
 import { CheckboxesArgs, DetailsArgs, RadiosArgs } from '../../../../../utils/govukFrontendTypes'
 
+interface RiskInformationLabelArgs {
+  class: string
+  text: string
+}
+type RiskToSelfLabelText = 'Yes' | 'No' | "Don't know"
+interface RiskToSelfLabelArgs {
+  class: string
+  text: RiskToSelfLabelText
+}
+export interface RiskInformationArgs {
+  summary: {
+    whoIsAtRisk: {
+      label?: RiskInformationLabelArgs
+      text: string | null
+    }
+    natureOfRisk: {
+      label?: RiskInformationLabelArgs
+      text: string | null
+    }
+    riskImminence: {
+      label?: RiskInformationLabelArgs
+      text: string | null
+    }
+  }
+  riskToSelf: {
+    suicide: {
+      label: RiskToSelfLabelArgs
+      text: string | null
+    }
+    selfHarm: {
+      label: RiskToSelfLabelArgs
+      text: string | null
+    }
+    hostelSetting: {
+      label: RiskToSelfLabelArgs
+      text: string | null
+    }
+    vulnerability: {
+      label: RiskToSelfLabelArgs
+      text: string | null
+    }
+  }
+  additionalRiskInformation: {
+    label?: RiskInformationLabelArgs
+    text: string | null
+  }
+}
 export default class OasysRiskInformationView {
   riskView: RiskView
 
@@ -10,47 +57,21 @@ export default class OasysRiskInformationView {
     this.riskView = new RiskView(this.presenter.riskPresenter, 'probation-practitioner')
   }
 
-  private get additionalRiskInformationResponse(): { class: string; text: string } | undefined {
-    if (this.presenter.supplementaryRiskInformation != null) {
-      return undefined
-    }
+  private get noAdditionalRiskInformationLabel(): RiskInformationLabelArgs {
     return {
       class: 'app-oasys-text app-oasys-text--dark-grey',
       text: 'None',
     }
   }
 
-  private readonly noInformationProvidedResponse = {
-    class: 'app-oasys-text app-oasys-text--dark-grey',
-    text: 'No information provided',
+  private get noInformationProvidedLabel(): RiskInformationLabelArgs {
+    return {
+      class: 'app-oasys-text app-oasys-text--dark-grey',
+      text: 'No information provided',
+    }
   }
 
-  private riskSummaryResponse = {
-    whoIsAtRisk: this.presenter.riskSummary.summary.whoIsAtRisk ? undefined : this.noInformationProvidedResponse,
-    natureOfRisk: this.presenter.riskSummary.summary.natureOfRisk ? undefined : this.noInformationProvidedResponse,
-    riskImminence: this.presenter.riskSummary.summary.riskImminence ? undefined : this.noInformationProvidedResponse,
-  }
-
-  private riskToSelfResponse = {
-    suicide: {
-      class: this.riskToSelfResponseTextClass(this.presenter.riskSummary.riskToSelf.suicide),
-      text: this.riskToSelfResponseText(this.presenter.riskSummary.riskToSelf.suicide),
-    },
-    selfHarm: {
-      class: this.riskToSelfResponseTextClass(this.presenter.riskSummary.riskToSelf.selfHarm),
-      text: this.riskToSelfResponseText(this.presenter.riskSummary.riskToSelf.selfHarm),
-    },
-    hostelSetting: {
-      class: this.riskToSelfResponseTextClass(this.presenter.riskSummary.riskToSelf.hostelSetting),
-      text: this.riskToSelfResponseText(this.presenter.riskSummary.riskToSelf.hostelSetting),
-    },
-    vulnerability: {
-      class: this.riskToSelfResponseTextClass(this.presenter.riskSummary.riskToSelf.vulnerability),
-      text: this.riskToSelfResponseText(this.presenter.riskSummary.riskToSelf.vulnerability),
-    },
-  }
-
-  private riskToSelfResponseText(risk: Risk | undefined | null): string {
+  private riskToSelfLabelText(risk: Risk | undefined | null): RiskToSelfLabelText {
     if (!risk) {
       return "Don't know"
     }
@@ -64,7 +85,7 @@ export default class OasysRiskInformationView {
     }
   }
 
-  private riskToSelfResponseTextClass(risk: Risk | undefined | null): string {
+  private riskToSelfLabelClass(risk: Risk | undefined | null): string {
     if (!risk) {
       return 'app-oasys-text app-oasys-text--dark-grey'
     }
@@ -142,22 +163,73 @@ export default class OasysRiskInformationView {
     }
   }
 
+  get riskInformation(): RiskInformationArgs {
+    const { supplementaryRiskInformation } = this.presenter
+    const { summary, riskToSelf } = this.presenter.riskSummary
+    return {
+      summary: {
+        whoIsAtRisk: {
+          label: summary.whoIsAtRisk ? undefined : this.noInformationProvidedLabel,
+          text: summary.whoIsAtRisk ? summary.whoIsAtRisk : null,
+        },
+        natureOfRisk: {
+          label: summary.natureOfRisk ? undefined : this.noInformationProvidedLabel,
+          text: summary.natureOfRisk ? summary.natureOfRisk : null,
+        },
+        riskImminence: {
+          label: summary.riskImminence ? undefined : this.noInformationProvidedLabel,
+          text: summary.riskImminence ? summary.riskImminence : null,
+        },
+      },
+      riskToSelf: {
+        suicide: {
+          label: {
+            class: this.riskToSelfLabelClass(riskToSelf.suicide),
+            text: this.riskToSelfLabelText(riskToSelf.suicide),
+          },
+          text: riskToSelf.suicide ? riskToSelf.suicide.currentConcernsText : null,
+        },
+        selfHarm: {
+          label: {
+            class: this.riskToSelfLabelClass(riskToSelf.selfHarm),
+            text: this.riskToSelfLabelText(riskToSelf.selfHarm),
+          },
+          text: riskToSelf.selfHarm ? riskToSelf.selfHarm.currentConcernsText : null,
+        },
+        hostelSetting: {
+          label: {
+            class: this.riskToSelfLabelClass(riskToSelf.hostelSetting),
+            text: this.riskToSelfLabelText(riskToSelf.hostelSetting),
+          },
+          text: riskToSelf.hostelSetting ? riskToSelf.hostelSetting.currentConcernsText : null,
+        },
+        vulnerability: {
+          label: {
+            class: this.riskToSelfLabelClass(riskToSelf.vulnerability),
+            text: this.riskToSelfLabelText(riskToSelf.vulnerability),
+          },
+          text: riskToSelf.vulnerability ? riskToSelf.vulnerability.currentConcernsText : null,
+        },
+      },
+      additionalRiskInformation: {
+        label: supplementaryRiskInformation ? undefined : this.noAdditionalRiskInformationLabel,
+        text: supplementaryRiskInformation ? supplementaryRiskInformation.riskSummaryComments : null,
+      },
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'makeAReferral/riskInformationOasys',
       {
-        riskSummary: this.presenter.riskSummary.summary,
-        riskSummaryResponse: this.riskSummaryResponse,
-        riskToSelf: this.presenter.riskSummary.riskToSelf,
-        riskToSelfResponse: this.riskToSelfResponse,
-        additionalRiskInformation: this.presenter.supplementaryRiskInformation?.riskSummaryComments,
-        additionalRiskInformationResponse: this.additionalRiskInformationResponse,
+        riskInformation: this.riskInformation,
         latestAssessment: this.presenter.latestAssessment,
         roshPanelPresenter: this.presenter.riskPresenter,
         roshAnalysisTableArgs: this.riskView.roshAnalysisTableArgs.bind(this.riskView),
         editRiskConfirmationRadioButtonArgs: this.editRiskConfirmationRadioButtonArgs.bind(this),
         confirmUnderstoodWarningCheckboxArgs: this.confirmUnderstoodWarningCheckboxArgs,
         sensitiveInformationDetailsArgs: this.sensitiveInformationDetailsArgs,
+        noInformationProvided: this.noInformationProvidedLabel,
       },
     ]
   }

--- a/server/views/makeAReferral/riskInformationOasys.njk
+++ b/server/views/makeAReferral/riskInformationOasys.njk
@@ -24,51 +24,51 @@
         <hr/>
 
         <h2 class="govuk-heading-m">Who is at risk</h2>
-        {% if riskSummaryResponse.whoIsAtRisk %}
-            <p class="govuk-body {{riskSummaryResponse.whoIsAtRisk.class}}">{{ riskSummaryResponse.whoIsAtRisk.text }}</p>
+        {% if riskInformation.summary.whoIsAtRisk.label %}
+            <p class="govuk-body {{ riskInformation.summary.whoIsAtRisk.label.class}}">{{ riskInformation.summary.whoIsAtRisk.label.text }}</p>
         {% endif %}
-        <p class="govuk-body">{{ riskSummary.whoIsAtRisk | escape | nl2br }}</p>
+        <p class="govuk-body">{{ riskInformation.summary.whoIsAtRisk.text | escape | nl2br }}</p>
         <hr/>
 
         <h2 class="govuk-heading-m">What is the nature of the risk</h2>
-        {% if riskSummaryResponse.natureOfRisk %}
-            <p class="govuk-body {{riskSummaryResponse.natureOfRisk.class}}">{{ riskSummaryResponse.natureOfRisk.text }}</p>
+        {% if riskInformation.summary.natureOfRisk.label %}
+            <p class="govuk-body {{riskInformation.summary.natureOfRisk.label.class}}">{{ riskInformation.summary.natureOfRisk.label.text }}</p>
         {% endif %}
-        <p class="govuk-body">{{ riskSummary.natureOfRisk | escape | nl2br }}</p>
+        <p class="govuk-body">{{ riskInformation.summary.natureOfRisk.text | escape | nl2br }}</p>
         <hr/>
 
         <h2 class="govuk-heading-m">When is the risk likely to be greatest</h2>
-        {% if riskSummaryResponse.riskImminence %}
-            <p class="govuk-body {{riskSummaryResponse.riskImminence.class}}">{{ riskSummaryResponse.riskImminence.text }}</p>
+        {% if riskInformation.summary.riskImminence.label %}
+            <p class="govuk-body {{riskInformation.summary.riskImminence.label.class}}">{{ riskInformation.summary.riskImminence.label.text }}</p>
         {% endif %}
-        <p class="govuk-body">{{ riskSummary.riskImminence | escape | nl2br }}</p>
+        <p class="govuk-body">{{ riskInformation.summary.riskImminence.text | escape | nl2br }}</p>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to self-harm</h2>
-        <p class="govuk-body {{ riskToSelfResponse.selfHarm.class }}"> {{ riskToSelfResponse.selfHarm.text }}</p>
-        <p class="govuk-body">{{ riskToSelf.selfHarm.currentConcernsText | escape | nl2br }}</p>
+        <p class="govuk-body {{ riskInformation.riskToSelf.selfHarm.label.class }}"> {{ riskInformation.riskToSelf.selfHarm.label.text }}</p>
+        <p class="govuk-body">{{ riskInformation.riskToSelf.selfHarm.text | escape | nl2br }}</p>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to suicide</h2>
-        <p class="govuk-body {{ riskToSelfResponse.suicide.class }}"> {{ riskToSelfResponse.suicide.text }}</p>
-        <p class="govuk-body">{{ riskToSelf.suicide.currentConcernsText | escape | nl2br }}</p>
+        <p class="govuk-body {{ riskInformation.riskToSelf.suicide.label.class }}"> {{ riskInformation.riskToSelf.suicide.label.text }}</p>
+        <p class="govuk-body">{{ riskInformation.riskToSelf.suicide.text | escape | nl2br }}</p>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to coping in a hostel setting</h2>
-        <p class="govuk-body {{ riskToSelfResponse.hostelSetting.class }}"> {{ riskToSelfResponse.hostelSetting.text }}</p>
-        <p class="govuk-body">{{ riskToSelf.hostelSetting.currentConcernsText | escape | nl2br }}</p>
+        <p class="govuk-body {{ riskInformation.riskToSelf.hostelSetting.label.class }}"> {{ riskInformation.riskToSelf.hostelSetting.label.text }}</p>
+        <p class="govuk-body">{{ riskInformation.riskToSelf.hostelSetting.text | escape | nl2br }}</p>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to vulnerability</h2>
-        <p class="govuk-body {{ riskToSelfResponse.vulnerability.class }}"> {{ riskToSelfResponse.vulnerability.text }}</p>
-        <p class="govuk-body">{{ riskToSelf.vulnerability.currentConcernsText | escape | nl2br }}</p>
+        <p class="govuk-body {{ riskInformation.riskToSelf.vulnerability.label.class }}"> {{ riskInformation.riskToSelf.vulnerability.label.text }}</p>
+        <p class="govuk-body">{{ riskInformation.riskToSelf.vulnerability.text | escape | nl2br }}</p>
         <hr/>
 
         <h2 class="govuk-heading-m">Additional information</h2>
-        {% if additionalRiskInformationResponse %}
-            <p class="govuk-body {{additionalRiskInformationResponse.class}}">{{ additionalRiskInformationResponse.text }}</p>
+        {% if riskInformation.additionalRiskInformation.label %}
+            <p class="govuk-body {{ riskInformation.additionalRiskInformation.label.class }}">{{ riskInformation.additionalRiskInformation.label.text }}</p>
         {% endif %}
-        <p class="govuk-body">{{ additionalRiskInformation | escape | nl2br }}</p>
+        <p class="govuk-body">{{ riskInformation.additionalRiskInformation.text | escape | nl2br }}</p>
 
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
@@ -87,6 +87,7 @@
           </div>
           {% endset -%}
         {{ govukRadios(editRiskConfirmationRadioButtonArgs(noEditRiskSelectionHTML)) }}
+        {{ govukButton({ text: "Save and continue" }) }}
       </form>
     </div>
     <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
Combined all oasys risk information details into a single parameter map.
I felt that the old parameter names with ResponseText suffix was too ambiguous about it's intent. This parameter was responsible for showing the No|Yes|Don't know response - esentially a label about the risk information.
I've now moved this parameter to be part of a larger paramter map that includes the risk information coupled with the risk label.

This will be also be used by edit oasys risk information page to avoid duplication with view risk information.
