### PR TITLE
supply query params to SP referrals summary API calls

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 import createError from 'http-errors'
 import querystring from 'querystring'
 import CommunityApiService from '../../services/communityApiService'
-import InterventionsService, { InterventionsServiceError } from '../../services/interventionsService'
+import InterventionsService, { InterventionsServiceError, SPDashboardType } from '../../services/interventionsService'
 import ActionPlan from '../../models/actionPlan'
 import HmppsAuthService from '../../services/hmppsAuthService'
 import CheckAssignmentPresenter from './checkAssignmentPresenter'
@@ -76,7 +76,8 @@ export default class ServiceProviderReferralsController {
 
   async showMyCasesDashboard(req: Request, res: Response): Promise<void> {
     const referralsSummary = await this.interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
-      res.locals.user.token.accessToken
+      res.locals.user.token.accessToken,
+      SPDashboardType.MyCases
     )
     const filteredSummary = referralsSummary.filter(summary => {
       return summary.assignedToUserName === res.locals.user.username && !summary.endOfServiceReportSubmitted
@@ -87,7 +88,8 @@ export default class ServiceProviderReferralsController {
 
   async showAllOpenCasesDashboard(req: Request, res: Response): Promise<void> {
     const referralsSummary = await this.interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
-      res.locals.user.token.accessToken
+      res.locals.user.token.accessToken,
+      SPDashboardType.OpenCases
     )
     const openReferrals = referralsSummary.filter(summary => {
       return !summary.endOfServiceReportSubmitted
@@ -97,7 +99,8 @@ export default class ServiceProviderReferralsController {
 
   async showUnassignedCasesDashboard(req: Request, res: Response): Promise<void> {
     const referralsSummary = await this.interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
-      res.locals.user.token.accessToken
+      res.locals.user.token.accessToken,
+      SPDashboardType.UnassignedCases
     )
     const unassignedReferrals = referralsSummary.filter(summary => {
       return !summary.assignedToUserName && !summary.endOfServiceReportSubmitted
@@ -107,7 +110,8 @@ export default class ServiceProviderReferralsController {
 
   async showCompletedCasesDashboard(req: Request, res: Response): Promise<void> {
     const referralsSummary = await this.interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
-      res.locals.user.token.accessToken
+      res.locals.user.token.accessToken,
+      SPDashboardType.CompletedCases
     )
     const completedReferrals = referralsSummary.filter(summary => {
       return summary.endOfServiceReportSubmitted === true

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -83,6 +83,13 @@ export interface GetSentReferralsFilterParams {
   assignedTo?: string
 }
 
+export enum SPDashboardType {
+  MyCases = 'myCases',
+  OpenCases = 'openCases',
+  UnassignedCases = 'unassignedCases',
+  CompletedCases = 'completedCases',
+}
+
 export type InterventionsServiceError = RestClientError
 
 export interface CreateCaseNoteParams {
@@ -238,12 +245,15 @@ export default class InterventionsService {
   }
 
   async getServiceProviderSentReferralsSummaryForUserToken(
-    token: string
+    token: string,
+    dashboardType?: SPDashboardType
   ): Promise<ServiceProviderSentReferralSummary[]> {
     const restClient = this.createRestClient(token)
+    const query = dashboardType ? { dashboardType: SPDashboardType[dashboardType] } : undefined
 
     return (await restClient.get({
       path: `/sent-referrals/summary/service-provider`,
+      query,
       headers: { Accept: 'application/json' },
     })) as ServiceProviderSentReferralSummary[]
   }


### PR DESCRIPTION
## What does this pull request do?

adds query parameters to the '/sent-referrals/summary/service-provider' call to interventions service which specify which dashboard type is being loaded. 

the filtering in the UI is left in tact to ensure full backwards compatability with the existing API (however the API implementation should essentially render these as noops)

## What is the intent behind these changes?

allow the UI to streamline queries for SP sent referral requests
