### PR TITLE
fix how we construct the query params for SP case lists

### DIFF
--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -249,8 +249,7 @@ export default class InterventionsService {
     dashboardType?: SPDashboardType
   ): Promise<ServiceProviderSentReferralSummary[]> {
     const restClient = this.createRestClient(token)
-    const query = dashboardType ? { dashboardType: SPDashboardType[dashboardType] } : undefined
-
+    const query = dashboardType ? { dashboardType } : undefined
     return (await restClient.get({
       path: `/sent-referrals/summary/service-provider`,
       query,


### PR DESCRIPTION
## What does this pull request do?

fix how we construct the query params for SP case lists

## What is the intent behind these changes?

the reverse mapping on the enum isn't required for string type enums. before this change the query params are always `undefined`
