### PR TITLE
Edit oasys risk information  draft oasys risk information

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -19,6 +19,7 @@ $path: "/assets/images/"
 @import './components/checkboxes'
 @import './components/button-link'
 @import './components/oasys-text'
+@import './components/link'
 
 
 @import './layout/grid'

--- a/assets/sass/components/_link.scss
+++ b/assets/sass/components/_link.scss
@@ -1,0 +1,8 @@
+.link {
+  cursor: pointer;
+}
+
+.link__right-justified {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/browser/formUtils.ts
+++ b/browser/formUtils.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class FormUtils {
+  static replaceTextAreaFromAttribute(textAreaId: string, attributeId: string) {
+    const textArea = document.getElementById(textAreaId) as HTMLTextAreaElement
+    if (textArea !== null) {
+      const attributeText = textArea.getAttribute(attributeId)
+      if (attributeText !== null) {
+        textArea.value = attributeText
+      }
+    }
+  }
+}

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -266,5 +266,9 @@ module.exports = on => {
     stubUpdateDraftOasysRiskInformation: arg => {
       return interventionsService.stubUpdateDraftOasysRiskInformation(arg.responseJson)
     },
+
+    stubGetDraftOasysRiskInformation: arg => {
+      return interventionsService.stubGetDraftOasysRiskInformation(arg.referralId, arg.responseJson)
+    },
   })
 }

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -189,3 +189,7 @@ Cypress.Commands.add('stubGetMyInterventions', responseJson => {
 Cypress.Commands.add('stubUpdateDraftOasysRiskInformation', responseJson => {
   cy.task('stubUpdateDraftOasysRiskInformation', { responseJson })
 })
+
+Cypress.Commands.add('stubGetDraftOasysRiskInformation', (referralId, responseJson) => {
+  cy.task('stubGetDraftOasysRiskInformation', { referralId, responseJson })
+})

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -786,4 +786,20 @@ export default class InterventionsServiceMocks {
       },
     })
   }
+
+  stubGetDraftOasysRiskInformation = async (referralId: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/draft-referral/${referralId}/oasys-risk-information`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationPresenter.test.ts
@@ -9,7 +9,8 @@ describe('EditOasysRiskInformationPresenter', () => {
         const riskSummary = riskSummaryFactory.build({ assessedOn: '2021-09-20T09:31:45.062Z' })
         const presenter = new EditOasysRiskInformationPresenter(
           supplementaryRiskInformationFactory.build(),
-          riskSummary
+          riskSummary,
+          null
         )
 
         expect(presenter.latestAssessment).toEqual('20 September 2021')
@@ -20,7 +21,8 @@ describe('EditOasysRiskInformationPresenter', () => {
         const riskSummary = riskSummaryFactory.build({ assessedOn: null })
         const presenter = new EditOasysRiskInformationPresenter(
           supplementaryRiskInformationFactory.build(),
-          riskSummary
+          riskSummary,
+          null
         )
 
         expect(presenter.latestAssessment).toEqual('Assessment date not found')
@@ -29,7 +31,8 @@ describe('EditOasysRiskInformationPresenter', () => {
         const riskSummary = riskSummaryFactory.build({ assessedOn: undefined })
         const presenter = new EditOasysRiskInformationPresenter(
           supplementaryRiskInformationFactory.build(),
-          riskSummary
+          riskSummary,
+          null
         )
 
         expect(presenter.latestAssessment).toEqual('Assessment date not found')

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationPresenter.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationPresenter.ts
@@ -5,6 +5,7 @@ import { SupplementaryRiskInformation } from '../../../../../models/assessRisksA
 import RoshPanelPresenter from '../../../../shared/roshPanelPresenter'
 import PresenterUtils from '../../../../../utils/presenterUtils'
 import { FormValidationError } from '../../../../../utils/formValidationError'
+import { DraftOasysRiskInformation } from '../../../../../models/draftOasysRiskInformation'
 
 export default class EditOasysRiskInformationPresenter {
   riskPresenter: RoshPanelPresenter
@@ -12,6 +13,7 @@ export default class EditOasysRiskInformationPresenter {
   constructor(
     readonly supplementaryRiskInformation: SupplementaryRiskInformation | null,
     readonly riskSummary: RiskSummary | null,
+    readonly draftOasysRiskInformation: DraftOasysRiskInformation | null,
     private readonly error: FormValidationError | null = null
   ) {
     this.riskPresenter = new RoshPanelPresenter(riskSummary)

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.test.ts
@@ -1,0 +1,71 @@
+import EditOasysRiskInformationView from './editOasysRiskInformationView'
+import EditOasysRiskInformationPresenter from './editOasysRiskInformationPresenter'
+import { DraftOasysRiskInformation } from '../../../../../models/draftOasysRiskInformation'
+import riskSummaryFactory from '../../../../../../testutils/factories/riskSummary'
+import supplementaryRiskInformationFactory from '../../../../../../testutils/factories/supplementaryRiskInformation'
+import { TextareaArgs } from '../../../../../utils/govukFrontendTypes'
+
+describe('EditOasysRiskInformationView', () => {
+  describe('Risk Information', () => {
+    describe('when superseded by draft information', () => {
+      const riskSummary = riskSummaryFactory.build({
+        riskToSelf: {
+          suicide: { currentConcernsText: 'OAsysSuicide' },
+          selfHarm: { currentConcernsText: 'OAsysSelfHarm' },
+          hostelSetting: { currentConcernsText: 'OAsysHostelSetting' },
+          vulnerability: { currentConcernsText: 'OAsysVulnerability' },
+        },
+        summary: {
+          whoIsAtRisk: 'OAsysWhoIsAtRisk',
+          natureOfRisk: 'OAsysNatureOfRisk',
+          riskImminence: 'OAsysRiskImminence',
+        },
+      })
+      const additionalInformation = supplementaryRiskInformationFactory.build({
+        riskSummaryComments: 'OAsysAdditionalInformation',
+      })
+      it('should show OAsys version for each textbox field when draft does not exist', () => {
+        const editOasysRiskInformationPresenter = new EditOasysRiskInformationPresenter(
+          additionalInformation,
+          riskSummary,
+          null
+        )
+        const fields = new EditOasysRiskInformationView(editOasysRiskInformationPresenter).renderArgs[1]
+        expect((fields.whoIsAtRiskTextareaArgs as TextareaArgs).value).toEqual('OAsysWhoIsAtRisk')
+        expect((fields.natureOfRiskTextareaArgs as TextareaArgs).value).toEqual('OAsysNatureOfRisk')
+        expect((fields.riskImminenceTextareaArgs as TextareaArgs).value).toEqual('OAsysRiskImminence')
+        expect((fields.riskToSelfSuicideTextareaArgs as TextareaArgs).value).toEqual('OAsysSuicide')
+        expect((fields.riskToSelfSelfHarmTextareaArgs as TextareaArgs).value).toEqual('OAsysSelfHarm')
+        expect((fields.riskToSelfHostelSettingTextareaArgs as TextareaArgs).value).toEqual('OAsysHostelSetting')
+        expect((fields.riskToSelfVulnerabilityTextareaArgs as TextareaArgs).value).toEqual('OAsysVulnerability')
+        expect((fields.additionalInformationTextareaArgs as TextareaArgs).value).toEqual('OAsysAdditionalInformation')
+      })
+      it('should show draft version for each textbox field when draft exists', () => {
+        const draftOasysRiskInformation: DraftOasysRiskInformation = {
+          riskSummaryWhoIsAtRisk: 'draftWhoIsAtRisk',
+          riskSummaryNatureOfRisk: 'draftNatureOfRisk',
+          riskSummaryRiskImminence: 'draftRiskImminence',
+          riskToSelfSuicide: 'draftSuicide',
+          riskToSelfSelfHarm: 'draftSelfHarm',
+          riskToSelfHostelSetting: 'draftHostelSetting',
+          riskToSelfVulnerability: 'draftVulnerability',
+          additionalInformation: 'draftAdditionalInformation',
+        }
+        const editOasysRiskInformationPresenter = new EditOasysRiskInformationPresenter(
+          additionalInformation,
+          riskSummary,
+          draftOasysRiskInformation
+        )
+        const fields = new EditOasysRiskInformationView(editOasysRiskInformationPresenter).renderArgs[1]
+        expect((fields.whoIsAtRiskTextareaArgs as TextareaArgs).value).toEqual('draftWhoIsAtRisk')
+        expect((fields.natureOfRiskTextareaArgs as TextareaArgs).value).toEqual('draftNatureOfRisk')
+        expect((fields.riskImminenceTextareaArgs as TextareaArgs).value).toEqual('draftRiskImminence')
+        expect((fields.riskToSelfSuicideTextareaArgs as TextareaArgs).value).toEqual('draftSuicide')
+        expect((fields.riskToSelfSelfHarmTextareaArgs as TextareaArgs).value).toEqual('draftSelfHarm')
+        expect((fields.riskToSelfHostelSettingTextareaArgs as TextareaArgs).value).toEqual('draftHostelSetting')
+        expect((fields.riskToSelfVulnerabilityTextareaArgs as TextareaArgs).value).toEqual('draftVulnerability')
+        expect((fields.additionalInformationTextareaArgs as TextareaArgs).value).toEqual('draftAdditionalInformation')
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.ts
@@ -1,94 +1,114 @@
 import { CheckboxesArgs, TextareaArgs } from '../../../../../utils/govukFrontendTypes'
 import ViewUtils from '../../../../../utils/viewUtils'
+import { DraftOasysRiskInformation } from '../../../../../models/draftOasysRiskInformation'
 import EditOasysRiskInformationPresenter from './editOasysRiskInformationPresenter'
 import OasysRiskSummaryView from '../oasysRiskSummaryView'
 
 export default class EditOasysRiskInformationView {
   riskSummaryView: OasysRiskSummaryView
 
+  private readonly draftOasysRiskInformation: DraftOasysRiskInformation | null
+
   constructor(private readonly presenter: EditOasysRiskInformationPresenter) {
     this.riskSummaryView = new OasysRiskSummaryView(presenter.supplementaryRiskInformation, presenter.riskSummary)
+    this.draftOasysRiskInformation = presenter.draftOasysRiskInformation
   }
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errors.summary)
 
   private get whoIsAtRiskTextareaArgs(): TextareaArgs {
-    const whoIsAtRisk = this.riskSummaryView.riskInformation.summary.whoIsAtRisk.text || ''
+    const whoIsAtRisk = this.draftOasysRiskInformation
+      ? this.draftOasysRiskInformation.riskSummaryWhoIsAtRisk
+      : this.riskSummaryView.riskInformation.summary.whoIsAtRisk.text
     return {
       name: 'who-is-at-risk',
       id: 'who-is-at-risk',
       label: {},
-      value: ViewUtils.escape(whoIsAtRisk),
+      value: ViewUtils.escape(whoIsAtRisk || ''),
     }
   }
 
   private get natureOfRiskTextareaArgs(): TextareaArgs {
-    const natureOfRisk = this.riskSummaryView.riskInformation.summary.natureOfRisk.text || ''
+    const natureOfRisk = this.draftOasysRiskInformation
+      ? this.draftOasysRiskInformation.riskSummaryNatureOfRisk
+      : this.riskSummaryView.riskInformation.summary.natureOfRisk.text
     return {
       name: 'nature-of-risk',
       id: 'nature-of-risk',
       label: {},
-      value: ViewUtils.escape(natureOfRisk),
+      value: ViewUtils.escape(natureOfRisk || ''),
     }
   }
 
   private get riskImminenceTextareaArgs(): TextareaArgs {
-    const riskImminence = this.riskSummaryView.riskInformation.summary.riskImminence.text || ''
+    const riskImminence = this.draftOasysRiskInformation
+      ? this.draftOasysRiskInformation.riskSummaryRiskImminence
+      : this.riskSummaryView.riskInformation.summary.riskImminence.text
     return {
       name: 'risk-imminence',
       id: 'risk-imminence',
       label: {},
-      value: ViewUtils.escape(riskImminence),
+      value: ViewUtils.escape(riskImminence || ''),
     }
   }
 
   private get riskToSelfSelfHarmTextareaArgs(): TextareaArgs {
-    const selfHarm = this.riskSummaryView.riskInformation.riskToSelf.selfHarm.text || ''
+    const selfHarm = this.draftOasysRiskInformation
+      ? this.draftOasysRiskInformation.riskToSelfSelfHarm
+      : this.riskSummaryView.riskInformation.riskToSelf.selfHarm.text
     return {
       name: 'risk-to-self-self-harm',
       id: 'risk-to-self-self-harm',
       label: {},
-      value: ViewUtils.escape(selfHarm),
+      value: ViewUtils.escape(selfHarm || ''),
     }
   }
 
   private get riskToSelfSuicideTextareaArgs(): TextareaArgs {
-    const suicide = this.riskSummaryView.riskInformation.riskToSelf.suicide.text || ''
+    const suicide = this.draftOasysRiskInformation
+      ? this.draftOasysRiskInformation.riskToSelfSuicide
+      : this.riskSummaryView.riskInformation.riskToSelf.suicide.text
     return {
       name: 'risk-to-self-suicide',
       id: 'risk-to-self-suicide',
       label: {},
-      value: ViewUtils.escape(suicide),
+      value: ViewUtils.escape(suicide || ''),
     }
   }
 
   private get riskToSelfHostelSettingTextareaArgs(): TextareaArgs {
-    const hostelSetting = this.riskSummaryView.riskInformation.riskToSelf.hostelSetting.text || ''
+    const hostelSetting = this.draftOasysRiskInformation
+      ? this.draftOasysRiskInformation.riskToSelfHostelSetting
+      : this.riskSummaryView.riskInformation.riskToSelf.hostelSetting.text
     return {
       name: 'risk-to-self-hostel-setting',
       id: 'risk-to-self-hostel-setting',
       label: {},
-      value: ViewUtils.escape(hostelSetting),
+      value: ViewUtils.escape(hostelSetting || ''),
     }
   }
 
   private get riskToSelfVulnerabilityTextareaArgs(): TextareaArgs {
-    const vulnerability = this.riskSummaryView.riskInformation.riskToSelf.vulnerability.text || ''
+    const vulnerability = this.draftOasysRiskInformation
+      ? this.draftOasysRiskInformation.riskToSelfVulnerability
+      : this.riskSummaryView.riskInformation.riskToSelf.vulnerability.text
     return {
       name: 'risk-to-self-vulnerability',
       id: 'risk-to-self-vulnerability',
       label: {},
-      value: ViewUtils.escape(vulnerability),
+      value: ViewUtils.escape(vulnerability || ''),
     }
   }
 
   private get additionalInformationTextareaArgs(): TextareaArgs {
-    const additionalInformation = this.riskSummaryView.riskInformation.additionalRiskInformation.text || ''
+    const additionalInformation = this.draftOasysRiskInformation
+      ? this.draftOasysRiskInformation.additionalInformation
+      : this.riskSummaryView.riskInformation.additionalRiskInformation.text
     return {
       name: 'additional-information',
       id: 'additional-information',
       label: {},
-      value: ViewUtils.escape(additionalInformation),
+      value: ViewUtils.escape(additionalInformation || ''),
     }
   }
 

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.ts
@@ -17,98 +17,114 @@ export default class EditOasysRiskInformationView {
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errors.summary)
 
   private get whoIsAtRiskTextareaArgs(): TextareaArgs {
-    const whoIsAtRisk = this.draftOasysRiskInformation
-      ? this.draftOasysRiskInformation.riskSummaryWhoIsAtRisk
-      : this.riskSummaryView.riskInformation.summary.whoIsAtRisk.text
+    const oasysRiskInfoText = this.riskSummaryView.riskInformation.summary.whoIsAtRisk.text || ''
+    const whoIsAtRisk = this.draftOasysRiskInformation?.riskSummaryWhoIsAtRisk || oasysRiskInfoText
     return {
       name: 'who-is-at-risk',
       id: 'who-is-at-risk',
       label: {},
       value: ViewUtils.escape(whoIsAtRisk || ''),
+      attributes: {
+        oasysRiskInfo: ViewUtils.escape(oasysRiskInfoText),
+      },
     }
   }
 
   private get natureOfRiskTextareaArgs(): TextareaArgs {
-    const natureOfRisk = this.draftOasysRiskInformation
-      ? this.draftOasysRiskInformation.riskSummaryNatureOfRisk
-      : this.riskSummaryView.riskInformation.summary.natureOfRisk.text
+    const oasysRiskInfoText = this.riskSummaryView.riskInformation.summary.natureOfRisk.text || ''
+    const natureOfRisk = this.draftOasysRiskInformation?.riskSummaryNatureOfRisk || oasysRiskInfoText
     return {
       name: 'nature-of-risk',
       id: 'nature-of-risk',
       label: {},
       value: ViewUtils.escape(natureOfRisk || ''),
+      attributes: {
+        oasysRiskInfo: ViewUtils.escape(oasysRiskInfoText),
+      },
     }
   }
 
   private get riskImminenceTextareaArgs(): TextareaArgs {
-    const riskImminence = this.draftOasysRiskInformation
-      ? this.draftOasysRiskInformation.riskSummaryRiskImminence
-      : this.riskSummaryView.riskInformation.summary.riskImminence.text
+    const oasysRiskInfoText = this.riskSummaryView.riskInformation.summary.riskImminence.text || ''
+    const riskImminence = this.draftOasysRiskInformation?.riskSummaryRiskImminence || oasysRiskInfoText
     return {
       name: 'risk-imminence',
       id: 'risk-imminence',
       label: {},
       value: ViewUtils.escape(riskImminence || ''),
+      attributes: {
+        oasysRiskInfo: ViewUtils.escape(oasysRiskInfoText),
+      },
     }
   }
 
   private get riskToSelfSelfHarmTextareaArgs(): TextareaArgs {
-    const selfHarm = this.draftOasysRiskInformation
-      ? this.draftOasysRiskInformation.riskToSelfSelfHarm
-      : this.riskSummaryView.riskInformation.riskToSelf.selfHarm.text
+    const oasysRiskInfoText = this.riskSummaryView.riskInformation.riskToSelf.selfHarm.text || ''
+    const selfHarm = this.draftOasysRiskInformation?.riskToSelfSelfHarm || oasysRiskInfoText
     return {
       name: 'risk-to-self-self-harm',
       id: 'risk-to-self-self-harm',
       label: {},
       value: ViewUtils.escape(selfHarm || ''),
+      attributes: {
+        oasysRiskInfo: ViewUtils.escape(oasysRiskInfoText),
+      },
     }
   }
 
   private get riskToSelfSuicideTextareaArgs(): TextareaArgs {
-    const suicide = this.draftOasysRiskInformation
-      ? this.draftOasysRiskInformation.riskToSelfSuicide
-      : this.riskSummaryView.riskInformation.riskToSelf.suicide.text
+    const oasysRiskInfoText = this.riskSummaryView.riskInformation.riskToSelf.suicide.text || ''
+    const suicide = this.draftOasysRiskInformation?.riskToSelfSuicide || oasysRiskInfoText
     return {
       name: 'risk-to-self-suicide',
       id: 'risk-to-self-suicide',
       label: {},
       value: ViewUtils.escape(suicide || ''),
+      attributes: {
+        oasysRiskInfo: ViewUtils.escape(oasysRiskInfoText),
+      },
     }
   }
 
   private get riskToSelfHostelSettingTextareaArgs(): TextareaArgs {
-    const hostelSetting = this.draftOasysRiskInformation
-      ? this.draftOasysRiskInformation.riskToSelfHostelSetting
-      : this.riskSummaryView.riskInformation.riskToSelf.hostelSetting.text
+    const oasysRiskInfoText = this.riskSummaryView.riskInformation.riskToSelf.hostelSetting.text || ''
+    const hostelSetting = this.draftOasysRiskInformation?.riskToSelfHostelSetting || oasysRiskInfoText
     return {
       name: 'risk-to-self-hostel-setting',
       id: 'risk-to-self-hostel-setting',
       label: {},
       value: ViewUtils.escape(hostelSetting || ''),
+      attributes: {
+        oasysRiskInfo: ViewUtils.escape(oasysRiskInfoText),
+      },
     }
   }
 
   private get riskToSelfVulnerabilityTextareaArgs(): TextareaArgs {
-    const vulnerability = this.draftOasysRiskInformation
-      ? this.draftOasysRiskInformation.riskToSelfVulnerability
-      : this.riskSummaryView.riskInformation.riskToSelf.vulnerability.text
+    const oasysRiskInfoText = this.riskSummaryView.riskInformation.riskToSelf.vulnerability.text || ''
+    const vulnerability = this.draftOasysRiskInformation?.riskToSelfVulnerability || oasysRiskInfoText
     return {
       name: 'risk-to-self-vulnerability',
       id: 'risk-to-self-vulnerability',
       label: {},
       value: ViewUtils.escape(vulnerability || ''),
+      attributes: {
+        oasysRiskInfo: ViewUtils.escape(oasysRiskInfoText),
+      },
     }
   }
 
   private get additionalInformationTextareaArgs(): TextareaArgs {
-    const additionalInformation = this.draftOasysRiskInformation
-      ? this.draftOasysRiskInformation.additionalInformation
-      : this.riskSummaryView.riskInformation.additionalRiskInformation.text
+    const oasysRiskInfoText = this.riskSummaryView.riskInformation.additionalRiskInformation.text || ''
+    const additionalInformation = this.draftOasysRiskInformation?.additionalInformation || oasysRiskInfoText
     return {
       name: 'additional-information',
       id: 'additional-information',
       label: {},
       value: ViewUtils.escape(additionalInformation || ''),
+      attributes: {
+        oasysRiskInfo: ViewUtils.escape(oasysRiskInfoText),
+      },
     }
   }
 

--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationPresenter.test.ts
@@ -10,7 +10,8 @@ describe('OasysRiskInformationPresenter', () => {
         const presenter = new OasysRiskInformationPresenter(
           'referralId',
           supplementaryRiskInformationFactory.build(),
-          riskSummary
+          riskSummary,
+          null
         )
 
         expect(presenter.latestAssessment).toEqual('20 September 2021')
@@ -24,7 +25,8 @@ describe('OasysRiskInformationPresenter', () => {
         const presenter = new OasysRiskInformationPresenter(
           'referralId',
           supplementaryRiskInformationFactory.build(),
-          riskSummary
+          riskSummary,
+          null
         )
 
         expect(presenter.latestAssessment).toEqual('Assessment date not found')
@@ -37,7 +39,8 @@ describe('OasysRiskInformationPresenter', () => {
         const presenter = new OasysRiskInformationPresenter(
           'referralId',
           supplementaryRiskInformationFactory.build(),
-          riskSummary
+          riskSummary,
+          null
         )
 
         expect(presenter.latestAssessment).toEqual('Assessment date not found')

--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
@@ -87,6 +87,7 @@ export default class OasysRiskInformationView {
       'makeAReferral/riskInformationOasys',
       {
         errorSummaryArgs: this.errorSummaryArgs,
+        confirmEditActionHref: this.presenter.confirmEditOasysAction,
         riskInformation: this.riskSummaryView.riskInformation,
         latestAssessment: this.presenter.latestAssessment,
         roshPanelPresenter: this.presenter.riskPresenter,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -666,4 +666,12 @@ export default class InterventionsService {
       data: { ...draftOasysRiskInformation },
     })) as DraftOasysRiskInformation
   }
+
+  async getDraftOasysRiskInformation(token: string, referralId: string): Promise<DraftOasysRiskInformation> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.get({
+      path: `/draft-referral/${referralId}/oasys-risk-information`,
+      headers: { Accept: 'application/json' },
+    })) as DraftOasysRiskInformation
+  }
 }

--- a/server/views/makeAReferral/editRiskInformationOasys.njk
+++ b/server/views/makeAReferral/editRiskInformationOasys.njk
@@ -8,6 +8,8 @@
 {% set pageTitle = "Make a referral" %}
 {% set pageSubTitle = "Edit Service user's risk information" %}
 
+
+
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -22,43 +24,79 @@
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         <h2 class="govuk-heading-m">Who is at risk</h2>
         {{ govukTextarea(whoIsAtRiskTextareaArgs) }}
+        <a id='revert-who-is-at-risk' class="govuk-link link link__right-justified">
+            Revert to original OASys information
+        </a>
         <hr/>
 
         <h2 class="govuk-heading-m">What is the nature of the risk</h2>
         {{ govukTextarea(natureOfRiskTextareaArgs) }}
+        <a id='revert-nature-of-risk' class="govuk-link link link__right-justified">
+            Revert to original OASys information
+        </a>
         <hr/>
 
         <h2 class="govuk-heading-m">When is the risk likely to be greatest</h2>
         {{ govukTextarea(riskImminenceTextareaArgs) }}
+        <a id='revert-risk-imminence' class="govuk-link link link__right-justified">
+            Revert to original OASys information
+        </a>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to self-harm</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.selfHarm.label.class }}"> {{ riskInformation.riskToSelf.selfHarm.label.text }}</p>
         {{ govukTextarea(riskToSelfSelfHarmTextareaArgs) }}
+        <a id='revert-risk-to-self-self-harm' class="govuk-link link link__right-justified">
+            Revert to original OASys information
+        </a>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to suicide</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.suicide.label.class }}"> {{ riskInformation.riskToSelf.suicide.label.text }}</p>
         {{ govukTextarea(riskToSelfSuicideTextareaArgs) }}
+        <a id='revert-risk-to-self-suicide' class="govuk-link link link__right-justified">
+            Revert to original OASys information
+        </a>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to coping in a hostel setting</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.hostelSetting.label.class }}"> {{ riskInformation.riskToSelf.hostelSetting.label.text }}</p>
         {{ govukTextarea(riskToSelfHostelSettingTextareaArgs) }}
+        <a id='revert-risk-to-self-hostel-setting' class="govuk-link link link__right-justified">
+            Revert to original OASys information
+        </a>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to vulnerability</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.vulnerability.label.class }}"> {{ riskInformation.riskToSelf.vulnerability.label.text }}</p>
         {{ govukTextarea(riskToSelfVulnerabilityTextareaArgs) }}
+        <a id='revert-risk-to-self-vulnerability' class="govuk-link link link__right-justified">
+            Revert to original OASys information
+        </a>
         <hr/>
 
         <h2 class="govuk-heading-m">Additional information</h2>
         <p class="govuk-body {{ riskInformation.additionalRiskInformation.label.class }}">{{ riskInformation.additionalRiskInformation.label.text }}</p>
         {{ govukTextarea(additionalInformationTextareaArgs) }}
+        <a id='revert-additional-information' class="govuk-link link link__right-justified">
+            Revert to original OASys information
+        </a>
 
         {{ govukCheckboxes(confirmUnderstoodWarningCheckboxArgs) }}
         {{ govukButton({ text: "Save and continue" }) }}
       </form>
     </div>
   </div>
+        <script src="/assets/formUtils.js">
+        </script>
+    <script {% if cspNonce %} nonce="{{ cspNonce }}" {% endif %}>
+      document.getElementById("revert-who-is-at-risk").onclick = function(){FormUtils.replaceTextAreaFromAttribute("who-is-at-risk", "oasysRiskInfo");}
+      document.getElementById("revert-nature-of-risk").onclick = function(){FormUtils.replaceTextAreaFromAttribute("nature-of-risk", "oasysRiskInfo");}
+      document.getElementById("revert-risk-imminence").onclick = function(){FormUtils.replaceTextAreaFromAttribute("risk-imminence", "oasysRiskInfo");}
+      document.getElementById("revert-risk-to-self-self-harm").onclick = function(){FormUtils.replaceTextAreaFromAttribute("risk-to-self-self-harm", "oasysRiskInfo");}
+      document.getElementById("revert-risk-to-self-suicide").onclick = function(){FormUtils.replaceTextAreaFromAttribute("risk-to-self-suicide", "oasysRiskInfo");}
+      document.getElementById("revert-risk-to-self-hostel-setting").onclick = function(){FormUtils.replaceTextAreaFromAttribute("risk-to-self-hostel-setting", "oasysRiskInfo");}
+      document.getElementById("revert-risk-to-self-vulnerability").onclick = function(){FormUtils.replaceTextAreaFromAttribute("risk-to-self-vulnerability", "oasysRiskInfo");}
+      document.getElementById("revert-additional-information").onclick = function(){FormUtils.replaceTextAreaFromAttribute("additional-information", "oasysRiskInfo");}
+    </script>
 {% endblock %}


### PR DESCRIPTION
This PR introduces the ability to populate the text areaboxes of the `edit oasys risk information` page with draft OAsys risk information. This may be non-null if the user has revisited the page after clicking on `save and continue`. The actual submission to ARN occurs at `check your answers` page, we are using a draft object until that point has been reached.

In addition, a revert `button` allows the user to replace the edited text area with the latest ARN OAsys data.

![image](https://user-images.githubusercontent.com/83066216/142607179-a6fd3348-62d3-49a7-98b5-4f56ea4d715b.png)


Here is the commit overview for this PR:

commit d240aa57254f79bf7546be4d6b3220e76f32db45 

Added javascript revert functionality for text area boxes on edit oasys risk information page.

When activated the text area box will be replaced with content from OAsys.

commit d14ac10257e88a564281323e3010f13948bac116
DraftOasysRiskInformation populates text area boxes on edit oasys risk information page if it has been persisted to the backend; otherwise it will show the default OASys risk information.

commit c591f7936086fa156b7e2e30c9bdc92aa15b8484

Added GET /referrals/{id}/oasys-risk-information endpoint for interventions service

### note

These changes are behind a feature flag
