### PR TITLE
Trim trailing spaces from integer form inputs

### DIFF
--- a/server/utils/forms/inputs/calendarDayInput.test.ts
+++ b/server/utils/forms/inputs/calendarDayInput.test.ts
@@ -25,6 +25,20 @@ describe(CalendarDayInput, () => {
       })
     })
 
+    describe('with trailing or leading spaces', () => {
+      it('returns a CalendarDay value', async () => {
+        const request = TestUtils.createRequest({
+          'deadline-year': ' 2021 ',
+          'deadline-month': '09 ',
+          'deadline-day': ' 12',
+        })
+
+        const result = await new CalendarDayInput(request, 'deadline', messages).validate()
+
+        expect(result.value).toEqual(CalendarDay.fromComponents(12, 9, 2021))
+      })
+    })
+
     it('returns an error when a field is empty', async () => {
       const request = TestUtils.createRequest({
         'deadline-year': '',

--- a/server/utils/forms/inputs/calendarDayInput.ts
+++ b/server/utils/forms/inputs/calendarDayInput.ts
@@ -80,18 +80,21 @@ export default class CalendarDayInput {
         .notEmpty({ ignore_whitespace: true })
         .withMessage(this.errorMessages.dayEmpty)
         .bail()
+        .trim()
         .isInt()
         .withMessage(this.errorMessages.invalidDate),
       ExpressValidator.body(this.keys.month)
         .notEmpty({ ignore_whitespace: true })
         .withMessage(this.errorMessages.monthEmpty)
         .bail()
+        .trim()
         .isInt()
         .withMessage(this.errorMessages.invalidDate),
       ExpressValidator.body(this.keys.year)
         .notEmpty({ ignore_whitespace: true })
         .withMessage(this.errorMessages.yearEmpty)
         .bail()
+        .trim()
         .isInt({ max: 9999 }) // sure, dates bigger than this are real dates, but they're not valid here
         .withMessage(this.errorMessages.invalidDate),
     ]

--- a/server/utils/forms/inputs/durationInput.test.ts
+++ b/server/utils/forms/inputs/durationInput.test.ts
@@ -42,6 +42,17 @@ describe(DurationInput, () => {
 
         expect(result.value).toEqual(Duration.fromUnits(0, 30, 0))
       })
+
+      it('returns a Duration value when input have leading or trailing spaces', async () => {
+        const request = TestUtils.createRequest({
+          'session-duration-hours': ' 1',
+          'session-duration-minutes': '30 ',
+        })
+
+        const result = await new DurationInput(request, 'session-duration', messages).validate()
+
+        expect(result.value).toEqual(Duration.fromUnits(1, 30, 0))
+      })
     })
 
     it('returns an error when hours and minutes are both empty', async () => {

--- a/server/utils/forms/inputs/durationInput.ts
+++ b/server/utils/forms/inputs/durationInput.ts
@@ -81,10 +81,12 @@ export default class DurationInput {
       // These two express that any provided component must be an integer
       ExpressValidator.body(this.keys.hours)
         .if(ExpressValidator.body(this.keys.hours).notEmpty(isEmptyOptions))
+        .trim()
         .isInt()
         .withMessage(this.errorMessages.invalidDuration),
       ExpressValidator.body(this.keys.minutes)
         .if(ExpressValidator.body(this.keys.minutes).notEmpty(isEmptyOptions))
+        .trim()
         .isInt()
         .withMessage(this.errorMessages.invalidDuration),
     ]

--- a/server/utils/forms/inputs/twelveHourClockTimeInput.test.ts
+++ b/server/utils/forms/inputs/twelveHourClockTimeInput.test.ts
@@ -35,6 +35,18 @@ describe(TwelveHourClockTimeInput, () => {
 
         expect(result.value).toEqual(ClockTime.fromTwentyFourHourComponents(13, 5, 0))
       })
+
+      it('returns a ClockTime value for inputs with leading or trailing spaces', async () => {
+        const request = TestUtils.createRequest({
+          'alarm-time-hour': ' 1     ',
+          'alarm-time-minute': ' 05',
+          'alarm-time-part-of-day': 'am',
+        })
+
+        const result = await new TwelveHourClockTimeInput(request, 'alarm-time', messages).validate()
+
+        expect(result.value).toEqual(ClockTime.fromTwentyFourHourComponents(1, 5, 0))
+      })
     })
 
     it('returns an error when a field is empty', async () => {

--- a/server/utils/forms/inputs/twelveHourClockTimeInput.ts
+++ b/server/utils/forms/inputs/twelveHourClockTimeInput.ts
@@ -70,12 +70,14 @@ export default class TwelveHourClockTimeInput {
         .notEmpty({ ignore_whitespace: true })
         .withMessage(this.errorMessages.hourEmpty)
         .bail()
+        .trim()
         .isInt()
         .withMessage(this.errorMessages.invalidTime),
       ExpressValidator.body(this.keys.minute)
         .notEmpty({ ignore_whitespace: true })
         .withMessage(this.errorMessages.minuteEmpty)
         .bail()
+        .trim()
         .isInt()
         .withMessage(this.errorMessages.invalidTime),
       ExpressValidator.body(this.keys.partOfDay)


### PR DESCRIPTION
## What does this pull request do?

allows forms which take integer values to accept inputs with leading or trailing spaces.

this was originally reported for the 'date input' component, but the issue was seen in several validators. each is fixed in a seperate commit. 

## What is the intent behind these changes?

allow users to submit forms with leading or trailing spaces.
