### PR TITLE
uCSWMBxp: Change case notes return link

### DIFF
--- a/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationPresenter.ts
+++ b/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationPresenter.ts
@@ -11,7 +11,7 @@ export default class AddCaseNoteConfirmationPresenter {
     public loggedInUserType: 'service-provider' | 'probation-practitioner'
   ) {}
 
-  progressHref = `/${this.loggedInUserType}/referrals/${this.referral.id}/progress`
+  caseNotesHref = `/${this.loggedInUserType}/referrals/${this.referral.id}/case-notes`
 
   text = {
     whatHappensNext: `The case note will be available to view by the service user's ${this.loggedInUserTypeText}.`,

--- a/server/views/caseNotes/addNewCaseNoteConfirmation.njk
+++ b/server/views/caseNotes/addNewCaseNoteConfirmation.njk
@@ -21,7 +21,7 @@
         {{ presenter.text.whatHappensNext }}
       </p>
 
-      <a href="{{ presenter.progressHref }}" class="govuk-button">Return to intervention</a>
+      <a href="{{ presenter.caseNotesHref }}" class="govuk-button">Return to intervention</a>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
The link for "Return to intervention" one confirmation of creating a new case note should return the user to the case notes page rather than interventions progress page.

