### PR TITLE
Add supplementary risk info to referral details

### DIFF
--- a/mocks.ts
+++ b/mocks.ts
@@ -160,7 +160,7 @@ export default async function setUpMocks(): Promise<void> {
     ),
     communityApiMocks.stubGetActiveConvictionsByCRN('CRN24', [deliusConvictionFactory.build()]),
     communityApiMocks.stubGetServiceUserByCRN('CRN24', deliusServiceUser.build({ otherIds: { crn: 'CRN24' } })),
-    communityApiMocks.stubGetConvictionById('CRN24', 'null', deliusConvictionFactory.build()),
+    communityApiMocks.stubGetConvictionById('CRN24', '([0-9]+)', deliusConvictionFactory.build()),
     interventionsMocks.stubGetActionPlanAppointment(
       '1',
       1,

--- a/server/models/assessRisksAndNeeds/supplementaryRiskInformation.ts
+++ b/server/models/assessRisksAndNeeds/supplementaryRiskInformation.ts
@@ -1,3 +1,12 @@
 export interface SupplementaryRiskInformation {
   riskSummaryComments: string
+  redactedRisk: {
+    riskWho: string
+    riskWhen: string
+    riskNature: string
+    concernsSelfHarm: string
+    concernsSuicide: string
+    concernsHostel: string
+    concernsVulnerability: string
+  }
 }

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.ts
@@ -17,7 +17,7 @@ export default class EditOasysRiskInformationView {
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errors.summary)
 
   private get whoIsAtRiskTextareaArgs(): TextareaArgs {
-    const oasysRiskInfoText = this.riskSummaryView.riskInformation.summary.whoIsAtRisk.text || ''
+    const oasysRiskInfoText = this.riskSummaryView.oasysRiskInformationArgs.summary.whoIsAtRisk.text || ''
     const whoIsAtRisk = this.draftOasysRiskInformation?.riskSummaryWhoIsAtRisk || oasysRiskInfoText
     return {
       name: 'who-is-at-risk',
@@ -31,7 +31,7 @@ export default class EditOasysRiskInformationView {
   }
 
   private get natureOfRiskTextareaArgs(): TextareaArgs {
-    const oasysRiskInfoText = this.riskSummaryView.riskInformation.summary.natureOfRisk.text || ''
+    const oasysRiskInfoText = this.riskSummaryView.oasysRiskInformationArgs.summary.natureOfRisk.text || ''
     const natureOfRisk = this.draftOasysRiskInformation?.riskSummaryNatureOfRisk || oasysRiskInfoText
     return {
       name: 'nature-of-risk',
@@ -45,7 +45,7 @@ export default class EditOasysRiskInformationView {
   }
 
   private get riskImminenceTextareaArgs(): TextareaArgs {
-    const oasysRiskInfoText = this.riskSummaryView.riskInformation.summary.riskImminence.text || ''
+    const oasysRiskInfoText = this.riskSummaryView.oasysRiskInformationArgs.summary.riskImminence.text || ''
     const riskImminence = this.draftOasysRiskInformation?.riskSummaryRiskImminence || oasysRiskInfoText
     return {
       name: 'risk-imminence',
@@ -59,7 +59,7 @@ export default class EditOasysRiskInformationView {
   }
 
   private get riskToSelfSelfHarmTextareaArgs(): TextareaArgs {
-    const oasysRiskInfoText = this.riskSummaryView.riskInformation.riskToSelf.selfHarm.text || ''
+    const oasysRiskInfoText = this.riskSummaryView.oasysRiskInformationArgs.riskToSelf.selfHarm.text || ''
     const selfHarm = this.draftOasysRiskInformation?.riskToSelfSelfHarm || oasysRiskInfoText
     return {
       name: 'risk-to-self-self-harm',
@@ -73,7 +73,7 @@ export default class EditOasysRiskInformationView {
   }
 
   private get riskToSelfSuicideTextareaArgs(): TextareaArgs {
-    const oasysRiskInfoText = this.riskSummaryView.riskInformation.riskToSelf.suicide.text || ''
+    const oasysRiskInfoText = this.riskSummaryView.oasysRiskInformationArgs.riskToSelf.suicide.text || ''
     const suicide = this.draftOasysRiskInformation?.riskToSelfSuicide || oasysRiskInfoText
     return {
       name: 'risk-to-self-suicide',
@@ -87,7 +87,7 @@ export default class EditOasysRiskInformationView {
   }
 
   private get riskToSelfHostelSettingTextareaArgs(): TextareaArgs {
-    const oasysRiskInfoText = this.riskSummaryView.riskInformation.riskToSelf.hostelSetting.text || ''
+    const oasysRiskInfoText = this.riskSummaryView.oasysRiskInformationArgs.riskToSelf.hostelSetting.text || ''
     const hostelSetting = this.draftOasysRiskInformation?.riskToSelfHostelSetting || oasysRiskInfoText
     return {
       name: 'risk-to-self-hostel-setting',
@@ -101,7 +101,7 @@ export default class EditOasysRiskInformationView {
   }
 
   private get riskToSelfVulnerabilityTextareaArgs(): TextareaArgs {
-    const oasysRiskInfoText = this.riskSummaryView.riskInformation.riskToSelf.vulnerability.text || ''
+    const oasysRiskInfoText = this.riskSummaryView.oasysRiskInformationArgs.riskToSelf.vulnerability.text || ''
     const vulnerability = this.draftOasysRiskInformation?.riskToSelfVulnerability || oasysRiskInfoText
     return {
       name: 'risk-to-self-vulnerability',
@@ -115,7 +115,7 @@ export default class EditOasysRiskInformationView {
   }
 
   private get additionalInformationTextareaArgs(): TextareaArgs {
-    const oasysRiskInfoText = this.riskSummaryView.riskInformation.additionalRiskInformation.text || ''
+    const oasysRiskInfoText = this.riskSummaryView.oasysRiskInformationArgs.additionalRiskInformation.text || ''
     const additionalInformation = this.draftOasysRiskInformation?.additionalInformation || oasysRiskInfoText
     return {
       name: 'additional-information',
@@ -148,7 +148,7 @@ export default class EditOasysRiskInformationView {
       'makeAReferral/editRiskInformationOasys',
       {
         errorSummaryArgs: this.errorSummaryArgs,
-        riskInformation: this.riskSummaryView.riskInformation,
+        riskInformation: this.riskSummaryView.oasysRiskInformationArgs,
         latestAssessment: this.presenter.latestAssessment,
         whoIsAtRiskTextareaArgs: this.whoIsAtRiskTextareaArgs,
         natureOfRiskTextareaArgs: this.natureOfRiskTextareaArgs,

--- a/server/routes/makeAReferral/risk-information/oasys/oasysRiskSummaryView.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/oasysRiskSummaryView.test.ts
@@ -4,32 +4,32 @@ import OasysRiskSummaryView from './oasysRiskSummaryView'
 import { Risk } from '../../../../models/assessRisksAndNeeds/riskSummary'
 
 describe('OasysRiskSummaryView', () => {
-  describe('riskInformation', () => {
+  describe('oasysRiskInformationArgs', () => {
     describe('additionalRiskInformation', () => {
       it('returns special content to display if no additional risk information has been provided', () => {
         const riskSummary = riskSummaryFactory.build()
         const view = new OasysRiskSummaryView(null, riskSummary)
-        expect(view.riskInformation.additionalRiskInformation.label).toHaveProperty('text', 'None')
+        expect(view.oasysRiskInformationArgs.additionalRiskInformation.label).toHaveProperty('text', 'None')
       })
     })
 
     describe('when riskSummary is empty', () => {
       it('should display empty values', () => {
         const view = new OasysRiskSummaryView(null, null)
-        expect(view.riskInformation.summary.whoIsAtRisk.text).toBeNull()
-        expect(view.riskInformation.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
-        expect(view.riskInformation.summary.natureOfRisk.text).toBeNull()
-        expect(view.riskInformation.summary.natureOfRisk.label?.text).toEqual('No information provided')
-        expect(view.riskInformation.summary.riskImminence.text).toBeNull()
-        expect(view.riskInformation.summary.riskImminence.label?.text).toEqual('No information provided')
-        expect(view.riskInformation.riskToSelf.suicide.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.suicide.text).toBeNull()
-        expect(view.riskInformation.riskToSelf.selfHarm.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.selfHarm.text).toBeNull()
-        expect(view.riskInformation.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.hostelSetting.text).toBeNull()
-        expect(view.riskInformation.riskToSelf.vulnerability.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.vulnerability.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
+        expect(view.oasysRiskInformationArgs.summary.natureOfRisk.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.summary.natureOfRisk.label?.text).toEqual('No information provided')
+        expect(view.oasysRiskInformationArgs.summary.riskImminence.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.summary.riskImminence.label?.text).toEqual('No information provided')
+        expect(view.oasysRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.suicide.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.text).toBeNull()
       })
     })
     describe('summary', () => {
@@ -39,12 +39,12 @@ describe('OasysRiskSummaryView', () => {
           summary: { whoIsAtRisk: null, natureOfRisk: null, riskImminence: null },
         })
         const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummary)
-        expect(view.riskInformation.summary.whoIsAtRisk.text).toBeNull()
-        expect(view.riskInformation.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
-        expect(view.riskInformation.summary.natureOfRisk.text).toBeNull()
-        expect(view.riskInformation.summary.natureOfRisk.label?.text).toEqual('No information provided')
-        expect(view.riskInformation.summary.riskImminence.text).toBeNull()
-        expect(view.riskInformation.summary.riskImminence.label?.text).toEqual('No information provided')
+        expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
+        expect(view.oasysRiskInformationArgs.summary.natureOfRisk.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.summary.natureOfRisk.label?.text).toEqual('No information provided')
+        expect(view.oasysRiskInformationArgs.summary.riskImminence.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.summary.riskImminence.label?.text).toEqual('No information provided')
       })
 
       it('returns null text and label when no summary values provided ', () => {
@@ -53,12 +53,12 @@ describe('OasysRiskSummaryView', () => {
           summary: { whoIsAtRisk: undefined, natureOfRisk: undefined, riskImminence: undefined },
         })
         const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummary)
-        expect(view.riskInformation.summary.whoIsAtRisk.text).toBeNull()
-        expect(view.riskInformation.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
-        expect(view.riskInformation.summary.natureOfRisk.text).toBeNull()
-        expect(view.riskInformation.summary.natureOfRisk.label?.text).toEqual('No information provided')
-        expect(view.riskInformation.summary.riskImminence.text).toBeNull()
-        expect(view.riskInformation.summary.riskImminence.label?.text).toEqual('No information provided')
+        expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
+        expect(view.oasysRiskInformationArgs.summary.natureOfRisk.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.summary.natureOfRisk.label?.text).toEqual('No information provided')
+        expect(view.oasysRiskInformationArgs.summary.riskImminence.text).toBeNull()
+        expect(view.oasysRiskInformationArgs.summary.riskImminence.label?.text).toEqual('No information provided')
       })
 
       it('returns text and no label when summary values are provided ', () => {
@@ -67,12 +67,12 @@ describe('OasysRiskSummaryView', () => {
           summary: { whoIsAtRisk: 'whoIsAtRisk', natureOfRisk: 'natureOfRisk', riskImminence: 'riskImminence' },
         })
         const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummary)
-        expect(view.riskInformation.summary.whoIsAtRisk.text).toEqual('whoIsAtRisk')
-        expect(view.riskInformation.summary.whoIsAtRisk.label).toBeUndefined()
-        expect(view.riskInformation.summary.natureOfRisk.text).toEqual('natureOfRisk')
-        expect(view.riskInformation.summary.natureOfRisk.label).toBeUndefined()
-        expect(view.riskInformation.summary.riskImminence.text).toEqual('riskImminence')
-        expect(view.riskInformation.summary.riskImminence.label).toBeUndefined()
+        expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.text).toEqual('whoIsAtRisk')
+        expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.label).toBeUndefined()
+        expect(view.oasysRiskInformationArgs.summary.natureOfRisk.text).toEqual('natureOfRisk')
+        expect(view.oasysRiskInformationArgs.summary.natureOfRisk.label).toBeUndefined()
+        expect(view.oasysRiskInformationArgs.summary.riskImminence.text).toEqual('riskImminence')
+        expect(view.oasysRiskInformationArgs.summary.riskImminence.label).toBeUndefined()
       })
     })
 
@@ -88,10 +88,10 @@ describe('OasysRiskSummaryView', () => {
           },
         })
         const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummary)
-        expect(view.riskInformation.riskToSelf.suicide.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.selfHarm.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
       })
 
       it('returns "Don\'t know" label text when no values provided ', () => {
@@ -105,10 +105,10 @@ describe('OasysRiskSummaryView', () => {
           },
         })
         const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummary)
-        expect(view.riskInformation.riskToSelf.suicide.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.selfHarm.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
       })
 
       it('returns "Yes" label text when \'YES\' RiskResponse is provided', () => {
@@ -129,10 +129,10 @@ describe('OasysRiskSummaryView', () => {
             },
           })
         )
-        expect(view.riskInformation.riskToSelf.suicide.label.text).toEqual('Yes')
-        expect(view.riskInformation.riskToSelf.selfHarm.label.text).toEqual('Yes')
-        expect(view.riskInformation.riskToSelf.hostelSetting.label.text).toEqual('Yes')
-        expect(view.riskInformation.riskToSelf.vulnerability.label.text).toEqual('Yes')
+        expect(view.oasysRiskInformationArgs.riskToSelf.suicide.label.text).toEqual('Yes')
+        expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual('Yes')
+        expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual('Yes')
+        expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual('Yes')
       })
 
       it('returns "No" label text when \'NO\' RiskResponse is provided', () => {
@@ -153,10 +153,10 @@ describe('OasysRiskSummaryView', () => {
             },
           })
         )
-        expect(view.riskInformation.riskToSelf.suicide.label.text).toEqual('No')
-        expect(view.riskInformation.riskToSelf.selfHarm.label.text).toEqual('No')
-        expect(view.riskInformation.riskToSelf.hostelSetting.label.text).toEqual('No')
-        expect(view.riskInformation.riskToSelf.vulnerability.label.text).toEqual('No')
+        expect(view.oasysRiskInformationArgs.riskToSelf.suicide.label.text).toEqual('No')
+        expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual('No')
+        expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual('No')
+        expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual('No')
       })
 
       it("returns \"Don't know\" label text when 'DK' RiskResponse is provided", () => {
@@ -177,10 +177,10 @@ describe('OasysRiskSummaryView', () => {
             },
           })
         )
-        expect(view.riskInformation.riskToSelf.suicide.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.selfHarm.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
       })
 
       it('returns "Don\'t know" label text when no values for current are provided', () => {
@@ -201,10 +201,178 @@ describe('OasysRiskSummaryView', () => {
             },
           })
         )
-        expect(view.riskInformation.riskToSelf.suicide.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.selfHarm.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
-        expect(view.riskInformation.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+      })
+    })
+  })
+
+  describe('supplementaryRiskInformationArgs', () => {
+    describe('additionalRiskInformation', () => {
+      it('returns special content to display if no additional risk information has been provided', () => {
+        const riskSummary = riskSummaryFactory.build()
+        const view = new OasysRiskSummaryView(null, riskSummary)
+        expect(view.supplementaryRiskInformationArgs.additionalRiskInformation.label).toHaveProperty('text', 'None')
+      })
+    })
+
+    describe('summary', () => {
+      it('returns null text and no label when no supplementary provided', () => {
+        const view = new OasysRiskSummaryView(null, null)
+        expect(view.supplementaryRiskInformationArgs.summary.whoIsAtRisk.text).toBeNull()
+        expect(view.supplementaryRiskInformationArgs.summary.whoIsAtRisk.label).toBeUndefined()
+        expect(view.supplementaryRiskInformationArgs.summary.natureOfRisk.text).toBeNull()
+        expect(view.supplementaryRiskInformationArgs.summary.natureOfRisk.label).toBeUndefined()
+        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.text).toBeNull()
+        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.label).toBeUndefined()
+      })
+
+      it('returns text when supplementary information provided', () => {
+        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
+          riskSummaryComments: 'Some risk information about the user',
+          redactedRisk: {
+            riskWho: 'some information for who is at risk',
+            riskWhen: 'some information for when is the risk',
+            riskNature: 'some information on the nature of risk',
+          },
+        })
+        const view = new OasysRiskSummaryView(supplementaryRiskInformation, null)
+        expect(view.supplementaryRiskInformationArgs.summary.whoIsAtRisk.text).toEqual(
+          'some information for who is at risk'
+        )
+        expect(view.supplementaryRiskInformationArgs.summary.natureOfRisk.text).toEqual(
+          'some information on the nature of risk'
+        )
+        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.text).toEqual(
+          'some information for when is the risk'
+        )
+        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.text).toEqual(
+          'some information for when is the risk'
+        )
+      })
+    })
+
+    describe('riskToSelf', () => {
+      it('returns "Don\'t know" label text when null riskToSelf values provided ', () => {
+        const riskSummary = riskSummaryFactory.build({
+          riskToSelf: {
+            suicide: null,
+            selfHarm: null,
+            hostelSetting: null,
+            vulnerability: null,
+          },
+        })
+        const view = new OasysRiskSummaryView(null, riskSummary)
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+      })
+
+      it('returns "Don\'t know" label text when no values provided', () => {
+        const riskSummary = riskSummaryFactory.build({
+          riskToSelf: {
+            suicide: undefined,
+            selfHarm: undefined,
+            hostelSetting: undefined,
+            vulnerability: undefined,
+          },
+        })
+        const view = new OasysRiskSummaryView(null, riskSummary)
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+      })
+
+      it('returns "Yes" label text when \'YES\' RiskResponse is provided', () => {
+        const yesRisk: Risk = {
+          risk: null,
+          current: 'YES',
+          currentConcernsText: null,
+        }
+        const view = new OasysRiskSummaryView(
+          null,
+          riskSummaryFactory.build({
+            riskToSelf: {
+              suicide: yesRisk,
+              selfHarm: yesRisk,
+              hostelSetting: yesRisk,
+              vulnerability: yesRisk,
+            },
+          })
+        )
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual('Yes')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual('Yes')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual('Yes')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual('Yes')
+      })
+
+      it('returns "No" label text when \'NO\' RiskResponse is provided', () => {
+        const noRisk: Risk = {
+          risk: null,
+          current: 'NO',
+          currentConcernsText: null,
+        }
+        const view = new OasysRiskSummaryView(
+          null,
+          riskSummaryFactory.build({
+            riskToSelf: {
+              suicide: noRisk,
+              selfHarm: noRisk,
+              hostelSetting: noRisk,
+              vulnerability: noRisk,
+            },
+          })
+        )
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual('No')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual('No')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual('No')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual('No')
+      })
+
+      it("returns \"Don't know\" label text when 'DK' RiskResponse is provided", () => {
+        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
+        const dkRisk: Risk = {
+          risk: null,
+          current: 'DK',
+          currentConcernsText: null,
+        }
+        const view = new OasysRiskSummaryView(
+          supplementaryRiskInformation,
+          riskSummaryFactory.build({
+            riskToSelf: {
+              suicide: dkRisk,
+              selfHarm: dkRisk,
+              hostelSetting: dkRisk,
+              vulnerability: dkRisk,
+            },
+          })
+        )
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+      })
+
+      it('returns text when supplementary information provided', () => {
+        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
+          redactedRisk: {
+            concernsSelfHarm: 'some concerns for self harm',
+            concernsSuicide: 'some concerns for suicide',
+            concernsHostel: 'some concerns for hostel',
+            concernsVulnerability: 'some concerns for vulnerability',
+          },
+        })
+        const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummaryFactory.build())
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.text).toEqual('some concerns for suicide')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.text).toEqual('some concerns for self harm')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.text).toEqual('some concerns for hostel')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.text).toEqual(
+          'some concerns for vulnerability'
+        )
       })
     })
   })

--- a/server/routes/makeAReferral/risk-information/oasys/oasysRiskSummaryView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/oasysRiskSummaryView.ts
@@ -54,7 +54,7 @@ export default class OasysRiskSummaryView {
     readonly riskSummary: RiskSummary | null
   ) {}
 
-  get riskInformation(): RiskInformationArgs {
+  get oasysRiskInformationArgs(): RiskInformationArgs {
     const summary = this.riskSummary?.summary
     const riskToSelf = this.riskSummary?.riskToSelf
     return {
@@ -100,6 +100,57 @@ export default class OasysRiskSummaryView {
             text: this.riskToSelfLabelText(riskToSelf?.vulnerability),
           },
           text: riskToSelf?.vulnerability ? riskToSelf.vulnerability.currentConcernsText : null,
+        },
+      },
+      additionalRiskInformation: {
+        label: this.supplementaryRiskInformation ? undefined : this.noAdditionalRiskInformationLabel,
+        text: this.supplementaryRiskInformation ? this.supplementaryRiskInformation.riskSummaryComments : null,
+      },
+    }
+  }
+
+  get supplementaryRiskInformationArgs(): RiskInformationArgs {
+    const riskToSelf = this.riskSummary?.riskToSelf
+    return {
+      summary: {
+        whoIsAtRisk: {
+          text: this.supplementaryRiskInformation?.redactedRisk.riskWho || null,
+        },
+        natureOfRisk: {
+          text: this.supplementaryRiskInformation?.redactedRisk.riskNature || null,
+        },
+        riskImminence: {
+          text: this.supplementaryRiskInformation?.redactedRisk.riskWhen || null,
+        },
+      },
+      riskToSelf: {
+        suicide: {
+          label: {
+            class: this.riskToSelfLabelClass(riskToSelf?.suicide),
+            text: this.riskToSelfLabelText(riskToSelf?.suicide),
+          },
+          text: this.supplementaryRiskInformation?.redactedRisk.concernsSuicide || null,
+        },
+        selfHarm: {
+          label: {
+            class: this.riskToSelfLabelClass(riskToSelf?.selfHarm),
+            text: this.riskToSelfLabelText(riskToSelf?.selfHarm),
+          },
+          text: this.supplementaryRiskInformation?.redactedRisk.concernsSelfHarm || null,
+        },
+        hostelSetting: {
+          label: {
+            class: this.riskToSelfLabelClass(riskToSelf?.hostelSetting),
+            text: this.riskToSelfLabelText(riskToSelf?.hostelSetting),
+          },
+          text: this.supplementaryRiskInformation?.redactedRisk.concernsHostel || null,
+        },
+        vulnerability: {
+          label: {
+            class: this.riskToSelfLabelClass(riskToSelf?.vulnerability),
+            text: this.riskToSelfLabelText(riskToSelf?.vulnerability),
+          },
+          text: this.supplementaryRiskInformation?.redactedRisk.concernsVulnerability || null,
         },
       },
       additionalRiskInformation: {

--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
@@ -88,7 +88,7 @@ export default class OasysRiskInformationView {
       {
         errorSummaryArgs: this.errorSummaryArgs,
         confirmEditActionHref: this.presenter.confirmEditOasysAction,
-        riskInformation: this.riskSummaryView.riskInformation,
+        riskInformation: this.riskSummaryView.oasysRiskInformationArgs,
         latestAssessment: this.presenter.latestAssessment,
         roshPanelPresenter: this.presenter.riskPresenter,
         roshAnalysisTableArgs: this.roshPanelView.roshAnalysisTableArgs.bind(this.roshPanelView),

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -21,6 +21,7 @@ import RiskSummary from '../../models/assessRisksAndNeeds/riskSummary'
 import RoshPanelPresenter from './roshPanelPresenter'
 import { DeliusOffenderManager } from '../../models/delius/deliusOffenderManager'
 import DateUtils from '../../utils/dateUtils'
+import config from '../../config'
 
 export default class ShowReferralPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
@@ -31,14 +32,14 @@ export default class ShowReferralPresenter {
     private readonly sentReferral: SentReferral,
     private readonly intervention: Intervention,
     private readonly conviction: DeliusConviction,
-    private readonly riskInformation: SupplementaryRiskInformation,
+    readonly riskInformation: SupplementaryRiskInformation,
     private readonly sentBy: DeliusUser,
     private readonly assignee: AuthUserDetails | null,
     private readonly assignEmailError: FormValidationError | null,
     readonly userType: 'service-provider' | 'probation-practitioner',
     readonly canAssignReferral: boolean,
     private readonly deliusServiceUser: ExpandedDeliusServiceUser,
-    private readonly riskSummary: RiskSummary | null,
+    readonly riskSummary: RiskSummary | null,
     private readonly responsibleOfficer: DeliusOffenderManager | null
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
@@ -131,6 +132,13 @@ export default class ShowReferralPresenter {
     })
 
     return items
+  }
+
+  get canShowFullSupplementaryRiskInformation(): boolean {
+    if (this.userType === 'probation-practitioner') {
+      return false
+    }
+    return config.apis.assessRisksAndNeedsApi.riskSummaryEnabled
   }
 
   private getReferralDesiredOutcomesForServiceCategory(serviceCategory: ServiceCategory): DesiredOutcome[] {

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -2,6 +2,7 @@ import ShowReferralPresenter from './showReferralPresenter'
 import ViewUtils from '../../utils/viewUtils'
 import { InputArgs, SummaryListArgs, TagArgs } from '../../utils/govukFrontendTypes'
 import RoshPanelView from './roshPanelView'
+import OasysRiskSummaryView from '../makeAReferral/risk-information/oasys/oasysRiskSummaryView'
 
 interface ServiceCategorySection {
   name: string
@@ -9,7 +10,11 @@ interface ServiceCategorySection {
 }
 
 export default class ShowReferralView {
-  constructor(private readonly presenter: ShowReferralPresenter) {}
+  supplementaryRiskInformationView: OasysRiskSummaryView
+
+  constructor(private readonly presenter: ShowReferralPresenter) {
+    this.supplementaryRiskInformationView = new OasysRiskSummaryView(presenter.riskInformation, presenter.riskSummary)
+  }
 
   private readonly roshPanelView = new RoshPanelView(this.presenter.roshPanelPresenter, this.presenter.userType)
 
@@ -73,6 +78,7 @@ export default class ShowReferralView {
         backLinkArgs: this.backLinkArgs,
         roshAnalysisTableArgs: this.roshPanelView.roshAnalysisTableArgs.bind(this.roshPanelView),
         riskLevelDetailsArgs: this.roshPanelView.riskLevelDetailsArgs,
+        supplementaryRiskInformation: this.supplementaryRiskInformationView.supplementaryRiskInformationArgs,
       },
     ]
   }

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -45,7 +45,57 @@
 
       {% endif %}
 
-      {{ govukSummaryList(serviceUserRisksSummaryListArgs) }}
+      {% if presenter.canShowFullSupplementaryRiskInformation %}
+         <h2 class="govuk-heading-m">Who is at risk</h2>
+         {% if supplementaryRiskInformation.summary.whoIsAtRisk.label %}
+             <p class="govuk-body {{ supplementaryRiskInformation.summary.whoIsAtRisk.label.class}}">{{ supplementaryRiskInformation.summary.whoIsAtRisk.label.text }}</p>
+         {% endif %}
+         <p class="govuk-body">{{ supplementaryRiskInformation.summary.whoIsAtRisk.text | escape | nl2br }}</p>
+         <hr/>
+
+         <h2 class="govuk-heading-m">What is the nature of the risk</h2>
+         {% if supplementaryRiskInformation.summary.natureOfRisk.label %}
+             <p class="govuk-body {{supplementaryRiskInformation.summary.natureOfRisk.label.class}}">{{ supplementaryRiskInformation.summary.natureOfRisk.label.text }}</p>
+         {% endif %}
+         <p class="govuk-body">{{ supplementaryRiskInformation.summary.natureOfRisk.text | escape | nl2br }}</p>
+         <hr/>
+
+         <h2 class="govuk-heading-m">When is the risk likely to be greatest</h2>
+         {% if supplementaryRiskInformation.summary.riskImminence.label %}
+             <p class="govuk-body {{supplementaryRiskInformation.summary.riskImminence.label.class}}">{{ supplementaryRiskInformation.summary.riskImminence.label.text }}</p>
+         {% endif %}
+         <p class="govuk-body">{{ supplementaryRiskInformation.summary.riskImminence.text | escape | nl2br }}</p>
+         <hr/>
+
+         <h2 class="govuk-heading-m">Concerns in relation to self-harm</h2>
+         <p class="govuk-body {{ supplementaryRiskInformation.riskToSelf.selfHarm.label.class }}"> {{ supplementaryRiskInformation.riskToSelf.selfHarm.label.text }}</p>
+         <p class="govuk-body">{{ supplementaryRiskInformation.riskToSelf.selfHarm.text | escape | nl2br }}</p>
+         <hr/>
+
+         <h2 class="govuk-heading-m">Concerns in relation to suicide</h2>
+         <p class="govuk-body {{ supplementaryRiskInformation.riskToSelf.suicide.label.class }}"> {{ supplementaryRiskInformation.riskToSelf.suicide.label.text }}</p>
+         <p class="govuk-body">{{ supplementaryRiskInformation.riskToSelf.suicide.text | escape | nl2br }}</p>
+         <hr/>
+
+         <h2 class="govuk-heading-m">Concerns in relation to coping in a hostel setting</h2>
+         <p class="govuk-body {{ supplementaryRiskInformation.riskToSelf.hostelSetting.label.class }}"> {{ supplementaryRiskInformation.riskToSelf.hostelSetting.label.text }}</p>
+         <p class="govuk-body">{{ supplementaryRiskInformation.riskToSelf.hostelSetting.text | escape | nl2br }}</p>
+         <hr/>
+
+         <h2 class="govuk-heading-m">Concerns in relation to vulnerability</h2>
+         <p class="govuk-body {{ supplementaryRiskInformation.riskToSelf.vulnerability.label.class }}"> {{ supplementaryRiskInformation.riskToSelf.vulnerability.label.text }}</p>
+         <p class="govuk-body">{{ supplementaryRiskInformation.riskToSelf.vulnerability.text | escape | nl2br }}</p>
+         <hr/>
+
+         <h2 class="govuk-heading-m">Additional information</h2>
+         {% if supplementaryRiskInformation.additionalRiskInformation.label %}
+             <p class="govuk-body {{ supplementaryRiskInformation.additionalRiskInformation.label.class }}">{{ supplementaryRiskInformation.additionalRiskInformation.label.text }}</p>
+         {% endif %}
+         <p class="govuk-body">{{ supplementaryRiskInformation.additionalRiskInformation.text | escape | nl2br }}</p>
+      {% else %}
+        {{ govukSummaryList(serviceUserRisksSummaryListArgs) }}
+      {% endif %}
+
 
       <h2 class="govuk-heading-m">Service user's needs</h2>
       {{ govukSummaryList(serviceUserNeedsSummaryListArgs) }}

--- a/testutils/factories/supplementaryRiskInformation.ts
+++ b/testutils/factories/supplementaryRiskInformation.ts
@@ -3,4 +3,13 @@ import { SupplementaryRiskInformation } from '../../server/models/assessRisksAnd
 
 export default Factory.define<SupplementaryRiskInformation>(() => ({
   riskSummaryComments: 'Some risk information about the user',
+  redactedRisk: {
+    riskWho: 'some information for who is at risk',
+    riskWhen: 'some information for when is the risk',
+    riskNature: 'some information on the nature of risk',
+    concernsSelfHarm: 'some concerns for self harm',
+    concernsSuicide: 'some concerns for suicide',
+    concernsHostel: 'some concerns for hostel',
+    concernsVulnerability: 'some concerns for vulnerability',
+  },
 }))


### PR DESCRIPTION
  
  commit c32bec89f9b55599bddbeca5f9ce3c88797f0bd8
  
  Added mock for communityApi to return conviction for crn CRN24 and any conviction id
  
  
  commit 865e3b7993de5a742dc5e56be97b85ae4d5203cb
  Added redactedRisk values into SupplementaryRiskInformation that is returned by ARN. This is the information that was entered in as part of MakeAReferral journey
  
  commit f215a222997e96a66c4eb500e9537f876a69c831
  
  Add a new method to oasysRiskSummaryView.ts that presents supplementary risk information formatted in correct styleing for use within nunjuck components.
  
  
  commit 722498197dd2d3c44827d1e0824c39f695eb9b8a 
  
  Added presentation of supplementary risk information to referral details page. It only shows for service provider and if the feature has been enabled, else only additional information is presented.
  
  
  
  
  
  
  ### screen shot
  ![image](https://user-images.githubusercontent.com/83066216/143473232-b852b4ec-bd9f-419e-9746-04fece6c02e9.png)