### PR TITLE
Edit oasys risk info  submit oasys draft

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -262,5 +262,9 @@ module.exports = on => {
     stubGetMyInterventions: arg => {
       return interventionsService.stubGetMyInterventions(arg.responseJson)
     },
+
+    stubUpdateDraftOasysRiskInformation: arg => {
+      return interventionsService.stubUpdateDraftOasysRiskInformation(arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -185,3 +185,7 @@ Cypress.Commands.add('stubGetCaseNote', (caseNoteId, responseJson) => {
 Cypress.Commands.add('stubGetMyInterventions', responseJson => {
   cy.task('stubGetMyInterventions', { responseJson })
 })
+
+Cypress.Commands.add('stubUpdateDraftOasysRiskInformation', responseJson => {
+  cy.task('stubUpdateDraftOasysRiskInformation', { responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -770,4 +770,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubUpdateDraftOasysRiskInformation = async (referralId: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `/draft-referral/${referralId}/oasys-risk-information`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/models/draftOasysRiskInformation.ts
+++ b/server/models/draftOasysRiskInformation.ts
@@ -1,0 +1,10 @@
+export interface DraftOasysRiskInformation {
+  riskSummaryWhoIsAtRisk: string | null
+  riskSummaryNatureOfRisk: string | null
+  riskSummaryRiskImminence: string | null
+  riskToSelfSuicide: string | null
+  riskToSelfSelfHarm: string | null
+  riskToSelfHostelSetting: string | null
+  riskToSelfVulnerability: string | null
+  additionalInformation: string | null
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -142,6 +142,10 @@ function probationPractitionerRoutesWithoutPrefix(router: Router, services: Serv
     makeAReferralController.editOasysRiskInformation(req, res)
   )
 
+  post(router, '/referrals/:id/edit-oasys-risk-information', (req, res) =>
+    makeAReferralController.editOasysRiskInformation(req, res)
+  )
+
   get(router, '/referrals/:id/enforceable-days', (req, res) => makeAReferralController.viewEnforceableDays(req, res))
   post(router, '/referrals/:id/enforceable-days', (req, res) => makeAReferralController.updateEnforceableDays(req, res))
   get(router, '/referrals/:id/check-answers', (req, res) => makeAReferralController.checkAnswers(req, res))

--- a/server/routes/makeAReferral/makeAReferralController.test.ts
+++ b/server/routes/makeAReferral/makeAReferralController.test.ts
@@ -18,6 +18,7 @@ import MockAssessRisksAndNeedsService from '../testutils/mocks/mockAssessRisksAn
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
 import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
+import draftOasysRiskInformation from '../../../testutils/factories/draftOasysRiskInformation'
 
 jest.mock('../../services/interventionsService')
 jest.mock('../../services/communityApiService')
@@ -475,6 +476,44 @@ describe('GET /referrals/:id/edit-oasys-risk-information', () => {
           })
       })
     })
+  })
+})
+
+describe('POST /referrals/:id/edit-oasys-risk-information', () => {
+  it('updates the draft oasys risk information on the backend and redirects to the next question', async () => {
+    interventionsService.updateDraftOasysRiskInformation.mockResolvedValue(draftOasysRiskInformation.build())
+
+    await request(app)
+      .post('/referrals/1/edit-oasys-risk-information')
+      .type('form')
+      .send({
+        'who-is-at-risk': 'Risk to staff.',
+        'nature-of-risk': 'Physically aggressive',
+        'risk-imminence': 'Can happen at the drop of a hat',
+        'risk-to-self-suicide': 'Manic episodes are common',
+        'risk-to-self-self-harm': 'No self harm',
+        'risk-to-self-hostel-setting': 'No hostel',
+        'risk-to-self-vulnerability': 'Not vulnerable',
+        'additional-information': 'No more comments.',
+        'confirm-understood': 'understood',
+      })
+      .expect(302)
+      .expect('Location', '/referrals/1/needs-and-requirements')
+
+    expect(interventionsService.updateDraftOasysRiskInformation.mock.calls[0]).toEqual([
+      'token',
+      '1',
+      {
+        riskSummaryWhoIsAtRisk: 'Risk to staff.',
+        riskSummaryNatureOfRisk: 'Physically aggressive',
+        riskSummaryRiskImminence: 'Can happen at the drop of a hat',
+        riskToSelfSuicide: 'Manic episodes are common',
+        riskToSelfSelfHarm: 'No self harm',
+        riskToSelfHostelSetting: 'No hostel',
+        riskToSelfVulnerability: 'Not vulnerable',
+        additionalInformation: 'No more comments.',
+      },
+    ])
   })
 })
 

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationForm.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationForm.test.ts
@@ -1,0 +1,45 @@
+import TestUtils from '../../../../../../testutils/testUtils'
+import EditOasysRiskInformationForm from './editOasysRiskInformationForm'
+
+describe('EditOasysRiskInformationForm', () => {
+  describe('from validation', () => {
+    describe('when no request exists', () => {
+      it('should not be valid and produce an error', async () => {
+        const request = TestUtils.createRequest({})
+        const form = await EditOasysRiskInformationForm.createForm(request)
+        expect(form.isValid).toEqual(false)
+        expect(form.error?.errors).toContainEqual({
+          errorSummaryLinkedField: 'confirm-understood',
+          formFields: ['confirm-understood'],
+          message:
+            'You must confirm that you understand that this information will be shared with the Service Provider',
+        })
+      })
+    })
+    describe('when user does not select "confirm understood" checkbox', () => {
+      it('should not be valid and produce an error', async () => {
+        const request = TestUtils.createRequest({
+          'confirm-understood': 'no',
+        })
+        const form = await EditOasysRiskInformationForm.createForm(request)
+        expect(form.isValid).toEqual(false)
+        expect(form.error?.errors).toContainEqual({
+          errorSummaryLinkedField: 'confirm-understood',
+          formFields: ['confirm-understood'],
+          message:
+            'You must confirm that you understand that this information will be shared with the Service Provider',
+        })
+      })
+    })
+    describe('when user selected "confirm understood" checkbox', () => {
+      it('should be valid and produce no error', async () => {
+        const request = TestUtils.createRequest({
+          'confirm-understood': 'understood',
+        })
+        const form = await EditOasysRiskInformationForm.createForm(request)
+        expect(form.isValid).toEqual(true)
+        expect(form.error).toBeNull()
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationForm.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationForm.ts
@@ -1,0 +1,56 @@
+import { Request } from 'express'
+import { body, Result, ValidationChain, ValidationError } from 'express-validator'
+import errorMessages from '../../../../../utils/errorMessages'
+import FormUtils from '../../../../../utils/formUtils'
+import { FormValidationError } from '../../../../../utils/formValidationError'
+import { DraftOasysRiskInformation } from '../../../../../models/draftOasysRiskInformation'
+
+export default class EditOasysRiskInformationForm {
+  private constructor(private readonly request: Request, private readonly result: Result<ValidationError>) {}
+
+  static async createForm(request: Request): Promise<EditOasysRiskInformationForm> {
+    return new EditOasysRiskInformationForm(
+      request,
+      await FormUtils.runValidations({ request, validations: this.validations() })
+    )
+  }
+
+  static validations(): ValidationChain[] {
+    return [
+      body('confirm-understood')
+        .contains('understood')
+        .withMessage(errorMessages.oasysRiskInformation.confirmUnderstood.notSelected),
+    ]
+  }
+
+  get isValid(): boolean {
+    return this.error == null
+  }
+
+  get editedDraftRiskInformation(): DraftOasysRiskInformation {
+    return {
+      riskSummaryWhoIsAtRisk: this.request.body['who-is-at-risk'],
+      riskSummaryNatureOfRisk: this.request.body['nature-of-risk'],
+      riskSummaryRiskImminence: this.request.body['risk-imminence'],
+      riskToSelfSuicide: this.request.body['risk-to-self-suicide'],
+      riskToSelfSelfHarm: this.request.body['risk-to-self-self-harm'],
+      riskToSelfHostelSetting: this.request.body['risk-to-self-hostel-setting'],
+      riskToSelfVulnerability: this.request.body['risk-to-self-vulnerability'],
+      additionalInformation: this.request.body['additional-information'],
+    }
+  }
+
+  get error(): FormValidationError | null {
+    if (this.result.isEmpty()) {
+      return null
+    }
+
+    return {
+      errors: this.result.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
+  }
+}

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationPresenter.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationPresenter.ts
@@ -3,15 +3,23 @@ import DateUtils from '../../../../../utils/dateUtils'
 import { SupplementaryRiskInformation } from '../../../../../models/assessRisksAndNeeds/supplementaryRiskInformation'
 
 import RoshPanelPresenter from '../../../../shared/roshPanelPresenter'
+import PresenterUtils from '../../../../../utils/presenterUtils'
+import { FormValidationError } from '../../../../../utils/formValidationError'
 
 export default class EditOasysRiskInformationPresenter {
   riskPresenter: RoshPanelPresenter
 
   constructor(
     readonly supplementaryRiskInformation: SupplementaryRiskInformation | null,
-    readonly riskSummary: RiskSummary | null
+    readonly riskSummary: RiskSummary | null,
+    private readonly error: FormValidationError | null = null
   ) {
     this.riskPresenter = new RoshPanelPresenter(riskSummary)
+  }
+
+  readonly errors = {
+    summary: PresenterUtils.errorSummary(this.error),
+    confirmUnderstood: PresenterUtils.errorMessage(this.error, 'confirm-understood'),
   }
 
   get latestAssessment(): string {

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.ts
@@ -1,4 +1,4 @@
-import { TextareaArgs } from '../../../../../utils/govukFrontendTypes'
+import { CheckboxesArgs, TextareaArgs } from '../../../../../utils/govukFrontendTypes'
 import ViewUtils from '../../../../../utils/viewUtils'
 import EditOasysRiskInformationPresenter from './editOasysRiskInformationPresenter'
 import OasysRiskSummaryView from '../oasysRiskSummaryView'
@@ -9,6 +9,8 @@ export default class EditOasysRiskInformationView {
   constructor(private readonly presenter: EditOasysRiskInformationPresenter) {
     this.riskSummaryView = new OasysRiskSummaryView(presenter.supplementaryRiskInformation, presenter.riskSummary)
   }
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errors.summary)
 
   private get whoIsAtRiskTextareaArgs(): TextareaArgs {
     const whoIsAtRisk = this.riskSummaryView.riskInformation.summary.whoIsAtRisk.text || ''
@@ -44,7 +46,7 @@ export default class EditOasysRiskInformationView {
     const selfHarm = this.riskSummaryView.riskInformation.riskToSelf.selfHarm.text || ''
     return {
       name: 'risk-to-self-self-harm',
-      id: 'risk-to-self',
+      id: 'risk-to-self-self-harm',
       label: {},
       value: ViewUtils.escape(selfHarm),
     }
@@ -73,8 +75,8 @@ export default class EditOasysRiskInformationView {
   private get riskToSelfVulnerabilityTextareaArgs(): TextareaArgs {
     const vulnerability = this.riskSummaryView.riskInformation.riskToSelf.vulnerability.text || ''
     return {
-      name: 'who-is-at-risk-vulnerability',
-      id: 'who-is-at-risk-vulnerability',
+      name: 'risk-to-self-vulnerability',
+      id: 'risk-to-self-vulnerability',
       label: {},
       value: ViewUtils.escape(vulnerability),
     }
@@ -90,10 +92,26 @@ export default class EditOasysRiskInformationView {
     }
   }
 
+  private get confirmUnderstoodWarningCheckboxArgs(): CheckboxesArgs {
+    return {
+      idPrefix: 'confirm-understood',
+      name: 'confirm-understood',
+      items: [
+        {
+          value: 'understood',
+          text: 'I understand this information will be shared with the Service Provider',
+        },
+      ],
+      classes: 'govuk-checkboxes__inset--grey',
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.errors.confirmUnderstood),
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'makeAReferral/editRiskInformationOasys',
       {
+        errorSummaryArgs: this.errorSummaryArgs,
         riskInformation: this.riskSummaryView.riskInformation,
         latestAssessment: this.presenter.latestAssessment,
         whoIsAtRiskTextareaArgs: this.whoIsAtRiskTextareaArgs,
@@ -104,6 +122,7 @@ export default class EditOasysRiskInformationView {
         riskToSelfHostelSettingTextareaArgs: this.riskToSelfHostelSettingTextareaArgs,
         riskToSelfVulnerabilityTextareaArgs: this.riskToSelfVulnerabilityTextareaArgs,
         additionalInformationTextareaArgs: this.additionalInformationTextareaArgs,
+        confirmUnderstoodWarningCheckboxArgs: this.confirmUnderstoodWarningCheckboxArgs,
       },
     ]
   }

--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
@@ -42,7 +42,7 @@ export default class OasysRiskInformationView {
   private get confirmUnderstoodWarningCheckboxArgs(): CheckboxesArgs {
     return {
       idPrefix: 'confirm-understood',
-      name: 'confirm-understood[]',
+      name: 'confirm-understood',
       items: [
         {
           value: 'understood',

--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
@@ -46,7 +46,7 @@ export default class OasysRiskInformationView {
       items: [
         {
           value: 'understood',
-          text: 'I understand this information will be shared with the service provider',
+          text: 'I understand this information will be shared with the Service Provider',
         },
       ],
       classes: 'govuk-checkboxes__inset--grey',
@@ -58,10 +58,10 @@ export default class OasysRiskInformationView {
     return {
       classes: 'govuk-radios',
       idPrefix: 'edit-risk-confirmation',
-      name: 'relevant-sentence-id',
+      name: 'edit-risk-confirmation',
       fieldset: {
         legend: {
-          text: 'Do you want to edit this OASys risk information for the service provider?',
+          text: 'Do you want to edit this OASys risk information for the Service Provider?',
           classes: 'govuk-fieldset__legend--m',
         },
       },

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -27,6 +27,7 @@ import {
 import ApprovedActionPlanSummary from '../models/approvedActionPlanSummary'
 import { Page } from '../models/pagination'
 import { CaseNote } from '../models/caseNote'
+import { DraftOasysRiskInformation } from '../models/draftOasysRiskInformation'
 
 export interface InterventionsServiceValidationError {
   field: string
@@ -651,5 +652,18 @@ export default class InterventionsService {
       path: `/case-note/${caseNoteId}`,
       headers: { Accept: 'application/json' },
     })) as CaseNote
+  }
+
+  async updateDraftOasysRiskInformation(
+    token: string,
+    referralId: string,
+    draftOasysRiskInformation: DraftOasysRiskInformation
+  ): Promise<DraftOasysRiskInformation> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.patch({
+      path: `/draft-referral/${referralId}/oasys-risk-information`,
+      headers: { Accept: 'application/json' },
+      data: { ...draftOasysRiskInformation },
+    })) as DraftOasysRiskInformation
   }
 }

--- a/server/views/makeAReferral/editRiskInformationOasys.njk
+++ b/server/views/makeAReferral/editRiskInformationOasys.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 
 {% extends "../partials/layout.njk" %}
@@ -11,6 +12,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">OASys risk information</h1>
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
 
       <p class="govuk-body">Latest assessment: {{ latestAssessment }} </p>
       <hr/>
@@ -52,6 +56,7 @@
         <p class="govuk-body {{ riskInformation.additionalRiskInformation.label.class }}">{{ riskInformation.additionalRiskInformation.label.text }}</p>
         {{ govukTextarea(additionalInformationTextareaArgs) }}
 
+        {{ govukCheckboxes(confirmUnderstoodWarningCheckboxArgs) }}
         {{ govukButton({ text: "Save and continue" }) }}
       </form>
     </div>

--- a/testutils/factories/draftOasysRiskInformation.ts
+++ b/testutils/factories/draftOasysRiskInformation.ts
@@ -1,0 +1,15 @@
+import { Factory } from 'fishery'
+import { DraftOasysRiskInformation } from '../../server/models/draftOasysRiskInformation'
+
+class DraftOasysRiskInformationFactory extends Factory<DraftOasysRiskInformation> {}
+
+export default DraftOasysRiskInformationFactory.define(() => ({
+  riskSummaryWhoIsAtRisk: 'Risk to staff.',
+  riskSummaryNatureOfRisk: 'Physically aggressive',
+  riskSummaryRiskImminence: 'Can happen at the drop of a hat',
+  riskToSelfSuicide: 'Manic episodes are common',
+  riskToSelfSelfHarm: null,
+  riskToSelfHostelSetting: null,
+  riskToSelfVulnerability: null,
+  additionalInformation: 'No more comments.',
+}))


### PR DESCRIPTION
commit 2e78cb5706a332c3b32d0d67045f25620408e965

Added PATCH draft oasys risk information endpoint for interventions service.
This allows the ability to update/create a draft details for OASys risk information as part of make a referral journey.

commit 5eb20371195b70b01c8d6f674935c3dcd201b189

Edited information for oasys risk information is now validated and persisted to the back-end when the user clicks on save-and-continue as part of make a referral journey.

The user is redirected to the next question when the patch to the backend is successful.

### note
These changes are behind a feature branch.