### PR TITLE
change heading to supplier assessment appointment on progress page for pp & sp

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -228,7 +228,7 @@ describe('Probation practitioner referrals dashboard', () => {
             cy.visit(`/probation-practitioner/referrals/${assignedReferral.id}/progress`)
 
             cy.contains('This intervention is assigned to John Smith (john.smith@example.com)')
-            cy.contains('Initial assessment appointment')
+            cy.contains('Supplier assessment appointment')
               .next()
               .contains('The appointment has been scheduled by the supplier')
               .next()
@@ -259,7 +259,7 @@ describe('Probation practitioner referrals dashboard', () => {
 
             cy.contains('This intervention is assigned to John Smith (john.smith@example.com)')
 
-            cy.contains('Initial assessment appointment')
+            cy.contains('Supplier assessment appointment')
               .next()
               .contains('The appointment has been scheduled by the supplier')
               .next()
@@ -283,7 +283,7 @@ describe('Probation practitioner referrals dashboard', () => {
 
           cy.contains('This intervention is assigned to John Smith (john.smith@example.com)')
 
-          cy.contains('Initial assessment appointment')
+          cy.contains('Supplier assessment appointment')
             .next()
             .contains('The initial assessment has been delivered and feedback added.')
             .next()
@@ -306,7 +306,7 @@ describe('Probation practitioner referrals dashboard', () => {
 
           cy.contains('This intervention is assigned to John Smith (john.smith@example.com)')
 
-          cy.contains('Initial assessment appointment')
+          cy.contains('Supplier assessment appointment')
             .next()
             .contains('The initial assessment has been delivered and feedback added.')
             .next()

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -2143,7 +2143,7 @@ describe('Service provider referrals dashboard', () => {
 
           cy.visit(`/service-provider/referrals/${sentReferral.id}/progress`)
 
-          cy.contains('Initial assessment appointment')
+          cy.contains('Supplier assessment appointment')
             .next()
             .contains('Feedback needs to be added on the same day the assessment is delivered.')
 
@@ -2220,7 +2220,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Return to progress').click()
           cy.location('pathname').should('equal', `/service-provider/referrals/${sentReferral.id}/progress`)
 
-          cy.contains('Initial assessment appointment')
+          cy.contains('Supplier assessment appointment')
             .next()
             .contains('Feedback needs to be added on the same day the assessment is delivered.')
             .next()
@@ -2264,7 +2264,7 @@ describe('Service provider referrals dashboard', () => {
 
           cy.visit(`/service-provider/referrals/${sentReferral.id}/progress`)
 
-          cy.contains('Initial assessment appointment')
+          cy.contains('Supplier assessment appointment')
             .next()
             .contains('Feedback needs to be added on the same day the assessment is delivered.')
 
@@ -2368,7 +2368,7 @@ describe('Service provider referrals dashboard', () => {
 
           cy.visit(`/service-provider/referrals/${sentReferral.id}/progress`)
 
-          cy.contains('Initial assessment appointment')
+          cy.contains('Supplier assessment appointment')
             .next()
             .contains('Feedback needs to be added on the same day the assessment is delivered.')
 
@@ -2479,7 +2479,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Return to progress').click()
           cy.location('pathname').should('equal', `/service-provider/referrals/${sentReferral.id}/progress`)
 
-          cy.contains('Initial assessment appointment')
+          cy.contains('Supplier assessment appointment')
             .next()
             .contains('The initial assessment has been delivered and feedback added.')
 

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -13,7 +13,7 @@
     <p class="govuk-body">This intervention is assigned to <strong>{{ presenter.assignedCaseworkerFullName }}</strong> (<a href="mailto:{{ presenter.assignedCaseworkerEmail }}">{{ presenter.assignedCaseworkerEmail }}</a>).</p>
   {% endif %}
 
-  <h2 class="govuk-heading-m">Initial assessment appointment</h2>
+  <h2 class="govuk-heading-m">Supplier assessment appointment</h2>
 
   <p class="govuk-body">
   {{ presenter.supplierAssessmentMessage }}

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -18,7 +18,7 @@
     <p class="govuk-body">This intervention is assigned to <strong>{{ presenter.assignedCaseworkerFullName }}</strong> (<a href="mailto:{{ presenter.assignedCaseworkerEmail }}">{{ presenter.assignedCaseworkerEmail }}</a>).</p>
   {% endif %}
 
-  <h2 class="govuk-heading-m">Initial assessment appointment</h2>
+  <h2 class="govuk-heading-m">Supplier assessment appointment</h2>
 
   {% if presenter.referralAssigned %}
     <p class="govuk-body">


### PR DESCRIPTION
## What does this pull request do?

Changes the heading on the progress page from initial assessment appointment to supplier assessment appointment

## What is the intent behind these changes?

Slowly moving towards using supplier assessment as a term, rather than initial assessment. https://trello.com/c/s7ROoAfu/149-update-headlines-for-pp-sp-around-supplier-assessment-appointment
