### PR TITLE
Add subnavigation menu to pages

### DIFF
--- a/server/routes/findInterventions/findInterventionsController.ts
+++ b/server/routes/findInterventions/findInterventionsController.ts
@@ -18,7 +18,7 @@ export default class FindInterventionsController {
       this.interventionsService.getPccRegions(res.locals.user.token.accessToken),
     ])
 
-    const presenter = new SearchResultsPresenter(interventions, filter, pccRegions)
+    const presenter = new SearchResultsPresenter(interventions, filter, pccRegions, res.locals.user)
     const view = new SearchResultsView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, null)

--- a/server/routes/findInterventions/findInterventionsController.ts
+++ b/server/routes/findInterventions/findInterventionsController.ts
@@ -30,7 +30,7 @@ export default class FindInterventionsController {
       req.params.id
     )
 
-    const presenter = new InterventionDetailsPresenter(intervention)
+    const presenter = new InterventionDetailsPresenter(intervention, res.locals.user)
     const view = new InterventionDetailsView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, null)

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -8,13 +8,16 @@ import InterventionDetailsPresenter from './interventionDetailsPresenter'
 import TestUtils from '../../../testutils/testUtils'
 import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 import pccRegion from '../../../testutils/factories/pccRegion'
+import loggedInUserFactory from '../../../testutils/factories/loggedInUser'
 
 describe(InterventionDetailsPresenter, () => {
+  const loggedInUser = loggedInUserFactory.probationUser().build()
   describe('title', () => {
     const presenter = new InterventionDetailsPresenter(
       interventionFactory.build({
         title: 'Accommodation',
-      })
+      }),
+      loggedInUser
     )
     it('returns the intervention title', () => {
       expect(presenter.title).toEqual('Accommodation')
@@ -25,7 +28,8 @@ describe(InterventionDetailsPresenter, () => {
     const presenter = new InterventionDetailsPresenter(
       interventionFactory.build({
         id: '65b5cc27-0b87-4f44-8a35-bb08fc64e90e',
-      })
+      }),
+      loggedInUser
     )
     it('returns the link to make a referral', () => {
       expect(presenter.hrefReferralStart).toEqual('/intervention/65b5cc27-0b87-4f44-8a35-bb08fc64e90e/refer')
@@ -36,7 +40,8 @@ describe(InterventionDetailsPresenter, () => {
     const presenter = new InterventionDetailsPresenter(
       interventionFactory.build({
         id: '65b5cc27-0b87-4f44-8a35-bb08fc64e90e',
-      })
+      }),
+      loggedInUser
     )
     it('returns the link to the intervention', () => {
       expect(presenter.hrefInterventionDetails).toEqual(
@@ -49,7 +54,8 @@ describe(InterventionDetailsPresenter, () => {
     const presenter = new InterventionDetailsPresenter(
       interventionFactory.build({
         description: 'Some information about the intervention',
-      })
+      }),
+      loggedInUser
     )
     it('returns the intervention description', () => {
       expect(presenter.description).toEqual('Some information about the intervention')
@@ -61,7 +67,8 @@ describe(InterventionDetailsPresenter, () => {
       const presenter = new InterventionDetailsPresenter(
         interventionFactory.build({
           description: 'Some information about the intervention',
-        })
+        }),
+        loggedInUser
       )
       expect(presenter.truncatedDescription).toEqual('Some information about the intervention')
     })
@@ -73,7 +80,8 @@ describe(InterventionDetailsPresenter, () => {
 that is longer than one line
 and even longer than
 three lines.`,
-        })
+        }),
+        loggedInUser
       )
       expect(presenter.truncatedDescription).toEqual('Some information about the intervention')
     })
@@ -82,7 +90,8 @@ three lines.`,
       const presenter = new InterventionDetailsPresenter(
         interventionFactory.build({
           description: new Array(1000).join('x'),
-        })
+        }),
+        loggedInUser
       )
       expect(presenter.truncatedDescription).toEqual(`${new Array(501).join('x')}...`)
     })
@@ -91,7 +100,8 @@ three lines.`,
       const presenter = new InterventionDetailsPresenter(
         interventionFactory.build({
           description: `${new Array(1000).join('x')}\n${new Array(1000).join('z')}`,
-        })
+        }),
+        loggedInUser
       )
       expect(presenter.truncatedDescription).toEqual(`${new Array(501).join('x')}...`)
     })
@@ -101,7 +111,8 @@ three lines.`,
     const presenter = new InterventionDetailsPresenter(
       interventionFactory.build({
         serviceProvider: serviceProviderFactory.build({ name: 'Harmony Living' }),
-      })
+      }),
+      loggedInUser
     )
 
     it('returns an array of summary lists, each with an id and title', () => {
@@ -122,7 +133,7 @@ three lines.`,
 
   describe('summary', () => {
     function summaryForParams(params: DeepPartial<Intervention>): SummaryListItem[] {
-      return new InterventionDetailsPresenter(interventionFactory.build(params)).summary
+      return new InterventionDetailsPresenter(interventionFactory.build(params), loggedInUser).summary
     }
 
     function linesForKey(key: string, params: DeepPartial<Intervention>): string[] | null {

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -1,9 +1,13 @@
 import Intervention, { Eligibility } from '../../models/intervention'
 import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 import utils from '../../utils/utils'
+import PrimaryNavBarPresenter from '../shared/primaryNavBar/primaryNavBarPresenter'
+import LoggedInUser from '../../models/loggedInUser'
 
 export default class InterventionDetailsPresenter {
-  constructor(private readonly intervention: Intervention) {}
+  constructor(private readonly intervention: Intervention, private readonly loggedInUser: LoggedInUser) {}
+
+  readonly navItemsPresenter = new PrimaryNavBarPresenter('Find interventions', this.loggedInUser)
 
   get title(): string {
     return this.intervention.title

--- a/server/routes/findInterventions/interventionDetailsView.ts
+++ b/server/routes/findInterventions/interventionDetailsView.ts
@@ -34,6 +34,7 @@ export default class InterventionDetailsView {
         presenter: this.presenter,
         summaryListArgs: InterventionDetailsView.summaryListArgs,
         tabsArgs: this.tabsArgs.bind(this),
+        primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items),
       },
     ]
   }

--- a/server/routes/findInterventions/searchResultsPresenter.test.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.test.ts
@@ -2,11 +2,18 @@ import SearchResultsPresenter from './searchResultsPresenter'
 import interventionFactory from '../../../testutils/factories/intervention'
 import InterventionsFilter from './interventionsFilter'
 import pccRegionFactory from '../../../testutils/factories/pccRegion'
+import loggedInUserFactory from '../../../testutils/factories/loggedInUser'
 
 describe(SearchResultsPresenter, () => {
+  const loggedInUser = loggedInUserFactory.probationUser().build()
   describe('results', () => {
     it('contains as many items as there are interventions', () => {
-      const presenter = new SearchResultsPresenter(interventionFactory.buildList(3), new InterventionsFilter(), [])
+      const presenter = new SearchResultsPresenter(
+        interventionFactory.buildList(3),
+        new InterventionsFilter(),
+        [],
+        loggedInUser
+      )
 
       expect(presenter.results.length).toBe(3)
     })
@@ -16,7 +23,7 @@ describe(SearchResultsPresenter, () => {
     describe('results', () => {
       describe('with no results', () => {
         it('is correctly pluralised', () => {
-          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [])
+          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [], loggedInUser)
 
           expect(presenter.text.results).toEqual({ count: '0', countSuffix: 'results found.' })
         })
@@ -24,7 +31,12 @@ describe(SearchResultsPresenter, () => {
 
       describe('with 1 result', () => {
         it('is correctly pluralised', () => {
-          const presenter = new SearchResultsPresenter(interventionFactory.buildList(1), new InterventionsFilter(), [])
+          const presenter = new SearchResultsPresenter(
+            interventionFactory.buildList(1),
+            new InterventionsFilter(),
+            [],
+            loggedInUser
+          )
 
           expect(presenter.text.results).toEqual({ count: '1', countSuffix: 'result found.' })
         })
@@ -32,7 +44,12 @@ describe(SearchResultsPresenter, () => {
 
       describe('with > 1 result', () => {
         it('is correctly pluralised', () => {
-          const presenter = new SearchResultsPresenter(interventionFactory.buildList(2), new InterventionsFilter(), [])
+          const presenter = new SearchResultsPresenter(
+            interventionFactory.buildList(2),
+            new InterventionsFilter(),
+            [],
+            loggedInUser
+          )
 
           expect(presenter.text.results).toEqual({ count: '2', countSuffix: 'results found.' })
         })
@@ -48,7 +65,7 @@ describe(SearchResultsPresenter, () => {
     const pccRegions = [lancashire, norfolk, cheshire]
 
     it('has the correct name and value in alphabetical order', () => {
-      const presenter = new SearchResultsPresenter([], new InterventionsFilter(), pccRegions)
+      const presenter = new SearchResultsPresenter([], new InterventionsFilter(), pccRegions, loggedInUser)
 
       expect(presenter.pccRegionFilters).toMatchObject([
         { value: cheshire.id, text: 'Cheshire' },
@@ -60,7 +77,7 @@ describe(SearchResultsPresenter, () => {
     describe('checked', () => {
       describe('when filter doesn’t specify PCC region IDs', () => {
         it('is false for all regions', () => {
-          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), pccRegions)
+          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), pccRegions, loggedInUser)
 
           expect(presenter.pccRegionFilters).toMatchObject([{ checked: false }, { checked: false }, { checked: false }])
         })
@@ -70,7 +87,7 @@ describe(SearchResultsPresenter, () => {
         it('returns true for a region listed in the filter and false for a region not listed in the filter', () => {
           const filter = new InterventionsFilter()
           filter.pccRegionIds = [cheshire.id]
-          const presenter = new SearchResultsPresenter([], filter, pccRegions)
+          const presenter = new SearchResultsPresenter([], filter, pccRegions, loggedInUser)
 
           expect(presenter.pccRegionFilters).toMatchObject([{ checked: true }, { checked: false }, { checked: false }])
         })
@@ -80,7 +97,7 @@ describe(SearchResultsPresenter, () => {
 
   describe('genderFilters', () => {
     it('has the correct name and value', () => {
-      const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [])
+      const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [], loggedInUser)
 
       expect(presenter.genderFilters).toMatchObject([
         { value: 'male', text: 'Male' },
@@ -91,7 +108,7 @@ describe(SearchResultsPresenter, () => {
     describe('checked', () => {
       describe('when filter doesn’t specify gender', () => {
         it('is false for all values', () => {
-          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [])
+          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [], loggedInUser)
 
           expect(presenter.genderFilters).toMatchObject([{ checked: false }, { checked: false }])
         })
@@ -101,7 +118,7 @@ describe(SearchResultsPresenter, () => {
         it('is true for male', () => {
           const filter = new InterventionsFilter()
           filter.gender = ['male']
-          const presenter = new SearchResultsPresenter([], filter, [])
+          const presenter = new SearchResultsPresenter([], filter, [], loggedInUser)
 
           expect(presenter.genderFilters[0]).toMatchObject({ checked: true })
         })
@@ -111,7 +128,7 @@ describe(SearchResultsPresenter, () => {
         it('is true for female', () => {
           const filter = new InterventionsFilter()
           filter.gender = ['female']
-          const presenter = new SearchResultsPresenter([], filter, [])
+          const presenter = new SearchResultsPresenter([], filter, [], loggedInUser)
 
           expect(presenter.genderFilters[1]).toMatchObject({ checked: true })
         })
@@ -121,7 +138,7 @@ describe(SearchResultsPresenter, () => {
 
   describe('ageFilters', () => {
     it('has the correct name and value', () => {
-      const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [])
+      const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [], loggedInUser)
 
       expect(presenter.ageFilters).toMatchObject([{ value: '18-to-25-only', text: 'Only for ages 18 to 25' }])
     })
@@ -129,7 +146,7 @@ describe(SearchResultsPresenter, () => {
     describe('checked', () => {
       describe('when filter doesn’t specify age', () => {
         it('is false for all values', () => {
-          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [])
+          const presenter = new SearchResultsPresenter([], new InterventionsFilter(), [], loggedInUser)
 
           expect(presenter.ageFilters).toMatchObject([{ checked: false }])
         })
@@ -139,7 +156,7 @@ describe(SearchResultsPresenter, () => {
         it('is true for 18 to 25 only', () => {
           const filter = new InterventionsFilter()
           filter.age = ['18-to-25-only']
-          const presenter = new SearchResultsPresenter([], filter, [])
+          const presenter = new SearchResultsPresenter([], filter, [], loggedInUser)
 
           expect(presenter.ageFilters).toMatchObject([{ checked: true }])
         })

--- a/server/routes/findInterventions/searchResultsPresenter.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.ts
@@ -3,13 +3,18 @@ import PCCRegion from '../../models/pccRegion'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
 import InterventionsFilter from './interventionsFilter'
 import SearchSummaryPresenter from './searchSummaryPresenter'
+import LoggedInUser from '../../models/loggedInUser'
+import PrimaryNavBarPresenter from '../shared/primaryNavBar/primaryNavBarPresenter'
 
 export default class SearchResultsPresenter {
   constructor(
     private readonly interventions: Intervention[],
     private readonly filter: InterventionsFilter,
-    private readonly pccRegions: PCCRegion[]
+    private readonly pccRegions: PCCRegion[],
+    private readonly loggedInUser: LoggedInUser
   ) {}
+
+  readonly navItemsPresenter = new PrimaryNavBarPresenter('Find interventions', this.loggedInUser)
 
   readonly pccRegionFilters: {
     value: string

--- a/server/routes/findInterventions/searchResultsPresenter.ts
+++ b/server/routes/findInterventions/searchResultsPresenter.ts
@@ -60,7 +60,7 @@ export default class SearchResultsPresenter {
   readonly summary: SearchSummaryPresenter = new SearchSummaryPresenter(this.filter, this.pccRegions)
 
   readonly results: InterventionDetailsPresenter[] = this.interventions.map(
-    intervention => new InterventionDetailsPresenter(intervention)
+    intervention => new InterventionDetailsPresenter(intervention, this.loggedInUser)
   )
 
   readonly text = {

--- a/server/routes/findInterventions/searchResultsView.ts
+++ b/server/routes/findInterventions/searchResultsView.ts
@@ -68,6 +68,7 @@ export default class SearchResultsView {
         ageCheckboxArgs: this.ageCheckboxArgs,
         summaryListArgs: SearchResultsView.summaryListArgs,
         searchSummarySummaryListArgs: this.searchSummarySummaryListArgs,
+        primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items),
       },
     ]
   }

--- a/server/routes/makeAReferral/confirmation/confirmationPresenter.test.ts
+++ b/server/routes/makeAReferral/confirmation/confirmationPresenter.test.ts
@@ -1,11 +1,13 @@
 import ConfirmationPresenter from './confirmationPresenter'
 import sentReferralFactory from '../../../../testutils/factories/sentReferral'
+import loggedInUserFactory from '../../../../testutils/factories/loggedInUser'
 
 describe(ConfirmationPresenter, () => {
+  const loggedInUser = loggedInUserFactory.probationUser().build()
   describe('text', () => {
     it('returns text to be displayed', () => {
       const referral = sentReferralFactory.build()
-      const presenter = new ConfirmationPresenter(referral)
+      const presenter = new ConfirmationPresenter(referral, loggedInUser)
 
       expect(presenter.text).toEqual({
         title: `We’ve sent your referral to Harmony Living`,

--- a/server/routes/makeAReferral/confirmation/confirmationPresenter.ts
+++ b/server/routes/makeAReferral/confirmation/confirmationPresenter.ts
@@ -1,7 +1,11 @@
 import SentReferral from '../../../models/sentReferral'
+import LoggedInUser from '../../../models/loggedInUser'
+import PrimaryNavBarPresenter from '../../shared/primaryNavBar/primaryNavBarPresenter'
 
 export default class ConfirmationPresenter {
-  constructor(private readonly referral: SentReferral) {}
+  constructor(private readonly referral: SentReferral, private readonly loggedInUser: LoggedInUser) {}
+
+  readonly navItemsPresenter = new PrimaryNavBarPresenter('Find interventions', this.loggedInUser)
 
   readonly text = {
     title: `We’ve sent your referral to ${this.referral.referral.serviceProvider.name}`,

--- a/server/routes/makeAReferral/confirmation/confirmationView.ts
+++ b/server/routes/makeAReferral/confirmation/confirmationView.ts
@@ -18,6 +18,7 @@ export default class ConfirmationView {
       {
         presenter: this.presenter,
         panelArgs: this.panelArgs,
+        primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items),
       },
     ]
   }

--- a/server/routes/makeAReferral/makeAReferralController.ts
+++ b/server/routes/makeAReferral/makeAReferralController.ts
@@ -666,7 +666,7 @@ export default class MakeAReferralController {
     const referral = await this.interventionsService.getSentReferral(res.locals.user.token.accessToken, req.params.id)
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new ConfirmationPresenter(referral)
+    const presenter = new ConfirmationPresenter(referral, res.locals.user)
     const view = new ConfirmationView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/views/findInterventions/interventionDetails.njk
+++ b/server/views/findInterventions/interventionDetails.njk
@@ -1,11 +1,16 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = "Find interventions" %}
 {% set pageSubTitle = "Intervention summary" %}
+
+{% block primaryNav %}
+  {{ mojPrimaryNavigation(primaryNavArgs) }}
+{% endblock %}
 
 {% block pageContent %}
   <div class="govuk-grid-row govuk-!-margin-bottom-7">

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -1,11 +1,16 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = "Find interventions" %}
 {% set pageSubTitle = "Find results" %}
+
+{% block primaryNav %}
+  {{ mojPrimaryNavigation(primaryNavArgs) }}
+{% endblock %}
 
 {% block pageContent %}
   <div class="govuk-grid-row govuk-!-margin-bottom-7">

--- a/server/views/makeAReferral/confirmation.njk
+++ b/server/views/makeAReferral/confirmation.njk
@@ -1,10 +1,16 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = "Make a referral" %}
 {% set pageSubTitle = "Submit confirmation" %}
+
+{% block primaryNav %}
+  {{ mojPrimaryNavigation(primaryNavArgs) }}
+{% endblock %}
+
 
 {% block pageContent %}
   <div class="govuk-grid-row">


### PR DESCRIPTION
commit e444ccafa2363a757c4209c2732ba14a658aa6f6 

Added sub navigation menu for make a referral submit confirmation screen.

commit f9ed6eadf5e7a336861d7607fc8d9ccd1625a7d8

Added sub navigation menu for intervention details screen after selecting an intervention from Find Interventions search results.

commit 8dd659683ea14db34e6716eaf35a117c0562b11d

Added sub navigation menu for find-interventions search results screen.


The submenu navigation looks like:

![image](https://user-images.githubusercontent.com/83066216/141131160-c724818e-2eda-40f5-9225-ddd1d12510e0.png)
