### PR TITLE
Reduce dependency update frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
     time: "03:00"
     timezone: Europe/London
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 10


### PR DESCRIPTION


## What does this pull request do?

Reduce dependency update frequency to weekly

## What is the intent behind these changes?

Since we use many packages and the node ecosystem is lively, we get lots
of dependency updates almost every day

To reduce the amount of overview we have to do, we opted to have it run
every week instead, with the trade off of having more dependency PRs

An alternative to this approach would be to setup auto-merging on
dependency PRs if they pass the test suite, but that's not mutually
exclusive with this solution
