### PR TITLE
Migration: switch to new cluster on dev and preprod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ workflows:
             - approve_postdev
           context:
             - hmpps-common-vars
-            - hmpps-interventions-ui-preprod
+            - hmpps-interventions-preprod-deploy
       - tag_pact_version:
           name: "tag_pact_version_preprod"
           tag: "deployed:preprod"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ workflows:
             - vulnerability_scan_and_monitor
           context:
             - hmpps-common-vars
+            - hmpps-interventions-dev-deploy
       - tag_pact_version:
           name: "tag_pact_version_dev"
           tag: "deployed:dev"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,6 +1,7 @@
 generic-service:
   ingress:
     host: hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+    contextColour: green
   env:
     INGRESS_URL: "https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
     DEPLOYMENT_ENV: dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,6 +1,7 @@
 generic-service:
   ingress:
     host: hmpps-interventions-ui-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
+    contextColour: green
     modsecurity_enabled: true
   env:
     INGRESS_URL: "https://hmpps-interventions-ui-preprod.apps.live-1.cloud-platform.service.justice.gov.uk"


### PR DESCRIPTION
## What does this pull request do?

Deploy to the new Cloud Platform cluster on dev and preprod environments

## What is the intent behind these changes?

We would like to migrate by the end of 2021.

The service and delius-interventions-listener are already migrated.

🌳 When this is merged, `dev` and `preprod` live-1 namespaces can be deleted 🎐 