### PR TITLE
Action plan activities out of order for new revised action plan

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1507,7 +1507,19 @@ describe('POST /service-provider/referrals/:id/action-plan/edit', () => {
         {
           id: 'd67217a8-82eb-4e8d-bdce-60dbd6ba6db9',
           createdAt: '2020-12-07T20:45:21.986389Z',
-          description: 'existing activity',
+          description: 'existing activity - 2020-12-07T20:45:21.986389Z',
+        },
+
+        {
+          id: '4f3db97b-b258-4aeb-8fc1-4d712cde3e43',
+          createdAt: '2020-12-07T20:50:21.986389Z',
+          description: 'existing activity - 2020-12-07T20:50:21.986389Z',
+        },
+
+        {
+          id: '091f94a7-939a-43e2-ba79-e5a948f1f1c3',
+          createdAt: '2020-12-10T19:45:21.986389Z',
+          description: 'existing activity - 2020-12-10T19:45:21.986389Z',
         },
       ],
     })
@@ -1524,7 +1536,9 @@ describe('POST /service-provider/referrals/:id/action-plan/edit', () => {
       .expect('Location', `/service-provider/action-plan/${newActionPlan.id}/add-activity/1`)
 
     expect(interventionsService.createDraftActionPlan).toBeCalledWith('token', referral.id, 5, [
-      { description: 'existing activity' },
+      { description: 'existing activity - 2020-12-07T20:45:21.986389Z' },
+      { description: 'existing activity - 2020-12-07T20:50:21.986389Z' },
+      { description: 'existing activity - 2020-12-10T19:45:21.986389Z' },
     ])
   })
 })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -818,9 +818,11 @@ export default class ServiceProviderReferralsController {
       accessToken,
       sentReferral.id,
       existingActionPlan.numberOfSessions || undefined,
-      existingActionPlan.activities.map(it => {
-        return { description: it.description }
-      })
+      existingActionPlan.activities
+        .sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1))
+        .map(it => {
+          return { description: it.description }
+        })
     )
     res.redirect(303, `/service-provider/action-plan/${newDraftActionPlan.id}/add-activity/1`)
   }


### PR DESCRIPTION
We have a bug with creating a new action plan from an old one whereby the activities on the new action plan are created out of order compared with the old action plan.

This fix is to order the activities before submitting them to create the new draft action plan.