### PR TITLE
Removed filtering for SP dashboards.

### DIFF
--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -493,33 +493,21 @@ describe('Dashboards', () => {
 
     describe('SP logs in and accesses "My cases"', () => {
       beforeEach(() => {
-        const assignedToSelf = serviceProviderSentReferralSummaryFactory
+        const referralSummary = serviceProviderSentReferralSummaryFactory
           .withAssignedUser('USER1')
-          .build({ referenceNumber: 'ASSIGNED_TO_SELF' })
-        const unassigned = serviceProviderSentReferralSummaryFactory
-          .unassigned()
-          .build({ referenceNumber: 'UNASSIGNED' })
-        const assignedToOther = serviceProviderSentReferralSummaryFactory
-          .withAssignedUser('other')
-          .build({ referenceNumber: 'ASSIGNED_TO_OTHER' })
-        const completed = serviceProviderSentReferralSummaryFactory.completed().build({ referenceNumber: 'COMPLETED' })
-        cy.stubGetServiceProviderSentReferralsSummaryForUserToken([
-          assignedToSelf,
-          unassigned,
-          assignedToOther,
-          completed,
-        ])
+          .build({ referenceNumber: 'REFERRAL_REF' })
+        cy.stubGetServiceProviderSentReferralsSummaryForUserToken([referralSummary])
         cy.login()
       })
 
-      it('should see "My cases" and cases that are assigned to themselves only', () => {
+      it('should see "My cases" with no Caseworker details', () => {
         cy.get('h1').contains('My cases')
         cy.get('table')
           .getTable()
           .should('deep.equal', [
             {
               'Date received': '26 Jan 2021',
-              Referral: 'ASSIGNED_TO_SELF',
+              Referral: 'REFERRAL_REF',
               'Service user': 'Jenny Jones',
               'Intervention type': 'Social Inclusion - West Midlands',
               Action: 'View',
@@ -528,7 +516,7 @@ describe('Dashboards', () => {
       })
 
       describe('Selecting "All open cases"', () => {
-        it('should see "All open cases" and cases that are not concluded', () => {
+        it('should see "All open cases" and Caseworker details', () => {
           cy.get('h1').contains('My cases')
           cy.contains('All open cases').click()
           cy.get('h1').contains('All open cases')
@@ -537,26 +525,10 @@ describe('Dashboards', () => {
             .should('deep.equal', [
               {
                 'Date received': '26 Jan 2021',
-                Referral: 'ASSIGNED_TO_SELF',
+                Referral: 'REFERRAL_REF',
                 'Service user': 'Jenny Jones',
                 'Intervention type': 'Social Inclusion - West Midlands',
                 Caseworker: 'USER1',
-                Action: 'View',
-              },
-              {
-                'Date received': '26 Jan 2021',
-                Referral: 'UNASSIGNED',
-                'Service user': 'Jenny Jones',
-                'Intervention type': 'Social Inclusion - West Midlands',
-                Caseworker: '',
-                Action: 'View',
-              },
-              {
-                'Date received': '26 Jan 2021',
-                Referral: 'ASSIGNED_TO_OTHER',
-                'Service user': 'Jenny Jones',
-                'Intervention type': 'Social Inclusion - West Midlands',
-                Caseworker: 'other',
                 Action: 'View',
               },
             ])
@@ -564,7 +536,7 @@ describe('Dashboards', () => {
       })
 
       describe('Selecting "Unassigned cases"', () => {
-        it('should see "Unassigned cases" and cases that are not assigned', () => {
+        it('should see "Unassigned cases" and no Caseworker details', () => {
           cy.get('h1').contains('My cases')
           cy.contains('Unassigned cases').click()
           cy.get('h1').contains('Unassigned cases')
@@ -573,7 +545,7 @@ describe('Dashboards', () => {
             .should('deep.equal', [
               {
                 'Date received': '26 Jan 2021',
-                Referral: 'UNASSIGNED',
+                Referral: 'REFERRAL_REF',
                 'Service user': 'Jenny Jones',
                 'Intervention type': 'Social Inclusion - West Midlands',
                 Action: 'View',
@@ -583,7 +555,7 @@ describe('Dashboards', () => {
       })
 
       describe('Selecting "Completed cases"', () => {
-        it('should see "Completed cases" and cases that are concluded', () => {
+        it('should see "Completed cases" and Caseworker details', () => {
           cy.get('h1').contains('My cases')
           cy.contains('Completed cases').click()
           cy.get('h1').contains('Completed cases')
@@ -592,10 +564,10 @@ describe('Dashboards', () => {
             .should('deep.equal', [
               {
                 'Date received': '26 Jan 2021',
-                Referral: 'COMPLETED',
+                Referral: 'REFERRAL_REF',
                 'Service user': 'Jenny Jones',
                 'Intervention type': 'Social Inclusion - West Midlands',
-                Caseworker: '',
+                Caseworker: 'USER1',
                 Action: 'View',
               },
             ])

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -125,123 +125,63 @@ describe('GET /service-provider/dashboard', () => {
 
 describe('GET /service-provider/dashboard/my-cases', () => {
   it('displays a list of my cases', async () => {
-    const undefinedRef = serviceProviderSentReferralSummaryFactory.build({
-      referenceNumber: 'undefinedRef',
-      assignedToUserName: undefined,
-      endOfServiceReportSubmitted: undefined,
-    })
     const assignedToSelf = serviceProviderSentReferralSummaryFactory.withAssignedUser('user1').open().build({
       referenceNumber: 'assignedToSelfRef',
     })
-    const unassigned = serviceProviderSentReferralSummaryFactory.unassigned().open().build({
-      referenceNumber: 'unassignedRef',
-    })
-    const completed = serviceProviderSentReferralSummaryFactory.completed().build({
-      referenceNumber: 'completedRef',
-    })
-    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, completed]
-    interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue(referralsSummary)
+    interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue([assignedToSelf])
     await request(app)
       .get('/service-provider/dashboard')
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('My cases')
         expect(res.text).toContain('assignedToSelfRef')
-        expect(res.text).not.toContain('undefinedRef')
-        expect(res.text).not.toContain('unassignedRef')
-        expect(res.text).not.toContain('completedRef')
       })
   })
 })
 
 describe('GET /service-provider/dashboard/all-open-cases', () => {
   it('displays a list of all open cases', async () => {
-    const undefinedRef = serviceProviderSentReferralSummaryFactory.build({
-      referenceNumber: 'undefinedRef',
-      assignedToUserName: undefined,
-      endOfServiceReportSubmitted: undefined,
-    })
     const assignedToSelf = serviceProviderSentReferralSummaryFactory.withAssignedUser('user1').open().build({
       referenceNumber: 'assignedToSelfRef',
     })
-    const unassigned = serviceProviderSentReferralSummaryFactory.unassigned().open().build({
-      referenceNumber: 'unassignedRef',
-    })
-    const completed = serviceProviderSentReferralSummaryFactory.completed().build({
-      referenceNumber: 'completedRef',
-    })
-    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, completed]
-    interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue(referralsSummary)
+    interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue([assignedToSelf])
     await request(app)
       .get('/service-provider/dashboard/all-open-cases')
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('All open cases')
         expect(res.text).toContain('assignedToSelfRef')
-        expect(res.text).toContain('undefinedRef')
-        expect(res.text).toContain('unassignedRef')
-        expect(res.text).not.toContain('completedRef')
       })
   })
 })
 
 describe('GET /service-provider/dashboard/unassigned-cases', () => {
   it('displays a list of unassigned cases', async () => {
-    const undefinedRef = serviceProviderSentReferralSummaryFactory.build({
-      referenceNumber: 'undefinedRef',
-      assignedToUserName: undefined,
-      endOfServiceReportSubmitted: undefined,
-    })
-    const assignedToSelf = serviceProviderSentReferralSummaryFactory.withAssignedUser('user1').open().build({
-      referenceNumber: 'assignedToSelfRef',
-    })
     const unassigned = serviceProviderSentReferralSummaryFactory.unassigned().open().build({
       referenceNumber: 'unassignedRef',
     })
-    const completed = serviceProviderSentReferralSummaryFactory.completed().build({
-      referenceNumber: 'completedRef',
-    })
-    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, completed]
-    interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue(referralsSummary)
+    interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue([unassigned])
     await request(app)
       .get('/service-provider/dashboard/unassigned-cases')
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Unassigned cases')
-        expect(res.text).not.toContain('assignedToSelfRef')
-        expect(res.text).toContain('undefinedRef')
         expect(res.text).toContain('unassignedRef')
-        expect(res.text).not.toContain('completedRef')
       })
   })
 })
 
 describe('GET /service-provider/dashboard/completed-cases', () => {
-  it('displays a list of my cases', async () => {
-    const undefinedRef = serviceProviderSentReferralSummaryFactory.build({
-      referenceNumber: 'undefinedRef',
-      assignedToUserName: undefined,
-      endOfServiceReportSubmitted: undefined,
-    })
-    const assignedToSelf = serviceProviderSentReferralSummaryFactory.withAssignedUser('user1').open().build({
-      referenceNumber: 'assignedToSelfRef',
-    })
-    const unassigned = serviceProviderSentReferralSummaryFactory.unassigned().open().build({
-      referenceNumber: 'unassignedRef',
-    })
+  it('displays a list of completed cases', async () => {
     const completed = serviceProviderSentReferralSummaryFactory.completed().build({
       referenceNumber: 'completedRef',
     })
-    const referralsSummary: ServiceProviderSentReferralSummary[] = [undefinedRef, assignedToSelf, unassigned, completed]
-    interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue(referralsSummary)
+    interventionsService.getServiceProviderSentReferralsSummaryForUserToken.mockResolvedValue([completed])
     await request(app)
       .get('/service-provider/dashboard/completed-cases')
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Completed cases')
-        expect(res.text).not.toContain('assignedToSelfRef')
-        expect(res.text).not.toContain('undefinedRef')
-        expect(res.text).not.toContain('unassignedRef')
         expect(res.text).toContain('completedRef')
       })
   })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -79,11 +79,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       SPDashboardType.MyCases
     )
-    const filteredSummary = referralsSummary.filter(summary => {
-      return summary.assignedToUserName === res.locals.user.username && !summary.endOfServiceReportSubmitted
-    })
-
-    this.renderDashboard(res, filteredSummary, 'My cases')
+    this.renderDashboard(res, referralsSummary, 'My cases')
   }
 
   async showAllOpenCasesDashboard(req: Request, res: Response): Promise<void> {
@@ -91,10 +87,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       SPDashboardType.OpenCases
     )
-    const openReferrals = referralsSummary.filter(summary => {
-      return !summary.endOfServiceReportSubmitted
-    })
-    this.renderDashboard(res, openReferrals, 'All open cases')
+    this.renderDashboard(res, referralsSummary, 'All open cases')
   }
 
   async showUnassignedCasesDashboard(req: Request, res: Response): Promise<void> {
@@ -102,10 +95,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       SPDashboardType.UnassignedCases
     )
-    const unassignedReferrals = referralsSummary.filter(summary => {
-      return !summary.assignedToUserName && !summary.endOfServiceReportSubmitted
-    })
-    this.renderDashboard(res, unassignedReferrals, 'Unassigned cases')
+    this.renderDashboard(res, referralsSummary, 'Unassigned cases')
   }
 
   async showCompletedCasesDashboard(req: Request, res: Response): Promise<void> {
@@ -113,10 +103,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       SPDashboardType.CompletedCases
     )
-    const completedReferrals = referralsSummary.filter(summary => {
-      return summary.endOfServiceReportSubmitted === true
-    })
-    this.renderDashboard(res, completedReferrals, 'Completed cases')
+    this.renderDashboard(res, referralsSummary, 'Completed cases')
   }
 
   private renderDashboard(


### PR DESCRIPTION

Removed filtering for SP dashboards. Filtering is done for us by the backend already.
By keeping the filtering in place it restricts us from changing the filtering strategy on the back end.

This is in preparation for including some cancelled referrals for Completed cases.