### PR TITLE
Bug fix for PP view supplier assessment feedback

### DIFF
--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -86,7 +86,7 @@ export default function probationPractitionerRoutes(router: Router, services: Se
   get(router, '/referrals/:id/supplier-assessment', (req, res) =>
     probationPractitionerReferralsController.showSupplierAssessmentAppointment(req, res)
   )
-  get(router, '/referrals/:id/supplier-assessment/post-assessment-feedback', (req, res) =>
+  get(router, '/referrals/:referralId/supplier-assessment/post-assessment-feedback', (req, res) =>
     appointmentsController.viewSupplierAssessmentFeedback(req, res, 'probation-practitioner')
   )
   get(router, '/referrals/:id/action-plan', (req, res) =>


### PR DESCRIPTION
There is a bug which prevents PP user from accessing viewing supplier assessment feedback.

This bug is caused because the route specifies the referral id as `:id` yet the controller code expects this to be named `:referralId`.

https://github.com/ministryofjustice/hmpps-interventions-ui/blob/2b2b6de83078cec8496c17860535497c5511d840/server/routes/appointments/appointmentsController.ts#L563