### PR TITLE
Display caseworker details for appointment feedback

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -267,7 +267,10 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
       cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
-      cy.stubGetAuthUserByUsername(assignedReferral.assignedTo.username, hmppsAuthUserFactory.build())
+      cy.stubGetAuthUserByUsername(
+        assignedReferral.assignedTo.username,
+        hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', email: 'john.smith@email.com' })
+      )
 
       const appointmentsWithSubmittedFeedback = [
         actionPlanAppointmentFactory.scheduled().build({
@@ -295,7 +298,7 @@ describe('Probation Practitioner monitor journey', () => {
 
       cy.contains('View feedback form').click()
 
-      cy.contains('john.smith')
+      cy.contains('John Smith (john.smith@email.com)')
       cy.contains('Alex attended the session')
       cy.contains('Yes, they were on time')
       cy.contains('Alex was well-behaved')

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1495,6 +1495,7 @@ describe('Service provider referrals dashboard', () => {
             notifyProbationPractitioner: false,
           },
           submitted: true,
+          submittedBy: serviceProvider,
         },
       }),
     ]
@@ -1557,6 +1558,8 @@ describe('Service provider referrals dashboard', () => {
       cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
       cy.contains('Intervention cancelled').should('not.exist')
       cy.contains('View feedback form').click()
+      cy.contains('Caseworker').next().contains('Case Worker (auth.user@someagency.justice.gov.uk)')
+      cy.contains('Feedback submitted by').next().contains('Case Worker (auth.user@someagency.justice.gov.uk)')
       cy.contains('Alex attended the session')
       cy.contains('Yes, they were on time')
       cy.contains('Alex was well-behaved')

--- a/server/routes/appointments/appointmentSummary.test.ts
+++ b/server/routes/appointments/appointmentSummary.test.ts
@@ -51,45 +51,54 @@ describe(AppointmentSummary, () => {
       })
     })
 
-    describe('when the assigned case worker is provided', () => {
-      describe('and it is an DeliusAuthUser', () => {
-        describe('and only firstname is provided', () => {
-          it('contains the firstname as the caseworker', () => {
-            const appointment = initialAssessmentAppointmentFactory.build()
-            const summaryComponent = new AppointmentSummary(appointment, { firstName: 'Liam' })
-            expect(summaryComponent.appointmentSummaryList[0]).toEqual({ key: 'Caseworker', lines: ['Liam'] })
+    describe('when the feedback submitted case worker is provided', () => {
+      it('it is included in summary list', () => {
+        const appointment = initialAssessmentAppointmentFactory.build()
+        const summaryComponent = new AppointmentSummary(
+          appointment,
+          null,
+          null,
+          hmppsAuthUserFactory.build({
+            firstName: 'firstName',
+            lastName: 'lastName',
+            email: 'email',
           })
-        })
+        )
 
-        describe('and only lastname is provided', () => {
-          it('contains the lastname as the caseworker', () => {
-            const appointment = initialAssessmentAppointmentFactory.build()
-            const summaryComponent = new AppointmentSummary(appointment, { lastName: 'Johnson' })
-            expect(summaryComponent.appointmentSummaryList[0]).toEqual({ key: 'Caseworker', lines: ['Johnson'] })
-          })
-        })
-
-        describe('and fullname is provided', () => {
-          it('contains the fullname as the caseworker', () => {
-            const appointment = initialAssessmentAppointmentFactory.build()
-            const assignee = hmppsAuthUserFactory.build({ firstName: 'Liam', lastName: 'Johnson' })
-            const summaryComponent = new AppointmentSummary(appointment, assignee)
-
-            expect(summaryComponent.appointmentSummaryList[0]).toEqual({ key: 'Caseworker', lines: ['Liam Johnson'] })
-          })
+        expect(summaryComponent.appointmentSummaryList[0]).toMatchObject({
+          key: 'Feedback submitted by',
+          lines: [
+            {
+              firstName: 'firstName',
+              lastName: 'lastName',
+              email: 'email',
+            },
+          ],
         })
       })
+    })
 
-      describe('and it is a User', () => {
-        it('contains the username of the referral’s assignee', () => {
-          const appointment = initialAssessmentAppointmentFactory.build()
-          const assignee = { username: 'hellouser@username', userId: 'userId', authSource: 'authSource' }
-          const summaryComponent = new AppointmentSummary(appointment, assignee)
-
-          expect(summaryComponent.appointmentSummaryList[0]).toEqual({
-            key: 'Caseworker',
-            lines: ['hellouser@username'],
+    describe('when the assigned case worker is provided', () => {
+      it('it is included in summary list', () => {
+        const appointment = initialAssessmentAppointmentFactory.build()
+        const summaryComponent = new AppointmentSummary(
+          appointment,
+          hmppsAuthUserFactory.build({
+            firstName: 'firstName',
+            lastName: 'lastName',
+            email: 'email',
           })
+        )
+
+        expect(summaryComponent.appointmentSummaryList[0]).toMatchObject({
+          key: 'Caseworker',
+          lines: [
+            {
+              firstName: 'firstName',
+              lastName: 'lastName',
+              email: 'email',
+            },
+          ],
         })
       })
     })

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -5,26 +5,25 @@ import Address from '../../models/address'
 import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
 import DateUtils from '../../utils/dateUtils'
 import { AppointmentSchedulingDetails } from '../../models/appointment'
+import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
 
-interface Caseworker {
-  username?: string
-  firstName?: string
-  lastName?: string
-}
 export default class AppointmentSummary {
   constructor(
     private readonly appointment: AppointmentSchedulingDetails,
-    private readonly assignedCaseworker: Caseworker | null = null,
-    private readonly deliusOfficeLocation: DeliusOfficeLocation | null = null
+    private readonly assignedCaseworker: AuthUserDetails | string | null = null,
+    private readonly deliusOfficeLocation: DeliusOfficeLocation | null = null,
+    private readonly feedbackSubmittedBy: AuthUserDetails | string | null = null
   ) {}
 
   private readonly appointmentDecorator = new AppointmentDecorator(this.appointment)
 
   get appointmentSummaryList(): SummaryListItem[] {
     const summary: SummaryListItem[] = []
-    const caseworkerName = this.assignedCaseworkerName
-    if (caseworkerName !== null) {
-      summary.push({ key: 'Caseworker', lines: [caseworkerName] })
+    if (this.assignedCaseworker) {
+      summary.push({ key: 'Caseworker', lines: [this.assignedCaseworker] })
+    }
+    if (this.feedbackSubmittedBy) {
+      summary.push({ key: 'Feedback submitted by', lines: [this.feedbackSubmittedBy] })
     }
     if (this.appointmentDecorator.britishDay) {
       summary.push({
@@ -69,18 +68,6 @@ export default class AppointmentSummary {
       })
     }
     return summary
-  }
-
-  private get assignedCaseworkerName(): string | null {
-    if (this.assignedCaseworker?.firstName || this.assignedCaseworker?.lastName) {
-      const firstName = this.assignedCaseworker.firstName ? this.assignedCaseworker.firstName : ''
-      const lastName = this.assignedCaseworker.lastName ? this.assignedCaseworker.lastName : ''
-      return `${firstName} ${lastName}`.trim()
-    }
-    if (this.assignedCaseworker?.username) {
-      return this.assignedCaseworker.username
-    }
-    return null
   }
 
   private deliveryMethod(appointmentDeliveryType: AppointmentDeliveryType): string {

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -1698,6 +1698,13 @@ describe('Adding post delivery session feedback', () => {
           interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
           interventionsService.getSentReferral.mockResolvedValue(referral)
           interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
+          hmppsAuthService.getSPUserByUsername.mockResolvedValue(
+            hmppsAuthUserFactory.build({
+              firstName: 'caseworkerFirstName',
+              lastName: 'caseworkerLastName',
+              email: 'caseworker@email.com',
+            })
+          )
 
           await request(app)
             .get(
@@ -1706,7 +1713,8 @@ describe('Adding post delivery session feedback', () => {
             .expect(200)
             .expect(res => {
               expect(res.text).toContain('View feedback')
-              expect(res.text).toContain('Kay.Swerker')
+              expect(res.text).toContain('caseworkerFirstName caseworkerLastName')
+              expect(res.text).toContain('caseworker@email.com')
               expect(res.text).toContain('They were early to the session')
               expect(res.text).toContain('Yes, they were on time')
               expect(res.text).toContain('Alex was well-behaved')
@@ -1749,6 +1757,13 @@ describe('Adding post delivery session feedback', () => {
           interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
           interventionsService.getSentReferral.mockResolvedValue(referral)
           interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
+          hmppsAuthService.getSPUserByUsername.mockResolvedValue(
+            hmppsAuthUserFactory.build({
+              firstName: 'caseworkerFirstName',
+              lastName: 'caseworkerLastName',
+              email: 'caseworker@email.com',
+            })
+          )
 
           await request(app)
             .get(
@@ -1757,7 +1772,7 @@ describe('Adding post delivery session feedback', () => {
             .expect(200)
             .expect(res => {
               expect(res.text).toContain('View feedback')
-              expect(res.text).toContain('Kay.Swerker')
+              expect(res.text).toContain('caseworkerFirstName caseworkerLastName')
               expect(res.text).toContain('They were early to the session')
               expect(res.text).toContain('Yes, they were on time')
               expect(res.text).toContain('Alex was well-behaved')

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -6,7 +6,7 @@ import serviceCategoryFactory from '../../../testutils/factories/serviceCategory
 import Intervention from '../../models/intervention'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
 import TestUtils from '../../../testutils/testUtils'
-import { ListStyle, SummaryListItem } from '../../utils/summaryList'
+import { ListStyle, SummaryListItem, SummaryListItemContent } from '../../utils/summaryList'
 import pccRegion from '../../../testutils/factories/pccRegion'
 import loggedInUserFactory from '../../../testutils/factories/loggedInUser'
 
@@ -136,7 +136,7 @@ three lines.`,
       return new InterventionDetailsPresenter(interventionFactory.build(params), loggedInUser).summary
     }
 
-    function linesForKey(key: string, params: DeepPartial<Intervention>): string[] | null {
+    function linesForKey(key: string, params: DeepPartial<Intervention>): SummaryListItemContent[] | null {
       return TestUtils.linesForKey(key, () => summaryForParams(params))
     }
 

--- a/server/routes/findInterventions/searchSummaryPresenter.test.ts
+++ b/server/routes/findInterventions/searchSummaryPresenter.test.ts
@@ -3,6 +3,7 @@ import SearchSummaryPresenter from './searchSummaryPresenter'
 import pccRegionFactory from '../../../testutils/factories/pccRegion'
 import PCCRegion from '../../models/pccRegion'
 import TestUtils from '../../../testutils/testUtils'
+import { SummaryListItemContent } from '../../utils/summaryList'
 
 describe(SearchSummaryPresenter, () => {
   describe('summary', () => {
@@ -14,7 +15,7 @@ describe(SearchSummaryPresenter, () => {
       })
     })
 
-    function linesForKey(key: string, args: [InterventionsFilter, PCCRegion[]]): string[] | null {
+    function linesForKey(key: string, args: [InterventionsFilter, PCCRegion[]]): SummaryListItemContent[] | null {
       return TestUtils.linesForKey(key, () => new SearchSummaryPresenter(...args).summary)
     }
 

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -84,7 +84,7 @@ export default function probationPractitionerRoutes(router: Router, services: Se
   )
 
   get(router, '/referrals/:id/supplier-assessment', (req, res) =>
-    probationPractitionerReferralsController.showSupplierAssessmentAppointment(req, res)
+    appointmentsController.showSupplierAssessmentAppointment(req, res, 'probation-practitioner')
   )
   get(router, '/referrals/:referralId/supplier-assessment/post-assessment-feedback', (req, res) =>
     appointmentsController.viewSupplierAssessmentFeedback(req, res, 'probation-practitioner')

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -73,8 +73,16 @@ describe(ScheduleAppointmentPresenter, () => {
             ),
             []
           )
-          expect(presenter.appointmentSummary).toEqual([
-            { key: 'Caseworker', lines: ['firstName lastName'] },
+          expect(presenter.appointmentSummary).toMatchObject([
+            {
+              key: 'Caseworker',
+              lines: [
+                {
+                  firstName: 'firstName',
+                  lastName: 'lastName',
+                },
+              ],
+            },
             { key: 'Date', lines: ['2 January 2021'] },
             { key: 'Time', lines: ['Midday to 1:00pm'] },
             { key: 'Method', lines: ['Video call'] },

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -160,7 +160,7 @@ export default function serviceProviderRoutes(router: Router, services: Services
     appointmentsController.submitSupplierAssessmentAppointment(req, res)
   )
   get(router, '/referrals/:id/supplier-assessment', (req, res) =>
-    appointmentsController.showSupplierAssessmentAppointment(req, res)
+    appointmentsController.showSupplierAssessmentAppointment(req, res, 'service-provider')
   )
   get(router, '/referrals/:id/supplier-assessment/scheduled-confirmation', (req, res) =>
     appointmentsController.showSupplierAssessmentAppointmentConfirmation(req, res, { isReschedule: false })

--- a/server/routes/shared/supplierAssessmentAppointmentPresenter.test.ts
+++ b/server/routes/shared/supplierAssessmentAppointmentPresenter.test.ts
@@ -22,7 +22,15 @@ describe(SupplierAssessmentAppointmentPresenter, () => {
           }
         )
 
-        expect(presenter.summary[0]).toEqual({ key: 'Caseworker', lines: ['Liam Johnson'] })
+        expect(presenter.summary[0]).toMatchObject({
+          key: 'Caseworker',
+          lines: [
+            {
+              firstName: 'Liam',
+              lastName: 'Johnson',
+            },
+          ],
+        })
       })
     })
 

--- a/server/utils/summaryList.ts
+++ b/server/utils/summaryList.ts
@@ -1,11 +1,15 @@
+import AuthUserDetails from '../models/hmppsAuth/authUserDetails'
+
 export enum ListStyle {
   noMarkers,
   bulleted,
 }
 
+export type SummaryListItemContent = string | AuthUserDetails
+
 export interface SummaryListItem {
   key: string
-  lines: string[]
+  lines: SummaryListItemContent[]
   listStyle?: ListStyle
   changeLink?: string
 }

--- a/server/utils/viewUtils.test.ts
+++ b/server/utils/viewUtils.test.ts
@@ -1,6 +1,7 @@
 import * as nunjucks from 'nunjucks'
 import { ListStyle } from './summaryList'
 import ViewUtils from './viewUtils'
+import hmppsAuthUserFactory from '../../testutils/factories/hmppsAuthUser'
 
 describe('ViewUtils', () => {
   describe('escape', () => {
@@ -91,6 +92,12 @@ describe('ViewUtils', () => {
           { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], listStyle: ListStyle.bulleted },
           { key: 'Gender', lines: ['Male'] },
           { key: 'Address', lines: ['Flat 2', '27 Test Walk', 'SY16 1AQ'] },
+          {
+            key: 'AuthUserDetailsLine',
+            lines: [
+              hmppsAuthUserFactory.build({ firstName: 'firstName', lastName: 'lastName', email: 'user@email.com' }),
+            ],
+          },
         ])
       ).toEqual({
         classes: undefined,
@@ -144,6 +151,15 @@ describe('ViewUtils', () => {
             },
             value: {
               html: '<p class="govuk-body">Flat 2</p>\n<p class="govuk-body">27 Test Walk</p>\n<p class="govuk-body">SY16 1AQ</p>',
+            },
+            actions: null,
+          },
+          {
+            key: {
+              text: 'AuthUserDetailsLine',
+            },
+            value: {
+              html: '<p class="govuk-body">firstName lastName (<a href="mailto: user@email.com">user@email.com</a>)</p>',
             },
             actions: null,
           },

--- a/testutils/testUtils.ts
+++ b/testutils/testUtils.ts
@@ -1,8 +1,8 @@
 import { Request } from 'express'
-import { SummaryListItem } from '../server/utils/summaryList'
+import { SummaryListItem, SummaryListItemContent } from '../server/utils/summaryList'
 
 export default class TestUtils {
-  static linesForKey(key: string, list: () => SummaryListItem[]): string[] | null {
+  static linesForKey(key: string, list: () => SummaryListItem[]): SummaryListItemContent[] | null {
     const items = list()
     const item = items.find(anItem => anItem.key === key)
     return item?.lines ?? null


### PR DESCRIPTION
Changed the appointment feedback page to show the firstname, lastname and email address of caseworker for the user who is assigned and the user who submitted the feedback.

These values will always be SP users so it makes sense to only call hmppsAuth to obtain the caseworker details; however if there were any issues in obtaining this information then the username is used as a fallback.

## Screenshot 

![image](https://user-images.githubusercontent.com/83066216/144593768-bcf66d0f-ea74-4d09-9d71-be5eb993f2e6.png)
