### PR TITLE
Switch UI deploy to the new cluster on dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ workflows:
             - vulnerability_scan_and_monitor
           context:
             - hmpps-common-vars
+            - hmpps-interventions-dev-deploy
       - tag_pact_version:
           name: "tag_pact_version_dev"
           tag: "deployed:dev"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,6 +1,7 @@
 generic-service:
   ingress:
     host: hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+    contextColour: green
   env:
     INGRESS_URL: "https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
     DEPLOYMENT_ENV: dev


### PR DESCRIPTION
## What does this pull request do?

Switch dev environment deployment to the new cluster.

🚨 If this is successful the ingress/deployment/pods will be **removed** from live-1 (manually)

This is controlled by `ingress.contextColour` values in `values-{env}.yaml`

- 🔵 "blue": goes to the current cluster
- 🟢 "green": goes to the new cluster

## Background work

Manually copied all unprovisioned secrets over to the new cluster that blocked boot (`session`)

## What is the intent behind these changes?

We need to migrate over to the new cluster this year.