### PR TITLE
Show error message for reassign referral

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -119,6 +119,7 @@ export default class ServiceProviderReferralsController {
 
   async showReferral(req: Request, res: Response): Promise<void> {
     const { accessToken } = res.locals.user.token
+
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
 
     const { crn } = sentReferral.referral.serviceUser
@@ -139,18 +140,16 @@ export default class ServiceProviderReferralsController {
         : await this.hmppsAuthService.getSPUserByUsername(accessToken, sentReferral.assignedTo.username)
 
     let formError: FormValidationError | null = null
-    if (assignee === null) {
-      const error = req.query.error as string
-      if (error !== undefined || error !== '') {
-        formError = {
-          errors: [
-            {
-              formFields: ['email'],
-              errorSummaryLinkedField: 'email',
-              message: error,
-            },
-          ],
-        }
+    const error = req.query.error as string
+    if (error !== undefined || error !== '') {
+      formError = {
+        errors: [
+          {
+            formFields: ['email'],
+            errorSummaryLinkedField: 'email',
+            message: error,
+          },
+        ],
       }
     }
 


### PR DESCRIPTION

No error message is shown when attempting to reassign a referral and the email address is not found.

## Screenshot of what the error message should show
![image](https://user-images.githubusercontent.com/83066216/144259977-e6cbef69-e65e-40c2-bb78-da0c3be8d1be.png)
