### PR TITLE
Risk Information - check answers

### DIFF
--- a/server/routes/makeAReferral/check-answers/checkAnswersPresenter.ts
+++ b/server/routes/makeAReferral/check-answers/checkAnswersPresenter.ts
@@ -12,13 +12,15 @@ import DeliusConviction from '../../../models/delius/deliusConviction'
 import SentencePresenter from '../relevant-sentence/sentencePresenter'
 import { ExpandedDeliusServiceUser } from '../../../models/delius/deliusServiceUser'
 import DateUtils from '../../../utils/dateUtils'
+import { DraftOasysRiskInformation } from '../../../models/draftOasysRiskInformation'
 
 export default class CheckAnswersPresenter {
   constructor(
     private readonly referral: DraftReferral,
     private readonly intervention: Intervention,
     private readonly conviction: DeliusConviction,
-    private readonly deliusServiceUser: ExpandedDeliusServiceUser
+    private readonly deliusServiceUser: ExpandedDeliusServiceUser,
+    private readonly editedOasysRiskInformation: DraftOasysRiskInformation | null = null
   ) {}
 
   get serviceUserDetailsSection(): { title: string; summary: SummaryListItem[] } {
@@ -29,6 +31,53 @@ export default class CheckAnswersPresenter {
   }
 
   get riskSection(): { title: string; summary: SummaryListItem[] } {
+    if (this.editedOasysRiskInformation) {
+      return {
+        title: `OAsys risk information`,
+        summary: [
+          {
+            key: 'Who is at risk',
+            lines: [this.editedOasysRiskInformation.riskSummaryWhoIsAtRisk || ''],
+            changeLink: `/referrals/${this.referral.id}/edit-oasys-risk-information`,
+          },
+          {
+            key: 'What is the nature of the risk',
+            lines: [this.editedOasysRiskInformation.riskSummaryNatureOfRisk || ''],
+            changeLink: `/referrals/${this.referral.id}/edit-oasys-risk-information`,
+          },
+          {
+            key: 'When is the risk likely to be greatest',
+            lines: [this.editedOasysRiskInformation.riskSummaryRiskImminence || ''],
+            changeLink: `/referrals/${this.referral.id}/edit-oasys-risk-information`,
+          },
+          {
+            key: 'Concerns in relation to self-harm',
+            lines: [this.editedOasysRiskInformation.riskToSelfSelfHarm || ''],
+            changeLink: `/referrals/${this.referral.id}/edit-oasys-risk-information`,
+          },
+          {
+            key: 'Concerns in relation to suicide',
+            lines: [this.editedOasysRiskInformation.riskToSelfSuicide || ''],
+            changeLink: `/referrals/${this.referral.id}/edit-oasys-risk-information`,
+          },
+          {
+            key: 'Concerns in relation to coping in a hostel setting',
+            lines: [this.editedOasysRiskInformation.riskToSelfHostelSetting || ''],
+            changeLink: `/referrals/${this.referral.id}/edit-oasys-risk-information`,
+          },
+          {
+            key: 'Concerns in relation to vulnerability',
+            lines: [this.editedOasysRiskInformation.riskToSelfVulnerability || ''],
+            changeLink: `/referrals/${this.referral.id}/edit-oasys-risk-information`,
+          },
+          {
+            key: 'Additional information',
+            lines: [this.editedOasysRiskInformation.additionalInformation || ''],
+            changeLink: `/referrals/${this.referral.id}/edit-oasys-risk-information`,
+          },
+        ],
+      }
+    }
     return {
       title: `${this.serviceUserName}’s risk information`,
       summary: [

--- a/server/routes/makeAReferral/form/referralFormPresenter.test.ts
+++ b/server/routes/makeAReferral/form/referralFormPresenter.test.ts
@@ -5,6 +5,7 @@ import cohortReferralFormSectionFactory from '../../../../testutils/factories/co
 import serviceCategoryFactory from '../../../../testutils/factories/serviceCategory'
 import ServiceCategory from '../../../models/serviceCategory'
 import interventionFactory from '../../../../testutils/factories/intervention'
+import draftOasysRiskInformationFactory from '../../../../testutils/factories/draftOasysRiskInformation'
 
 describe('ReferralFormPresenter', () => {
   describe('for a single referral', () => {
@@ -41,37 +42,91 @@ describe('ReferralFormPresenter', () => {
             ]
             expect(presenter.sections).toEqual(expected)
           })
+          describe('with full risk information enabled', () => {
+            it('should contain a "Not started" label and "risk-information" url visible', () => {
+              const referral = draftReferralFactory
+                .serviceUserSelected()
+                .build({ serviceCategoryIds: [serviceCategory.id] })
+              const presenter = new ReferralFormPresenter(referral, nonCohortIntervention, null)
+              const expected = [
+                referralFormSectionFactory.reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information').build(),
+                referralFormSectionFactory
+                  .interventionDetails('accommodation', ReferralFormStatus.CannotStartYet)
+                  .build(),
+                referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+              ]
+              expect(presenter.sections).toEqual(expected)
+            })
+          })
         })
         describe('when "risk information" has been set', () => {
-          it('should contain a "Not started" label and "needs-and-requirements" url visible', () => {
-            const referral = draftReferralFactory.filledFormUpToRiskInformation([serviceCategory]).build()
-            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
-            const expected = [
-              referralFormSectionFactory
-                .reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information', 'needs-and-requirements')
-                .build(),
-              referralFormSectionFactory
-                .interventionDetails('accommodation', ReferralFormStatus.CannotStartYet)
-                .build(),
-              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
-            ]
-            expect(presenter.sections).toEqual(expected)
+          describe('with additional risk information', () => {
+            it('should contain a "Not started" label and "needs-and-requirements" url visible', () => {
+              const referral = draftReferralFactory.filledFormUpToRiskInformation([serviceCategory]).build()
+              const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
+              const expected = [
+                referralFormSectionFactory
+                  .reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information', 'needs-and-requirements')
+                  .build(),
+                referralFormSectionFactory
+                  .interventionDetails('accommodation', ReferralFormStatus.CannotStartYet)
+                  .build(),
+                referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+              ]
+              expect(presenter.sections).toEqual(expected)
+            })
+          })
+          describe('with full risk information', () => {
+            it('should contain a "Not started" label and "needs-and-requirements" url visible', () => {
+              const referral = draftReferralFactory.serviceUserSelected().build()
+              const draftOasysRiskInformation = draftOasysRiskInformationFactory.build()
+              const presenter = new ReferralFormPresenter(referral, nonCohortIntervention, draftOasysRiskInformation)
+              const expected = [
+                referralFormSectionFactory
+                  .reviewServiceUser(ReferralFormStatus.NotStarted, 'risk-information', 'needs-and-requirements')
+                  .build(),
+                referralFormSectionFactory
+                  .interventionDetails('accommodation', ReferralFormStatus.CannotStartYet)
+                  .build(),
+                referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+              ]
+              expect(presenter.sections).toEqual(expected)
+            })
           })
         })
         describe('when all required values have been set', () => {
-          it('should contain a "Completed" label and service category details section can be started', () => {
-            const referral = draftReferralFactory.filledFormUpToNeedsAndRequirements([serviceCategory]).build()
-            const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
-            const expected = [
-              referralFormSectionFactory
-                .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
-                .build(),
-              referralFormSectionFactory
-                .interventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence')
-                .build(),
-              referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
-            ]
-            expect(presenter.sections).toEqual(expected)
+          describe('with additional risk information', () => {
+            it('should contain a "Completed" label and service category details section can be started', () => {
+              const referral = draftReferralFactory.filledFormUpToNeedsAndRequirements([serviceCategory]).build()
+              const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
+              const expected = [
+                referralFormSectionFactory
+                  .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+                  .build(),
+                referralFormSectionFactory
+                  .interventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence')
+                  .build(),
+                referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+              ]
+              expect(presenter.sections).toEqual(expected)
+            })
+          })
+          describe('with full risk information', () => {
+            it('should contain a "Completed" label and service category details section can be started', () => {
+              const referral = draftReferralFactory.filledFormUpToNeedsAndRequirements([serviceCategory], true).build()
+              const draftOasysRiskInformation = draftOasysRiskInformationFactory.build()
+              const presenter = new ReferralFormPresenter(referral, nonCohortIntervention, draftOasysRiskInformation)
+              const expected = [
+                referralFormSectionFactory
+                  .reviewServiceUser(ReferralFormStatus.Completed, 'risk-information', 'needs-and-requirements')
+                  .build(),
+                referralFormSectionFactory
+                  .interventionDetails('accommodation', ReferralFormStatus.NotStarted, 'relevant-sentence')
+                  .build(),
+                referralFormSectionFactory.checkAnswers(ReferralFormStatus.CannotStartYet).build(),
+              ]
+              expect(presenter.sections).toEqual(expected)
+            })
           })
         })
       })

--- a/server/routes/makeAReferral/form/referralFormPresenter.ts
+++ b/server/routes/makeAReferral/form/referralFormPresenter.ts
@@ -3,6 +3,7 @@ import InterventionDecorator from '../../../decorators/interventionDecorator'
 import DraftReferral from '../../../models/draftReferral'
 import Intervention from '../../../models/intervention'
 import utils from '../../../utils/utils'
+import { DraftOasysRiskInformation } from '../../../models/draftOasysRiskInformation'
 
 export default class ReferralFormPresenter {
   private readonly taskValues: TaskValues
@@ -11,8 +12,12 @@ export default class ReferralFormPresenter {
 
   private readonly formSectionBuilder: FormSectionBuilder
 
-  constructor(private readonly referral: DraftReferral, private readonly intervention: Intervention) {
-    this.taskValues = new TaskValues(referral)
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly intervention: Intervention,
+    private readonly draftOasysRiskInformation: DraftOasysRiskInformation | null = null
+  ) {
+    this.taskValues = new TaskValues(referral, draftOasysRiskInformation)
     this.sectionValues = new SectionValues(this.taskValues)
     this.formSectionBuilder = new FormSectionBuilder(referral, intervention, this.taskValues, this.sectionValues)
   }
@@ -321,15 +326,19 @@ class SectionValues {
   }
 }
 class TaskValues {
-  constructor(private referral: DraftReferral) {}
+  constructor(
+    private referral: DraftReferral,
+    private draftOasysRiskInfo: DraftOasysRiskInformation | null | undefined
+  ) {}
 
   // TODO: IC-1676. We need a field to confirm that the user has "checked" service user details.
   get serviceUserDetails(): DraftReferralValues {
     return []
   }
 
+  // TODO: remove this.referral.additionalRiskInformation once switched over to full risk information
   get riskInformation(): DraftReferralValues {
-    return [this.referral.additionalRiskInformation]
+    return [this.draftOasysRiskInfo || this.referral.additionalRiskInformation ? true : null]
   }
 
   get needsAndRequirements(): DraftReferralValues {

--- a/server/routes/makeAReferral/makeAReferralController.ts
+++ b/server/routes/makeAReferral/makeAReferralController.ts
@@ -153,11 +153,31 @@ export default class MakeAReferralController {
     res.redirect(`/referrals/${req.params.id}/risk-information`)
   }
 
+  private async getDraftOasysRiskInformation(
+    accessToken: string,
+    referralId: string
+  ): Promise<DraftOasysRiskInformation | null> {
+    if (config.apis.assessRisksAndNeedsApi.riskSummaryEnabled) {
+      try {
+        return await this.interventionsService.getDraftOasysRiskInformation(accessToken, referralId)
+      } catch (e) {
+        const restClientError = e as RestClientError
+        if (restClientError.status === 404) {
+          return null
+        }
+        throw e
+      }
+    }
+    return null
+  }
+
   async viewReferralForm(req: Request, res: Response): Promise<void> {
-    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
+    const { accessToken } = res.locals.user.token
+    const referralId = req.params.id
+    const referral = await this.interventionsService.getDraftReferral(accessToken, referralId)
 
     const [intervention, serviceUser] = await Promise.all([
-      this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
+      this.interventionsService.getIntervention(accessToken, referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.serviceUser.crn),
     ])
     if (
@@ -167,7 +187,8 @@ export default class MakeAReferralController {
       throw new Error('No service category selected')
     }
 
-    const presenter = new ReferralFormPresenter(referral, intervention)
+    const draftOasysRiskInformation = await this.getDraftOasysRiskInformation(accessToken, referralId)
+    const presenter = new ReferralFormPresenter(referral, intervention, draftOasysRiskInformation)
     const view = new ReferralFormView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/makeAReferral/makeAReferralController.ts
+++ b/server/routes/makeAReferral/makeAReferralController.ts
@@ -705,7 +705,8 @@ export default class MakeAReferralController {
   }
 
   async checkAnswers(req: Request, res: Response): Promise<void> {
-    const referral = await this.interventionsService.getDraftReferral(res.locals.user.token.accessToken, req.params.id)
+    const { accessToken } = res.locals.user.token
+    const referral = await this.interventionsService.getDraftReferral(accessToken, req.params.id)
     if (referral.serviceCategoryIds === null) {
       throw new Error('Attempting to check answers without service categories selected')
     }
@@ -714,12 +715,20 @@ export default class MakeAReferralController {
     }
 
     const [intervention, expandedDeliusServiceUser, conviction] = await Promise.all([
-      this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.interventionId),
+      this.interventionsService.getIntervention(accessToken, referral.interventionId),
       this.communityApiService.getExpandedServiceUserByCRN(referral.serviceUser.crn),
       this.communityApiService.getConvictionById(referral.serviceUser.crn, referral.relevantSentenceId),
     ])
-
-    const presenter = new CheckAnswersPresenter(referral, intervention, conviction, expandedDeliusServiceUser)
+    const editedOasysRiskInformation = config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
+      ? await this.interventionsService.getDraftOasysRiskInformation(accessToken, referral.id)
+      : null
+    const presenter = new CheckAnswersPresenter(
+      referral,
+      intervention,
+      conviction,
+      expandedDeliusServiceUser,
+      editedOasysRiskInformation
+    )
     const view = new CheckAnswersView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, expandedDeliusServiceUser)

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -65,8 +65,17 @@ class DraftReferralFactory extends Factory<DraftReferral> {
     })
   }
 
-  filledFormUpToNeedsAndRequirements(serviceCategories: ServiceCategory[] = [serviceCategoryFactory.build()]) {
-    return this.filledFormUpToRiskInformation(serviceCategories).params({
+  filledFormUpToNeedsAndRequirements(
+    serviceCategories: ServiceCategory[] = [serviceCategoryFactory.build()],
+    skipAdditionalRiskInformation = false
+  ) {
+    let filledForm: this
+    if (skipAdditionalRiskInformation) {
+      filledForm = this.selectedServiceCategories(serviceCategories)
+    } else {
+      filledForm = this.filledFormUpToRiskInformation(serviceCategories)
+    }
+    return filledForm.params({
       additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
       accessibilityNeeds: 'She uses a wheelchair',
       needsInterpreter: true,


### PR DESCRIPTION
Changes are behind a feature flag.
This PR adds risk information to check your answers page and ensures that the status links on make a referral form reflect draft oasys risk information.

commit 8d36edfecb533b5b3a26272e4dbb948e24210ad5

Added edited OAsys risk information to check your answers page.


commit f9c70cb5c677a2babffeac02cc7bbe6188bb96a5

Added oasys risk information to selection links on form page.

This shows the status for each of the  make a referral sections.
We now want to set the 'risk information' task to 'Complete' depending on the draft risk information being persisted.

Since some requests may be inflight, during turning this feature on, we need to ensure that this is based on either the additional risk information being set or the draft risk information being persisted.

At a future point in time we can completely remove the check for additional risk information as it will be deprecated.

