### PR TITLE
Remove supplementary risk information when user edits arn risk info

### DIFF
--- a/integration_tests/integration/referral.spec.js
+++ b/integration_tests/integration/referral.spec.js
@@ -8,7 +8,6 @@ import interventionFactory from '../../testutils/factories/intervention'
 import ReferralSectionVerifier from './make_a_referral/referralSectionVerifier'
 import riskSummaryFactory from '../../testutils/factories/riskSummary'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
-import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 
 describe('Referral form', () => {
   const deliusServiceUser = deliusServiceUserFactory.build({
@@ -144,10 +143,6 @@ describe('Referral form', () => {
       cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
       cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
       cy.stubGetRiskSummary(draftReferral.serviceUser.crn, riskSummaryFactory.build())
-      cy.stubGetSupplementaryRiskInformationForCrn(
-        draftReferral.serviceUser.crn,
-        supplementaryRiskInformationFactory.build()
-      )
 
       cy.login()
 
@@ -580,10 +575,6 @@ describe('Referral form', () => {
       cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
       cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
       cy.stubGetRiskSummary(draftReferral.serviceUser.crn, riskSummaryFactory.build())
-      cy.stubGetSupplementaryRiskInformationForCrn(
-        draftReferral.serviceUser.crn,
-        supplementaryRiskInformationFactory.build()
-      )
 
       cy.login()
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -211,10 +211,6 @@ export default on => {
       return assessRisksAndNeedsService.stubGetSupplementaryRiskInformation(arg.riskId, arg.responseJson)
     },
 
-    stubGetSupplementaryRiskInformationForCrn: arg => {
-      return assessRisksAndNeedsService.stubGetSupplementaryRiskInformationForCrn(arg.crn, arg.responseJson)
-    },
-
     stubGetRiskSummary: arg => {
       return assessRisksAndNeedsService.stubGetRiskSummary(arg.crn, arg.responseJson)
     },

--- a/integration_tests/support/assessRisksAndNeedsServiceStubs.js
+++ b/integration_tests/support/assessRisksAndNeedsServiceStubs.js
@@ -2,10 +2,6 @@ Cypress.Commands.add('stubGetSupplementaryRiskInformation', (riskId, responseJso
   cy.task('stubGetSupplementaryRiskInformation', { riskId, responseJson })
 })
 
-Cypress.Commands.add('stubGetSupplementaryRiskInformationForCrn', (crn, responseJson) => {
-  cy.task('stubGetSupplementaryRiskInformationForCrn', { crn, responseJson })
-})
-
 Cypress.Commands.add('stubGetRiskSummary', (crn, responseJson) => {
   cy.task('stubGetRiskSummary', { crn, responseJson })
 })

--- a/mockApis/assessRisksAndNeedsService.ts
+++ b/mockApis/assessRisksAndNeedsService.ts
@@ -19,22 +19,6 @@ export default class AssessRisksAndNeedsServiceMocks {
     })
   }
 
-  stubGetSupplementaryRiskInformationForCrn = async (crn: string, responseJson: unknown): Promise<unknown> => {
-    return this.wiremock.stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: `${this.mockPrefix}/risks/supplementary/crn/${crn}`,
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        jsonBody: responseJson,
-      },
-    })
-  }
-
   stubGetRiskSummary = async (crn: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/routes/makeAReferral/makeAReferralController.test.ts
+++ b/server/routes/makeAReferral/makeAReferralController.test.ts
@@ -17,7 +17,6 @@ import MockCommunityApiService from '../testutils/mocks/mockCommunityApiService'
 import MockAssessRisksAndNeedsService from '../testutils/mocks/mockAssessRisksAndNeedsService'
 import AssessRisksAndNeedsService from '../../services/assessRisksAndNeedsService'
 import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
-import supplementaryRiskInformationFactory from '../../../testutils/factories/supplementaryRiskInformation'
 import draftOasysRiskInformation from '../../../testutils/factories/draftOasysRiskInformation'
 
 jest.mock('../../services/interventionsService')
@@ -305,19 +304,6 @@ describe('GET /referrals/:id/risk-information', () => {
       })
   })
 
-  it('renders an error when the get risk supplementary call for crn fails', async () => {
-    assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummaryFactory.build())
-    assessRisksAndNeedsService.getSupplementaryRiskInformationForCrn.mockRejectedValue(
-      new Error('failed to get risk supplementary info')
-    )
-    await request(app)
-      .get('/referrals/1/risk-information')
-      .expect(500)
-      .expect(res => {
-        expect(res.text).toContain('failed to get risk supplementary info')
-      })
-  })
-
   it('renders an error when the get referral call fails', async () => {
     interventionsService.getDraftReferral.mockRejectedValue(new Error('Failed to get draft referral'))
 
@@ -332,10 +318,6 @@ describe('GET /referrals/:id/risk-information', () => {
   describe('when risk information exists in OASys', () => {
     beforeEach(() => {
       const riskSummary = riskSummaryFactory.build()
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
-        riskSummaryComments: 'supplementary comments',
-      })
-      assessRisksAndNeedsService.getSupplementaryRiskInformationForCrn.mockResolvedValue(supplementaryRiskInformation)
       assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
     })
 
@@ -345,23 +327,8 @@ describe('GET /referrals/:id/risk-information', () => {
         .expect(200)
         .expect(res => {
           expect(res.text).toContain('OASys risk information')
-          expect(res.text).toContain('supplementary comments')
+          expect(res.text).toContain('physically aggressive')
         })
-    })
-
-    describe('when no supplementary risk information exists in OASys', () => {
-      beforeEach(() => {
-        assessRisksAndNeedsService.getSupplementaryRiskInformationForCrn.mockRejectedValue({ status: 404 })
-      })
-
-      it('renders an OASys risk information page', async () => {
-        await request(app)
-          .get('/referrals/1/risk-information')
-          .expect(200)
-          .expect(res => {
-            expect(res.text).toContain('OASys risk information')
-          })
-      })
     })
   })
 })
@@ -445,10 +412,6 @@ describe('GET /referrals/:id/edit-oasys-risk-information', () => {
   describe('when risk information exists in OASys', () => {
     beforeEach(() => {
       const riskSummary = riskSummaryFactory.build()
-      const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
-        riskSummaryComments: 'supplementary comments',
-      })
-      assessRisksAndNeedsService.getSupplementaryRiskInformationForCrn.mockResolvedValue(supplementaryRiskInformation)
       assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
     })
 
@@ -458,23 +421,8 @@ describe('GET /referrals/:id/edit-oasys-risk-information', () => {
         .expect(200)
         .expect(res => {
           expect(res.text).toContain('OASys risk information')
-          expect(res.text).toContain('supplementary comments')
+          expect(res.text).toContain('physically aggressive')
         })
-    })
-
-    describe('when no supplementary risk information exists in OASys', () => {
-      beforeEach(() => {
-        assessRisksAndNeedsService.getSupplementaryRiskInformationForCrn.mockRejectedValue({ status: 404 })
-      })
-
-      it('renders an OASys risk information page', async () => {
-        await request(app)
-          .get('/referrals/1/risk-information')
-          .expect(200)
-          .expect(res => {
-            expect(res.text).toContain('OASys risk information')
-          })
-      })
     })
   })
 })

--- a/server/routes/makeAReferral/risk-information/oasys/arnRiskSummaryView.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/arnRiskSummaryView.test.ts
@@ -1,0 +1,182 @@
+import riskSummaryFactory from '../../../../../testutils/factories/riskSummary'
+import supplementaryRiskInformationFactory from '../../../../../testutils/factories/supplementaryRiskInformation'
+import { Risk } from '../../../../models/assessRisksAndNeeds/riskSummary'
+import ArnRiskSummaryView from './arnRiskSummaryView'
+
+describe('ArnRiskSummaryView', () => {
+  describe('supplementaryRiskInformationArgs', () => {
+    describe('additionalRiskInformation', () => {
+      it('returns no information label if no additional risk information has been provided', () => {
+        const riskSummary = riskSummaryFactory.build()
+        const view = new ArnRiskSummaryView(
+          riskSummary,
+          supplementaryRiskInformationFactory.build({
+            riskSummaryComments: undefined,
+          })
+        )
+        expect(view.supplementaryRiskInformationArgs.additionalRiskInformation.label).toHaveProperty('text', 'None')
+      })
+    })
+
+    describe('summary', () => {
+      it('returns null text when undefined redactedRisk provided', () => {
+        const view = new ArnRiskSummaryView(
+          riskSummaryFactory.build(),
+          supplementaryRiskInformationFactory.build({ redactedRisk: undefined })
+        )
+        expect(view.supplementaryRiskInformationArgs.summary.whoIsAtRisk.text).toBeNull()
+        expect(view.supplementaryRiskInformationArgs.summary.natureOfRisk.text).toBeNull()
+        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.text).toBeNull()
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.text).toBeNull()
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.text).toBeNull()
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.text).toBeNull()
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.text).toBeNull()
+      })
+
+      it('returns correct text when supplementary information provided', () => {
+        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
+          riskSummaryComments: 'Some risk information about the user',
+          redactedRisk: {
+            riskWho: 'some information for who is at risk',
+            riskWhen: 'some information for when is the risk',
+            riskNature: 'some information on the nature of risk',
+          },
+        })
+        const view = new ArnRiskSummaryView(riskSummaryFactory.build(), supplementaryRiskInformation)
+        expect(view.supplementaryRiskInformationArgs.summary.whoIsAtRisk.text).toEqual(
+          'some information for who is at risk'
+        )
+        expect(view.supplementaryRiskInformationArgs.summary.natureOfRisk.text).toEqual(
+          'some information on the nature of risk'
+        )
+        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.text).toEqual(
+          'some information for when is the risk'
+        )
+        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.text).toEqual(
+          'some information for when is the risk'
+        )
+      })
+    })
+
+    describe('riskToSelf', () => {
+      it('returns "Don\'t know" label text when null riskToSelf values provided ', () => {
+        const riskSummary = riskSummaryFactory.build({
+          riskToSelf: {
+            suicide: null,
+            selfHarm: null,
+            hostelSetting: null,
+            vulnerability: null,
+          },
+        })
+        const view = new ArnRiskSummaryView(riskSummary, supplementaryRiskInformationFactory.build())
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+      })
+
+      it('returns "Don\'t know" label text when no values provided', () => {
+        const riskSummary = riskSummaryFactory.build({
+          riskToSelf: {
+            suicide: undefined,
+            selfHarm: undefined,
+            hostelSetting: undefined,
+            vulnerability: undefined,
+          },
+        })
+        const view = new ArnRiskSummaryView(riskSummary, supplementaryRiskInformationFactory.build())
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+      })
+
+      it('returns "Yes" label text when \'YES\' RiskResponse is provided', () => {
+        const yesRisk: Risk = {
+          risk: null,
+          current: 'YES',
+          currentConcernsText: null,
+        }
+        const view = new ArnRiskSummaryView(
+          riskSummaryFactory.build({
+            riskToSelf: {
+              suicide: yesRisk,
+              selfHarm: yesRisk,
+              hostelSetting: yesRisk,
+              vulnerability: yesRisk,
+            },
+          }),
+          supplementaryRiskInformationFactory.build()
+        )
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual('Yes')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual('Yes')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual('Yes')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual('Yes')
+      })
+
+      it('returns "No" label text when \'NO\' RiskResponse is provided', () => {
+        const noRisk: Risk = {
+          risk: null,
+          current: 'NO',
+          currentConcernsText: null,
+        }
+        const view = new ArnRiskSummaryView(
+          riskSummaryFactory.build({
+            riskToSelf: {
+              suicide: noRisk,
+              selfHarm: noRisk,
+              hostelSetting: noRisk,
+              vulnerability: noRisk,
+            },
+          }),
+          supplementaryRiskInformationFactory.build()
+        )
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual('No')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual('No')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual('No')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual('No')
+      })
+
+      it("returns \"Don't know\" label text when 'DK' RiskResponse is provided", () => {
+        const dkRisk: Risk = {
+          risk: null,
+          current: 'DK',
+          currentConcernsText: null,
+        }
+        const view = new ArnRiskSummaryView(
+          riskSummaryFactory.build({
+            riskToSelf: {
+              suicide: dkRisk,
+              selfHarm: dkRisk,
+              hostelSetting: dkRisk,
+              vulnerability: dkRisk,
+            },
+          }),
+          supplementaryRiskInformationFactory.build()
+        )
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
+      })
+
+      it('returns text when supplementary information provided', () => {
+        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
+          redactedRisk: {
+            concernsSelfHarm: 'some concerns for self harm',
+            concernsSuicide: 'some concerns for suicide',
+            concernsHostel: 'some concerns for hostel',
+            concernsVulnerability: 'some concerns for vulnerability',
+          },
+        })
+        const view = new ArnRiskSummaryView(riskSummaryFactory.build(), supplementaryRiskInformation)
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.text).toEqual('some concerns for suicide')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.text).toEqual('some concerns for self harm')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.text).toEqual('some concerns for hostel')
+        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.text).toEqual(
+          'some concerns for vulnerability'
+        )
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/risk-information/oasys/arnRiskSummaryView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/arnRiskSummaryView.ts
@@ -1,0 +1,57 @@
+import { SupplementaryRiskInformation } from '../../../../models/assessRisksAndNeeds/supplementaryRiskInformation'
+import RiskSummary from '../../../../models/assessRisksAndNeeds/riskSummary'
+import { RiskInformationArgs, RiskInformationLabels } from './riskInformationLabels'
+
+// This is for presenting the supplementary risk information that the user has entered as part of Make A Referral
+// i.e. the edited OAsys risk information
+export default class ArnRiskSummaryView {
+  private readonly riskInformationLabels: RiskInformationLabels
+
+  constructor(
+    readonly riskSummary: RiskSummary | null,
+    readonly supplementaryRiskInformation: SupplementaryRiskInformation
+  ) {
+    this.riskInformationLabels = new RiskInformationLabels()
+  }
+
+  get supplementaryRiskInformationArgs(): RiskInformationArgs {
+    const riskToSelf = this.riskSummary?.riskToSelf
+    return {
+      summary: {
+        whoIsAtRisk: {
+          text: this.supplementaryRiskInformation?.redactedRisk?.riskWho || null,
+        },
+        natureOfRisk: {
+          text: this.supplementaryRiskInformation?.redactedRisk?.riskNature || null,
+        },
+        riskImminence: {
+          text: this.supplementaryRiskInformation?.redactedRisk?.riskWhen || null,
+        },
+      },
+      riskToSelf: {
+        suicide: {
+          label: this.riskInformationLabels.riskToSelfLabel(riskToSelf?.suicide),
+          text: this.supplementaryRiskInformation?.redactedRisk?.concernsSuicide || null,
+        },
+        selfHarm: {
+          label: this.riskInformationLabels.riskToSelfLabel(riskToSelf?.selfHarm),
+          text: this.supplementaryRiskInformation?.redactedRisk?.concernsSelfHarm || null,
+        },
+        hostelSetting: {
+          label: this.riskInformationLabels.riskToSelfLabel(riskToSelf?.hostelSetting),
+          text: this.supplementaryRiskInformation?.redactedRisk?.concernsHostel || null,
+        },
+        vulnerability: {
+          label: this.riskInformationLabels.riskToSelfLabel(riskToSelf?.vulnerability),
+          text: this.supplementaryRiskInformation?.redactedRisk?.concernsVulnerability || null,
+        },
+      },
+      additionalRiskInformation: {
+        label: this.supplementaryRiskInformation?.riskSummaryComments
+          ? undefined
+          : this.riskInformationLabels.noAdditionalRiskInformationLabel,
+        text: this.supplementaryRiskInformation ? this.supplementaryRiskInformation.riskSummaryComments : null,
+      },
+    }
+  }
+}

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationPresenter.test.ts
@@ -1,5 +1,4 @@
 import riskSummaryFactory from '../../../../../../testutils/factories/riskSummary'
-import supplementaryRiskInformationFactory from '../../../../../../testutils/factories/supplementaryRiskInformation'
 import EditOasysRiskInformationPresenter from './editOasysRiskInformationPresenter'
 
 describe('EditOasysRiskInformationPresenter', () => {
@@ -7,11 +6,7 @@ describe('EditOasysRiskInformationPresenter', () => {
     describe('when the risk summary has an "assessed on" date', () => {
       it('returns the correctly formatted date', () => {
         const riskSummary = riskSummaryFactory.build({ assessedOn: '2021-09-20T09:31:45.062Z' })
-        const presenter = new EditOasysRiskInformationPresenter(
-          supplementaryRiskInformationFactory.build(),
-          riskSummary,
-          null
-        )
+        const presenter = new EditOasysRiskInformationPresenter(riskSummary, null)
 
         expect(presenter.latestAssessment).toEqual('20 September 2021')
       })
@@ -19,21 +14,13 @@ describe('EditOasysRiskInformationPresenter', () => {
     describe('when the risk summary does not have an "assess on" date', () => {
       it('returns "Assessment date not found" when null', () => {
         const riskSummary = riskSummaryFactory.build({ assessedOn: null })
-        const presenter = new EditOasysRiskInformationPresenter(
-          supplementaryRiskInformationFactory.build(),
-          riskSummary,
-          null
-        )
+        const presenter = new EditOasysRiskInformationPresenter(riskSummary, null)
 
         expect(presenter.latestAssessment).toEqual('Assessment date not found')
       })
       it('returns "Assessment date not found" when undefined', () => {
         const riskSummary = riskSummaryFactory.build({ assessedOn: undefined })
-        const presenter = new EditOasysRiskInformationPresenter(
-          supplementaryRiskInformationFactory.build(),
-          riskSummary,
-          null
-        )
+        const presenter = new EditOasysRiskInformationPresenter(riskSummary, null)
 
         expect(presenter.latestAssessment).toEqual('Assessment date not found')
       })

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationPresenter.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationPresenter.ts
@@ -1,6 +1,5 @@
 import RiskSummary from '../../../../../models/assessRisksAndNeeds/riskSummary'
 import DateUtils from '../../../../../utils/dateUtils'
-import { SupplementaryRiskInformation } from '../../../../../models/assessRisksAndNeeds/supplementaryRiskInformation'
 
 import RoshPanelPresenter from '../../../../shared/roshPanelPresenter'
 import PresenterUtils from '../../../../../utils/presenterUtils'
@@ -11,7 +10,6 @@ export default class EditOasysRiskInformationPresenter {
   riskPresenter: RoshPanelPresenter
 
   constructor(
-    readonly supplementaryRiskInformation: SupplementaryRiskInformation | null,
     readonly riskSummary: RiskSummary | null,
     readonly draftOasysRiskInformation: DraftOasysRiskInformation | null,
     private readonly error: FormValidationError | null = null

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.test.ts
@@ -2,7 +2,6 @@ import EditOasysRiskInformationView from './editOasysRiskInformationView'
 import EditOasysRiskInformationPresenter from './editOasysRiskInformationPresenter'
 import { DraftOasysRiskInformation } from '../../../../../models/draftOasysRiskInformation'
 import riskSummaryFactory from '../../../../../../testutils/factories/riskSummary'
-import supplementaryRiskInformationFactory from '../../../../../../testutils/factories/supplementaryRiskInformation'
 import { TextareaArgs } from '../../../../../utils/govukFrontendTypes'
 
 describe('EditOasysRiskInformationView', () => {
@@ -21,15 +20,8 @@ describe('EditOasysRiskInformationView', () => {
           riskImminence: 'OAsysRiskImminence',
         },
       })
-      const additionalInformation = supplementaryRiskInformationFactory.build({
-        riskSummaryComments: 'OAsysAdditionalInformation',
-      })
       it('should show OAsys version for each textbox field when draft does not exist', () => {
-        const editOasysRiskInformationPresenter = new EditOasysRiskInformationPresenter(
-          additionalInformation,
-          riskSummary,
-          null
-        )
+        const editOasysRiskInformationPresenter = new EditOasysRiskInformationPresenter(riskSummary, null)
         const fields = new EditOasysRiskInformationView(editOasysRiskInformationPresenter).renderArgs[1]
         expect((fields.whoIsAtRiskTextareaArgs as TextareaArgs).value).toEqual('OAsysWhoIsAtRisk')
         expect((fields.natureOfRiskTextareaArgs as TextareaArgs).value).toEqual('OAsysNatureOfRisk')
@@ -38,7 +30,7 @@ describe('EditOasysRiskInformationView', () => {
         expect((fields.riskToSelfSelfHarmTextareaArgs as TextareaArgs).value).toEqual('OAsysSelfHarm')
         expect((fields.riskToSelfHostelSettingTextareaArgs as TextareaArgs).value).toEqual('OAsysHostelSetting')
         expect((fields.riskToSelfVulnerabilityTextareaArgs as TextareaArgs).value).toEqual('OAsysVulnerability')
-        expect((fields.additionalInformationTextareaArgs as TextareaArgs).value).toEqual('OAsysAdditionalInformation')
+        expect((fields.additionalInformationTextareaArgs as TextareaArgs).value).toEqual('')
       })
       it('should show draft version for each textbox field when draft exists', () => {
         const draftOasysRiskInformation: DraftOasysRiskInformation = {
@@ -52,7 +44,6 @@ describe('EditOasysRiskInformationView', () => {
           additionalInformation: 'draftAdditionalInformation',
         }
         const editOasysRiskInformationPresenter = new EditOasysRiskInformationPresenter(
-          additionalInformation,
           riskSummary,
           draftOasysRiskInformation
         )

--- a/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/edit/editOasysRiskInformationView.ts
@@ -10,7 +10,7 @@ export default class EditOasysRiskInformationView {
   private readonly draftOasysRiskInformation: DraftOasysRiskInformation | null
 
   constructor(private readonly presenter: EditOasysRiskInformationPresenter) {
-    this.riskSummaryView = new OasysRiskSummaryView(presenter.supplementaryRiskInformation, presenter.riskSummary)
+    this.riskSummaryView = new OasysRiskSummaryView(presenter.riskSummary)
     this.draftOasysRiskInformation = presenter.draftOasysRiskInformation
   }
 

--- a/server/routes/makeAReferral/risk-information/oasys/oasysRiskSummaryView.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/oasysRiskSummaryView.test.ts
@@ -1,44 +1,24 @@
 import riskSummaryFactory from '../../../../../testutils/factories/riskSummary'
-import supplementaryRiskInformationFactory from '../../../../../testutils/factories/supplementaryRiskInformation'
 import OasysRiskSummaryView from './oasysRiskSummaryView'
 import { Risk } from '../../../../models/assessRisksAndNeeds/riskSummary'
 
 describe('OasysRiskSummaryView', () => {
   describe('oasysRiskInformationArgs', () => {
     describe('additionalRiskInformation', () => {
-      it('returns special content to display if no additional risk information has been provided', () => {
+      it('always returns "no additional information" label', () => {
         const riskSummary = riskSummaryFactory.build()
-        const view = new OasysRiskSummaryView(null, riskSummary)
-        expect(view.oasysRiskInformationArgs.additionalRiskInformation.label).toHaveProperty('text', 'None')
+        const view = new OasysRiskSummaryView(riskSummary)
+        expect(view.oasysRiskInformationArgs.additionalRiskInformation.label?.text).toEqual('None')
+        expect(view.oasysRiskInformationArgs.additionalRiskInformation.text).toBeNull()
       })
     })
 
-    describe('when riskSummary is empty', () => {
-      it('should display empty values', () => {
-        const view = new OasysRiskSummaryView(null, null)
-        expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.text).toBeNull()
-        expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
-        expect(view.oasysRiskInformationArgs.summary.natureOfRisk.text).toBeNull()
-        expect(view.oasysRiskInformationArgs.summary.natureOfRisk.label?.text).toEqual('No information provided')
-        expect(view.oasysRiskInformationArgs.summary.riskImminence.text).toBeNull()
-        expect(view.oasysRiskInformationArgs.summary.riskImminence.label?.text).toEqual('No information provided')
-        expect(view.oasysRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
-        expect(view.oasysRiskInformationArgs.riskToSelf.suicide.text).toBeNull()
-        expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
-        expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.text).toBeNull()
-        expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
-        expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.text).toBeNull()
-        expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
-        expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.text).toBeNull()
-      })
-    })
     describe('summary', () => {
       it('returns null text and label when null summary values provided ', () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
         const riskSummary = riskSummaryFactory.build({
           summary: { whoIsAtRisk: null, natureOfRisk: null, riskImminence: null },
         })
-        const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummary)
+        const view = new OasysRiskSummaryView(riskSummary)
         expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.text).toBeNull()
         expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
         expect(view.oasysRiskInformationArgs.summary.natureOfRisk.text).toBeNull()
@@ -48,11 +28,10 @@ describe('OasysRiskSummaryView', () => {
       })
 
       it('returns null text and label when no summary values provided ', () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
         const riskSummary = riskSummaryFactory.build({
           summary: { whoIsAtRisk: undefined, natureOfRisk: undefined, riskImminence: undefined },
         })
-        const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummary)
+        const view = new OasysRiskSummaryView(riskSummary)
         expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.text).toBeNull()
         expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.label?.text).toEqual('No information provided')
         expect(view.oasysRiskInformationArgs.summary.natureOfRisk.text).toBeNull()
@@ -62,11 +41,10 @@ describe('OasysRiskSummaryView', () => {
       })
 
       it('returns text and no label when summary values are provided ', () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
         const riskSummary = riskSummaryFactory.build({
           summary: { whoIsAtRisk: 'whoIsAtRisk', natureOfRisk: 'natureOfRisk', riskImminence: 'riskImminence' },
         })
-        const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummary)
+        const view = new OasysRiskSummaryView(riskSummary)
         expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.text).toEqual('whoIsAtRisk')
         expect(view.oasysRiskInformationArgs.summary.whoIsAtRisk.label).toBeUndefined()
         expect(view.oasysRiskInformationArgs.summary.natureOfRisk.text).toEqual('natureOfRisk')
@@ -78,7 +56,6 @@ describe('OasysRiskSummaryView', () => {
 
     describe('riskToSelf', () => {
       it('returns "Don\'t know" label text when null riskToSelf values provided ', () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
         const riskSummary = riskSummaryFactory.build({
           riskToSelf: {
             suicide: null,
@@ -87,7 +64,7 @@ describe('OasysRiskSummaryView', () => {
             vulnerability: null,
           },
         })
-        const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummary)
+        const view = new OasysRiskSummaryView(riskSummary)
         expect(view.oasysRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
         expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
         expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
@@ -95,7 +72,6 @@ describe('OasysRiskSummaryView', () => {
       })
 
       it('returns "Don\'t know" label text when no values provided ', () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
         const riskSummary = riskSummaryFactory.build({
           riskToSelf: {
             suicide: undefined,
@@ -104,7 +80,7 @@ describe('OasysRiskSummaryView', () => {
             vulnerability: undefined,
           },
         })
-        const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummary)
+        const view = new OasysRiskSummaryView(riskSummary)
         expect(view.oasysRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
         expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
         expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
@@ -112,14 +88,12 @@ describe('OasysRiskSummaryView', () => {
       })
 
       it('returns "Yes" label text when \'YES\' RiskResponse is provided', () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
         const yesRisk: Risk = {
           risk: null,
           current: 'YES',
           currentConcernsText: null,
         }
         const view = new OasysRiskSummaryView(
-          supplementaryRiskInformation,
           riskSummaryFactory.build({
             riskToSelf: {
               suicide: yesRisk,
@@ -136,14 +110,12 @@ describe('OasysRiskSummaryView', () => {
       })
 
       it('returns "No" label text when \'NO\' RiskResponse is provided', () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
         const noRisk: Risk = {
           risk: null,
           current: 'NO',
           currentConcernsText: null,
         }
         const view = new OasysRiskSummaryView(
-          supplementaryRiskInformation,
           riskSummaryFactory.build({
             riskToSelf: {
               suicide: noRisk,
@@ -160,14 +132,12 @@ describe('OasysRiskSummaryView', () => {
       })
 
       it("returns \"Don't know\" label text when 'DK' RiskResponse is provided", () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
         const dkRisk: Risk = {
           risk: null,
           current: 'DK',
           currentConcernsText: null,
         }
         const view = new OasysRiskSummaryView(
-          supplementaryRiskInformation,
           riskSummaryFactory.build({
             riskToSelf: {
               suicide: dkRisk,
@@ -184,14 +154,12 @@ describe('OasysRiskSummaryView', () => {
       })
 
       it('returns "Don\'t know" label text when no values for current are provided', () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
         const nullRisk: Risk = {
           risk: null,
           current: null,
           currentConcernsText: null,
         }
         const view = new OasysRiskSummaryView(
-          supplementaryRiskInformation,
           riskSummaryFactory.build({
             riskToSelf: {
               suicide: nullRisk,
@@ -205,188 +173,6 @@ describe('OasysRiskSummaryView', () => {
         expect(view.oasysRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
         expect(view.oasysRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
         expect(view.oasysRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
-      })
-    })
-  })
-
-  describe('supplementaryRiskInformationArgs', () => {
-    describe('additionalRiskInformation', () => {
-      it('returns special content to display if no additional risk information has been provided', () => {
-        const riskSummary = riskSummaryFactory.build()
-        const view = new OasysRiskSummaryView(null, riskSummary)
-        expect(view.supplementaryRiskInformationArgs.additionalRiskInformation.label).toHaveProperty('text', 'None')
-      })
-    })
-
-    describe('summary', () => {
-      it('returns null text when undefined redactedRisk provided', () => {
-        const view = new OasysRiskSummaryView(
-          supplementaryRiskInformationFactory.build({ redactedRisk: undefined }),
-          null
-        )
-        expect(view.supplementaryRiskInformationArgs.summary.whoIsAtRisk.text).toBeNull()
-        expect(view.supplementaryRiskInformationArgs.summary.natureOfRisk.text).toBeNull()
-        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.text).toBeNull()
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.text).toBeNull()
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.text).toBeNull()
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.text).toBeNull()
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.text).toBeNull()
-      })
-
-      it('returns null text and no label when no supplementary provided', () => {
-        const view = new OasysRiskSummaryView(null, null)
-        expect(view.supplementaryRiskInformationArgs.summary.whoIsAtRisk.text).toBeNull()
-        expect(view.supplementaryRiskInformationArgs.summary.whoIsAtRisk.label).toBeUndefined()
-        expect(view.supplementaryRiskInformationArgs.summary.natureOfRisk.text).toBeNull()
-        expect(view.supplementaryRiskInformationArgs.summary.natureOfRisk.label).toBeUndefined()
-        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.text).toBeNull()
-        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.label).toBeUndefined()
-      })
-
-      it('returns text when supplementary information provided', () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
-          riskSummaryComments: 'Some risk information about the user',
-          redactedRisk: {
-            riskWho: 'some information for who is at risk',
-            riskWhen: 'some information for when is the risk',
-            riskNature: 'some information on the nature of risk',
-          },
-        })
-        const view = new OasysRiskSummaryView(supplementaryRiskInformation, null)
-        expect(view.supplementaryRiskInformationArgs.summary.whoIsAtRisk.text).toEqual(
-          'some information for who is at risk'
-        )
-        expect(view.supplementaryRiskInformationArgs.summary.natureOfRisk.text).toEqual(
-          'some information on the nature of risk'
-        )
-        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.text).toEqual(
-          'some information for when is the risk'
-        )
-        expect(view.supplementaryRiskInformationArgs.summary.riskImminence.text).toEqual(
-          'some information for when is the risk'
-        )
-      })
-    })
-
-    describe('riskToSelf', () => {
-      it('returns "Don\'t know" label text when null riskToSelf values provided ', () => {
-        const riskSummary = riskSummaryFactory.build({
-          riskToSelf: {
-            suicide: null,
-            selfHarm: null,
-            hostelSetting: null,
-            vulnerability: null,
-          },
-        })
-        const view = new OasysRiskSummaryView(null, riskSummary)
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
-      })
-
-      it('returns "Don\'t know" label text when no values provided', () => {
-        const riskSummary = riskSummaryFactory.build({
-          riskToSelf: {
-            suicide: undefined,
-            selfHarm: undefined,
-            hostelSetting: undefined,
-            vulnerability: undefined,
-          },
-        })
-        const view = new OasysRiskSummaryView(null, riskSummary)
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
-      })
-
-      it('returns "Yes" label text when \'YES\' RiskResponse is provided', () => {
-        const yesRisk: Risk = {
-          risk: null,
-          current: 'YES',
-          currentConcernsText: null,
-        }
-        const view = new OasysRiskSummaryView(
-          null,
-          riskSummaryFactory.build({
-            riskToSelf: {
-              suicide: yesRisk,
-              selfHarm: yesRisk,
-              hostelSetting: yesRisk,
-              vulnerability: yesRisk,
-            },
-          })
-        )
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual('Yes')
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual('Yes')
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual('Yes')
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual('Yes')
-      })
-
-      it('returns "No" label text when \'NO\' RiskResponse is provided', () => {
-        const noRisk: Risk = {
-          risk: null,
-          current: 'NO',
-          currentConcernsText: null,
-        }
-        const view = new OasysRiskSummaryView(
-          null,
-          riskSummaryFactory.build({
-            riskToSelf: {
-              suicide: noRisk,
-              selfHarm: noRisk,
-              hostelSetting: noRisk,
-              vulnerability: noRisk,
-            },
-          })
-        )
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual('No')
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual('No')
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual('No')
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual('No')
-      })
-
-      it("returns \"Don't know\" label text when 'DK' RiskResponse is provided", () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-        const dkRisk: Risk = {
-          risk: null,
-          current: 'DK',
-          currentConcernsText: null,
-        }
-        const view = new OasysRiskSummaryView(
-          supplementaryRiskInformation,
-          riskSummaryFactory.build({
-            riskToSelf: {
-              suicide: dkRisk,
-              selfHarm: dkRisk,
-              hostelSetting: dkRisk,
-              vulnerability: dkRisk,
-            },
-          })
-        )
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.label.text).toEqual("Don't know")
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.label.text).toEqual("Don't know")
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.label.text).toEqual("Don't know")
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.label.text).toEqual("Don't know")
-      })
-
-      it('returns text when supplementary information provided', () => {
-        const supplementaryRiskInformation = supplementaryRiskInformationFactory.build({
-          redactedRisk: {
-            concernsSelfHarm: 'some concerns for self harm',
-            concernsSuicide: 'some concerns for suicide',
-            concernsHostel: 'some concerns for hostel',
-            concernsVulnerability: 'some concerns for vulnerability',
-          },
-        })
-        const view = new OasysRiskSummaryView(supplementaryRiskInformation, riskSummaryFactory.build())
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.suicide.text).toEqual('some concerns for suicide')
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.selfHarm.text).toEqual('some concerns for self harm')
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.hostelSetting.text).toEqual('some concerns for hostel')
-        expect(view.supplementaryRiskInformationArgs.riskToSelf.vulnerability.text).toEqual(
-          'some concerns for vulnerability'
-        )
       })
     })
   })

--- a/server/routes/makeAReferral/risk-information/oasys/oasysRiskSummaryView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/oasysRiskSummaryView.ts
@@ -1,58 +1,13 @@
-import { SupplementaryRiskInformation } from '../../../../models/assessRisksAndNeeds/supplementaryRiskInformation'
-import RiskSummary, { Risk } from '../../../../models/assessRisksAndNeeds/riskSummary'
+import RiskSummary from '../../../../models/assessRisksAndNeeds/riskSummary'
+import { RiskInformationArgs, RiskInformationLabels } from './riskInformationLabels'
 
-export interface RiskInformationLabelArgs {
-  class: string
-  text: string
-}
-export type RiskToSelfLabelText = 'Yes' | 'No' | "Don't know"
-export interface RiskToSelfLabelArgs {
-  class: string
-  text: RiskToSelfLabelText
-}
-export interface RiskInformationArgs {
-  summary: {
-    whoIsAtRisk: {
-      label?: RiskInformationLabelArgs
-      text: string | null
-    }
-    natureOfRisk: {
-      label?: RiskInformationLabelArgs
-      text: string | null
-    }
-    riskImminence: {
-      label?: RiskInformationLabelArgs
-      text: string | null
-    }
-  }
-  riskToSelf: {
-    suicide: {
-      label: RiskToSelfLabelArgs
-      text: string | null
-    }
-    selfHarm: {
-      label: RiskToSelfLabelArgs
-      text: string | null
-    }
-    hostelSetting: {
-      label: RiskToSelfLabelArgs
-      text: string | null
-    }
-    vulnerability: {
-      label: RiskToSelfLabelArgs
-      text: string | null
-    }
-  }
-  additionalRiskInformation: {
-    label?: RiskInformationLabelArgs
-    text: string | null
-  }
-}
+// This is for presenting the non-editable OAsys risk information in Make A Referral journey
 export default class OasysRiskSummaryView {
-  constructor(
-    readonly supplementaryRiskInformation: SupplementaryRiskInformation | null,
-    readonly riskSummary: RiskSummary | null
-  ) {}
+  private readonly riskInformationLabels: RiskInformationLabels
+
+  constructor(readonly riskSummary: RiskSummary | null) {
+    this.riskInformationLabels = new RiskInformationLabels()
+  }
 
   get oasysRiskInformationArgs(): RiskInformationArgs {
     const summary = this.riskSummary?.summary
@@ -60,145 +15,40 @@ export default class OasysRiskSummaryView {
     return {
       summary: {
         whoIsAtRisk: {
-          label: summary?.whoIsAtRisk ? undefined : this.noInformationProvidedLabel,
+          label: summary?.whoIsAtRisk ? undefined : this.riskInformationLabels.noInformationProvidedLabel,
           text: summary?.whoIsAtRisk ? summary.whoIsAtRisk : null,
         },
         natureOfRisk: {
-          label: summary?.natureOfRisk ? undefined : this.noInformationProvidedLabel,
+          label: summary?.natureOfRisk ? undefined : this.riskInformationLabels.noInformationProvidedLabel,
           text: summary?.natureOfRisk ? summary.natureOfRisk : null,
         },
         riskImminence: {
-          label: summary?.riskImminence ? undefined : this.noInformationProvidedLabel,
+          label: summary?.riskImminence ? undefined : this.riskInformationLabels.noInformationProvidedLabel,
           text: summary?.riskImminence ? summary.riskImminence : null,
         },
       },
       riskToSelf: {
         suicide: {
-          label: {
-            class: this.riskToSelfLabelClass(riskToSelf?.suicide),
-            text: this.riskToSelfLabelText(riskToSelf?.suicide),
-          },
+          label: this.riskInformationLabels.riskToSelfLabel(riskToSelf?.suicide),
           text: riskToSelf?.suicide ? riskToSelf.suicide.currentConcernsText : null,
         },
         selfHarm: {
-          label: {
-            class: this.riskToSelfLabelClass(riskToSelf?.selfHarm),
-            text: this.riskToSelfLabelText(riskToSelf?.selfHarm),
-          },
+          label: this.riskInformationLabels.riskToSelfLabel(riskToSelf?.selfHarm),
           text: riskToSelf?.selfHarm ? riskToSelf?.selfHarm.currentConcernsText : null,
         },
         hostelSetting: {
-          label: {
-            class: this.riskToSelfLabelClass(riskToSelf?.hostelSetting),
-            text: this.riskToSelfLabelText(riskToSelf?.hostelSetting),
-          },
+          label: this.riskInformationLabels.riskToSelfLabel(riskToSelf?.hostelSetting),
           text: riskToSelf?.hostelSetting ? riskToSelf?.hostelSetting.currentConcernsText : null,
         },
         vulnerability: {
-          label: {
-            class: this.riskToSelfLabelClass(riskToSelf?.vulnerability),
-            text: this.riskToSelfLabelText(riskToSelf?.vulnerability),
-          },
+          label: this.riskInformationLabels.riskToSelfLabel(riskToSelf?.vulnerability),
           text: riskToSelf?.vulnerability ? riskToSelf.vulnerability.currentConcernsText : null,
         },
       },
       additionalRiskInformation: {
-        label: this.supplementaryRiskInformation ? undefined : this.noAdditionalRiskInformationLabel,
-        text: this.supplementaryRiskInformation ? this.supplementaryRiskInformation.riskSummaryComments : null,
+        label: this.riskInformationLabels.noAdditionalRiskInformationLabel,
+        text: null,
       },
-    }
-  }
-
-  get supplementaryRiskInformationArgs(): RiskInformationArgs {
-    const riskToSelf = this.riskSummary?.riskToSelf
-    return {
-      summary: {
-        whoIsAtRisk: {
-          text: this.supplementaryRiskInformation?.redactedRisk?.riskWho || null,
-        },
-        natureOfRisk: {
-          text: this.supplementaryRiskInformation?.redactedRisk?.riskNature || null,
-        },
-        riskImminence: {
-          text: this.supplementaryRiskInformation?.redactedRisk?.riskWhen || null,
-        },
-      },
-      riskToSelf: {
-        suicide: {
-          label: {
-            class: this.riskToSelfLabelClass(riskToSelf?.suicide),
-            text: this.riskToSelfLabelText(riskToSelf?.suicide),
-          },
-          text: this.supplementaryRiskInformation?.redactedRisk?.concernsSuicide || null,
-        },
-        selfHarm: {
-          label: {
-            class: this.riskToSelfLabelClass(riskToSelf?.selfHarm),
-            text: this.riskToSelfLabelText(riskToSelf?.selfHarm),
-          },
-          text: this.supplementaryRiskInformation?.redactedRisk?.concernsSelfHarm || null,
-        },
-        hostelSetting: {
-          label: {
-            class: this.riskToSelfLabelClass(riskToSelf?.hostelSetting),
-            text: this.riskToSelfLabelText(riskToSelf?.hostelSetting),
-          },
-          text: this.supplementaryRiskInformation?.redactedRisk?.concernsHostel || null,
-        },
-        vulnerability: {
-          label: {
-            class: this.riskToSelfLabelClass(riskToSelf?.vulnerability),
-            text: this.riskToSelfLabelText(riskToSelf?.vulnerability),
-          },
-          text: this.supplementaryRiskInformation?.redactedRisk?.concernsVulnerability || null,
-        },
-      },
-      additionalRiskInformation: {
-        label: this.supplementaryRiskInformation ? undefined : this.noAdditionalRiskInformationLabel,
-        text: this.supplementaryRiskInformation ? this.supplementaryRiskInformation.riskSummaryComments : null,
-      },
-    }
-  }
-
-  private get noAdditionalRiskInformationLabel(): RiskInformationLabelArgs {
-    return {
-      class: 'app-oasys-text app-oasys-text--dark-grey',
-      text: 'None',
-    }
-  }
-
-  private get noInformationProvidedLabel(): RiskInformationLabelArgs {
-    return {
-      class: 'app-oasys-text app-oasys-text--dark-grey',
-      text: 'No information provided',
-    }
-  }
-
-  private riskToSelfLabelText(risk: Risk | undefined | null): RiskToSelfLabelText {
-    if (!risk) {
-      return "Don't know"
-    }
-    switch (risk.current) {
-      case 'YES':
-        return 'Yes'
-      case 'NO':
-        return 'No'
-      default:
-        return "Don't know"
-    }
-  }
-
-  private riskToSelfLabelClass(risk: Risk | undefined | null): string {
-    if (!risk) {
-      return 'app-oasys-text app-oasys-text--dark-grey'
-    }
-    switch (risk.current) {
-      case 'YES':
-        return 'app-oasys-text app-oasys-text--green'
-      case 'NO':
-        return 'app-oasys-text app-oasys-text--red'
-      default:
-        return 'app-oasys-text app-oasys-text--dark-grey'
     }
   }
 }

--- a/server/routes/makeAReferral/risk-information/oasys/riskInformationLabels.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/riskInformationLabels.ts
@@ -1,0 +1,100 @@
+import { Risk } from '../../../../models/assessRisksAndNeeds/riskSummary'
+
+export interface RiskInformationLabelArgs {
+  class: string
+  text: string
+}
+export type RiskToSelfLabelText = 'Yes' | 'No' | "Don't know"
+export interface RiskToSelfLabelArgs {
+  class: string
+  text: RiskToSelfLabelText
+}
+export interface RiskInformationArgs {
+  summary: {
+    whoIsAtRisk: {
+      label?: RiskInformationLabelArgs
+      text: string | null
+    }
+    natureOfRisk: {
+      label?: RiskInformationLabelArgs
+      text: string | null
+    }
+    riskImminence: {
+      label?: RiskInformationLabelArgs
+      text: string | null
+    }
+  }
+  riskToSelf: {
+    suicide: {
+      label: RiskToSelfLabelArgs
+      text: string | null
+    }
+    selfHarm: {
+      label: RiskToSelfLabelArgs
+      text: string | null
+    }
+    hostelSetting: {
+      label: RiskToSelfLabelArgs
+      text: string | null
+    }
+    vulnerability: {
+      label: RiskToSelfLabelArgs
+      text: string | null
+    }
+  }
+  additionalRiskInformation: {
+    label?: RiskInformationLabelArgs
+    text: string | null
+  }
+}
+
+export class RiskInformationLabels {
+  get noAdditionalRiskInformationLabel(): RiskInformationLabelArgs {
+    return {
+      class: 'app-oasys-text app-oasys-text--dark-grey',
+      text: 'None',
+    }
+  }
+
+  get noInformationProvidedLabel(): RiskInformationLabelArgs {
+    return {
+      class: 'app-oasys-text app-oasys-text--dark-grey',
+      text: 'No information provided',
+    }
+  }
+
+  riskToSelfLabel(risk: Risk | undefined | null): RiskToSelfLabelArgs {
+    return {
+      class: this.riskToSelfLabelClass(risk),
+      text: this.riskToSelfLabelText(risk),
+    }
+  }
+
+  private riskToSelfLabelText(risk: Risk | undefined | null): RiskToSelfLabelText {
+    if (!risk) {
+      return "Don't know"
+    }
+    switch (risk.current) {
+      case 'YES':
+        return 'Yes'
+      case 'NO':
+        return 'No'
+      default:
+        return "Don't know"
+    }
+  }
+
+  private riskToSelfLabelClass(risk: Risk | undefined | null): string {
+    if (!risk) {
+      return 'app-oasys-text app-oasys-text--dark-grey'
+    }
+    switch (risk.current) {
+      case 'YES':
+        return 'app-oasys-text app-oasys-text--green'
+      case 'NO':
+        return 'app-oasys-text app-oasys-text--red'
+      default:
+        return 'app-oasys-text app-oasys-text--dark-grey'
+    }
+  }
+}

--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationPresenter.test.ts
@@ -1,18 +1,12 @@
 import OasysRiskInformationPresenter from './oasysRiskInformationPresenter'
 import riskSummaryFactory from '../../../../../../testutils/factories/riskSummary'
-import supplementaryRiskInformationFactory from '../../../../../../testutils/factories/supplementaryRiskInformation'
 
 describe('OasysRiskInformationPresenter', () => {
   describe('latestAssessment', () => {
     describe('when the risk summary has an "assessed on" date', () => {
       it('returns the correctly formatted date', () => {
         const riskSummary = riskSummaryFactory.build({ assessedOn: '2021-09-20T09:31:45.062Z' })
-        const presenter = new OasysRiskInformationPresenter(
-          'referralId',
-          supplementaryRiskInformationFactory.build(),
-          riskSummary,
-          null
-        )
+        const presenter = new OasysRiskInformationPresenter('referralId', riskSummary, null)
 
         expect(presenter.latestAssessment).toEqual('20 September 2021')
       })
@@ -22,12 +16,7 @@ describe('OasysRiskInformationPresenter', () => {
       it('displays a "not found" message', () => {
         const riskSummary = riskSummaryFactory.build()
         riskSummary.assessedOn = undefined
-        const presenter = new OasysRiskInformationPresenter(
-          'referralId',
-          supplementaryRiskInformationFactory.build(),
-          riskSummary,
-          null
-        )
+        const presenter = new OasysRiskInformationPresenter('referralId', riskSummary, null)
 
         expect(presenter.latestAssessment).toEqual('Assessment date not found')
       })
@@ -36,12 +25,7 @@ describe('OasysRiskInformationPresenter', () => {
     describe('when the risk summary has a null "assessed on" date', () => {
       it('displays a "not found" message', () => {
         const riskSummary = riskSummaryFactory.build({ assessedOn: null })
-        const presenter = new OasysRiskInformationPresenter(
-          'referralId',
-          supplementaryRiskInformationFactory.build(),
-          riskSummary,
-          null
-        )
+        const presenter = new OasysRiskInformationPresenter('referralId', riskSummary, null)
 
         expect(presenter.latestAssessment).toEqual('Assessment date not found')
       })

--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationPresenter.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationPresenter.ts
@@ -1,6 +1,5 @@
 import RiskSummary from '../../../../../models/assessRisksAndNeeds/riskSummary'
 import DateUtils from '../../../../../utils/dateUtils'
-import { SupplementaryRiskInformation } from '../../../../../models/assessRisksAndNeeds/supplementaryRiskInformation'
 
 import RoshPanelPresenter from '../../../../shared/roshPanelPresenter'
 import { FormValidationError } from '../../../../../utils/formValidationError'
@@ -11,7 +10,6 @@ export default class OasysRiskInformationPresenter {
 
   constructor(
     readonly referralId: string,
-    readonly supplementaryRiskInformation: SupplementaryRiskInformation | null,
     readonly riskSummary: RiskSummary | null,
     private readonly error: FormValidationError | null = null
   ) {

--- a/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
+++ b/server/routes/makeAReferral/risk-information/oasys/view/oasysRiskInformationView.ts
@@ -11,7 +11,7 @@ export default class OasysRiskInformationView {
 
   constructor(readonly presenter: OasysRiskInformationPresenter) {
     this.roshPanelView = new RoshPanelView(this.presenter.riskPresenter, 'probation-practitioner')
-    this.riskSummaryView = new OasysRiskSummaryView(presenter.supplementaryRiskInformation, presenter.riskSummary)
+    this.riskSummaryView = new OasysRiskSummaryView(presenter.riskSummary)
   }
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errors.summary)

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -2,7 +2,7 @@ import ShowReferralPresenter from './showReferralPresenter'
 import ViewUtils from '../../utils/viewUtils'
 import { InputArgs, SummaryListArgs, TagArgs } from '../../utils/govukFrontendTypes'
 import RoshPanelView from './roshPanelView'
-import OasysRiskSummaryView from '../makeAReferral/risk-information/oasys/oasysRiskSummaryView'
+import ArnRiskSummaryView from '../makeAReferral/risk-information/oasys/arnRiskSummaryView'
 
 interface ServiceCategorySection {
   name: string
@@ -10,10 +10,10 @@ interface ServiceCategorySection {
 }
 
 export default class ShowReferralView {
-  supplementaryRiskInformationView: OasysRiskSummaryView
+  supplementaryRiskInformationView: ArnRiskSummaryView
 
   constructor(private readonly presenter: ShowReferralPresenter) {
-    this.supplementaryRiskInformationView = new OasysRiskSummaryView(presenter.riskInformation, presenter.riskSummary)
+    this.supplementaryRiskInformationView = new ArnRiskSummaryView(presenter.riskSummary, presenter.riskInformation)
   }
 
   private readonly roshPanelView = new RoshPanelView(this.presenter.roshPanelPresenter, this.presenter.userType)

--- a/server/services/assessRisksAndNeedsService.test.ts
+++ b/server/services/assessRisksAndNeedsService.test.ts
@@ -25,21 +25,6 @@ describe(AssessRisksAndNeedsService, () => {
     })
   })
 
-  describe('getSupplementaryRiskInformationForCrn', () => {
-    const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
-
-    const assessRisksAndNeedsService = new AssessRisksAndNeedsService(restClientMock, true)
-
-    const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
-
-    it('makes a request to the Assess Risks and Needs API', async () => {
-      restClientMock.get.mockResolvedValue(supplementaryRiskInformation)
-      await assessRisksAndNeedsService.getSupplementaryRiskInformationForCrn('crn', 'token')
-
-      expect(restClientMock.get).toHaveBeenCalledWith({ path: `/risks/supplementary/crn/crn`, token: 'token' })
-    })
-  })
-
   describe('getRiskSummary', () => {
     const restClientMock = new MockRestClient() as jest.Mocked<RestClient>
 

--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -17,14 +17,6 @@ export default class AssessRisksAndNeedsService {
     })) as SupplementaryRiskInformation
   }
 
-  async getSupplementaryRiskInformationForCrn(crn: string, token: string): Promise<SupplementaryRiskInformation> {
-    logger.info({ crn }, 'getting supplementary risk information for crn')
-    return (await this.restClient.get({
-      path: `/risks/supplementary/crn/${crn}`,
-      token,
-    })) as SupplementaryRiskInformation
-  }
-
   async getRiskSummary(crn: string, token: string): Promise<RiskSummary | null> {
     if (!this.riskSummaryEnabled) {
       logger.info('not getting risk summary information; disabled')


### PR DESCRIPTION
commit 4663aed0ecc82fc0c8c5f915a05543184f82b037 

Removed getSupplementaryRiskInformationForCrn() from assessRisksAndNeedsService.
We should always be getting supplementary risk based on the referral id rather than CRN.

commit d38fdfb2ddd388d585583ff248a619c4fdceb780

Removed additional information from supplementary risk for CRN when viewing OAsys risk information as part of make a referral journey.
This was coded with an invalid assumption that the supplementary risk for CRN should be displayed. Only original OAsys data should be displayed on this page.

Defined a class for how to display OAsys risk information and for how to display ARN risk information.

ARN risk information is used by referral details screen whilst OAsys risk information is used for make a referral journey.