### PR TITLE
Add EKS migration annotations

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-ui/templates/ingress.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
   annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ .Release.Namespace }}-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
     {{- if .Values.env_details.contains_live_data }}
     kubernetes.io/ingress.class: "modsec01"


### PR DESCRIPTION

## What does this pull request do?

Add EKS migration annotations

## What is the intent behind these changes?

This is to allow migration of the current Kubernetes cluster to AWS' Elastic Kubernetes Service

Following https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrate-to-live-ingress-annotation.html

