### PR TITLE
Renamed 'Caseworker' to 'Current caseworker' for appointment feedback details.

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1558,7 +1558,7 @@ describe('Service provider referrals dashboard', () => {
       cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
       cy.contains('Intervention cancelled').should('not.exist')
       cy.contains('View feedback form').click()
-      cy.contains('Caseworker').next().contains('Case Worker (auth.user@someagency.justice.gov.uk)')
+      cy.contains('Current caseworker').next().contains('Case Worker (auth.user@someagency.justice.gov.uk)')
       cy.contains('Feedback submitted by').next().contains('Case Worker (auth.user@someagency.justice.gov.uk)')
       cy.contains('Alex attended the session')
       cy.contains('Yes, they were on time')

--- a/server/routes/appointments/appointmentSummary.test.ts
+++ b/server/routes/appointments/appointmentSummary.test.ts
@@ -91,7 +91,7 @@ describe(AppointmentSummary, () => {
         )
 
         expect(summaryComponent.appointmentSummaryList[0]).toMatchObject({
-          key: 'Caseworker',
+          key: 'Current caseworker',
           lines: [
             {
               firstName: 'firstName',

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -20,7 +20,7 @@ export default class AppointmentSummary {
   get appointmentSummaryList(): SummaryListItem[] {
     const summary: SummaryListItem[] = []
     if (this.assignedCaseworker) {
-      summary.push({ key: 'Caseworker', lines: [this.assignedCaseworker] })
+      summary.push({ key: 'Current caseworker', lines: [this.assignedCaseworker] })
     }
     if (this.feedbackSubmittedBy) {
       summary.push({ key: 'Feedback submitted by', lines: [this.feedbackSubmittedBy] })

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.test.ts
@@ -75,7 +75,7 @@ describe(ScheduleAppointmentPresenter, () => {
           )
           expect(presenter.appointmentSummary).toMatchObject([
             {
-              key: 'Caseworker',
+              key: 'Current caseworker',
               lines: [
                 {
                   firstName: 'firstName',

--- a/server/routes/shared/supplierAssessmentAppointmentPresenter.test.ts
+++ b/server/routes/shared/supplierAssessmentAppointmentPresenter.test.ts
@@ -23,7 +23,7 @@ describe(SupplierAssessmentAppointmentPresenter, () => {
         )
 
         expect(presenter.summary[0]).toMatchObject({
-          key: 'Caseworker',
+          key: 'Current caseworker',
           lines: [
             {
               firstName: 'Liam',


### PR DESCRIPTION
Renamed 'Caseworker' to 'Current caseworker' for appointment feedback details table.