### PR TITLE
[Hb65aVRv] Add new routes for new appointment endpoints for Delivery Sessions

### DIFF
--- a/integration_tests/integration/appointmentFeedback.spec.js
+++ b/integration_tests/integration/appointmentFeedback.spec.js
@@ -1,0 +1,307 @@
+import actionPlanFactory from '../../testutils/factories/actionPlan'
+import actionPlanAppointmentFactory from '../../testutils/factories/actionPlanAppointment'
+import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
+import deliusUserFactory from '../../testutils/factories/deliusUser'
+import hmppsAuthUserFactory from '../../testutils/factories/hmppsAuthUser'
+import interventionFactory from '../../testutils/factories/intervention'
+import sentReferralFactory from '../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
+import supplierAssessmentFactory from '../../testutils/factories/supplierAssessment'
+
+describe('Delivery session appointment feedback', () => {
+  const deliusServiceUser = deliusServiceUserFactory.build()
+  const probationPractitioner = deliusUserFactory.build({
+    firstName: 'John',
+    surname: 'Smith',
+    username: 'john.smith',
+  })
+
+  const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+  const intervention = interventionFactory.build({
+    contractType: { code: 'ACC', name: 'accommodation' },
+    serviceCategories: [serviceCategory],
+  })
+  const referralParams = {
+    id: 'f478448c-2e29-42c1-ac3d-78707df23e50',
+    referral: { interventionId: intervention.id, serviceCategoryIds: [serviceCategory.id] },
+  }
+  const serviceProvider = hmppsAuthUserFactory.build({
+    firstName: 'Case',
+    lastName: 'Worker',
+    username: 'case.worker',
+  })
+  const actionPlan = actionPlanFactory.submitted().build({
+    referralId: referralParams.id,
+    numberOfSessions: 4,
+  })
+  const assignedReferral = sentReferralFactory.assigned().build({
+    ...referralParams,
+    assignedTo: { username: serviceProvider.username },
+    actionPlanId: actionPlan.id,
+  })
+
+  const appointments = [
+    actionPlanAppointmentFactory.build({
+      sessionNumber: 1,
+      appointmentTime: '2021-03-24T09:02:02Z',
+      durationInMinutes: 75,
+      appointmentDeliveryType: 'PHONE_CALL',
+    }),
+    actionPlanAppointmentFactory.build({
+      sessionNumber: 2,
+      appointmentTime: '2021-03-31T09:02:02Z',
+      durationInMinutes: 75,
+      appointmentDeliveryType: 'PHONE_CALL',
+    }),
+  ]
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubLogin')
+    cy.task('stubServiceProviderToken')
+    cy.task('stubServiceProviderAuthUser')
+
+    cy.stubGetSentReferralsForUserToken([assignedReferral])
+    cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
+    cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+    cy.stubGetIntervention(intervention.id, intervention)
+    cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+    cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
+    cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
+    cy.stubGetAuthUserByUsername(serviceProvider.username, serviceProvider)
+    cy.stubGetDeliverySessionAppointment(assignedReferral.id, appointments[0].id, appointments[0])
+  })
+
+  describe('Adding feedback', () => {
+    it('user records the Service user as having attended, and fills out behaviour screen', () => {
+      cy.login()
+
+      cy.visit(
+        `/service-provider/referral/${assignedReferral.id}/session/${appointments[0].sessionNumber}/appointment/${appointments[0].id}/feedback/attendance`
+      )
+
+      cy.contains('Yes').click()
+      cy.contains("Add additional information about Alex's attendance").type('Alex attended the session')
+
+      const appointmentWithAttendanceRecorded = {
+        ...appointments[0],
+        sessionFeedback: {
+          attendance: {
+            attended: 'yes',
+            additionalAttendanceInformation: 'Alex attended the session',
+          },
+        },
+      }
+
+      cy.stubRecordDeliverySessionAppointmentAttendance(
+        assignedReferral.id,
+        appointments[0].id,
+        appointmentWithAttendanceRecorded
+      )
+
+      cy.contains('Save and continue').click()
+
+      cy.contains('Add behaviour feedback')
+
+      cy.contains("Describe Alex's behaviour in this session").type('Alex was well behaved')
+      cy.contains('No').click()
+
+      const appointmentWithBehaviourRecorded = {
+        ...appointmentWithAttendanceRecorded,
+        sessionFeedback: {
+          attendance: {
+            attended: 'yes',
+            additionalAttendanceInformation: 'Alex attended the session',
+          },
+          behaviour: {
+            behaviourDescription: 'Alex was well-behaved',
+            notifyProbationPractitioner: false,
+          },
+        },
+      }
+
+      cy.stubRecordDeliverySessionAppointmentBehaviour(
+        assignedReferral.id,
+        appointments[0].id,
+        appointmentWithBehaviourRecorded
+      )
+
+      cy.stubGetDeliverySessionAppointment(assignedReferral.id, appointments[0].id, appointmentWithBehaviourRecorded)
+
+      cy.contains('Save and continue').click()
+
+      cy.contains('Confirm feedback')
+      cy.contains('Alex attended the session')
+      cy.contains('Yes, they were on time')
+      cy.contains('Alex was well-behaved')
+      cy.contains('No')
+
+      // Required for checking the number of sessions on an action plan and displaying on confirmation screen
+      cy.stubGetActionPlan(actionPlan.id, actionPlan)
+      cy.stubGetActionPlanAppointment(actionPlan.id, 2, appointments[1])
+
+      const appointmentWithSubmittedFeedback = {
+        ...appointmentWithBehaviourRecorded,
+        sessionFeedback: {
+          attendance: {
+            attended: 'yes',
+            additionalAttendanceInformation: 'Alex attended the session',
+          },
+          behaviour: {
+            behaviourDescription: 'Alex was well-behaved',
+            notifyProbationPractitioner: false,
+          },
+          submitted: true,
+        },
+      }
+      cy.stubSubmitDeliverySessionFeedback(assignedReferral.id, appointments[0].id, appointmentWithSubmittedFeedback)
+
+      cy.get('form').contains('Confirm').click()
+
+      cy.contains('Session feedback added and submitted to the probation practitioner')
+      cy.contains('You can now deliver the next session scheduled for 31 March 2021.')
+
+      const updatedAppointments = [appointmentWithSubmittedFeedback, appointments[1]]
+      cy.stubGetActionPlanAppointments(actionPlan.id, updatedAppointments)
+
+      cy.contains('Return to service progress').click()
+
+      cy.get('[data-cy=session-table]')
+        .getTable()
+        .should('deep.equal', [
+          {
+            'Session details': 'Session 1',
+            'Date and time': '9:02am on 24 Mar 2021',
+            Status: 'completed',
+            Action: 'View feedback form',
+          },
+          {
+            'Session details': 'Session 2',
+            'Date and time': '10:02am on 31 Mar 2021',
+            Status: 'scheduled',
+            Action: 'Reschedule sessionGive feedback',
+          },
+        ])
+    })
+
+    it('user records the Service user as having not attended, and skips behaviour screen', () => {
+      cy.login()
+
+      cy.visit(
+        `/service-provider/referral/${assignedReferral.id}/session/${appointments[0].sessionNumber}/appointment/${appointments[0].id}/feedback/attendance`
+      )
+
+      cy.contains('No').click()
+      cy.contains("Add additional information about Alex's attendance").type("Alex didn't attend")
+
+      const appointmentWithAttendanceRecorded = {
+        ...appointments[0],
+        sessionFeedback: {
+          attendance: {
+            attended: 'no',
+            additionalAttendanceInformation: "Alex didn't attend",
+          },
+          behaviour: {
+            behaviourDescription: null,
+            notifyProbationPractitioner: null,
+          },
+        },
+      }
+      cy.stubRecordDeliverySessionAppointmentAttendance(
+        assignedReferral.id,
+        appointments[0].id,
+        appointmentWithAttendanceRecorded
+      )
+
+      cy.stubGetDeliverySessionAppointment(assignedReferral.id, appointments[0].id, appointmentWithAttendanceRecorded)
+
+      cy.contains('Save and continue').click()
+
+      cy.contains('Confirm feedback')
+      cy.contains('No')
+      cy.contains("Alex didn't attend")
+
+      const appointmentWithSubmittedFeedback = {
+        ...appointmentWithAttendanceRecorded,
+        sessionFeedback: {
+          attendance: {
+            attended: 'no',
+            additionalAttendanceInformation: "Alex didn't attend",
+          },
+          behaviour: {
+            behaviourDescription: null,
+            notifyProbationPractitioner: null,
+          },
+          submitted: true,
+        },
+      }
+      cy.stubSubmitDeliverySessionFeedback(assignedReferral.id, appointments[0].id, appointmentWithSubmittedFeedback)
+      // Required for checking the number of sessions on an action plan and displaying on confirmation screen
+      cy.stubGetActionPlan(actionPlan.id, actionPlan)
+      cy.stubGetActionPlanAppointment(actionPlan.id, 2, appointments[1])
+
+      cy.get('form').contains('Confirm').click()
+
+      cy.contains('Session feedback added and submitted to the probation practitioner')
+      cy.contains('You can now deliver the next session scheduled for 31 March 2021.')
+
+      const updatedAppointments = [appointmentWithSubmittedFeedback, appointments[1]]
+      cy.stubGetActionPlanAppointments(actionPlan.id, updatedAppointments)
+
+      cy.contains('Return to service progress').click()
+
+      cy.get('[data-cy=session-table]')
+        .getTable()
+        .should('deep.equal', [
+          {
+            'Session details': 'Session 1',
+            'Date and time': '9:02am on 24 Mar 2021',
+            Status: 'did not attend',
+            Action: 'View feedback form',
+          },
+          {
+            'Session details': 'Session 2',
+            'Date and time': '10:02am on 31 Mar 2021',
+            Status: 'scheduled',
+            Action: 'Reschedule sessionGive feedback',
+          },
+        ])
+    })
+  })
+
+  describe('Viewing feedback', () => {
+    it('allows users to click through to a page to view session feedback', () => {
+      cy.login()
+
+      const appointmentWithSubmittedFeedback = actionPlanAppointmentFactory.scheduled().build({
+        sessionNumber: 1,
+        sessionFeedback: {
+          attendance: {
+            attended: 'yes',
+            additionalAttendanceInformation: 'Alex attended the session',
+          },
+          behaviour: {
+            behaviourDescription: 'Alex was well-behaved',
+            notifyProbationPractitioner: false,
+          },
+          submitted: true,
+        },
+      })
+      cy.stubGetDeliverySessionAppointment(
+        assignedReferral.id,
+        appointmentWithSubmittedFeedback.id,
+        appointmentWithSubmittedFeedback
+      )
+
+      cy.visit(
+        `/service-provider/referral/${assignedReferral.id}/session/${appointmentWithSubmittedFeedback.sessionNumber}/appointment/${appointmentWithSubmittedFeedback.id}/feedback`
+      )
+      cy.contains('Intervention cancelled').should('not.exist')
+      cy.contains('Alex attended the session')
+      cy.contains('Yes, they were on time')
+      cy.contains('Alex was well-behaved')
+      cy.contains('No')
+    })
+  })
+})

--- a/integration_tests/integration/appointmentScheduling.spec.js
+++ b/integration_tests/integration/appointmentScheduling.spec.js
@@ -1,0 +1,305 @@
+import sentReferralFactory from '../../testutils/factories/sentReferral'
+import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
+import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
+import actionPlanAppointmentFactory from '../../testutils/factories/actionPlanAppointment'
+import interventionFactory from '../../testutils/factories/intervention'
+import supplierAssessmentFactory from '../../testutils/factories/supplierAssessment'
+
+describe('Scheduling appointments', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubLogin')
+    cy.task('stubServiceProviderToken')
+    cy.task('stubServiceProviderAuthUser')
+  })
+
+  describe('User schedules and views a delivery session appointment', () => {
+    const serviceCategory = serviceCategoryFactory.build()
+    const intervention = interventionFactory.build()
+    const referral = sentReferralFactory.build({
+      referral: { serviceCategoryIds: [serviceCategory.id], interventionId: intervention.id },
+    })
+    const appointment = actionPlanAppointmentFactory.newlyCreated().build({ referralId: referral.id, sessionNumber: 1 })
+    const deliusServiceUser = deliusServiceUserFactory.build()
+
+    beforeEach(() => {
+      cy.stubGetSentReferralsForUserToken([])
+      cy.stubGetServiceProviderSentReferralsSummaryForUserToken([])
+      cy.stubGetIntervention(intervention.id, intervention)
+      cy.stubGetDeliverySessionAppointment(referral.id, appointment.id, appointment)
+      cy.stubGetSentReferral(referral.id, referral)
+      cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
+      cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+      cy.stubGetSupplierAssessment(referral.id, supplierAssessmentFactory.build())
+      cy.login()
+    })
+
+    describe('with valid inputs', () => {
+      describe('when booking for an In-Person Meeting - Other Location', () => {
+        it.only('should present no errors and display scheduled appointment', () => {
+          cy.visit(`/service-provider/referral/${referral.id}/session/1/appointment/${appointment.id}/edit/start`)
+          cy.get('#date-day').type('24')
+          cy.get('#date-month').type('3')
+          cy.get('#date-year').type('2021')
+          cy.get('#time-hour').type('9')
+          cy.get('#time-minute').type('02')
+          cy.get('#time-part-of-day').select('AM')
+          cy.get('#duration-hours').type('1')
+          cy.get('#duration-minutes').type('15')
+          cy.contains('Group session').click()
+          cy.contains('In-person meeting - Other locations').click()
+          cy.get('#method-other-location-address-line-1').type('Harmony Living Office, Room 4')
+          cy.get('#method-other-location-address-line-2').type('44 Bouverie Road')
+          cy.get('#method-other-location-address-town-or-city').type('Blackpool')
+          cy.get('#method-other-location-address-county').type('Lancashire')
+          cy.get('#method-other-location-address-postcode').type('SY4 0RE')
+
+          const scheduledAppointment = actionPlanAppointmentFactory.build({
+            ...appointment,
+            appointmentTime: '2021-03-24T09:02:02Z',
+            durationInMinutes: 75,
+            sessionType: 'GROUP',
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+            appointmentDeliveryAddress: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY4 0RE',
+            },
+          })
+          cy.stubGetDeliverySessionAppointment(referral.id, appointment.id, scheduledAppointment)
+          cy.stubUpdateDeliverySessionAppointment(referral.id, appointment.id, scheduledAppointment)
+
+          cy.contains('Save and continue').click()
+
+          cy.get('h1').contains('Confirm session 1 details')
+          cy.contains('24 March 2021')
+          cy.contains('9:02am to 10:17am')
+          cy.contains('In-person meeting')
+          cy.contains('Harmony Living Office, Room 4')
+          cy.contains('44 Bouverie Road')
+          cy.contains('Blackpool')
+          cy.contains('Lancashire')
+          cy.contains('SY4 0RE')
+
+          cy.get('button').contains('Confirm').click()
+
+          cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
+
+          cy.visit(`/service-provider/referral/${referral.id}/session/1/appointment/${appointment.id}/edit/start`)
+
+          cy.get('#date-day').should('have.value', '24')
+          cy.get('#date-month').should('have.value', '3')
+          cy.get('#date-year').should('have.value', '2021')
+          cy.get('#time-hour').should('have.value', '9')
+          cy.get('#time-minute').should('have.value', '02')
+          // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
+          cy.get('#time-part-of-day').find('option:selected').should('have.text', 'AM')
+          cy.get('#duration-hours').should('have.value', '1')
+          cy.get('#duration-minutes').should('have.value', '15')
+          cy.contains('Group session').parent().find('input').should('be.checked')
+          cy.get('#method-other-location-address-line-1').should('have.value', 'Harmony Living Office, Room 4')
+          cy.get('#method-other-location-address-line-2').should('have.value', '44 Bouverie Road')
+          cy.get('#method-other-location-address-town-or-city').should('have.value', 'Blackpool')
+          cy.get('#method-other-location-address-county').should('have.value', 'Lancashire')
+          cy.get('#method-other-location-address-postcode').should('have.value', 'SY4 0RE')
+        })
+
+        describe('and their chosen date causes a clash of appointments', () => {
+          it('the user is able to amend their chosen date and re-submit', () => {
+            cy.visit(`/service-provider/referral/${referral.id}/session/1/appointment/${appointment.id}/edit/start`)
+            cy.get('#date-day').type('24')
+            cy.get('#date-month').type('3')
+            cy.get('#date-year').type('2021')
+            cy.get('#time-hour').type('9')
+            cy.get('#time-minute').type('02')
+            cy.get('#time-part-of-day').select('AM')
+            cy.get('#duration-hours').type('1')
+            cy.get('#duration-minutes').type('15')
+            cy.contains('Group session').click()
+            cy.contains('In-person meeting - Other locations').click()
+            cy.get('#method-other-location-address-line-1').type('Harmony Living Office, Room 4')
+            cy.get('#method-other-location-address-line-2').type('44 Bouverie Road')
+            cy.get('#method-other-location-address-town-or-city').type('Blackpool')
+            cy.get('#method-other-location-address-county').type('Lancashire')
+            cy.get('#method-other-location-address-postcode').type('SY4 0RE')
+
+            cy.contains('Save and continue').click()
+
+            cy.get('h1').contains('Confirm session 1 details')
+            cy.contains('24 March 2021')
+            cy.contains('9:02am to 10:17am')
+            cy.contains('In-person meeting')
+            cy.contains('Harmony Living Office, Room 4')
+            cy.contains('44 Bouverie Road')
+            cy.contains('Blackpool')
+            cy.contains('Lancashire')
+            cy.contains('SY4 0RE')
+
+            cy.stubUpdateDeliverySessionAppointmentClash(referral.id, appointment.id)
+
+            cy.get('button').contains('Confirm').click()
+
+            cy.contains('The proposed date and time you selected clashes with another appointment.')
+
+            cy.get('h1').contains('Add session 1 details')
+            cy.get('#date-day').should('have.value', '24')
+            cy.get('#date-month').should('have.value', '3')
+            cy.get('#date-year').should('have.value', '2021')
+            cy.get('#time-hour').should('have.value', '9')
+            cy.get('#time-minute').should('have.value', '02')
+            cy.get('#time-part-of-day').get('[selected]').should('have.text', 'AM')
+            cy.get('#duration-hours').should('have.value', '1')
+            cy.get('#duration-minutes').should('have.value', '15')
+            cy.get('#meeting-method-meeting-other').should('be.checked')
+            cy.get('#method-other-location-address-line-1').should('have.value', 'Harmony Living Office, Room 4')
+            cy.get('#method-other-location-address-line-2').should('have.value', '44 Bouverie Road')
+            cy.get('#method-other-location-address-town-or-city').should('have.value', 'Blackpool')
+            cy.get('#method-other-location-address-county').should('have.value', 'Lancashire')
+            cy.get('#method-other-location-address-postcode').should('have.value', 'SY4 0RE')
+
+            cy.get('#date-day').type('{selectall}{backspace}25')
+
+            cy.contains('Save and continue').click()
+
+            const scheduledAppointment = actionPlanAppointmentFactory.build({
+              ...appointment,
+              appointmentTime: '2021-03-25T09:02:02Z',
+              durationInMinutes: 75,
+              sessionType: 'GROUP',
+              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+              appointmentDeliveryAddress: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '44 Bouverie Road',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY4 0RE',
+              },
+            })
+            cy.stubGetDeliverySessionAppointment(referral.id, appointment.id, scheduledAppointment)
+            cy.stubUpdateDeliverySessionAppointment(referral.id, appointment.id, scheduledAppointment)
+
+            cy.get('h1').contains('Confirm session 1 details')
+            cy.get('button').contains('Confirm').click()
+
+            cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
+          })
+        })
+      })
+
+      describe('when booking for an In-Person Meeting - NPS Location', () => {
+        it('should present no errors and display scheduled appointment', () => {
+          cy.visit(`/service-provider/referral/${referral.id}/session/1/appointment/${appointment.id}/edit/start`)
+          cy.get('#date-day').type('24')
+          cy.get('#date-month').type('3')
+          cy.get('#date-year').type('2021')
+          cy.get('#time-hour').type('9')
+          cy.get('#time-minute').type('02')
+          cy.get('#time-part-of-day').select('AM')
+          cy.get('#duration-hours').type('1')
+          cy.get('#duration-minutes').type('15')
+          cy.contains('Group session').click()
+          cy.contains('In-person meeting - NPS offices').click()
+          cy.get('#delius-office-location-code').select('Blackpool: Blackpool Probation Office')
+
+          const scheduledAppointment = actionPlanAppointmentFactory.build({
+            ...appointment,
+            appointmentTime: '2021-03-24T09:02:02Z',
+            durationInMinutes: 75,
+            sessionType: 'GROUP',
+            appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
+            appointmentDeliveryAddress: null,
+            npsOfficeCode: 'CRS0105',
+          })
+          cy.stubGetDeliverySessionAppointment(referral.id, appointment.id, scheduledAppointment)
+          cy.stubUpdateDeliverySessionAppointment(referral.id, appointment.id, scheduledAppointment)
+
+          cy.contains('Save and continue').click()
+
+          cy.get('h1').contains('Confirm session 1 details')
+          cy.contains('24 March 2021')
+          cy.contains('9:02am to 10:17am')
+          cy.contains('In-person meeting (probation office)')
+
+          cy.get('button').contains('Confirm').click()
+
+          cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
+          // TODO: Add checks for NPS Office address on this page
+
+          cy.visit(`/service-provider/referral/${referral.id}/session/1/appointment/${appointment.id}/edit/start`)
+
+          cy.get('#date-day').should('have.value', '24')
+          cy.get('#date-month').should('have.value', '3')
+          cy.get('#date-year').should('have.value', '2021')
+          cy.get('#time-hour').should('have.value', '9')
+          cy.get('#time-minute').should('have.value', '02')
+          // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
+          cy.get('#time-part-of-day').find('option:selected').should('have.text', 'AM')
+          cy.get('#duration-hours').should('have.value', '1')
+          cy.get('#duration-minutes').should('have.value', '15')
+          cy.contains('Group session').parent().find('input').should('be.checked')
+          cy.get('#delius-office-location-code option:selected').should(
+            'have.text',
+            'Blackpool: Blackpool Probation Office'
+          )
+        })
+      })
+    })
+
+    describe('with invalid inputs', () => {
+      describe("when the user doesn't select a session type", () => {
+        it('should show an error', () => {
+          cy.visit(`/service-provider/referral/${referral.id}/session/1/appointment/${appointment.id}/edit/start`)
+          cy.get('#date-day').type('24')
+          cy.get('#date-month').type('3')
+          cy.get('#date-year').type('2021')
+          cy.get('#time-hour').type('9')
+          cy.get('#time-minute').type('02')
+          cy.get('#time-part-of-day').select('AM')
+          cy.get('#duration-hours').type('1')
+          cy.get('#duration-minutes').type('15')
+          cy.contains('In-person meeting').click()
+          cy.contains('Save and continue').click()
+          cy.contains('There is a problem').next().contains('Select the session type')
+        })
+      })
+
+      describe("when the user doesn't select meeting method", () => {
+        it('should show an error', () => {
+          cy.visit(`/service-provider/referral/${referral.id}/session/1/appointment/${appointment.id}/edit/start`)
+          cy.get('#date-day').type('24')
+          cy.get('#date-month').type('3')
+          cy.get('#date-year').type('2021')
+          cy.get('#time-hour').type('9')
+          cy.get('#time-minute').type('02')
+          cy.get('#time-part-of-day').select('AM')
+          cy.get('#duration-hours').type('1')
+          cy.get('#duration-minutes').type('15')
+          cy.contains('1:1').click()
+          cy.contains('Save and continue').click()
+          cy.contains('There is a problem').next().contains('Select a meeting method')
+        })
+      })
+
+      describe("when the user doesn't enter an address", () => {
+        it('should show an error', () => {
+          cy.visit(`/service-provider/referral/${referral.id}/session/1/appointment/${appointment.id}/edit/start`)
+          cy.get('#date-day').type('24')
+          cy.get('#date-month').type('3')
+          cy.get('#date-year').type('2021')
+          cy.get('#time-hour').type('9')
+          cy.get('#time-minute').type('02')
+          cy.get('#time-part-of-day').select('AM')
+          cy.get('#duration-hours').type('1')
+          cy.get('#duration-minutes').type('15')
+          cy.contains('1:1').click()
+          cy.contains('In-person meeting - Other locations').click()
+          cy.contains('Save and continue').click()
+          cy.contains('There is a problem').next().contains('Enter a value for address line 1')
+          cy.contains('There is a problem').next().contains('Enter a postcode')
+        })
+      })
+    })
+  })
+})

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -147,6 +147,15 @@ export default on => {
       return interventionsService.stubSubmitActionPlan(arg.id, arg.responseJson)
     },
 
+    stubRecordDeliverySessionAppointmentAttendance: arg => {
+      return interventionsService.stubRecordDeliverySessionAppointmentAttendance(
+        arg.referralId,
+        arg.appointmentId,
+        arg.responseJson
+      )
+    },
+
+    // Deprecated
     stubRecordActionPlanAppointmentAttendance: arg => {
       return interventionsService.stubRecordActionPlanAppointmentAttendance(
         arg.actionPlanId,
@@ -155,6 +164,15 @@ export default on => {
       )
     },
 
+    stubRecordDeliverySessionAppointmentBehaviour: arg => {
+      return interventionsService.stubRecordDeliverySessionAppointmentBehaviour(
+        arg.referralId,
+        arg.appointmentId,
+        arg.responseJson
+      )
+    },
+
+    // Deprecated
     stubRecordActionPlanAppointmentBehavior: arg => {
       return interventionsService.stubRecordActionPlanAppointmentBehavior(
         arg.actionPlanId,
@@ -163,22 +181,51 @@ export default on => {
       )
     },
 
+    stubGetDeliverySessionAppointments: arg => {
+      return interventionsService.stubGetDeliverySessionAppointments(arg.id, arg.responseJson)
+    },
+
+    // Deprecated
     stubGetActionPlanAppointments: arg => {
       return interventionsService.stubGetActionPlanAppointments(arg.id, arg.responseJson)
     },
 
+    stubGetDeliverySessionAppointment: arg => {
+      return interventionsService.stubGetDeliverySessionAppointment(arg.referralId, arg.appointmentId, arg.responseJson)
+    },
+
+    // Deprecated
     stubGetActionPlanAppointment: arg => {
       return interventionsService.stubGetActionPlanAppointment(arg.id, arg.session, arg.responseJson)
     },
 
+    stubUpdateDeliverySessionAppointment: arg => {
+      return interventionsService.stubUpdateDeliverySessionAppointment(
+        arg.referralId,
+        arg.appointmentId,
+        arg.responseJson
+      )
+    },
+
+    // Deprecated
     stubUpdateActionPlanAppointment: arg => {
       return interventionsService.stubUpdateActionPlanAppointment(arg.id, arg.session, arg.responseJson)
     },
 
+    stubUpdateDeliverySessionAppointmentClash: arg => {
+      return interventionsService.stubUpdateDeliverySessionAppointmentClash(arg.referralId, arg.appointmentId)
+    },
+
+    // Deprecated
     stubUpdateActionPlanAppointmentClash: arg => {
       return interventionsService.stubUpdateActionPlanAppointmentClash(arg.actionPlanId, arg.sessionNumber)
     },
 
+    stubSubmitDeliverySessionFeedback: arg => {
+      return interventionsService.stubSubmitDeliverySessionFeedback(arg.referralId, arg.appointmentId, arg.responseJson)
+    },
+
+    // Deprecated
     stubSubmitActionPlanSessionFeedback: arg => {
       return interventionsService.stubSubmitActionPlanSessionFeedback(arg.actionPlanId, arg.session, arg.responseJson)
     },

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -90,6 +90,34 @@ Cypress.Commands.add('stubSubmitActionPlan', (id, responseJson) => {
   cy.task('stubSubmitActionPlan', { id, responseJson })
 })
 
+Cypress.Commands.add('stubRecordDeliverySessionAppointmentAttendance', (referralId, appointmentId, responseJson) => {
+  cy.task('stubRecordDeliverySessionAppointmentAttendance', { referralId, appointmentId, responseJson })
+})
+
+Cypress.Commands.add('stubRecordDeliverySessionAppointmentBehaviour', (referralId, appointmentId, responseJson) => {
+  cy.task('stubRecordDeliverySessionAppointmentBehaviour', { referralId, appointmentId, responseJson })
+})
+
+Cypress.Commands.add('stubGetDeliverySessionAppointments', (id, responseJson) => {
+  cy.task('stubGetDeliverySessionAppointments', { id, responseJson })
+})
+
+Cypress.Commands.add('stubGetDeliverySessionAppointment', (referralId, appointmentId, responseJson) => {
+  cy.task('stubGetDeliverySessionAppointment', { referralId, appointmentId, responseJson })
+})
+
+Cypress.Commands.add('stubUpdateDeliverySessionAppointment', (referralId, appointmentId, responseJson) => {
+  cy.task('stubUpdateDeliverySessionAppointment', { referralId, appointmentId, responseJson })
+})
+
+Cypress.Commands.add('stubUpdateDeliverySessionAppointmentClash', (referralId, appointmentId) => {
+  cy.task('stubUpdateDeliverySessionAppointmentClash', { referralId, appointmentId })
+})
+
+Cypress.Commands.add('stubSubmitDeliverySessionFeedback', (referralId, appointmentId, responseJson) => {
+  cy.task('stubSubmitDeliverySessionFeedback', { referralId, appointmentId, responseJson })
+})
+
 Cypress.Commands.add('stubRecordActionPlanAppointmentAttendance', (actionPlanId, sessionNumber, responseJson) => {
   cy.task('stubRecordActionPlanAppointmentAttendance', { actionPlanId, sessionNumber, responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -367,6 +367,27 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubRecordDeliverySessionAppointmentAttendance = async (
+    referralId: string,
+    appointmentId: string,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}/record-attendance`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubRecordActionPlanAppointmentAttendance = async (
     actionPlanId: string,
     sessionNumber: string,
@@ -387,6 +408,27 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubRecordDeliverySessionAppointmentBehaviour = async (
+    referralId: string,
+    appointmentId: string,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}/record-behaviour`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubRecordActionPlanAppointmentBehavior = async (
     actionPlanId: string,
     sessionNumber: string,
@@ -407,6 +449,23 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubGetDeliverySessionAppointments = async (id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/referral/${id}/appointments`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubGetActionPlanAppointments = async (id: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
@@ -423,6 +482,27 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubGetDeliverySessionAppointment = async (
+    referralId: string,
+    appointmentId: number,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubGetActionPlanAppointment = async (id: string, session: number, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
@@ -439,6 +519,27 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubUpdateDeliverySessionAppointment = async (
+    referralId: string,
+    appointmentId: number,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubUpdateActionPlanAppointment = async (id: string, session: number, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
@@ -455,6 +556,23 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubUpdateDeliverySessionAppointmentClash = async (referralId: string, appointmentId: number): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      },
+      response: {
+        status: 409,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: {},
+      },
+    })
+  }
+
+  // Deprecated
   stubUpdateActionPlanAppointmentClash = async (actionPlanId: string, sessionNumber: number): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
@@ -471,6 +589,27 @@ export default class InterventionsServiceMocks {
     })
   }
 
+  stubSubmitDeliverySessionFeedback = async (
+    referralId: string,
+    appointmentId: string,
+    responseJson: unknown
+  ): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/delivery-session-appointment/${appointmentId}/submit`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+
+  // Deprecated
   stubSubmitActionPlanSessionFeedback = async (
     actionPlanId: string,
     session: number,

--- a/server/models/appointment.ts
+++ b/server/models/appointment.ts
@@ -8,6 +8,7 @@ export interface InitialAssessmentAppointment extends Appointment {
 }
 
 export interface ActionPlanAppointment extends Appointment {
+  id: string
   sessionNumber: number
 }
 

--- a/server/models/appointment.ts
+++ b/server/models/appointment.ts
@@ -8,11 +8,12 @@ export interface InitialAssessmentAppointment extends Appointment {
 }
 
 export interface ActionPlanAppointment extends Appointment {
+  // This id is the session id rather than delivery session appointment id
   id: string
   sessionNumber: number
 }
 
-interface Appointment extends AppointmentSchedulingDetails {
+export interface Appointment extends AppointmentSchedulingDetails {
   sessionFeedback: SessionFeedback
 }
 

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -1618,131 +1618,310 @@ describe('Adding supplier assessment feedback', () => {
 })
 
 describe('Adding post delivery session feedback', () => {
-  describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', () => {
-    it('renders a page with which the Service Provider can record the Service user‘s attendance', async () => {
-      const deliusServiceUser = deliusServiceUserFactory.build()
-      const referral = sentReferralFactory.assigned().build()
-      const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
-      const appointment = actionPlanAppointmentFactory.build({
-        appointmentTime: '2021-02-01T13:00:00Z',
-        durationInMinutes: 60,
-        appointmentDeliveryType: 'PHONE_CALL',
-      })
-
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-      interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-      interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
-
-      await request(app)
-        .get(
-          `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/attendance`
-        )
-        .expect(200)
-        .expect(res => {
-          expect(res.text).toContain('Add attendance feedback')
-          expect(res.text).toContain('Session details')
-          expect(res.text).toContain('1 February 2021')
-          expect(res.text).toContain('1:00pm to 2:00pm')
+  describe('Deprecated action plan routes', () => {
+    describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', () => {
+      it('renders a page with which the Service Provider can record the Service user‘s attendance', async () => {
+        const deliusServiceUser = deliusServiceUserFactory.build()
+        const referral = sentReferralFactory.assigned().build()
+        const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+        const appointment = actionPlanAppointmentFactory.build({
+          appointmentTime: '2021-02-01T13:00:00Z',
+          durationInMinutes: 60,
+          appointmentDeliveryType: 'PHONE_CALL',
         })
+
+        communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+        interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+        interventionsService.getSentReferral.mockResolvedValue(referral)
+        interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
+
+        await request(app)
+          .get(
+            `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/attendance`
+          )
+          .expect(200)
+          .expect(res => {
+            expect(res.text).toContain('Add attendance feedback')
+            expect(res.text).toContain('Session details')
+            expect(res.text).toContain('1 February 2021')
+            expect(res.text).toContain('1:00pm to 2:00pm')
+          })
+      })
     })
-  })
 
-  describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/attendance', () => {
-    it('renders a page with which the Service Provider can record the Service user‘s attendance', async () => {
-      const deliusServiceUser = deliusServiceUserFactory.build()
-      const referral = sentReferralFactory.assigned().build()
-      const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
-      const appointment = actionPlanAppointmentFactory.build({
-        appointmentTime: '2021-02-01T13:00:00Z',
-        durationInMinutes: 60,
-        appointmentDeliveryType: 'PHONE_CALL',
-      })
-
-      const draftAppointment: DraftAppointment = draftAppointmentFactory.build()
-
-      const draftAppointmentResult = draftAppointmentBookingFactory.build({
-        data: draftAppointment,
-      })
-      draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
-
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-      interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-      interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
-
-      await request(app)
-        .get(
-          `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/attendance`
-        )
-        .expect(200)
-        .expect(res => {
-          expect(res.text).toContain('Add attendance feedback')
-          expect(res.text).toContain('Session details')
-          expect(res.text).toContain('1 February 2021')
-          expect(res.text).toContain('1:00pm to 2:00pm')
+    describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/attendance', () => {
+      it('renders a page with which the Service Provider can record the Service user‘s attendance', async () => {
+        const deliusServiceUser = deliusServiceUserFactory.build()
+        const referral = sentReferralFactory.assigned().build()
+        const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+        const appointment = actionPlanAppointmentFactory.build({
+          appointmentTime: '2021-02-01T13:00:00Z',
+          durationInMinutes: 60,
+          appointmentDeliveryType: 'PHONE_CALL',
         })
-    })
-  })
 
-  describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', () => {
-    describe('when the Service Provider marks the Service user as having attended the session', () => {
-      it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the behaviour page', async () => {
+        const draftAppointment: DraftAppointment = draftAppointmentFactory.build()
+
+        const draftAppointmentResult = draftAppointmentBookingFactory.build({
+          data: draftAppointment,
+        })
+        draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
+
+        communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+        interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+        interventionsService.getSentReferral.mockResolvedValue(referral)
+        interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
+
+        await request(app)
+          .get(
+            `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/attendance`
+          )
+          .expect(200)
+          .expect(res => {
+            expect(res.text).toContain('Add attendance feedback')
+            expect(res.text).toContain('Session details')
+            expect(res.text).toContain('1 February 2021')
+            expect(res.text).toContain('1:00pm to 2:00pm')
+          })
+      })
+    })
+
+    describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', () => {
+      describe('when the Service Provider marks the Service user as having attended the session', () => {
+        it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the behaviour page', async () => {
+          const updatedAppointment = actionPlanAppointmentFactory.build({
+            sessionNumber: 1,
+            sessionFeedback: {
+              attendance: {
+                attended: 'yes',
+                additionalAttendanceInformation: 'Alex made the session on time',
+              },
+            },
+          })
+
+          const actionPlan = actionPlanFactory.build()
+
+          interventionsService.recordActionPlanAppointmentAttendance.mockResolvedValue(updatedAppointment)
+
+          await request(app)
+            .post(
+              `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/attendance`
+            )
+            .type('form')
+            .send({
+              attended: 'yes',
+              'additional-attendance-information': 'Alex made the session on time',
+            })
+            .expect(302)
+            .expect(
+              'Location',
+              `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/behaviour`
+            )
+        })
+      })
+
+      describe('when the Service Provider marks the Service user as not having attended the session', () => {
+        it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the check-your-answers page', async () => {
+          const updatedAppointment = actionPlanAppointmentFactory.build({
+            sessionNumber: 1,
+            sessionFeedback: {
+              attendance: {
+                attended: 'no',
+                additionalAttendanceInformation: "I haven't heard from Alex",
+              },
+            },
+          })
+
+          const actionPlan = actionPlanFactory.build()
+
+          interventionsService.recordActionPlanAppointmentAttendance.mockResolvedValue(updatedAppointment)
+
+          await request(app)
+            .post(
+              `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/attendance`
+            )
+            .type('form')
+            .send({
+              attended: 'no',
+              'additional-attendance-information': "I haven't heard from Alex",
+            })
+            .expect(302)
+            .expect(
+              'Location',
+              `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/check-your-answers`
+            )
+        })
+      })
+    })
+
+    describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/attendance', () => {
+      describe('when the Service Provider marks the Service user as having attended the session', () => {
+        it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the behaviour page', async () => {
+          const updatedAppointment = actionPlanAppointmentFactory.build({
+            sessionNumber: 1,
+            sessionFeedback: {
+              attendance: {
+                attended: 'yes',
+                additionalAttendanceInformation: 'Alex made the session on time',
+              },
+            },
+          })
+
+          const actionPlan = actionPlanFactory.build()
+          const draftAppointment: DraftAppointment = draftAppointmentFactory.withAttendanceFeedback().build()
+
+          const draftAppointmentResult = draftAppointmentBookingFactory.build({
+            data: draftAppointment,
+          })
+          draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
+
+          interventionsService.recordActionPlanAppointmentAttendance.mockResolvedValue(updatedAppointment)
+
+          await request(app)
+            .post(
+              `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/attendance`
+            )
+            .type('form')
+            .send({
+              attended: 'yes',
+              'additional-attendance-information': 'Alex made the session on time',
+            })
+            .expect(302)
+            .expect(
+              'Location',
+              `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/behaviour`
+            )
+        })
+      })
+
+      describe('when the Service Provider marks the Service user as not having attended the session', () => {
+        it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the check-your-answers page', async () => {
+          const updatedAppointment = actionPlanAppointmentFactory.build({
+            sessionNumber: 1,
+            sessionFeedback: {
+              attendance: {
+                attended: 'no',
+                additionalAttendanceInformation: "I haven't heard from Alex",
+              },
+            },
+          })
+
+          const actionPlan = actionPlanFactory.build()
+
+          const draftAppointment: DraftAppointment = draftAppointmentFactory
+            .withAttendanceFeedback('no', "I haven't heard from Alex")
+            .build()
+
+          const draftAppointmentResult = draftAppointmentBookingFactory.build({
+            data: draftAppointment,
+          })
+          draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
+
+          interventionsService.recordActionPlanAppointmentAttendance.mockResolvedValue(updatedAppointment)
+
+          await request(app)
+            .post(
+              `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/attendance`
+            )
+            .type('form')
+            .send({
+              attended: 'no',
+              'additional-attendance-information': "I haven't heard from Alex",
+            })
+            .expect(302)
+            .expect(
+              'Location',
+              `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/check-your-answers`
+            )
+        })
+      })
+    })
+
+    describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', () => {
+      it('renders a page with which the Service Provider can record the Service user‘s behaviour', async () => {
+        const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+        const deliusServiceUser = deliusServiceUserFactory.build()
+        const referral = sentReferralFactory.assigned().build()
+        const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+        const appointment = actionPlanAppointmentFactory.build({
+          appointmentTime: '2021-02-01T13:00:00Z',
+        })
+
+        communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+        interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+        interventionsService.getSentReferral.mockResolvedValue(referral)
+        interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+        interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
+
+        await request(app)
+          .get(
+            `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/behaviour`
+          )
+          .expect(200)
+          .expect(res => {
+            expect(res.text).toContain('Add behaviour feedback')
+          })
+      })
+    })
+
+    describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/behaviour', () => {
+      it('renders a page with which the Service Provider can record the Service user‘s behaviour', async () => {
+        const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+        const deliusServiceUser = deliusServiceUserFactory.build()
+        const referral = sentReferralFactory.assigned().build()
+        const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+        const appointment = actionPlanAppointmentFactory.build({
+          appointmentTime: '2021-02-01T13:00:00Z',
+        })
+
+        const draftAppointment: DraftAppointment = draftAppointmentFactory.withAttendanceFeedback().build()
+
+        const draftAppointmentResult = draftAppointmentBookingFactory.build({
+          data: draftAppointment,
+        })
+        draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
+
+        communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+        interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+        interventionsService.getSentReferral.mockResolvedValue(referral)
+        interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+        interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
+
+        await request(app)
+          .get(
+            `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/behaviour`
+          )
+          .expect(200)
+          .expect(res => {
+            expect(res.text).toContain('Add behaviour feedback')
+          })
+      })
+    })
+
+    describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', () => {
+      it('makes a request to the interventions service to record the Service user‘s behaviour and redirects to the check your answers page', async () => {
         const updatedAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 1,
           sessionFeedback: {
-            attendance: {
-              attended: 'yes',
-              additionalAttendanceInformation: 'Alex made the session on time',
+            behaviour: {
+              behaviourDescription: 'Alex was well-behaved',
+              notifyProbationPractitioner: false,
             },
           },
         })
 
         const actionPlan = actionPlanFactory.build()
 
-        interventionsService.recordActionPlanAppointmentAttendance.mockResolvedValue(updatedAppointment)
+        interventionsService.recordActionPlanAppointmentBehavior.mockResolvedValue(updatedAppointment)
 
         await request(app)
           .post(
-            `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/attendance`
-          )
-          .type('form')
-          .send({
-            attended: 'yes',
-            'additional-attendance-information': 'Alex made the session on time',
-          })
-          .expect(302)
-          .expect(
-            'Location',
             `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/behaviour`
           )
-      })
-    })
-
-    describe('when the Service Provider marks the Service user as not having attended the session', () => {
-      it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the check-your-answers page', async () => {
-        const updatedAppointment = actionPlanAppointmentFactory.build({
-          sessionNumber: 1,
-          sessionFeedback: {
-            attendance: {
-              attended: 'no',
-              additionalAttendanceInformation: "I haven't heard from Alex",
-            },
-          },
-        })
-
-        const actionPlan = actionPlanFactory.build()
-
-        interventionsService.recordActionPlanAppointmentAttendance.mockResolvedValue(updatedAppointment)
-
-        await request(app)
-          .post(
-            `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/attendance`
-          )
           .type('form')
           .send({
-            attended: 'no',
-            'additional-attendance-information': "I haven't heard from Alex",
+            'behaviour-description': 'Alex was well-behaved',
+            'notify-probation-practitioner': 'no',
           })
           .expect(302)
           .expect(
@@ -1751,81 +1930,36 @@ describe('Adding post delivery session feedback', () => {
           )
       })
     })
-  })
 
-  describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/attendance', () => {
-    describe('when the Service Provider marks the Service user as having attended the session', () => {
-      it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the behaviour page', async () => {
+    describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/behaviour', () => {
+      it('makes a request to the interventions service to record the Service user‘s behaviour and redirects to the check your answers page', async () => {
         const updatedAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 1,
           sessionFeedback: {
-            attendance: {
-              attended: 'yes',
-              additionalAttendanceInformation: 'Alex made the session on time',
+            behaviour: {
+              behaviourDescription: 'Alex was well-behaved',
+              notifyProbationPractitioner: false,
             },
           },
         })
-
         const actionPlan = actionPlanFactory.build()
-        const draftAppointment: DraftAppointment = draftAppointmentFactory.withAttendanceFeedback().build()
+        const draftAppointment: DraftAppointment = draftAppointmentFactory.withBehaviourFeedback().build()
 
         const draftAppointmentResult = draftAppointmentBookingFactory.build({
           data: draftAppointment,
         })
         draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
 
-        interventionsService.recordActionPlanAppointmentAttendance.mockResolvedValue(updatedAppointment)
+        interventionsService.recordActionPlanAppointmentBehavior.mockResolvedValue(updatedAppointment)
 
         await request(app)
           .post(
-            `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/attendance`
-          )
-          .type('form')
-          .send({
-            attended: 'yes',
-            'additional-attendance-information': 'Alex made the session on time',
-          })
-          .expect(302)
-          .expect(
-            'Location',
             `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/behaviour`
           )
-      })
-    })
-
-    describe('when the Service Provider marks the Service user as not having attended the session', () => {
-      it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the check-your-answers page', async () => {
-        const updatedAppointment = actionPlanAppointmentFactory.build({
-          sessionNumber: 1,
-          sessionFeedback: {
-            attendance: {
-              attended: 'no',
-              additionalAttendanceInformation: "I haven't heard from Alex",
-            },
-          },
-        })
-
-        const actionPlan = actionPlanFactory.build()
-
-        const draftAppointment: DraftAppointment = draftAppointmentFactory
-          .withAttendanceFeedback('no', "I haven't heard from Alex")
-          .build()
-
-        const draftAppointmentResult = draftAppointmentBookingFactory.build({
-          data: draftAppointment,
-        })
-        draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
-
-        interventionsService.recordActionPlanAppointmentAttendance.mockResolvedValue(updatedAppointment)
-
-        await request(app)
-          .post(
-            `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/attendance`
-          )
           .type('form')
           .send({
-            attended: 'no',
-            'additional-attendance-information': "I haven't heard from Alex",
+            'behaviour-description': 'Alex was well-behaved',
+            'notify-probation-practitioner': 'no',
           })
           .expect(302)
           .expect(
@@ -1834,519 +1968,390 @@ describe('Adding post delivery session feedback', () => {
           )
       })
     })
-  })
 
-  describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', () => {
-    it('renders a page with which the Service Provider can record the Service user‘s behaviour', async () => {
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-      const deliusServiceUser = deliusServiceUserFactory.build()
-      const referral = sentReferralFactory.assigned().build()
-      const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
-      const appointment = actionPlanAppointmentFactory.build({
-        appointmentTime: '2021-02-01T13:00:00Z',
-      })
-
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-      interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-      interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
-      interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
-
-      await request(app)
-        .get(
-          `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/behaviour`
-        )
-        .expect(200)
-        .expect(res => {
-          expect(res.text).toContain('Add behaviour feedback')
-        })
-    })
-  })
-
-  describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/behaviour', () => {
-    it('renders a page with which the Service Provider can record the Service user‘s behaviour', async () => {
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-      const deliusServiceUser = deliusServiceUserFactory.build()
-      const referral = sentReferralFactory.assigned().build()
-      const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
-      const appointment = actionPlanAppointmentFactory.build({
-        appointmentTime: '2021-02-01T13:00:00Z',
-      })
-
-      const draftAppointment: DraftAppointment = draftAppointmentFactory.withAttendanceFeedback().build()
-
-      const draftAppointmentResult = draftAppointmentBookingFactory.build({
-        data: draftAppointment,
-      })
-      draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
-
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-      interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-      interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
-      interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
-
-      await request(app)
-        .get(
-          `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/behaviour`
-        )
-        .expect(200)
-        .expect(res => {
-          expect(res.text).toContain('Add behaviour feedback')
-        })
-    })
-  })
-
-  describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', () => {
-    it('makes a request to the interventions service to record the Service user‘s behaviour and redirects to the check your answers page', async () => {
-      const updatedAppointment = actionPlanAppointmentFactory.build({
-        sessionNumber: 1,
-        sessionFeedback: {
-          behaviour: {
-            behaviourDescription: 'Alex was well-behaved',
-            notifyProbationPractitioner: false,
-          },
-        },
-      })
-
-      const actionPlan = actionPlanFactory.build()
-
-      interventionsService.recordActionPlanAppointmentBehavior.mockResolvedValue(updatedAppointment)
-
-      await request(app)
-        .post(
-          `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/behaviour`
-        )
-        .type('form')
-        .send({
-          'behaviour-description': 'Alex was well-behaved',
-          'notify-probation-practitioner': 'no',
-        })
-        .expect(302)
-        .expect(
-          'Location',
-          `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/check-your-answers`
-        )
-    })
-  })
-
-  describe('POST /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/behaviour', () => {
-    it('makes a request to the interventions service to record the Service user‘s behaviour and redirects to the check your answers page', async () => {
-      const updatedAppointment = actionPlanAppointmentFactory.build({
-        sessionNumber: 1,
-        sessionFeedback: {
-          behaviour: {
-            behaviourDescription: 'Alex was well-behaved',
-            notifyProbationPractitioner: false,
-          },
-        },
-      })
-      const actionPlan = actionPlanFactory.build()
-      const draftAppointment: DraftAppointment = draftAppointmentFactory.withBehaviourFeedback().build()
-
-      const draftAppointmentResult = draftAppointmentBookingFactory.build({
-        data: draftAppointment,
-      })
-      draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
-
-      interventionsService.recordActionPlanAppointmentBehavior.mockResolvedValue(updatedAppointment)
-
-      await request(app)
-        .post(
-          `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/behaviour`
-        )
-        .type('form')
-        .send({
-          'behaviour-description': 'Alex was well-behaved',
-          'notify-probation-practitioner': 'no',
-        })
-        .expect(302)
-        .expect(
-          'Location',
-          `/service-provider/action-plan/${actionPlan.id}/appointment/${updatedAppointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/check-your-answers`
-        )
-    })
-  })
-
-  describe('GET /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/check-your-answers', () => {
-    it('renders a page with answers the user has so far selected', async () => {
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-      const deliusServiceUser = deliusServiceUserFactory.build()
-      const referral = sentReferralFactory.assigned().build()
-      const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
-      const appointment = actionPlanAppointmentFactory.build({
-        appointmentTime: '2021-02-01T13:00:00Z',
-        durationInMinutes: 60,
-        appointmentDeliveryType: 'PHONE_CALL',
-      })
-
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-      interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-      interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
-      interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
-
-      await request(app)
-        .get(
-          `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/check-your-answers`
-        )
-        .expect(200)
-        .expect(res => {
-          expect(res.text).toContain('Confirm feedback')
-        })
-    })
-  })
-
-  describe('GET /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/check-your-answers', () => {
-    it('renders a page with answers the user has so far selected', async () => {
-      const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-      const deliusServiceUser = deliusServiceUserFactory.build()
-      const referral = sentReferralFactory.assigned().build()
-      const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
-      const appointment = actionPlanAppointmentFactory.build({
-        appointmentTime: '2021-02-01T13:00:00Z',
-        durationInMinutes: 60,
-        appointmentDeliveryType: 'PHONE_CALL',
-      })
-
-      const draftAppointment: DraftAppointment = draftAppointmentFactory.withBehaviourFeedback().build()
-
-      const draftAppointmentResult = draftAppointmentBookingFactory.build({
-        data: draftAppointment,
-      })
-      draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
-
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-      interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-      interventionsService.getSentReferral.mockResolvedValue(referral)
-      interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
-      interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
-
-      await request(app)
-        .get(
-          `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/check-your-answers`
-        )
-        .expect(200)
-        .expect(res => {
-          expect(res.text).toContain('Confirm feedback')
-        })
-    })
-  })
-
-  describe('POST /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/submit', () => {
-    it('marks the appointment as submitted and redirects to the confirmation page', async () => {
-      const actionPlanId = '91e7ceab-74fd-45d8-97c8-ec58844618dd'
-      const sessionNumber = 2
-
-      await request(app)
-        .post(`/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/submit`)
-        .expect(302)
-        .expect(
-          'Location',
-          `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/confirmation`
-        )
-
-      expect(interventionsService.submitActionPlanSessionFeedback).toHaveBeenCalledWith(
-        'token',
-        actionPlanId,
-        sessionNumber
-      )
-    })
-  })
-
-  describe('POST /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/submit', () => {
-    it('marks the appointment as submitted and redirects to the confirmation page', async () => {
-      const actionPlanId = '91e7ceab-74fd-45d8-97c8-ec58844618dd'
-      const sessionNumber = 2
-
-      const draftAppointment: DraftAppointment = draftAppointmentFactory.withSubmittedFeedback().build()
-
-      const draftAppointmentResult = draftAppointmentBookingFactory.build({
-        data: draftAppointment,
-      })
-      draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
-
-      await request(app)
-        .post(
-          `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/submit`
-        )
-        .expect(302)
-        .expect(
-          'Location',
-          `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/confirmation`
-        )
-
-      expect(interventionsService.recordAndSubmitActionPlanAppointmentWithFeedback).toHaveBeenCalledWith(
-        'token',
-        actionPlanId,
-        sessionNumber,
-        {
-          appointmentTime: draftAppointment!.appointmentTime,
-          durationInMinutes: draftAppointment!.durationInMinutes,
-          appointmentDeliveryType: draftAppointment!.appointmentDeliveryType,
-          sessionType: draftAppointment!.sessionType,
-          appointmentDeliveryAddress: draftAppointment!.appointmentDeliveryAddress,
-          npsOfficeCode: draftAppointment!.npsOfficeCode,
-          appointmentAttendance: { ...draftAppointment!.sessionFeedback!.attendance },
-          appointmentBehaviour: { ...draftAppointment!.sessionFeedback!.behaviour },
-        }
-      )
-    })
-  })
-
-  describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation', () => {
-    describe('when final appointment attendance has been recorded', () => {
-      it('renders a page confirming that the action plan has been submitted', async () => {
+    describe('GET /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/check-your-answers', () => {
+      it('renders a page with answers the user has so far selected', async () => {
+        const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+        const deliusServiceUser = deliusServiceUserFactory.build()
         const referral = sentReferralFactory.assigned().build()
-        const finalSessionNumber = 2
-        const submittedActionPlan = actionPlanFactory
-          .submitted()
-          .build({ referralId: referral.id, numberOfSessions: finalSessionNumber })
+        const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+        const appointment = actionPlanAppointmentFactory.build({
+          appointmentTime: '2021-02-01T13:00:00Z',
+          durationInMinutes: 60,
+          appointmentDeliveryType: 'PHONE_CALL',
+        })
 
+        communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
         interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-
-        const finalAppointment = actionPlanAppointmentFactory.build({ sessionNumber: finalSessionNumber })
-
-        interventionsService.getActionPlanAppointment.mockResolvedValue(finalAppointment)
-        interventionsService.getSubsequentActionPlanAppointment.mockResolvedValue(null)
-
-        interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+        interventionsService.getSentReferral.mockResolvedValue(referral)
+        interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+        interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
 
         await request(app)
           .get(
-            `/service-provider/action-plan/${submittedActionPlan.id}/appointment/2/post-session-feedback/confirmation`
+            `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/check-your-answers`
           )
           .expect(200)
           .expect(res => {
-            expect(res.text).toContain('Please submit the end of service report within 5 working days.')
+            expect(res.text).toContain('Confirm feedback')
           })
       })
     })
 
-    describe('when any non-final session has been recorded and more sessions are scheduled', () => {
-      it('renders a page confirming that the action plan has been submitted', async () => {
+    describe('GET /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/check-your-answers', () => {
+      it('renders a page with answers the user has so far selected', async () => {
+        const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+        const deliusServiceUser = deliusServiceUserFactory.build()
         const referral = sentReferralFactory.assigned().build()
-        const finalSessionNumber = 3
-        const submittedActionPlan = actionPlanFactory
-          .submitted()
-          .build({ referralId: referral.id, numberOfSessions: finalSessionNumber })
-
-        interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-
-        const penultimateAppointment = actionPlanAppointmentFactory.build({ sessionNumber: 2 })
-
-        const nextAppointment = actionPlanAppointmentFactory.build({
-          sessionNumber: finalSessionNumber,
-          appointmentTime: '2021-03-31T10:50:10.790Z',
+        const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+        const appointment = actionPlanAppointmentFactory.build({
+          appointmentTime: '2021-02-01T13:00:00Z',
+          durationInMinutes: 60,
+          appointmentDeliveryType: 'PHONE_CALL',
         })
 
-        interventionsService.getActionPlanAppointment.mockResolvedValue(penultimateAppointment)
-        interventionsService.getSubsequentActionPlanAppointment.mockResolvedValue(nextAppointment)
+        const draftAppointment: DraftAppointment = draftAppointmentFactory.withBehaviourFeedback().build()
 
-        interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+        const draftAppointmentResult = draftAppointmentBookingFactory.build({
+          data: draftAppointment,
+        })
+        draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
 
-        await request(app)
-          .get(
-            `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${penultimateAppointment.sessionNumber}/post-session-feedback/confirmation`
-          )
-          .expect(200)
-          .expect(res => {
-            expect(res.text).toContain('You can now deliver the next session scheduled for 31 March 2021.')
-          })
-      })
-    })
-
-    describe('when any non-final session has been recorded but no more sessions are scheduled', () => {
-      it('renders a page confirming that the action plan has been submitted', async () => {
-        const referral = sentReferralFactory.assigned().build()
-        const finalSessionNumber = 3
-        const submittedActionPlan = actionPlanFactory
-          .submitted()
-          .build({ referralId: referral.id, numberOfSessions: finalSessionNumber })
-
+        communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
         interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-
-        const penultimateAppointment = actionPlanAppointmentFactory.build({ sessionNumber: 2 })
-
-        interventionsService.getActionPlanAppointment.mockResolvedValue(penultimateAppointment)
-        interventionsService.getSubsequentActionPlanAppointment.mockResolvedValue(null)
-
-        interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+        interventionsService.getSentReferral.mockResolvedValue(referral)
+        interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+        interventionsService.getActionPlanAppointment.mockResolvedValue(appointment)
 
         await request(app)
           .get(
-            `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${penultimateAppointment.sessionNumber}/post-session-feedback/confirmation`
+            `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${appointment.sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/check-your-answers`
           )
           .expect(200)
           .expect(res => {
-            expect(res.text).toContain('The probation practitioner has been sent a copy of the session feedback form.')
+            expect(res.text).toContain('Confirm feedback')
           })
       })
     })
-  })
 
-  describe('Viewing post session feedback', () => {
-    describe('as an SP', () => {
-      describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', () => {
-        it('renders a page displaying feedback answers', async () => {
-          const actionPlanId = 'bdd50f63-efea-42b8-a1a4-cc3963d41223'
-          const referral = sentReferralFactory.assigned().build({ actionPlanId })
+    describe('POST /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/submit', () => {
+      it('marks the appointment as submitted and redirects to the confirmation page', async () => {
+        const actionPlanId = '91e7ceab-74fd-45d8-97c8-ec58844618dd'
+        const sessionNumber = 2
+
+        await request(app)
+          .post(
+            `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/submit`
+          )
+          .expect(302)
+          .expect(
+            'Location',
+            `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/confirmation`
+          )
+
+        expect(interventionsService.submitActionPlanSessionFeedback).toHaveBeenCalledWith(
+          'token',
+          actionPlanId,
+          sessionNumber
+        )
+      })
+    })
+
+    describe('POST /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/submit', () => {
+      it('marks the appointment as submitted and redirects to the confirmation page', async () => {
+        const actionPlanId = '91e7ceab-74fd-45d8-97c8-ec58844618dd'
+        const sessionNumber = 2
+
+        const draftAppointment: DraftAppointment = draftAppointmentFactory.withSubmittedFeedback().build()
+
+        const draftAppointmentResult = draftAppointmentBookingFactory.build({
+          data: draftAppointment,
+        })
+        draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
+
+        await request(app)
+          .post(
+            `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/submit`
+          )
+          .expect(302)
+          .expect(
+            'Location',
+            `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/confirmation`
+          )
+
+        expect(interventionsService.recordAndSubmitActionPlanAppointmentWithFeedback).toHaveBeenCalledWith(
+          'token',
+          actionPlanId,
+          sessionNumber,
+          {
+            appointmentTime: draftAppointment!.appointmentTime,
+            durationInMinutes: draftAppointment!.durationInMinutes,
+            appointmentDeliveryType: draftAppointment!.appointmentDeliveryType,
+            sessionType: draftAppointment!.sessionType,
+            appointmentDeliveryAddress: draftAppointment!.appointmentDeliveryAddress,
+            npsOfficeCode: draftAppointment!.npsOfficeCode,
+            appointmentAttendance: { ...draftAppointment!.sessionFeedback!.attendance },
+            appointmentBehaviour: { ...draftAppointment!.sessionFeedback!.behaviour },
+          }
+        )
+      })
+    })
+
+    describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation', () => {
+      describe('when final appointment attendance has been recorded', () => {
+        it('renders a page confirming that the action plan has been submitted', async () => {
+          const referral = sentReferralFactory.assigned().build()
+          const finalSessionNumber = 2
           const submittedActionPlan = actionPlanFactory
             .submitted()
-            .build({ referralId: referral.id, numberOfSessions: 1, id: actionPlanId })
-          const deliusServiceUser = deliusServiceUserFactory.build()
+            .build({ referralId: referral.id, numberOfSessions: finalSessionNumber })
 
-          const appointmentWithSubmittedFeedback = actionPlanAppointmentFactory.build({
-            appointmentTime: '2021-02-01T13:00:00Z',
-            durationInMinutes: 60,
-            appointmentDeliveryType: 'PHONE_CALL',
-            sessionNumber: 1,
-            sessionFeedback: {
-              attendance: {
-                attended: 'yes',
-                additionalAttendanceInformation: 'They were early to the session',
-              },
-              behaviour: {
-                behaviourDescription: 'Alex was well-behaved',
-                notifyProbationPractitioner: false,
-              },
-              submitted: true,
-            },
-          })
-
-          communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
           interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-          interventionsService.getSentReferral.mockResolvedValue(referral)
-          interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
 
-          await request(app)
-            .get(`/service-provider/action-plan/${submittedActionPlan.id}/appointment/1/post-session-feedback`)
-            .expect(200)
-            .expect(res => {
-              expect(res.text).toContain('View feedback')
-              expect(res.text).toContain('They were early to the session')
-              expect(res.text).toContain('Yes, they were on time')
-              expect(res.text).toContain('Alex was well-behaved')
-              expect(res.text).toContain('No')
-            })
-        })
-      })
-    })
+          const finalAppointment = actionPlanAppointmentFactory.build({ sessionNumber: finalSessionNumber })
 
-    describe('as a PP', () => {
-      describe('GET /probation-practitioner/referrals/:referralId/appointment/:sessionNumber/post-session-feedback', () => {
-        it('renders a page displaying feedback answers', async () => {
-          const actionPlanId = '05f39e99-b5c7-4a9b-a857-bec04a28eb34'
-          const referral = sentReferralFactory
-            .assigned()
-            .build({ actionPlanId, assignedTo: { username: 'Kay.Swerker' } })
-          const submittedActionPlan = actionPlanFactory
-            .submitted()
-            .build({ id: actionPlanId, referralId: referral.id, numberOfSessions: 1 })
-          const serviceUser = deliusServiceUserFactory.build()
+          interventionsService.getActionPlanAppointment.mockResolvedValue(finalAppointment)
+          interventionsService.getSubsequentActionPlanAppointment.mockResolvedValue(null)
 
-          const appointmentWithSubmittedFeedback = actionPlanAppointmentFactory.build({
-            appointmentTime: '2021-02-01T13:00:00Z',
-            durationInMinutes: 60,
-            appointmentDeliveryType: 'PHONE_CALL',
-            sessionNumber: 1,
-            sessionFeedback: {
-              attendance: {
-                attended: 'yes',
-                additionalAttendanceInformation: 'They were early to the session',
-              },
-              behaviour: {
-                behaviourDescription: 'Alex was well-behaved',
-                notifyProbationPractitioner: false,
-              },
-              submitted: true,
-            },
-          })
-
-          communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
-          interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-          interventionsService.getSentReferral.mockResolvedValue(referral)
-          interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
-          hmppsAuthService.getSPUserByUsername.mockResolvedValue(
-            hmppsAuthUserFactory.build({
-              firstName: 'caseworkerFirstName',
-              lastName: 'caseworkerLastName',
-              email: 'caseworker@email.com',
-            })
-          )
+          interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
 
           await request(app)
             .get(
-              `/probation-practitioner/referrals/${referral.id}/appointment/${appointmentWithSubmittedFeedback.sessionNumber}/post-session-feedback`
+              `/service-provider/action-plan/${submittedActionPlan.id}/appointment/2/post-session-feedback/confirmation`
             )
             .expect(200)
             .expect(res => {
-              expect(res.text).toContain('View feedback')
-              expect(res.text).toContain('caseworkerFirstName caseworkerLastName')
-              expect(res.text).toContain('caseworker@email.com')
-              expect(res.text).toContain('They were early to the session')
-              expect(res.text).toContain('Yes, they were on time')
-              expect(res.text).toContain('Alex was well-behaved')
-              expect(res.text).toContain('No')
+              expect(res.text).toContain('Please submit the end of service report within 5 working days.')
             })
         })
       })
 
-      // This is left to keep links in old emails still working - we'll monitor the endpoint and remove it when usage drops off.
-      describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', () => {
-        it('renders a page displaying feedback answers', async () => {
-          const actionPlanId = '05f39e99-b5c7-4a9b-a857-bec04a28eb34'
-          const referral = sentReferralFactory
-            .assigned()
-            .build({ actionPlanId, assignedTo: { username: 'Kay.Swerker' } })
+      describe('when any non-final session has been recorded and more sessions are scheduled', () => {
+        it('renders a page confirming that the action plan has been submitted', async () => {
+          const referral = sentReferralFactory.assigned().build()
+          const finalSessionNumber = 3
           const submittedActionPlan = actionPlanFactory
             .submitted()
-            .build({ id: actionPlanId, referralId: referral.id, numberOfSessions: 1 })
-          const serviceUser = deliusServiceUserFactory.build()
+            .build({ referralId: referral.id, numberOfSessions: finalSessionNumber })
 
-          const appointmentWithSubmittedFeedback = actionPlanAppointmentFactory.build({
-            appointmentTime: '2021-02-01T13:00:00Z',
-            durationInMinutes: 60,
-            appointmentDeliveryType: 'PHONE_CALL',
-            sessionNumber: 1,
-            sessionFeedback: {
-              attendance: {
-                attended: 'yes',
-                additionalAttendanceInformation: 'They were early to the session',
-              },
-              behaviour: {
-                behaviourDescription: 'Alex was well-behaved',
-                notifyProbationPractitioner: false,
-              },
-              submitted: true,
-            },
+          interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+
+          const penultimateAppointment = actionPlanAppointmentFactory.build({ sessionNumber: 2 })
+
+          const nextAppointment = actionPlanAppointmentFactory.build({
+            sessionNumber: finalSessionNumber,
+            appointmentTime: '2021-03-31T10:50:10.790Z',
           })
 
-          communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
-          interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
-          interventionsService.getSentReferral.mockResolvedValue(referral)
-          interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
-          hmppsAuthService.getSPUserByUsername.mockResolvedValue(
-            hmppsAuthUserFactory.build({
-              firstName: 'caseworkerFirstName',
-              lastName: 'caseworkerLastName',
-              email: 'caseworker@email.com',
-            })
-          )
+          interventionsService.getActionPlanAppointment.mockResolvedValue(penultimateAppointment)
+          interventionsService.getSubsequentActionPlanAppointment.mockResolvedValue(nextAppointment)
+
+          interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
 
           await request(app)
             .get(
-              `/probation-practitioner/action-plan/${actionPlanId}/appointment/${appointmentWithSubmittedFeedback.sessionNumber}/post-session-feedback`
+              `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${penultimateAppointment.sessionNumber}/post-session-feedback/confirmation`
             )
             .expect(200)
             .expect(res => {
-              expect(res.text).toContain('View feedback')
-              expect(res.text).toContain('caseworkerFirstName caseworkerLastName')
-              expect(res.text).toContain('They were early to the session')
-              expect(res.text).toContain('Yes, they were on time')
-              expect(res.text).toContain('Alex was well-behaved')
-              expect(res.text).toContain('No')
+              expect(res.text).toContain('You can now deliver the next session scheduled for 31 March 2021.')
             })
+        })
+      })
+
+      describe('when any non-final session has been recorded but no more sessions are scheduled', () => {
+        it('renders a page confirming that the action plan has been submitted', async () => {
+          const referral = sentReferralFactory.assigned().build()
+          const finalSessionNumber = 3
+          const submittedActionPlan = actionPlanFactory
+            .submitted()
+            .build({ referralId: referral.id, numberOfSessions: finalSessionNumber })
+
+          interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+
+          const penultimateAppointment = actionPlanAppointmentFactory.build({ sessionNumber: 2 })
+
+          interventionsService.getActionPlanAppointment.mockResolvedValue(penultimateAppointment)
+          interventionsService.getSubsequentActionPlanAppointment.mockResolvedValue(null)
+
+          interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+
+          await request(app)
+            .get(
+              `/service-provider/action-plan/${submittedActionPlan.id}/appointment/${penultimateAppointment.sessionNumber}/post-session-feedback/confirmation`
+            )
+            .expect(200)
+            .expect(res => {
+              expect(res.text).toContain(
+                'The probation practitioner has been sent a copy of the session feedback form.'
+              )
+            })
+        })
+      })
+    })
+
+    describe('Viewing post session feedback', () => {
+      describe('as an SP', () => {
+        describe('GET /service-provider/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', () => {
+          it('renders a page displaying feedback answers', async () => {
+            const actionPlanId = 'bdd50f63-efea-42b8-a1a4-cc3963d41223'
+            const referral = sentReferralFactory.assigned().build({ actionPlanId })
+            const submittedActionPlan = actionPlanFactory
+              .submitted()
+              .build({ referralId: referral.id, numberOfSessions: 1, id: actionPlanId })
+            const deliusServiceUser = deliusServiceUserFactory.build()
+
+            const appointmentWithSubmittedFeedback = actionPlanAppointmentFactory.build({
+              appointmentTime: '2021-02-01T13:00:00Z',
+              durationInMinutes: 60,
+              appointmentDeliveryType: 'PHONE_CALL',
+              sessionNumber: 1,
+              sessionFeedback: {
+                attendance: {
+                  attended: 'yes',
+                  additionalAttendanceInformation: 'They were early to the session',
+                },
+                behaviour: {
+                  behaviourDescription: 'Alex was well-behaved',
+                  notifyProbationPractitioner: false,
+                },
+                submitted: true,
+              },
+            })
+
+            communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
+            interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+            interventionsService.getSentReferral.mockResolvedValue(referral)
+            interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
+
+            await request(app)
+              .get(`/service-provider/action-plan/${submittedActionPlan.id}/appointment/1/post-session-feedback`)
+              .expect(200)
+              .expect(res => {
+                expect(res.text).toContain('View feedback')
+                expect(res.text).toContain('They were early to the session')
+                expect(res.text).toContain('Yes, they were on time')
+                expect(res.text).toContain('Alex was well-behaved')
+                expect(res.text).toContain('No')
+              })
+          })
+        })
+      })
+
+      describe('as a PP', () => {
+        describe('GET /probation-practitioner/referrals/:referralId/appointment/:sessionNumber/post-session-feedback', () => {
+          it('renders a page displaying feedback answers', async () => {
+            const actionPlanId = '05f39e99-b5c7-4a9b-a857-bec04a28eb34'
+            const referral = sentReferralFactory
+              .assigned()
+              .build({ actionPlanId, assignedTo: { username: 'Kay.Swerker' } })
+            const submittedActionPlan = actionPlanFactory
+              .submitted()
+              .build({ id: actionPlanId, referralId: referral.id, numberOfSessions: 1 })
+            const serviceUser = deliusServiceUserFactory.build()
+
+            const appointmentWithSubmittedFeedback = actionPlanAppointmentFactory.build({
+              appointmentTime: '2021-02-01T13:00:00Z',
+              durationInMinutes: 60,
+              appointmentDeliveryType: 'PHONE_CALL',
+              sessionNumber: 1,
+              sessionFeedback: {
+                attendance: {
+                  attended: 'yes',
+                  additionalAttendanceInformation: 'They were early to the session',
+                },
+                behaviour: {
+                  behaviourDescription: 'Alex was well-behaved',
+                  notifyProbationPractitioner: false,
+                },
+                submitted: true,
+              },
+            })
+
+            communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+            interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+            interventionsService.getSentReferral.mockResolvedValue(referral)
+            interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
+            hmppsAuthService.getSPUserByUsername.mockResolvedValue(
+              hmppsAuthUserFactory.build({
+                firstName: 'caseworkerFirstName',
+                lastName: 'caseworkerLastName',
+                email: 'caseworker@email.com',
+              })
+            )
+            await request(app)
+              .get(
+                `/probation-practitioner/referrals/${referral.id}/appointment/${appointmentWithSubmittedFeedback.sessionNumber}/post-session-feedback`
+              )
+              .expect(200)
+              .expect(res => {
+                expect(res.text).toContain('View feedback')
+                expect(res.text).toContain('caseworkerFirstName caseworkerLastName')
+                expect(res.text).toContain('caseworker@email.com')
+                expect(res.text).toContain('They were early to the session')
+                expect(res.text).toContain('Yes, they were on time')
+                expect(res.text).toContain('Alex was well-behaved')
+                expect(res.text).toContain('No')
+              })
+          })
+        })
+
+        // This is left to keep links in old emails still working - we'll monitor the endpoint and remove it when usage drops off.
+        describe('GET /probation-practitioner/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', () => {
+          it('renders a page displaying feedback answers', async () => {
+            const actionPlanId = '05f39e99-b5c7-4a9b-a857-bec04a28eb34'
+            const referral = sentReferralFactory
+              .assigned()
+              .build({ actionPlanId, assignedTo: { username: 'Kay.Swerker' } })
+            const submittedActionPlan = actionPlanFactory
+              .submitted()
+              .build({ id: actionPlanId, referralId: referral.id, numberOfSessions: 1 })
+            const serviceUser = deliusServiceUserFactory.build()
+
+            const appointmentWithSubmittedFeedback = actionPlanAppointmentFactory.build({
+              appointmentTime: '2021-02-01T13:00:00Z',
+              durationInMinutes: 60,
+              appointmentDeliveryType: 'PHONE_CALL',
+              sessionNumber: 1,
+              sessionFeedback: {
+                attendance: {
+                  attended: 'yes',
+                  additionalAttendanceInformation: 'They were early to the session',
+                },
+                behaviour: {
+                  behaviourDescription: 'Alex was well-behaved',
+                  notifyProbationPractitioner: false,
+                },
+                submitted: true,
+              },
+            })
+
+            communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
+            interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
+            interventionsService.getSentReferral.mockResolvedValue(referral)
+            interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
+            hmppsAuthService.getSPUserByUsername.mockResolvedValue(
+              hmppsAuthUserFactory.build({
+                firstName: 'caseworkerFirstName',
+                lastName: 'caseworkerLastName',
+                email: 'caseworker@email.com',
+              })
+            )
+
+            await request(app)
+              .get(
+                `/probation-practitioner/action-plan/${actionPlanId}/appointment/${appointmentWithSubmittedFeedback.sessionNumber}/post-session-feedback`
+              )
+              .expect(200)
+              .expect(res => {
+                expect(res.text).toContain('View feedback')
+                expect(res.text).toContain('caseworkerFirstName caseworkerLastName')
+                expect(res.text).toContain('They were early to the session')
+                expect(res.text).toContain('Yes, they were on time')
+                expect(res.text).toContain('Alex was well-behaved')
+                expect(res.text).toContain('No')
+              })
+          })
         })
       })
     })

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -779,7 +779,7 @@ describe('Scheduling a delivery session', () => {
         .expect(302)
         .expect('Location', `/service-provider/referrals/${referral.id}/progress`)
 
-      expect(interventionsService.updateDeliverySessionAppointment).toHaveBeenCalledWith(
+      expect(interventionsService.scheduleDeliverySessionAppointment).toHaveBeenCalledWith(
         'token',
         referral.id,
         updatedAppointment.id,
@@ -813,7 +813,7 @@ describe('Scheduling a delivery session', () => {
         const referral = sentReferralFactory.build()
 
         const error = { status: 409 }
-        interventionsService.updateDeliverySessionAppointment.mockRejectedValue(error)
+        interventionsService.scheduleDeliverySessionAppointment.mockRejectedValue(error)
 
         await request(app)
           .post(
@@ -847,7 +847,7 @@ describe('Scheduling a delivery session', () => {
         const referral = sentReferralFactory.build()
 
         const error = new Error('Failed to update appointment')
-        interventionsService.updateDeliverySessionAppointment.mockRejectedValue(error)
+        interventionsService.scheduleDeliverySessionAppointment.mockRejectedValue(error)
 
         await request(app)
           .post(

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -1835,11 +1835,12 @@ describe('Adding post delivery session feedback', () => {
   describe('GET /service-provider/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/feedback/confirmation', () => {
     describe('when final appointment attendance has been recorded', () => {
       it('renders a page confirming that the action plan has been submitted', async () => {
-        const referral = sentReferralFactory.assigned().build()
+        const actionPlanId = 'action-plan-id'
+        const referral = sentReferralFactory.assigned().build({ actionPlanId })
         const finalSessionNumber = 2
         const submittedActionPlan = actionPlanFactory
           .submitted()
-          .build({ referralId: referral.id, numberOfSessions: finalSessionNumber })
+          .build({ id: actionPlanId, referralId: referral.id, numberOfSessions: finalSessionNumber })
 
         interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
 
@@ -1848,7 +1849,7 @@ describe('Adding post delivery session feedback', () => {
         interventionsService.getDeliverySessionAppointment.mockResolvedValue(finalAppointment)
         interventionsService.getSubsequentActionPlanAppointment.mockResolvedValue(null)
 
-        interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+        interventionsService.getSentReferral.mockResolvedValue(referral)
 
         await request(app)
           .get(
@@ -1863,11 +1864,12 @@ describe('Adding post delivery session feedback', () => {
 
     describe('when any non-final session has been recorded and more sessions are scheduled', () => {
       it('renders a page confirming that the action plan has been submitted', async () => {
-        const referral = sentReferralFactory.assigned().build()
+        const actionPlanId = 'action-plan-id'
+        const referral = sentReferralFactory.assigned().build({ actionPlanId })
         const finalSessionNumber = 3
         const submittedActionPlan = actionPlanFactory
           .submitted()
-          .build({ referralId: referral.id, numberOfSessions: finalSessionNumber })
+          .build({ id: actionPlanId, referralId: referral.id, numberOfSessions: finalSessionNumber })
 
         interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
 
@@ -1881,7 +1883,7 @@ describe('Adding post delivery session feedback', () => {
         interventionsService.getDeliverySessionAppointment.mockResolvedValue(penultimateAppointment)
         interventionsService.getSubsequentActionPlanAppointment.mockResolvedValue(nextAppointment)
 
-        interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+        interventionsService.getSentReferral.mockResolvedValue(referral)
 
         await request(app)
           .get(
@@ -1896,11 +1898,12 @@ describe('Adding post delivery session feedback', () => {
 
     describe('when any non-final session has been recorded but no more sessions are scheduled', () => {
       it('renders a page confirming that the action plan has been submitted', async () => {
-        const referral = sentReferralFactory.assigned().build()
+        const actionPlanId = 'action-plan-id'
+        const referral = sentReferralFactory.assigned().build({ actionPlanId })
         const finalSessionNumber = 3
         const submittedActionPlan = actionPlanFactory
           .submitted()
-          .build({ referralId: referral.id, numberOfSessions: finalSessionNumber })
+          .build({ id: actionPlanId, referralId: referral.id, numberOfSessions: finalSessionNumber })
 
         interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
 
@@ -1909,7 +1912,7 @@ describe('Adding post delivery session feedback', () => {
         interventionsService.getDeliverySessionAppointment.mockResolvedValue(penultimateAppointment)
         interventionsService.getSubsequentActionPlanAppointment.mockResolvedValue(null)
 
-        interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
+        interventionsService.getSentReferral.mockResolvedValue(referral)
 
         await request(app)
           .get(

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -912,7 +912,10 @@ export default class AppointmentsController {
     const { referralId, appointmentId } = req.params
 
     const referral = await this.interventionsService.getSentReferral(accessToken, referralId)
-    const actionPlan = await this.interventionsService.getActionPlan(accessToken, referral.id)
+    if (referral.actionPlanId === null) {
+      throw new Error('Attempting to add feedback to a referral without an action plan')
+    }
+    const actionPlan = await this.interventionsService.getActionPlan(accessToken, referral.actionPlanId)
 
     const currentAppointment = await this.interventionsService.getDeliverySessionAppointment(
       accessToken,

--- a/server/routes/appointments/deliverySessions/deliverySessionSchedulingCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/deliverySessions/deliverySessionSchedulingCheckAnswersPresenter.test.ts
@@ -1,0 +1,57 @@
+import DeliverySessionSchedulingCheckAnswersPresenter from './deliverySessionSchedulingCheckAnswersPresenter'
+import { createDraftFactory } from '../../../../testutils/factories/draft'
+import { DraftAppointmentBooking } from '../../serviceProviderReferrals/draftAppointmentBooking'
+
+const draftBookingFactory = createDraftFactory<DraftAppointmentBooking>({
+  appointmentTime: '2021-03-24T09:02:00.000Z',
+  durationInMinutes: 75,
+  sessionType: 'ONE_TO_ONE',
+  appointmentDeliveryType: 'PHONE_CALL',
+  appointmentDeliveryAddress: null,
+  npsOfficeCode: null,
+})
+
+describe(DeliverySessionSchedulingCheckAnswersPresenter, () => {
+  describe('summary', () => {
+    it('returns a summary of the draft booking', () => {
+      const draft = draftBookingFactory.build()
+      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draft, '1', '1', 2)
+
+      expect(presenter.summary).toEqual([
+        { key: 'Date', lines: ['24 March 2021'] },
+        { key: 'Time', lines: ['9:02am to 10:17am'] },
+        { key: 'Method', lines: ['Phone call'] },
+      ])
+    })
+  })
+
+  describe('backLinkHref', () => {
+    it('returns the relative URL of the details page', () => {
+      const draft = draftBookingFactory.build()
+      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draft, '1', '1', 2)
+
+      expect(presenter.backLinkHref).toEqual(
+        `/service-provider/referral/1/session/2/appointment/1/edit/${draft.id}/details`
+      )
+    })
+  })
+
+  describe('formAction', () => {
+    it('returns the relative URL of the submit page', () => {
+      const draft = draftBookingFactory.build()
+      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draft, '1', '1', 2)
+
+      expect(presenter.formAction).toEqual(
+        `/service-provider/referral/1/session/2/appointment/1/edit/${draft.id}/submit`
+      )
+    })
+  })
+
+  describe('title', () => {
+    it('returns the page’s title', () => {
+      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draftBookingFactory.build(), '1', '1', 2)
+
+      expect(presenter.title).toEqual('Confirm session 2 details')
+    })
+  })
+})

--- a/server/routes/appointments/deliverySessions/deliverySessionSchedulingCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/deliverySessions/deliverySessionSchedulingCheckAnswersPresenter.test.ts
@@ -15,7 +15,7 @@ describe(DeliverySessionSchedulingCheckAnswersPresenter, () => {
   describe('summary', () => {
     it('returns a summary of the draft booking', () => {
       const draft = draftBookingFactory.build()
-      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draft, '1', '1', 2)
+      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draft, '1', '1', 2, 'reschedule-appointment')
 
       expect(presenter.summary).toEqual([
         { key: 'Date', lines: ['24 March 2021'] },
@@ -28,7 +28,7 @@ describe(DeliverySessionSchedulingCheckAnswersPresenter, () => {
   describe('backLinkHref', () => {
     it('returns the relative URL of the details page', () => {
       const draft = draftBookingFactory.build()
-      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draft, '1', '1', 2)
+      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draft, '1', '1', 2, 'reschedule-appointment')
 
       expect(presenter.backLinkHref).toEqual(
         `/service-provider/referral/1/session/2/appointment/1/edit/${draft.id}/details`
@@ -39,7 +39,7 @@ describe(DeliverySessionSchedulingCheckAnswersPresenter, () => {
   describe('formAction', () => {
     it('returns the relative URL of the submit page', () => {
       const draft = draftBookingFactory.build()
-      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draft, '1', '1', 2)
+      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draft, '1', '1', 2, 'reschedule-appointment')
 
       expect(presenter.formAction).toEqual(
         `/service-provider/referral/1/session/2/appointment/1/edit/${draft.id}/submit`
@@ -49,7 +49,13 @@ describe(DeliverySessionSchedulingCheckAnswersPresenter, () => {
 
   describe('title', () => {
     it('returns the page’s title', () => {
-      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(draftBookingFactory.build(), '1', '1', 2)
+      const presenter = new DeliverySessionSchedulingCheckAnswersPresenter(
+        draftBookingFactory.build(),
+        '1',
+        '1',
+        2,
+        'reschedule-appointment'
+      )
 
       expect(presenter.title).toEqual('Confirm session 2 details')
     })

--- a/server/routes/appointments/deliverySessions/deliverySessionSchedulingCheckAnswersPresenter.ts
+++ b/server/routes/appointments/deliverySessions/deliverySessionSchedulingCheckAnswersPresenter.ts
@@ -1,0 +1,26 @@
+import { Draft } from '../../../services/draftsService'
+import { DraftAppointmentBooking } from '../../serviceProviderReferrals/draftAppointmentBooking'
+import AppointmentSummary from '../appointmentSummary'
+
+export default class DeliverySessionSchedulingCheckAnswersPresenter {
+  constructor(
+    private readonly draft: Draft<DraftAppointmentBooking>,
+    private readonly referralId: string,
+    private readonly appointmentId: string,
+    private readonly sessionNumber: number
+  ) {}
+
+  readonly backLinkHref = `/service-provider/referral/${this.referralId}/session/${this.sessionNumber}/appointment/${this.appointmentId}/edit/${this.draft.id}/details`
+
+  readonly formAction = `/service-provider/referral/${this.referralId}/session/${this.sessionNumber}/appointment/${this.appointmentId}/edit/${this.draft.id}/submit`
+
+  readonly title = `Confirm session ${this.sessionNumber} details`
+
+  readonly summary = (() => {
+    if (this.draft.data === null) {
+      throw new Error('Draft has null data on check your answers page')
+    }
+
+    return new AppointmentSummary(this.draft.data, null).appointmentSummaryList
+  })()
+}

--- a/server/routes/appointments/deliverySessions/deliverySessionSchedulingCheckAnswersPresenter.ts
+++ b/server/routes/appointments/deliverySessions/deliverySessionSchedulingCheckAnswersPresenter.ts
@@ -6,15 +6,33 @@ export default class DeliverySessionSchedulingCheckAnswersPresenter {
   constructor(
     private readonly draft: Draft<DraftAppointmentBooking>,
     private readonly referralId: string,
-    private readonly appointmentId: string,
-    private readonly sessionNumber: number
+    private readonly appointmentId: string | undefined,
+    private readonly sessionNumber: number,
+    private readonly action: 'schedule-appointment' | 'reschedule-appointment'
   ) {}
 
-  readonly backLinkHref = `/service-provider/referral/${this.referralId}/session/${this.sessionNumber}/appointment/${this.appointmentId}/edit/${this.draft.id}/details`
+  get backLinkHref(): string {
+    if (this.action === 'reschedule-appointment') {
+      return `/service-provider/referral/${this.referralId}/session/${this.sessionNumber}/edit/${this.draft.id}/details`
+    }
+    return `/service-provider/referral/${this.referralId}/session/${this.sessionNumber}/appointment/${this.appointmentId}/edit/${this.draft.id}/details`
+  }
 
-  readonly formAction = `/service-provider/referral/${this.referralId}/session/${this.sessionNumber}/appointment/${this.appointmentId}/edit/${this.draft.id}/submit`
+  get formAction(): string {
+    if (this.action === 'reschedule-appointment') {
+      return `/service-provider/referral/${this.referralId}/session/${this.sessionNumber}/edit/${this.draft.id}/submit`
+    }
+    return `/service-provider/referral/${this.referralId}/session/${this.sessionNumber}/appointment/${this.appointmentId}/edit/${this.draft.id}/submit`
+  }
 
   readonly title = `Confirm session ${this.sessionNumber} details`
+
+  get pastAppointment(): boolean {
+    if (this.draft.data === null) {
+      throw new Error('Draft has null data on check your answers page')
+    }
+    return new Date(this.draft.data.appointmentTime!) < new Date()
+  }
 
   readonly summary = (() => {
     if (this.draft.data === null) {

--- a/server/routes/appointments/deliverySessions/feedback/deliverySessionBehaviourFeedbackPresenter.test.ts
+++ b/server/routes/appointments/deliverySessions/feedback/deliverySessionBehaviourFeedbackPresenter.test.ts
@@ -1,0 +1,17 @@
+import DeliverySessionBehaviourFeedbackPresenter from './deliverySessionBehaviourFeedbackPresenter'
+import actionPlanAppointmentFactory from '../../../../../testutils/factories/actionPlanAppointment'
+import deliusServiceUserFactory from '../../../../../testutils/factories/deliusServiceUser'
+
+describe(DeliverySessionBehaviourFeedbackPresenter, () => {
+  describe('backLinkHref', () => {
+    it('contains the link to the attendance page with the action plan id and session number', () => {
+      const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 2, id: 'appointment-id' })
+      const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
+      const presenter = new DeliverySessionBehaviourFeedbackPresenter(appointment, serviceUser, 'referral-id')
+
+      expect(presenter.backLinkHref).toEqual(
+        '/service-provider/referral/referral-id/session/2/appointment/appointment-id/feedback/attendance'
+      )
+    })
+  })
+})

--- a/server/routes/appointments/deliverySessions/feedback/deliverySessionBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/deliverySessions/feedback/deliverySessionBehaviourFeedbackPresenter.ts
@@ -1,0 +1,25 @@
+import { ActionPlanAppointment } from '../../../../models/appointment'
+import DeliusServiceUser from '../../../../models/delius/deliusServiceUser'
+import { FormValidationError } from '../../../../utils/formValidationError'
+import BehaviourFeedbackInputsPresenter from '../../feedback/shared/behaviour/behaviourFeedbackInputsPresenter'
+import BehaviourFeedbackQuestionnaire from '../../feedback/shared/behaviour/behaviourFeedbackQuestionnaire'
+
+export default class DeliverySessionBehaviourFeedbackPresenter {
+  constructor(
+    private readonly appointment: ActionPlanAppointment,
+    private readonly serviceUser: DeliusServiceUser,
+    private readonly referralId: string,
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  readonly text = {
+    title: `Add behaviour feedback`,
+  }
+
+  readonly questionnaire = new BehaviourFeedbackQuestionnaire(this.appointment, this.serviceUser)
+
+  readonly backLinkHref = `/service-provider/referral/${this.referralId}/session/${this.appointment.sessionNumber}/appointment/${this.appointment.id}/feedback/attendance`
+
+  readonly inputsPresenter = new BehaviourFeedbackInputsPresenter(this.appointment, this.error, this.userInputData)
+}

--- a/server/routes/appointments/deliverySessions/feedback/deliverySessionFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/deliverySessions/feedback/deliverySessionFeedbackCheckAnswersPresenter.test.ts
@@ -1,0 +1,90 @@
+import DeliverySessionFeedbackCheckAnswersPresenter from './deliverySessionFeedbackCheckAnswersPresenter'
+import actionPlanAppointmentFactory from '../../../../../testutils/factories/actionPlanAppointment'
+import deliusServiceUserFactory from '../../../../../testutils/factories/deliusServiceUser'
+import AppointmentSummary from '../../appointmentSummary'
+
+describe(DeliverySessionFeedbackCheckAnswersPresenter, () => {
+  describe('text', () => {
+    it('includes the title of the page', () => {
+      const appointment = actionPlanAppointmentFactory.build()
+      const serviceUser = deliusServiceUserFactory.build()
+      const referralId = 'f9d7c3fc-21e7-4b2e-b906-5a317b826642'
+
+      const presenter = new DeliverySessionFeedbackCheckAnswersPresenter(
+        appointment,
+        serviceUser,
+        referralId,
+        new AppointmentSummary(appointment)
+      )
+
+      expect(presenter.text).toMatchObject({
+        title: 'Confirm feedback',
+      })
+    })
+  })
+
+  describe('submitHref', () => {
+    it('includes the action plan id and session number', () => {
+      const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 1 })
+      const serviceUser = deliusServiceUserFactory.build()
+      const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
+
+      const presenter = new DeliverySessionFeedbackCheckAnswersPresenter(
+        appointment,
+        serviceUser,
+        referralId,
+        new AppointmentSummary(appointment)
+      )
+
+      expect(presenter.submitHref).toEqual(
+        `/service-provider/referral/${referralId}/session/${appointment.sessionNumber}/appointment/${appointment.id}/feedback/submit`
+      )
+    })
+  })
+
+  describe('backLinkHref', () => {
+    describe('when the appointment was attended', () => {
+      it('includes the referal id and link to the behaviour feedback page', () => {
+        const attendedAppointments = [
+          actionPlanAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'yes' } } }),
+          actionPlanAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'late' } } }),
+        ]
+
+        const serviceUser = deliusServiceUserFactory.build()
+        const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
+
+        attendedAppointments.forEach(appointment => {
+          const presenter = new DeliverySessionFeedbackCheckAnswersPresenter(
+            appointment,
+            serviceUser,
+            referralId,
+            new AppointmentSummary(appointment)
+          )
+
+          expect(presenter.backLinkHref).toEqual(
+            `/service-provider/referral/${referralId}/session/${appointment.sessionNumber}/appointment/${appointment.id}/feedback/behaviour`
+          )
+        })
+      })
+    })
+
+    describe('when the appointment was not attended', () => {
+      it('includes the referal id and link to the attendance feedback page', () => {
+        const appointment = actionPlanAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'no' } } })
+        const serviceUser = deliusServiceUserFactory.build()
+        const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
+
+        const presenter = new DeliverySessionFeedbackCheckAnswersPresenter(
+          appointment,
+          serviceUser,
+          referralId,
+          new AppointmentSummary(appointment)
+        )
+
+        expect(presenter.backLinkHref).toEqual(
+          `/service-provider/referral/${referralId}/session/${appointment.sessionNumber}/appointment/${appointment.id}/feedback/attendance`
+        )
+      })
+    })
+  })
+})

--- a/server/routes/appointments/deliverySessions/feedback/deliverySessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/deliverySessions/feedback/deliverySessionFeedbackCheckAnswersPresenter.ts
@@ -1,0 +1,26 @@
+import { ActionPlanAppointment } from '../../../../models/appointment'
+import DeliusServiceUser from '../../../../models/delius/deliusServiceUser'
+import AppointmentSummary from '../../appointmentSummary'
+import CheckFeedbackAnswersPresenter from '../../feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter'
+import FeedbackAnswersPresenter from '../../feedback/shared/viewFeedback/feedbackAnswersPresenter'
+
+export default class DeliverySessionFeedbackCheckAnswersPresenter extends CheckFeedbackAnswersPresenter {
+  readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
+
+  constructor(
+    private readonly deliverySessionAppointment: ActionPlanAppointment,
+    private readonly serviceUser: DeliusServiceUser,
+    private readonly referralId: string,
+    readonly appointmentSummary: AppointmentSummary
+  ) {
+    super(deliverySessionAppointment, appointmentSummary)
+    this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(deliverySessionAppointment, serviceUser)
+  }
+
+  readonly submitHref = `/service-provider/referral/${this.referralId}/session/${this.deliverySessionAppointment.sessionNumber}/appointment/${this.deliverySessionAppointment.id}/feedback/submit`
+
+  readonly backLinkHref =
+    this.deliverySessionAppointment.sessionFeedback.attendance.attended === 'no'
+      ? `/service-provider/referral/${this.referralId}/session/${this.deliverySessionAppointment.sessionNumber}/appointment/${this.deliverySessionAppointment.id}/feedback/attendance`
+      : `/service-provider/referral/${this.referralId}/session/${this.deliverySessionAppointment.sessionNumber}/appointment/${this.deliverySessionAppointment.id}/feedback/behaviour`
+}

--- a/server/routes/appointments/deliverySessions/scheduleDeliverySessionPresenter.test.ts
+++ b/server/routes/appointments/deliverySessions/scheduleDeliverySessionPresenter.test.ts
@@ -1,0 +1,24 @@
+import ScheduleDeliverySessionPresenter from './scheduleDeliverySessionPresenter'
+import actionPlanAppointmentFactory from '../../../../testutils/factories/actionPlanAppointment'
+import sentReferralFactory from '../../../../testutils/factories/sentReferral'
+import AppointmentSummary from '../appointmentSummary'
+
+describe(ScheduleDeliverySessionPresenter, () => {
+  const referral = sentReferralFactory.build()
+
+  // The rest of this class is tested in its superclass’s tests.
+
+  describe('text.title', () => {
+    it('contains the appointment number', () => {
+      const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 1 })
+      const presenter = new ScheduleDeliverySessionPresenter(
+        referral,
+        appointment,
+        new AppointmentSummary(appointment),
+        []
+      )
+
+      expect(presenter.text).toEqual({ title: 'Add session 1 details' })
+    })
+  })
+})

--- a/server/routes/appointments/deliverySessions/scheduleDeliverySessionPresenter.test.ts
+++ b/server/routes/appointments/deliverySessions/scheduleDeliverySessionPresenter.test.ts
@@ -15,7 +15,8 @@ describe(ScheduleDeliverySessionPresenter, () => {
         referral,
         appointment,
         new AppointmentSummary(appointment),
-        []
+        [],
+        '1'
       )
 
       expect(presenter.text).toEqual({ title: 'Add session 1 details' })

--- a/server/routes/appointments/deliverySessions/scheduleDeliverySessionPresenter.ts
+++ b/server/routes/appointments/deliverySessions/scheduleDeliverySessionPresenter.ts
@@ -1,0 +1,32 @@
+import { ActionPlanAppointment, AppointmentSchedulingDetails } from '../../../models/appointment'
+import DeliusOfficeLocation from '../../../models/deliusOfficeLocation'
+import SentReferral from '../../../models/sentReferral'
+import { FormValidationError } from '../../../utils/formValidationError'
+import ScheduleAppointmentPresenter from '../../serviceProviderReferrals/scheduleAppointmentPresenter'
+import AppointmentSummary from '../appointmentSummary'
+
+export default class ScheduleDeliverySessionPresenter extends ScheduleAppointmentPresenter {
+  constructor(
+    referral: SentReferral,
+    currentAppointment: ActionPlanAppointment,
+    currentAppointmentSummary: AppointmentSummary,
+    deliusOfficeLocations: DeliusOfficeLocation[],
+    validationError: FormValidationError | null = null,
+    draftSchedulingDetails: AppointmentSchedulingDetails | null = null,
+    userInputData: Record<string, unknown> | null = null,
+    serverError: FormValidationError | null = null
+  ) {
+    super(
+      'actionPlan',
+      referral,
+      currentAppointment,
+      currentAppointmentSummary,
+      deliusOfficeLocations,
+      validationError,
+      draftSchedulingDetails,
+      userInputData,
+      serverError
+    )
+    this.text.title = `Add session ${currentAppointment.sessionNumber} details`
+  }
+}

--- a/server/routes/appointments/deliverySessions/scheduleDeliverySessionPresenter.ts
+++ b/server/routes/appointments/deliverySessions/scheduleDeliverySessionPresenter.ts
@@ -1,4 +1,4 @@
-import { ActionPlanAppointment, AppointmentSchedulingDetails } from '../../../models/appointment'
+import { Appointment, AppointmentSchedulingDetails } from '../../../models/appointment'
 import DeliusOfficeLocation from '../../../models/deliusOfficeLocation'
 import SentReferral from '../../../models/sentReferral'
 import { FormValidationError } from '../../../utils/formValidationError'
@@ -8,9 +8,10 @@ import AppointmentSummary from '../appointmentSummary'
 export default class ScheduleDeliverySessionPresenter extends ScheduleAppointmentPresenter {
   constructor(
     referral: SentReferral,
-    currentAppointment: ActionPlanAppointment,
-    currentAppointmentSummary: AppointmentSummary,
+    currentAppointment: Appointment | null,
+    currentAppointmentSummary: AppointmentSummary | null,
     deliusOfficeLocations: DeliusOfficeLocation[],
+    sessionNumber: string,
     validationError: FormValidationError | null = null,
     draftSchedulingDetails: AppointmentSchedulingDetails | null = null,
     userInputData: Record<string, unknown> | null = null,
@@ -27,6 +28,6 @@ export default class ScheduleDeliverySessionPresenter extends ScheduleAppointmen
       userInputData,
       serverError
     )
-    this.text.title = `Add session ${currentAppointment.sessionNumber} details`
+    this.text.title = `Add session ${sessionNumber} details`
   }
 }

--- a/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.test.ts
@@ -11,7 +11,8 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
       const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
         appointment,
         serviceUser,
-        new AppointmentSummary(appointment)
+        new AppointmentSummary(appointment),
+        appointment.sessionNumber.toString()
       )
 
       expect(presenter.text).toMatchObject({
@@ -30,7 +31,8 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
           appointment,
           serviceUser,
-          new AppointmentSummary(appointment)
+          new AppointmentSummary(appointment),
+          appointment.sessionNumber.toString()
         )
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex join this phone call?')
       })
@@ -43,7 +45,8 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
           appointment,
           serviceUser,
-          new AppointmentSummary(appointment)
+          new AppointmentSummary(appointment),
+          appointment.sessionNumber.toString()
         )
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex join this video call?')
       })
@@ -56,7 +59,8 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
           appointment,
           serviceUser,
-          new AppointmentSummary(appointment)
+          new AppointmentSummary(appointment),
+          appointment.sessionNumber.toString()
         )
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex attend this in-person meeting?')
       })
@@ -71,7 +75,8 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
           appointment,
           serviceUser,
-          new AppointmentSummary(appointment)
+          new AppointmentSummary(appointment),
+          appointment.sessionNumber.toString()
         )
         expect(presenter.text.attendanceQuestion).toEqual('Did Alex attend this in-person meeting?')
       })
@@ -117,7 +122,8 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
         const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
           appointment,
           serviceUser,
-          new AppointmentSummary(appointment)
+          new AppointmentSummary(appointment),
+          appointment.sessionNumber.toString()
         )
         expect(presenter.backLinkHref).toEqual(null)
       })

--- a/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.ts
@@ -1,4 +1,4 @@
-import { ActionPlanAppointment } from '../../../../../models/appointment'
+import { Appointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import AttendanceFeedbackPresenter from '../../shared/attendance/attendanceFeedbackPresenter'
@@ -7,9 +7,10 @@ import AppointmentSummary from '../../../appointmentSummary'
 
 export default class ActionPlanPostSessionAttendanceFeedbackPresenter extends AttendanceFeedbackPresenter {
   constructor(
-    private readonly actionPlanAppointment: ActionPlanAppointment,
+    private readonly actionPlanAppointment: Appointment,
     private readonly serviceUser: DeliusServiceUser,
     readonly appointmentSummary: AppointmentSummary,
+    private readonly sessionNumber: string,
     private readonly referralId: string | null = null,
     private readonly actionPlanId: string | null = null,
     private readonly draftId: string | null = null,
@@ -32,8 +33,8 @@ export default class ActionPlanPostSessionAttendanceFeedbackPresenter extends At
   }
 
   get getBackLinkHref(): string | null {
-    if (this.actionPlanId && this.actionPlanAppointment.sessionNumber && this.draftId) {
-      return `/service-provider/action-plan/${this.actionPlanId}/sessions/${this.actionPlanAppointment.sessionNumber}/edit/${this.draftId}/check-answers`
+    if (this.actionPlanId && this.draftId) {
+      return `/service-provider/action-plan/${this.actionPlanId}/sessions/${this.sessionNumber}/edit/${this.draftId}/check-answers`
     }
     if (this.referralId) {
       return `/service-provider/referrals/${this.referralId}/progress`

--- a/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.test.ts
@@ -11,6 +11,7 @@ describe(ActionPlanSessionBehaviourFeedbackPresenter, () => {
         const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(
           appointment,
           serviceUser,
+          appointment.sessionNumber.toString(),
           'action-plan-id',
           null,
           null,
@@ -39,7 +40,12 @@ describe(ActionPlanSessionBehaviourFeedbackPresenter, () => {
       it('contains the link to the attendance page with the action plan id and session number', () => {
         const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 2 })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-        const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointment, serviceUser, null)
+        const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(
+          appointment,
+          serviceUser,
+          appointment.sessionNumber.toString(),
+          null
+        )
 
         expect(presenter.backLinkHref).toBeNull()
       })

--- a/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.ts
@@ -1,4 +1,4 @@
-import { ActionPlanAppointment } from '../../../../../models/appointment'
+import { Appointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import BehaviourFeedbackInputsPresenter from '../../shared/behaviour/behaviourFeedbackInputsPresenter'
@@ -6,8 +6,9 @@ import BehaviourFeedbackQuestionnaire from '../../shared/behaviour/behaviourFeed
 
 export default class ActionPlanSessionBehaviourFeedbackPresenter {
   constructor(
-    private readonly appointment: ActionPlanAppointment,
+    private readonly appointment: Appointment,
     private readonly serviceUser: DeliusServiceUser,
+    private readonly sessionNumber: string,
     private readonly actionPlanId: string | null = null,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null,
@@ -21,11 +22,11 @@ export default class ActionPlanSessionBehaviourFeedbackPresenter {
   readonly questionnaire = new BehaviourFeedbackQuestionnaire(this.appointment, this.serviceUser)
 
   get backLinkHref(): string | null {
-    if (this.actionPlanId && this.appointment.sessionNumber) {
+    if (this.actionPlanId) {
       if (this.draftId) {
-        return `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.appointment.sessionNumber}/post-session-feedback/edit/${this.draftId}/attendance`
+        return `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.sessionNumber}/post-session-feedback/edit/${this.draftId}/attendance`
       }
-      return `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.appointment.sessionNumber}/post-session-feedback/attendance`
+      return `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.sessionNumber}/post-session-feedback/attendance`
     }
     return null
   }

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/ActionPlanPostSessionFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/ActionPlanPostSessionFeedbackCheckAnswersPresenter.test.ts
@@ -14,6 +14,7 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
         appointment,
         serviceUser,
         actionPlanId,
+        appointment.sessionNumber.toString(),
         new AppointmentSummary(appointment)
       )
 
@@ -34,6 +35,7 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
           appointment,
           serviceUser,
           actionPlanId,
+          appointment.sessionNumber.toString(),
           new AppointmentSummary(appointment),
           'draftId'
         )
@@ -54,6 +56,7 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
           appointment,
           serviceUser,
           actionPlanId,
+          appointment.sessionNumber.toString(),
           new AppointmentSummary(appointment)
         )
 
@@ -81,6 +84,7 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
               appointment,
               serviceUser,
               referralId,
+              appointment.sessionNumber.toString(),
               new AppointmentSummary(appointment),
               'draftId'
             )
@@ -104,6 +108,7 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
             appointment,
             serviceUser,
             referralId,
+            appointment.sessionNumber.toString(),
             new AppointmentSummary(appointment),
             'draftId'
           )
@@ -130,6 +135,7 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
               appointment,
               serviceUser,
               referralId,
+              appointment.sessionNumber.toString(),
               new AppointmentSummary(appointment)
             )
 
@@ -152,6 +158,7 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
             appointment,
             serviceUser,
             referralId,
+            appointment.sessionNumber.toString(),
             new AppointmentSummary(appointment)
           )
 

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
@@ -1,4 +1,4 @@
-import { ActionPlanAppointment } from '../../../../../models/appointment'
+import { Appointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import CheckFeedbackAnswersPresenter from '../../shared/checkYourAnswers/checkFeedbackAnswersPresenter'
 import FeedbackAnswersPresenter from '../../shared/viewFeedback/feedbackAnswersPresenter'
@@ -8,9 +8,10 @@ export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends 
   readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
 
   constructor(
-    private readonly actionPlanAppointment: ActionPlanAppointment,
+    private readonly actionPlanAppointment: Appointment,
     private readonly serviceUser: DeliusServiceUser,
     private readonly actionPlanId: string,
+    private readonly sessionNumber: string,
     readonly appointmentSummary: AppointmentSummary,
     private readonly draftId: string | undefined = undefined
   ) {
@@ -19,17 +20,17 @@ export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends 
   }
 
   readonly submitHref = this.draftId
-    ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/edit/${this.draftId}/submit`
-    : `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/submit`
+    ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.sessionNumber}/post-session-feedback/edit/${this.draftId}/submit`
+    : `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.sessionNumber}/post-session-feedback/submit`
 
   get backLinkHref(): string {
     if (this.draftId) {
       return this.actionPlanAppointment.sessionFeedback.attendance.attended === 'no'
-        ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/edit/${this.draftId}/attendance`
-        : `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/edit/${this.draftId}/behaviour`
+        ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.sessionNumber}/post-session-feedback/edit/${this.draftId}/attendance`
+        : `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.sessionNumber}/post-session-feedback/edit/${this.draftId}/behaviour`
     }
     return this.actionPlanAppointment.sessionFeedback.attendance.attended === 'no'
-      ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/attendance`
-      : `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/behaviour`
+      ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.sessionNumber}/post-session-feedback/attendance`
+      : `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.sessionNumber}/post-session-feedback/behaviour`
   }
 }

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
@@ -1,6 +1,6 @@
 import PresenterUtils from '../../../../../utils/presenterUtils'
 import { FormValidationError } from '../../../../../utils/formValidationError'
-import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
+import { Appointment } from '../../../../../models/appointment'
 import AttendanceFeedbackQuestionnaire from './attendanceFeedbackQuestionnaire'
 import AppointmentSummary from '../../../appointmentSummary'
 
@@ -16,7 +16,7 @@ export default abstract class AttendanceFeedbackPresenter {
   readonly text: AttendanceFeedbackFormText
 
   protected constructor(
-    private readonly appointment: ActionPlanAppointment | InitialAssessmentAppointment,
+    private readonly appointment: Appointment,
     private readonly title: string,
     private readonly subTitle: string,
     private readonly attendanceFeedbackQuestionnaire: AttendanceFeedbackQuestionnaire,

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.ts
@@ -1,14 +1,11 @@
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
-import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
+import { Appointment } from '../../../../../models/appointment'
 import AppointmentDecorator from '../../../../../decorators/appointmentDecorator'
 
 export default class AttendanceFeedbackQuestionnaire {
   private readonly appointmentDecorator: AppointmentDecorator
 
-  constructor(
-    private appointment: InitialAssessmentAppointment | ActionPlanAppointment,
-    private serviceUser: DeliusServiceUser
-  ) {
+  constructor(private appointment: Appointment, private serviceUser: DeliusServiceUser) {
     this.appointmentDecorator = new AppointmentDecorator(appointment)
   }
 

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.ts
@@ -1,10 +1,10 @@
-import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
+import { Appointment } from '../../../../../models/appointment'
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import PresenterUtils from '../../../../../utils/presenterUtils'
 
 export default class BehaviourFeedbackInputsPresenter {
   constructor(
-    private readonly appointment: ActionPlanAppointment | InitialAssessmentAppointment,
+    private readonly appointment: Appointment,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackQuestionnaire.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackQuestionnaire.ts
@@ -1,14 +1,11 @@
 import AppointmentDecorator from '../../../../../decorators/appointmentDecorator'
-import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
+import { Appointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 
 export default class BehaviourFeedbackQuestionnaire {
   private readonly appointmentDecorator: AppointmentDecorator
 
-  constructor(
-    private appointment: InitialAssessmentAppointment | ActionPlanAppointment,
-    private serviceUser: DeliusServiceUser
-  ) {
+  constructor(private appointment: Appointment, private serviceUser: DeliusServiceUser) {
     this.appointmentDecorator = new AppointmentDecorator(appointment)
   }
 

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.ts
@@ -1,12 +1,9 @@
-import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
+import { Appointment } from '../../../../../models/appointment'
 import FeedbackAnswersPresenter from '../viewFeedback/feedbackAnswersPresenter'
 import AppointmentSummary from '../../../appointmentSummary'
 
 export default abstract class CheckFeedbackAnswersPresenter {
-  protected constructor(
-    protected appointment: ActionPlanAppointment | InitialAssessmentAppointment,
-    readonly appointmentSummary: AppointmentSummary
-  ) {}
+  protected constructor(protected appointment: Appointment, readonly appointmentSummary: AppointmentSummary) {}
 
   abstract readonly submitHref: string
 

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
@@ -1,4 +1,4 @@
-import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
+import { Appointment } from '../../../../../models/appointment'
 import AttendanceFeedbackQuestionnaire from '../attendance/attendanceFeedbackQuestionnaire'
 import BehaviourFeedbackQuestionnaire from '../behaviour/behaviourFeedbackQuestionnaire'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
@@ -8,10 +8,7 @@ export default class FeedbackAnswersPresenter {
 
   private readonly behaviourFeedbackQuestionnaire: BehaviourFeedbackQuestionnaire
 
-  constructor(
-    private readonly appointment: ActionPlanAppointment | InitialAssessmentAppointment,
-    private readonly serviceUser: DeliusServiceUser
-  ) {
+  constructor(private readonly appointment: Appointment, private readonly serviceUser: DeliusServiceUser) {
     this.attendanceFeedbackQuestionnaire = new AttendanceFeedbackQuestionnaire(appointment, serviceUser)
     this.behaviourFeedbackQuestionnaire = new BehaviourFeedbackQuestionnaire(appointment, serviceUser)
   }

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentCheckAnswersView.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentCheckAnswersView.ts
@@ -1,6 +1,6 @@
 import { BackLinkArgs, NotificationBannerArgs, SummaryListArgs } from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
-import DeliverySessionCheckAnswersPresenter from '../appointments/deliverySessions/deliverySessionCheckAnswersPresenter'
+import DeliverySessionSchedulingCheckAnswersPresenter from '../appointments/deliverySessions/deliverySessionSchedulingCheckAnswersPresenter'
 import ActionPlanSessionCheckAnswersPresenter from './actionPlanSessionCheckAnswersPresenter'
 import InitialAssessmentCheckAnswersPresenter from './initialAssessmentCheckAnswersPresenter'
 
@@ -9,7 +9,7 @@ export default class ScheduleAppointmentCheckAnswersView {
     private readonly presenter:
       | InitialAssessmentCheckAnswersPresenter
       | ActionPlanSessionCheckAnswersPresenter // deprecated
-      | DeliverySessionCheckAnswersPresenter
+      | DeliverySessionSchedulingCheckAnswersPresenter
   ) {}
 
   get renderArgs(): [string, Record<string, unknown>] {

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentCheckAnswersView.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentCheckAnswersView.ts
@@ -1,11 +1,15 @@
 import { BackLinkArgs, NotificationBannerArgs, SummaryListArgs } from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
+import DeliverySessionCheckAnswersPresenter from '../appointments/deliverySessions/deliverySessionCheckAnswersPresenter'
 import ActionPlanSessionCheckAnswersPresenter from './actionPlanSessionCheckAnswersPresenter'
 import InitialAssessmentCheckAnswersPresenter from './initialAssessmentCheckAnswersPresenter'
 
 export default class ScheduleAppointmentCheckAnswersView {
   constructor(
-    private readonly presenter: InitialAssessmentCheckAnswersPresenter | ActionPlanSessionCheckAnswersPresenter
+    private readonly presenter:
+      | InitialAssessmentCheckAnswersPresenter
+      | ActionPlanSessionCheckAnswersPresenter // deprecated
+      | DeliverySessionCheckAnswersPresenter
   ) {}
 
   get renderArgs(): [string, Record<string, unknown>] {

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -1,9 +1,5 @@
 import PresenterUtils from '../../utils/presenterUtils'
-import {
-  ActionPlanAppointment,
-  AppointmentSchedulingDetails,
-  InitialAssessmentAppointment,
-} from '../../models/appointment'
+import { Appointment, AppointmentSchedulingDetails } from '../../models/appointment'
 import { FormValidationError } from '../../utils/formValidationError'
 import AppointmentDecorator from '../../decorators/appointmentDecorator'
 import SentReferral from '../../models/sentReferral'
@@ -15,7 +11,7 @@ export default class ScheduleAppointmentPresenter {
   constructor(
     private readonly formType: 'supplierAssessment' | 'actionPlan',
     private readonly referral: SentReferral,
-    private readonly currentAppointment: InitialAssessmentAppointment | ActionPlanAppointment | null,
+    private readonly currentAppointment: Appointment | null,
     private readonly currentAppointmentSummary: AppointmentSummary | null,
     private readonly deliusOfficeLocations: DeliusOfficeLocation[],
     private readonly validationError: FormValidationError | null = null,

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -75,14 +75,29 @@ export default function serviceProviderRoutes(router: Router, services: Services
   post(router, '/action-plan/:id/number-of-sessions', (req, res) =>
     serviceProviderReferralsController.addNumberOfSessionsToActionPlan(req, res)
   )
+  get(router, '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/start', (req, res) =>
+    appointmentsController.startEditingDeliverySessionAppointment(req, res)
+  )
+  get(
+    router,
+    '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/:draftBookingId/details',
+    (req, res) => appointmentsController.editDeliverySessionAppointment(req, res)
+  )
+  post(
+    router,
+    '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/:draftBookingId/details',
+    (req, res) => appointmentsController.editDeliverySessionAppointment(req, res)
+  )
 
-  // START delivery session appointment scheduling
+  // Deprecated
   get(router, '/action-plan/:id/sessions/:sessionNumber/edit/start', (req, res) =>
     appointmentsController.startEditingActionPlanSessionAppointment(req, res)
   )
+  // Deprecated
   get(router, '/action-plan/:id/sessions/:sessionNumber/edit/:draftBookingId/details', (req, res) =>
     appointmentsController.editActionPlanSessionAppointment(req, res)
   )
+  // Deprecated
   post(router, '/action-plan/:id/sessions/:sessionNumber/edit/:draftBookingId/details', (req, res) =>
     appointmentsController.editActionPlanSessionAppointment(req, res)
   )

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -88,6 +88,16 @@ export default function serviceProviderRoutes(router: Router, services: Services
     '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/:draftBookingId/details',
     (req, res) => appointmentsController.editDeliverySessionAppointment(req, res)
   )
+  get(
+    router,
+    '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/:draftBookingId/check-answers',
+    (req, res) => appointmentsController.checkDeliverySessionAppointmentAnswers(req, res)
+  )
+  post(
+    router,
+    '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/:draftBookingId/submit',
+    (req, res) => appointmentsController.submitDeliverySessionAppointment(req, res)
+  )
 
   // Deprecated
   get(router, '/action-plan/:id/sessions/:sessionNumber/edit/start', (req, res) =>
@@ -101,14 +111,14 @@ export default function serviceProviderRoutes(router: Router, services: Services
   post(router, '/action-plan/:id/sessions/:sessionNumber/edit/:draftBookingId/details', (req, res) =>
     appointmentsController.editActionPlanSessionAppointment(req, res)
   )
+  // Deprecated
   get(router, '/action-plan/:id/sessions/:sessionNumber/edit/:draftBookingId/check-answers', (req, res) =>
     appointmentsController.checkActionPlanSessionAppointmentAnswers(req, res)
   )
+  // Deprecated
   post(router, '/action-plan/:id/sessions/:sessionNumber/edit/:draftBookingId/submit', (req, res) =>
     appointmentsController.submitActionPlanSessionAppointment(req, res)
   )
-
-  // START delivery session appointment feedback
   get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', (req, res) =>
     appointmentsController.addPostSessionAttendanceFeedback(req, res)
   )

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -119,6 +119,46 @@ export default function serviceProviderRoutes(router: Router, services: Services
   post(router, '/action-plan/:id/sessions/:sessionNumber/edit/:draftBookingId/submit', (req, res) =>
     appointmentsController.submitActionPlanSessionAppointment(req, res)
   )
+
+  get(
+    router,
+    '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/feedback/attendance',
+    (req, res) => appointmentsController.addDeliverySessionAttendanceFeedback(req, res)
+  )
+  post(
+    router,
+    '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/feedback/attendance',
+    (req, res) => appointmentsController.addDeliverySessionAttendanceFeedback(req, res)
+  )
+  get(
+    router,
+    '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/feedback/behaviour',
+    (req, res) => appointmentsController.addDeliverySessionBehaviourFeedback(req, res)
+  )
+  post(
+    router,
+    '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/feedback/behaviour',
+    (req, res) => appointmentsController.addDeliverySessionBehaviourFeedback(req, res)
+  )
+
+  get(
+    router,
+    '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/feedback/check-your-answers',
+    (req, res) => appointmentsController.checkDeliverySessionFeedbackAnswers(req, res)
+  )
+  post(router, '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/feedback/submit', (req, res) =>
+    appointmentsController.submitDeliverySessionFeedback(req, res)
+  )
+  get(
+    router,
+    '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/feedback/confirmation',
+    (req, res) => appointmentsController.showDeliverySessionFeedbackConfirmation(req, res)
+  )
+  get(router, '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/feedback', (req, res) =>
+    appointmentsController.viewSubmittedDeliverySessionAppointmentFeedback(req, res)
+  )
+
+  // Deprecated
   get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', (req, res) =>
     appointmentsController.addPostSessionAttendanceFeedback(req, res)
   )
@@ -140,6 +180,7 @@ export default function serviceProviderRoutes(router: Router, services: Services
   get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', (req, res) =>
     appointmentsController.addPostSessionBehaviourFeedback(req, res)
   )
+  // Deprecated
   post(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', (req, res) =>
     appointmentsController.addPostSessionBehaviourFeedback(req, res)
   )
@@ -175,6 +216,7 @@ export default function serviceProviderRoutes(router: Router, services: Services
   get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation', (req, res) =>
     appointmentsController.showPostSessionFeedbackConfirmation(req, res)
   )
+  // Deprecated
   get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback', (req, res) =>
     appointmentsController.viewSubmittedPostSessionFeedback(req, res, 'service-provider')
   )

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -75,29 +75,50 @@ export default function serviceProviderRoutes(router: Router, services: Services
   post(router, '/action-plan/:id/number-of-sessions', (req, res) =>
     serviceProviderReferralsController.addNumberOfSessionsToActionPlan(req, res)
   )
+
+  // Scheduling a new delivery session appointment START
+  get(router, '/referral/:referralId/session/:sessionNumber/edit/start', (req, res) =>
+    appointmentsController.startEditingDeliverySessionAppointment(req, res, 'schedule-appointment')
+  )
+  get(router, '/referral/:referralId/session/:sessionNumber/edit/:draftBookingId/details', (req, res) =>
+    appointmentsController.editDeliverySessionAppointment(req, res, 'schedule-appointment')
+  )
+  post(router, '/referral/:referralId/session/:sessionNumber/edit/:draftBookingId/details', (req, res) =>
+    appointmentsController.editDeliverySessionAppointment(req, res, 'schedule-appointment')
+  )
+  get(router, '/referral/:referralId/session/:sessionNumber/edit/:draftBookingId/check-answers', (req, res) =>
+    appointmentsController.checkDeliverySessionAppointmentAnswers(req, res, 'schedule-appointment')
+  )
+  post(router, '/referral/:referralId/session/:sessionNumber/edit/:draftBookingId/submit', (req, res) =>
+    appointmentsController.submitDeliverySessionAppointment(req, res, 'schedule-appointment')
+  )
+  // Scheduling a new delivery session appointment END
+
+  // Rescheduling a delivery session appointment START
   get(router, '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/start', (req, res) =>
-    appointmentsController.startEditingDeliverySessionAppointment(req, res)
+    appointmentsController.startEditingDeliverySessionAppointment(req, res, 'reschedule-appointment')
   )
   get(
     router,
     '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/:draftBookingId/details',
-    (req, res) => appointmentsController.editDeliverySessionAppointment(req, res)
+    (req, res) => appointmentsController.editDeliverySessionAppointment(req, res, 'reschedule-appointment')
   )
   post(
     router,
     '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/:draftBookingId/details',
-    (req, res) => appointmentsController.editDeliverySessionAppointment(req, res)
+    (req, res) => appointmentsController.editDeliverySessionAppointment(req, res, 'reschedule-appointment')
   )
   get(
     router,
     '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/:draftBookingId/check-answers',
-    (req, res) => appointmentsController.checkDeliverySessionAppointmentAnswers(req, res)
+    (req, res) => appointmentsController.checkDeliverySessionAppointmentAnswers(req, res, 'reschedule-appointment')
   )
   post(
     router,
     '/referral/:referralId/session/:sessionNumber/appointment/:appointmentId/edit/:draftBookingId/submit',
-    (req, res) => appointmentsController.submitDeliverySessionAppointment(req, res)
+    (req, res) => appointmentsController.submitDeliverySessionAppointment(req, res, 'reschedule-appointment')
   )
+  // Scheduling a new delivery session appointment END
 
   // Deprecated
   get(router, '/action-plan/:id/sessions/:sessionNumber/edit/start', (req, res) =>

--- a/server/services/deliusOfficeLocationFilter.ts
+++ b/server/services/deliusOfficeLocationFilter.ts
@@ -1,7 +1,7 @@
 import ReferenceDataService from './referenceDataService'
 import DeliusOfficeLocation from '../models/deliusOfficeLocation'
 import Intervention from '../models/intervention'
-import { ActionPlanAppointment, InitialAssessmentAppointment } from '../models/appointment'
+import { Appointment } from '../models/appointment'
 
 export default class DeliusOfficeLocationFilter {
   constructor(private referenceDataService: ReferenceDataService) {}
@@ -15,9 +15,7 @@ export default class DeliusOfficeLocationFilter {
     return this.findOfficesByNpsRegionIds(npsRegionIds)
   }
 
-  async findOfficeByAppointment(
-    appointment: InitialAssessmentAppointment | ActionPlanAppointment
-  ): Promise<DeliusOfficeLocation | null> {
+  async findOfficeByAppointment(appointment: Appointment): Promise<DeliusOfficeLocation | null> {
     if (appointment.npsOfficeCode === null) {
       return null
     }

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2727,6 +2727,53 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('getDeliverySessionAppointment', () => {
+    const deliverySessionAppointment = actionPlanAppointmentFactory.build({
+      id: '915fd66f-9d74-4e22-8b85-38972b36f6cf',
+      sessionNumber: 1,
+      appointmentTime: '2021-05-13T12:30:00Z',
+      durationInMinutes: 120,
+      sessionType: 'ONE_TO_ONE',
+      appointmentDeliveryType: 'PHONE_CALL',
+    })
+
+    const referralId = '8d107952-9bde-4854-ad1e-dee09daab992'
+
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: `a referral with ID ${referralId} exists and it has an appointment with ID ${deliverySessionAppointment.id}`,
+        uponReceiving: `a GET request for the appointment the appointment with ID ${deliverySessionAppointment.id}`,
+        withRequest: {
+          method: 'GET',
+          path: `/referral/${referralId}/delivery-session-appointment/${deliverySessionAppointment.id}`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(deliverySessionAppointment),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns the requested action plan appointment', async () => {
+      const appointment = await interventionsService.getDeliverySessionAppointment(
+        probationPractitionerToken,
+        referralId,
+        deliverySessionAppointment.id
+      )
+      expect(appointment.id).toEqual('915fd66f-9d74-4e22-8b85-38972b36f6cf')
+      expect(appointment.sessionNumber).toEqual(1)
+      expect(appointment.appointmentTime).toEqual('2021-05-13T12:30:00Z')
+      expect(appointment.durationInMinutes).toEqual(120)
+      expect(appointment.sessionType).toEqual('ONE_TO_ONE')
+      expect(appointment.appointmentDeliveryType).toEqual('PHONE_CALL')
+    })
+  })
+
+  // Deprecated
   describe('getActionPlanAppointment', () => {
     const actionPlanAppointment = actionPlanAppointmentFactory.build({
       sessionNumber: 1,

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2862,6 +2862,84 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('updateDeliverySessionAppointment', () => {
+    const referralId = '8d107952-9bde-4854-ad1e-dee09daab992'
+
+    describe('with non-null values', () => {
+      it('returns an updated delivery session appointment', async () => {
+        const deliverySessionAppointment = actionPlanAppointmentFactory.build({
+          sessionNumber: 2,
+          appointmentTime: '2021-05-13T12:30:00Z',
+          durationInMinutes: 60,
+          sessionType: 'ONE_TO_ONE',
+          appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+          appointmentDeliveryAddress: {
+            firstAddressLine: 'Harmony Living Office, Room 4',
+            secondAddressLine: '44 Bouverie Road',
+            townOrCity: 'Blackpool',
+            county: 'Lancashire',
+            postCode: 'SY40RE',
+          },
+        })
+
+        await provider.addInteraction({
+          state: `a referral exists with ID ${referralId} exists and has 2 2-hour appointments already`,
+          uponReceiving: `a PATCH request to update the appointment for session 2 to change the duration to an hour on action plan with ID ${referralId}`,
+          withRequest: {
+            method: 'PATCH',
+            path: `/referral/${referralId}/delivery-session-appointment/${deliverySessionAppointment.id}`,
+            body: {
+              appointmentTime: '2021-05-13T12:30:00Z',
+              durationInMinutes: 60,
+              sessionType: 'ONE_TO_ONE',
+              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+              appointmentDeliveryAddress: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '44 Bouverie Road',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY40RE',
+              },
+              npsOfficeCode: null,
+            },
+            headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+          },
+          // note - this is an exact match
+          willRespondWith: {
+            status: 200,
+            body: deliverySessionAppointment,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        })
+
+        expect(
+          await interventionsService.updateDeliverySessionAppointment(
+            probationPractitionerToken,
+            referralId,
+            deliverySessionAppointment.id,
+            {
+              appointmentTime: '2021-05-13T12:30:00Z',
+              durationInMinutes: 60,
+              sessionType: 'ONE_TO_ONE',
+              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+              appointmentDeliveryAddress: {
+                firstAddressLine: 'Harmony Living Office, Room 4',
+                secondAddressLine: '44 Bouverie Road',
+                townOrCity: 'Blackpool',
+                county: 'Lancashire',
+                postCode: 'SY40RE',
+              },
+              npsOfficeCode: null,
+            }
+          )
+        ).toMatchObject(deliverySessionAppointment)
+      })
+    })
+  })
+
+  // Deprecated
   describe('updateActionPlanAppointment', () => {
     describe('with a past appointment time', () => {
       it('returns a scheduled action plan appointment with feedback', async () => {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -3176,6 +3176,73 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('recordDeliverySessionAppointmentBehaviour', () => {
+    const referralId = '8d107952-9bde-4854-ad1e-dee09daab992'
+
+    const deliverySessionAppointment = actionPlanAppointmentFactory.build({
+      sessionNumber: 2,
+      appointmentTime: '2021-05-13T12:30:00Z',
+      durationInMinutes: 60,
+      sessionType: 'GROUP',
+      appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+      appointmentDeliveryAddress: {
+        firstAddressLine: 'Harmony Living Office, Room 4',
+        secondAddressLine: '44 Bouverie Road',
+        townOrCity: 'Blackpool',
+        county: 'Lancashire',
+        postCode: 'SY40RE',
+      },
+      sessionFeedback: {
+        attendance: {
+          attended: 'late',
+          additionalAttendanceInformation: 'Alex missed the bus',
+        },
+        behaviour: {
+          behaviourDescription: 'Alex was well behaved',
+          notifyProbationPractitioner: false,
+        },
+        submitted: false,
+        submittedBy: null,
+      },
+    })
+
+    it('returns an updated delivery session appointment with the service user‘s behaviour', async () => {
+      await provider.addInteraction({
+        state: `a referral with ID ${referralId} exists with appointment with ID ${deliverySessionAppointment.id} for which no session feedback has been recorded`,
+        uponReceiving: 'a POST request to record behaviour for for that appointment',
+        withRequest: {
+          method: 'POST',
+          path: `/referral/${referralId}/delivery-session-appointment/${deliverySessionAppointment.id}/record-behaviour`,
+          body: {
+            behaviourDescription: 'Alex was well behaved',
+            notifyProbationPractitioner: false,
+          },
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(deliverySessionAppointment),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+
+      const appointment = await interventionsService.recordDeliverySessionAppointmentBehaviour(
+        probationPractitionerToken,
+        referralId,
+        deliverySessionAppointment.id,
+        {
+          behaviourDescription: 'Alex was well behaved',
+          notifyProbationPractitioner: false,
+        }
+      )
+      expect(appointment.sessionFeedback!.behaviour!.behaviourDescription).toEqual('Alex was well behaved')
+      expect(appointment.sessionFeedback!.behaviour!.notifyProbationPractitioner).toEqual(false)
+    })
+  })
+
+  // Deprecated
   describe('recordActionPlanAppointmentBehavior', () => {
     it('returns an updated action plan appointment with the service user‘s behaviour', async () => {
       await provider.addInteraction({

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2616,6 +2616,63 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
+  describe('getDeliverySessionAppointments', () => {
+    const deliverySessionAppointments = [
+      actionPlanAppointmentFactory.build({
+        id: '915fd66f-9d74-4e22-8b85-38972b36f6cf',
+        sessionNumber: 1,
+        appointmentTime: '2021-05-13T12:30:00Z',
+        durationInMinutes: 120,
+        sessionType: 'GROUP',
+        appointmentDeliveryType: 'PHONE_CALL',
+      }),
+      actionPlanAppointmentFactory.build({
+        id: 'e3b59b74-fe85-4dac-bd1b-42de02c26267',
+        sessionNumber: 2,
+        appointmentTime: '2021-05-20T12:30:00Z',
+        durationInMinutes: 120,
+        sessionType: 'ONE_TO_ONE',
+        appointmentDeliveryType: 'PHONE_CALL',
+      }),
+      actionPlanAppointmentFactory.build({
+        id: '840488d1-0619-412e-a32c-89a84c4ca4f8',
+        sessionNumber: 3,
+        appointmentTime: '2021-05-27T12:30:00Z',
+        durationInMinutes: 120,
+        sessionType: 'GROUP',
+        appointmentDeliveryType: 'PHONE_CALL',
+      }),
+    ]
+
+    const referralId = '8d107952-9bde-4854-ad1e-dee09daab992'
+
+    beforeEach(async () => {
+      await provider.addInteraction({
+        state: `a referral with ID ${referralId} exists and it has 3 scheduled appointments`,
+        uponReceiving: 'a GET request for the delivery session appointments on the referral',
+        withRequest: {
+          method: 'GET',
+          path: `/referral/${referralId}/delivery-session-appointments`,
+          headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
+        },
+        willRespondWith: {
+          status: 200,
+          body: Matchers.like(deliverySessionAppointments),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      })
+    })
+
+    it('returns delivery session appointments', async () => {
+      expect(
+        await interventionsService.getDeliverySessionAppointments(probationPractitionerToken, referralId)
+      ).toMatchObject(deliverySessionAppointments)
+    })
+  })
+
+  // Deprecated
   describe('getActionPlanAppointments', () => {
     const actionPlanAppointments = [
       actionPlanAppointmentFactory.build({

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2862,7 +2862,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('updateDeliverySessionAppointment', () => {
+  describe('scheduleDeliverySessionAppointment', () => {
     const referralId = '8d107952-9bde-4854-ad1e-dee09daab992'
 
     describe('with non-null values', () => {
@@ -2884,7 +2884,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
         await provider.addInteraction({
           state: `a referral exists with ID ${referralId} exists and has 2 2-hour appointments already`,
-          uponReceiving: `a PATCH request to update the appointment for session 2 to change the duration to an hour on action plan with ID ${referralId}`,
+          uponReceiving: `a POST request to schedule an appointment for session 2 to change the duration to an hour on action plan with ID ${referralId}`,
           withRequest: {
             method: 'PATCH',
             path: `/referral/${referralId}/delivery-session-appointment/${deliverySessionAppointment.id}`,
@@ -2915,25 +2915,20 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         })
 
         expect(
-          await interventionsService.updateDeliverySessionAppointment(
-            probationPractitionerToken,
-            referralId,
-            deliverySessionAppointment.id,
-            {
-              appointmentTime: '2021-05-13T12:30:00Z',
-              durationInMinutes: 60,
-              sessionType: 'ONE_TO_ONE',
-              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
-              appointmentDeliveryAddress: {
-                firstAddressLine: 'Harmony Living Office, Room 4',
-                secondAddressLine: '44 Bouverie Road',
-                townOrCity: 'Blackpool',
-                county: 'Lancashire',
-                postCode: 'SY40RE',
-              },
-              npsOfficeCode: null,
-            }
-          )
+          await interventionsService.scheduleDeliverySessionAppointment(probationPractitionerToken, referralId, 2, {
+            appointmentTime: '2021-05-13T12:30:00Z',
+            durationInMinutes: 60,
+            sessionType: 'ONE_TO_ONE',
+            appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
+            appointmentDeliveryAddress: {
+              firstAddressLine: 'Harmony Living Office, Room 4',
+              secondAddressLine: '44 Bouverie Road',
+              townOrCity: 'Blackpool',
+              county: 'Lancashire',
+              postCode: 'SY40RE',
+            },
+            npsOfficeCode: null,
+          })
         ).toMatchObject(deliverySessionAppointment)
       })
     })

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -541,6 +541,20 @@ export default class InterventionsService {
     })) as ActionPlanAppointment
   }
 
+  async submitDeliverySessionAppointmentFeedback(
+    token: string,
+    referralId: string,
+    appointmentId: string
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}/submit`,
+      headers: { Accept: 'application/json' },
+    })) as ActionPlanAppointment
+  }
+
+  // Deprecated in favour of submitDeliverySessionAppointmentFeedback
   async submitActionPlanSessionFeedback(
     token: string,
     actionPlanId: string,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -479,6 +479,22 @@ export default class InterventionsService {
     })) as ActionPlanAppointment
   }
 
+  async recordDeliverySessionAppointmentAttendance(
+    token: string,
+    referralId: string,
+    appointmentId: string,
+    appointmentAttendanceUpdate: Partial<AppointmentAttendance>
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}/record-attendance`,
+      headers: { Accept: 'application/json' },
+      data: appointmentAttendanceUpdate,
+    })) as ActionPlanAppointment
+  }
+
+  // Deprecated in favour of `recordDeliverySessionAppointmentAttendance`
   async recordActionPlanAppointmentAttendance(
     token: string,
     actionPlanId: string,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -402,6 +402,18 @@ export default class InterventionsService {
     })) as ActionPlanAppointment[]
   }
 
+  async getDeliverySessionAppointment(
+    token: string,
+    referralId: string,
+    appointmentId: string
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.get({
+      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      headers: { Accept: 'application/json' },
+    })) as ActionPlanAppointment
+  }
+
   // Deprecated in favour of `getDeliverySessionAppointments`
   async getActionPlanAppointments(token: string, actionPlanId: string): Promise<ActionPlanAppointment[]> {
     const restClient = this.createRestClient(token)
@@ -411,6 +423,7 @@ export default class InterventionsService {
     })) as ActionPlanAppointment[]
   }
 
+  // Deprecated in favour of `getDeliverySessionAppointment`
   async getActionPlanAppointment(token: string, actionPlanId: string, session: number): Promise<ActionPlanAppointment> {
     const restClient = this.createRestClient(token)
     return (await restClient.get({

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -510,6 +510,22 @@ export default class InterventionsService {
     })) as ActionPlanAppointment
   }
 
+  async recordDeliverySessionAppointmentBehaviour(
+    token: string,
+    referralId: string,
+    appointmentId: string,
+    appointmentBehaviourUpdate: Partial<AppointmentBehaviour>
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+
+    return (await restClient.post({
+      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}/record-behaviour`,
+      headers: { Accept: 'application/json' },
+      data: appointmentBehaviourUpdate,
+    })) as ActionPlanAppointment
+  }
+
+  // Deprecated in favour of recordDeliverySessionAppointmentBehaviour
   async recordActionPlanAppointmentBehavior(
     token: string,
     actionPlanId: string,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -394,6 +394,15 @@ export default class InterventionsService {
     })) as ApprovedActionPlanSummary[]
   }
 
+  async getDeliverySessionAppointments(token: string, referralId: string): Promise<ActionPlanAppointment[]> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.get({
+      path: `/referral/${referralId}/delivery-session-appointments`,
+      headers: { Accept: 'application/json' },
+    })) as ActionPlanAppointment[]
+  }
+
+  // Deprecated in favour of `getDeliverySessionAppointments`
   async getActionPlanAppointments(token: string, actionPlanId: string): Promise<ActionPlanAppointment[]> {
     const restClient = this.createRestClient(token)
     return (await restClient.get({

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -451,6 +451,21 @@ export default class InterventionsService {
     )) as ActionPlanAppointment
   }
 
+  async updateDeliverySessionAppointment(
+    token: string,
+    referralId: string,
+    appointmentId: string,
+    appointmentUpdate: AppointmentSchedulingDetails
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.patch({
+      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      headers: { Accept: 'application/json' },
+      data: { ...appointmentUpdate },
+    })) as ActionPlanAppointment
+  }
+
+  // Deprecated in favour of updateDeliverySessionAppointment
   async updateActionPlanAppointment(
     token: string,
     actionPlanId: string,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -409,7 +409,7 @@ export default class InterventionsService {
   ): Promise<ActionPlanAppointment> {
     const restClient = this.createRestClient(token)
     return (await restClient.get({
-      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      path: `/referral/${referralId}/delivery-session-appointments/${appointmentId}`,
       headers: { Accept: 'application/json' },
     })) as ActionPlanAppointment
   }
@@ -451,21 +451,36 @@ export default class InterventionsService {
     )) as ActionPlanAppointment
   }
 
-  async updateDeliverySessionAppointment(
+  async scheduleDeliverySessionAppointment(
     token: string,
     referralId: string,
-    appointmentId: string,
+    sessionNumber: number,
     appointmentUpdate: AppointmentSchedulingDetails
   ): Promise<ActionPlanAppointment> {
     const restClient = this.createRestClient(token)
     return (await restClient.patch({
-      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}`,
+      path: `/referral/${referralId}/delivery-session-appointments`,
       headers: { Accept: 'application/json' },
-      data: { ...appointmentUpdate },
+      data: { ...appointmentUpdate, sessionId: sessionNumber },
     })) as ActionPlanAppointment
   }
 
-  // Deprecated in favour of updateDeliverySessionAppointment
+  async rescheduleDeliverySessionAppointment(
+    token: string,
+    referralId: string,
+    sessionNumber: number,
+    appointmentId: string,
+    appointmentUpdate: AppointmentSchedulingDetails
+  ): Promise<ActionPlanAppointment> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.put({
+      path: `/referral/${referralId}/delivery-session-appointments/${appointmentId}`,
+      headers: { Accept: 'application/json' },
+      data: { ...appointmentUpdate, sessionId: sessionNumber },
+    })) as ActionPlanAppointment
+  }
+
+  // Deprecated in favour of scheduleDeliverySessionAppointment/rescheduleDeliverySessionAppointment
   async updateActionPlanAppointment(
     token: string,
     actionPlanId: string,
@@ -503,7 +518,7 @@ export default class InterventionsService {
     const restClient = this.createRestClient(token)
 
     return (await restClient.post({
-      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}/record-attendance`,
+      path: `/referral/${referralId}/delivery-session-appointments/${appointmentId}/attendance`,
       headers: { Accept: 'application/json' },
       data: appointmentAttendanceUpdate,
     })) as ActionPlanAppointment
@@ -534,7 +549,7 @@ export default class InterventionsService {
     const restClient = this.createRestClient(token)
 
     return (await restClient.post({
-      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}/record-behaviour`,
+      path: `/referral/${referralId}/delivery-session-appointments/${appointmentId}/behaviour`,
       headers: { Accept: 'application/json' },
       data: appointmentBehaviourUpdate,
     })) as ActionPlanAppointment
@@ -564,7 +579,7 @@ export default class InterventionsService {
     const restClient = this.createRestClient(token)
 
     return (await restClient.post({
-      path: `/referral/${referralId}/delivery-session-appointment/${appointmentId}/submit`,
+      path: `/referral/${referralId}/delivery-session-appointments/${appointmentId}/submit-feedback`,
       headers: { Accept: 'application/json' },
     })) as ActionPlanAppointment
   }

--- a/testutils/factories/actionPlanAppointment.ts
+++ b/testutils/factories/actionPlanAppointment.ts
@@ -21,7 +21,8 @@ class ActionPlanAppointmentFactory extends Factory<ActionPlanAppointment> {
   }
 }
 
-export default ActionPlanAppointmentFactory.define(() => ({
+export default ActionPlanAppointmentFactory.define(({ sequence }) => ({
+  id: sequence.toString(),
   sessionNumber: 1,
   appointmentTime: null,
   durationInMinutes: null,


### PR DESCRIPTION
## Note: this PR depends on work done on previous branch in PR #962 - first commit for review here is [#bbb617deed](https://github.com/ministryofjustice/hmpps-interventions-ui/pull/985/commits/32b0b4a9aebc7acde8eb1fb7e2948e4d2c76150e)

## What does this pull request do?

Adds new routes to `serviceProviderRoutes.ts` for viewing Session feedback and scheduling an appointment, now using the new backend structure of an Appointment no longer being linked to an Action Plan (what we're now calling a `DeliverySessionAppointment`). 

These aren't currently linked to by the Intervention Progress page, but in theory users could navigate to the URLs directly - it may be worth putting these behind a feature flag, but it's probably safe to assume they won't be able to guess the IDs etc.

The original routes are still left in place, as we'll want to make sure none of the older links break, e.g. if a user clicks a link in an email to view feedback, we don't want it to break the journey. We should monitor these old routes and remove them once we no longer receive traffic.

## What is the intent behind these changes?

To pave the way for having multiple appointment linked to a Session, so we can allow users to reschedule appointments when an Appointment is marked as "Did Not Attend"
