### PR TITLE
CI/security: Replace snyk scannning with trivy scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   hmpps: ministryofjustice/hmpps@3.11
-  snyk: snyk/snyk@0.0.12
   node: circleci/node@4.1.0
   veracode: orb-01scan/sast-orb@0.0.9
 
@@ -108,24 +107,6 @@ jobs:
       - store_artifacts:
           path: integration_tests/screenshots
 
-  vulnerability_scan:
-    executor:
-      name: hmpps/node
-      tag: 14.16.0-browsers
-    parameters:
-      monitor:
-        type: boolean
-        default: false
-    steps:
-      - checkout
-      - run: npm install -q
-      - snyk/scan:
-          project: '${CIRCLE_PROJECT_REPONAME}'
-          monitor-on-build: << parameters.monitor >>
-          organization: "digital-probation-services"
-          severity-threshold: "high" # note: this does not affect snyk 'monitor' commands
-          fail-on-issues: true
-
 workflows:
   version: 2
   build_test_and_deploy:
@@ -133,34 +114,25 @@ workflows:
       - build
       - integration_test
       - hmpps/helm_lint
-      - vulnerability_scan:
-          name: vulnerability_scan_and_monitor
-          monitor: true
-          filters:
-            branches:
-              only:
-                - main
-      - vulnerability_scan:
-          filters:
-            branches:
-              ignore:
-                - main
       - hmpps/build_docker:
           name: build_docker_publish
-          snyk-scan: true
           git-lfs: true
+          publish: true
+          persist_container_image: true
           filters:
             branches:
-              only:
-                - main
+              only: [main]
       - hmpps/build_docker:
-          publish: false
-          snyk-scan: true
+          name: build_docker
           git-lfs: true
+          publish: false
+          persist_container_image: true
           filters:
             branches:
-              ignore:
-                - main
+              ignore: [main]
+      - hmpps/trivy_pipeline_scan:
+          name: vulnerability_scan
+          requires: [build_docker, build_docker_publish]
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"
@@ -175,7 +147,7 @@ workflows:
             - integration_test
             - hmpps/helm_lint
             - build_docker_publish
-            - vulnerability_scan_and_monitor
+            - vulnerability_scan
           context:
             - hmpps-common-vars
             - hmpps-interventions-dev-deploy
@@ -239,10 +211,6 @@ workflows:
       - appsec_scan:
           requires: [assemble]
           context: [veracode-credentials]
-      - vulnerability_scan:
-          name: vulnerability_scan_and_monitor
-          monitor: true
-      - hmpps/build_docker:
-          publish: false
-          snyk-scan: true
-          git-lfs: true
+      - hmpps/trivy_latest_scan:
+          slack_channel: "interventions-dev-notifications"
+          context: [hmpps-common-vars]

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
         "passport-oauth2": "^1.6.1",
         "redis": "^3.1.1",
         "superagent": "^6.1.0",
-        "tar": "^6.1.11",
         "timezone-support": "^2.0.2",
-        "uuid": "^8.3.2"
+        "uuid": "^8.3.2",
+        "validator": "^13.7.0"
       },
       "devDependencies": {
         "@pact-foundation/pact": "^9.17.0",
@@ -5547,6 +5547,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -8787,6 +8788,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -14691,6 +14693,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
       "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14702,6 +14705,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -17883,6 +17887,7 @@
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
       "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -17899,6 +17904,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -18809,9 +18815,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
-      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -23615,7 +23621,8 @@
     "chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true
     },
     "ci-info": {
       "version": "2.0.0",
@@ -26135,6 +26142,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -30660,6 +30668,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
       "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -30668,6 +30677,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -33102,6 +33112,7 @@
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
       "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dev": true,
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -33114,7 +33125,8 @@
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
         }
       }
     },
@@ -33803,9 +33815,9 @@
       }
     },
     "validator": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
-      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       "prettier --write"
     ]
   },
-  "//": "tar is not a direct dependency of our project; we’ve only added it here to remove a security vulnerability introduced by a transitive dependency. This should be removed; see IC-2177",
+  "//": "validator is pinned for CVE-2021-3765; remove when fixed upstream",
   "dependencies": {
     "@ministryofjustice/frontend": "1.0.1",
     "@sentry/node": "^6.16.1",
@@ -128,9 +128,9 @@
     "passport-oauth2": "^1.6.1",
     "redis": "^3.1.1",
     "superagent": "^6.1.0",
-    "tar": "^6.1.11",
     "timezone-support": "^2.0.2",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "validator": "^13.7.0"
   },
   "devDependencies": {
     "@pact-foundation/pact": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       "prettier --write"
     ]
   },
-  "//": "validator is pinned for CVE-2021-3765; remove when fixed upstream",
+  "//": "TODO validator is pinned for CVE-2021-3765; remove when fixed upstream",
   "dependencies": {
     "@ministryofjustice/frontend": "1.0.1",
     "@sentry/node": "^6.16.1",


### PR DESCRIPTION
## What does this pull request do?

Replace snyk scannning with trivy scanning

🔐 To make this pass, pinned `validator` to mitigate CVE-2021-3765

As an added bonus, now with Slack alerts if nightly scan fails :)

## What is the intent behind these changes?

Snyk has been replaced with Trivy as it's faster, smaller, and better
integrated.
