### PR TITLE
Add form validation for appointment scheduling which validates the appointment time is not before *today*.

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -885,7 +885,7 @@ describe('Service provider referrals dashboard', () => {
           cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type('24')
           cy.get('#date-month').type('3')
-          cy.get('#date-year').type('2021')
+          cy.get('#date-year').type('2025')
           cy.get('#time-hour').type('9')
           cy.get('#time-minute').type('02')
           cy.get('#time-part-of-day').select('AM')
@@ -901,7 +901,7 @@ describe('Service provider referrals dashboard', () => {
 
           const scheduledAppointment = actionPlanAppointmentFactory.build({
             ...appointment,
-            appointmentTime: '2021-03-24T09:02:02Z',
+            appointmentTime: '2025-03-24T09:02:02Z',
             durationInMinutes: 75,
             sessionType: 'GROUP',
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -919,7 +919,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           cy.get('h1').contains('Confirm session 1 details')
-          cy.contains('24 March 2021')
+          cy.contains('24 March 2025')
           cy.contains('9:02am to 10:17am')
           cy.contains('In-person meeting')
           cy.contains('Harmony Living Office, Room 4')
@@ -936,7 +936,7 @@ describe('Service provider referrals dashboard', () => {
 
           cy.get('#date-day').should('have.value', '24')
           cy.get('#date-month').should('have.value', '3')
-          cy.get('#date-year').should('have.value', '2021')
+          cy.get('#date-year').should('have.value', '2025')
           cy.get('#time-hour').should('have.value', '9')
           cy.get('#time-minute').should('have.value', '02')
           // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
@@ -956,7 +956,7 @@ describe('Service provider referrals dashboard', () => {
             cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
             cy.get('#date-day').type('24')
             cy.get('#date-month').type('3')
-            cy.get('#date-year').type('2021')
+            cy.get('#date-year').type('2025')
             cy.get('#time-hour').type('9')
             cy.get('#time-minute').type('02')
             cy.get('#time-part-of-day').select('AM')
@@ -973,7 +973,7 @@ describe('Service provider referrals dashboard', () => {
             cy.contains('Save and continue').click()
 
             cy.get('h1').contains('Confirm session 1 details')
-            cy.contains('24 March 2021')
+            cy.contains('24 March 2025')
             cy.contains('9:02am to 10:17am')
             cy.contains('In-person meeting')
             cy.contains('Harmony Living Office, Room 4')
@@ -991,7 +991,7 @@ describe('Service provider referrals dashboard', () => {
             cy.get('h1').contains('Add session 1 details')
             cy.get('#date-day').should('have.value', '24')
             cy.get('#date-month').should('have.value', '3')
-            cy.get('#date-year').should('have.value', '2021')
+            cy.get('#date-year').should('have.value', '2025')
             cy.get('#time-hour').should('have.value', '9')
             cy.get('#time-minute').should('have.value', '02')
             cy.get('#time-part-of-day').get('[selected]').should('have.text', 'AM')
@@ -1010,7 +1010,7 @@ describe('Service provider referrals dashboard', () => {
 
             const scheduledAppointment = actionPlanAppointmentFactory.build({
               ...appointment,
-              appointmentTime: '2021-03-25T09:02:02Z',
+              appointmentTime: '2025-03-25T09:02:02Z',
               durationInMinutes: 75,
               sessionType: 'GROUP',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -1038,7 +1038,7 @@ describe('Service provider referrals dashboard', () => {
           cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type('24')
           cy.get('#date-month').type('3')
-          cy.get('#date-year').type('2021')
+          cy.get('#date-year').type('2025')
           cy.get('#time-hour').type('9')
           cy.get('#time-minute').type('02')
           cy.get('#time-part-of-day').select('AM')
@@ -1050,7 +1050,7 @@ describe('Service provider referrals dashboard', () => {
 
           const scheduledAppointment = actionPlanAppointmentFactory.build({
             ...appointment,
-            appointmentTime: '2021-03-24T09:02:02Z',
+            appointmentTime: '2025-03-24T09:02:02Z',
             durationInMinutes: 75,
             sessionType: 'GROUP',
             appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
@@ -1063,7 +1063,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           cy.get('h1').contains('Confirm session 1 details')
-          cy.contains('24 March 2021')
+          cy.contains('24 March 2025')
           cy.contains('9:02am to 10:17am')
           cy.contains('In-person meeting (probation office)')
 
@@ -1076,7 +1076,7 @@ describe('Service provider referrals dashboard', () => {
 
           cy.get('#date-day').should('have.value', '24')
           cy.get('#date-month').should('have.value', '3')
-          cy.get('#date-year').should('have.value', '2021')
+          cy.get('#date-year').should('have.value', '2025')
           cy.get('#time-hour').should('have.value', '9')
           cy.get('#time-minute').should('have.value', '02')
           // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
@@ -1837,7 +1837,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.get('#date-day').type('24')
       cy.get('#date-month').type('3')
-      cy.get('#date-year').type('2021')
+      cy.get('#date-year').type('2025')
       cy.get('#time-hour').type('9')
       cy.get('#time-minute').type('02')
       cy.get('#time-part-of-day').select('AM')
@@ -1853,7 +1853,7 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('Save and continue').click()
 
       const scheduledAppointment = initialAssessmentAppointmentFactory.build({
-        appointmentTime: '3021-03-24T09:02:02Z',
+        appointmentTime: '2025-03-24T09:02:02Z',
         durationInMinutes: 75,
         appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
         appointmentDeliveryAddress: {
@@ -1872,7 +1872,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubScheduleSupplierAssessmentAppointment(supplierAssessment.id, scheduledAppointment)
 
       cy.get('h1').contains('Confirm appointment details')
-      cy.contains('24 March 2021')
+      cy.contains('24 March 2025')
       cy.contains('9:02am to 10:17am')
       cy.contains('In-person meeting')
       cy.contains('Harmony Living Office, Room 4')
@@ -1897,7 +1897,7 @@ describe('Service provider referrals dashboard', () => {
         .getTable()
         .should('deep.equal', [
           {
-            'Date and time': '9:02am on 24 Mar 3021',
+            'Date and time': '9:02am on 24 Mar 2025',
             Status: 'scheduled',
             Action: 'View details or reschedule',
           },
@@ -1906,7 +1906,7 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('View details or reschedule').click()
       cy.get('h1').contains('View appointment details')
 
-      cy.contains('24 March 3021')
+      cy.contains('24 March 2025')
       cy.contains('9:02am to 10:17am')
       cy.contains('In-person meeting')
       cy.contains('Harmony Living Office, Room 4')
@@ -1946,7 +1946,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.get('#date-day').type('24')
       cy.get('#date-month').type('3')
-      cy.get('#date-year').type('2021')
+      cy.get('#date-year').type('2025')
       cy.get('#time-hour').type('9')
       cy.get('#time-minute').type('02')
       cy.get('#time-part-of-day').select('AM')
@@ -1971,7 +1971,7 @@ describe('Service provider referrals dashboard', () => {
       cy.get('h1').contains('Add appointment details')
       cy.get('#date-day').should('have.value', '24')
       cy.get('#date-month').should('have.value', '3')
-      cy.get('#date-year').should('have.value', '2021')
+      cy.get('#date-year').should('have.value', '2025')
       cy.get('#time-hour').should('have.value', '9')
       cy.get('#time-minute').should('have.value', '02')
       cy.get('#time-part-of-day').get('[selected]').should('have.text', 'AM')
@@ -1989,7 +1989,7 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('Save and continue').click()
 
       const scheduledAppointment = initialAssessmentAppointmentFactory.build({
-        appointmentTime: '2021-03-25T09:02:02Z',
+        appointmentTime: '2025-03-25T09:02:02Z',
         durationInMinutes: 75,
         appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
         appointmentDeliveryAddress: {
@@ -2021,7 +2021,7 @@ describe('Service provider referrals dashboard', () => {
         referral: { serviceCategoryIds: [serviceCategory.id], interventionId: intervention.id },
       })
       const scheduledAppointment = initialAssessmentAppointmentFactory.build({
-        appointmentTime: '3021-03-24T09:02:00Z',
+        appointmentTime: '2025-03-24T09:02:00Z',
         durationInMinutes: 75,
       })
       const supplierAssessmentWithScheduledAppointment = supplierAssessmentFactory.justCreated.build({
@@ -2051,7 +2051,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.get('#date-day').should('have.value', '24')
       cy.get('#date-month').should('have.value', '3')
-      cy.get('#date-year').should('have.value', '3021')
+      cy.get('#date-year').should('have.value', '2025')
       cy.get('#time-hour').should('have.value', '9')
       cy.get('#time-minute').should('have.value', '02')
       // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
@@ -2061,7 +2061,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.get('#date-day').clear().type('10')
       cy.get('#date-month').clear().type('4')
-      cy.get('#date-year').clear().type('2021')
+      cy.get('#date-year').clear().type('2025')
       cy.get('#time-hour').clear().type('4')
       cy.get('#time-minute').clear().type('15')
       cy.get('#time-part-of-day').select('PM')
@@ -2071,7 +2071,7 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('Save and continue').click()
 
       const rescheduledAppointment = initialAssessmentAppointmentFactory.build({
-        appointmentTime: '3021-04-10T16:15:00Z',
+        appointmentTime: '2025-04-10T16:15:00Z',
         durationInMinutes: 45,
       })
       const supplierAssessmentWithRescheduledAppointment = supplierAssessmentFactory.build({
@@ -2085,7 +2085,7 @@ describe('Service provider referrals dashboard', () => {
       )
 
       cy.get('h1').contains('Confirm appointment details')
-      cy.contains('10 April 2021')
+      cy.contains('10 April 2025')
       cy.contains('4:15pm to 5:00pm')
 
       cy.get('button').contains('Confirm').click()
@@ -2244,7 +2244,7 @@ describe('Service provider referrals dashboard', () => {
           cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
 
           const unattendedAppointment = initialAssessmentAppointmentFactory.build({
-            appointmentTime: '2021-03-24T09:02:02Z',
+            appointmentTime: '2025-03-24T09:02:02Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             sessionFeedback: {
@@ -2275,7 +2275,7 @@ describe('Service provider referrals dashboard', () => {
             .getTable()
             .should('deep.equal', [
               {
-                'Date and time': '9:02am on 24 Mar 2021',
+                'Date and time': '9:02am on 24 Mar 2025',
                 Status: 'did not attend',
                 Action: 'RescheduleView feedback',
               },
@@ -2283,7 +2283,7 @@ describe('Service provider referrals dashboard', () => {
 
           cy.get('[data-cy=supplier-assessment-table]').contains('View feedback').click()
 
-          cy.contains('24 March 2021')
+          cy.contains('24 March 2025')
           cy.contains('9:02am to 10:17am')
           cy.contains('Did Alex attend the initial assessment appointment?')
           cy.contains('No')
@@ -2300,7 +2300,7 @@ describe('Service provider referrals dashboard', () => {
 
           cy.get('#date-day').clear().type('10')
           cy.get('#date-month').clear().type('2')
-          cy.get('#date-year').clear().type('3021')
+          cy.get('#date-year').clear().type('2025')
           cy.get('#time-hour').clear().type('4')
           cy.get('#time-minute').clear().type('15')
           cy.get('#time-part-of-day').select('PM')
@@ -2311,7 +2311,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           const rescheduledAppointment = initialAssessmentAppointmentFactory.build({
-            appointmentTime: '3021-02-10T16:15:00Z',
+            appointmentTime: '2025-02-10T16:15:00Z',
             durationInMinutes: 45,
           })
 
@@ -2327,7 +2327,7 @@ describe('Service provider referrals dashboard', () => {
           )
 
           cy.get('h1').contains('Confirm appointment details')
-          cy.contains('10 February 3021')
+          cy.contains('10 February 2025')
           cy.contains('4:15pm to 5:00pm')
 
           cy.get('button').contains('Confirm').click()
@@ -2342,14 +2342,14 @@ describe('Service provider referrals dashboard', () => {
             .getTable()
             .should('deep.equal', [
               {
-                'Date and time': '4:15pm on 10 Feb 3021',
-                Status: 'scheduled',
-                Action: 'View details or reschedule',
-              },
-              {
-                'Date and time': '9:02am on 24 Mar 2021',
+                'Date and time': '9:02am on 24 Mar 2025',
                 Status: 'did not attend',
                 Action: 'View feedback',
+              },
+              {
+                'Date and time': '4:15pm on 10 Feb 2025',
+                Status: 'scheduled',
+                Action: 'View details or reschedule',
               },
             ])
         })

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -211,7 +211,7 @@ describe('Scheduling a supplier assessment appointment', () => {
           .send({
             'date-day': '24',
             'date-month': '3',
-            'date-year': '2021',
+            'date-year': '2025',
             'time-hour': '9',
             'time-minute': '02',
             'time-part-of-day': 'am',
@@ -229,7 +229,7 @@ describe('Scheduling a supplier assessment appointment', () => {
         expect(draftsService.updateDraft).toHaveBeenCalledWith(
           draftBooking.id,
           {
-            appointmentTime: '2021-03-24T09:02:00.000Z',
+            appointmentTime: '2025-03-24T09:02:00.000Z',
             durationInMinutes: 75,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
@@ -616,7 +616,7 @@ describe('Scheduling a delivery session', () => {
           .send({
             'date-day': '24',
             'date-month': '3',
-            'date-year': '2021',
+            'date-year': '2025',
             'time-hour': '9',
             'time-minute': '02',
             'time-part-of-day': 'am',
@@ -635,7 +635,7 @@ describe('Scheduling a delivery session', () => {
           draftBooking.id,
           {
             appointmentDeliveryAddress: null,
-            appointmentTime: '2021-03-24T09:02:00.000Z',
+            appointmentTime: '2025-03-24T09:02:00.000Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             npsOfficeCode: null,

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
@@ -18,7 +18,7 @@ describe(ScheduleAppointmentForm, () => {
       describe('with a phone call appointment', () => {
         it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
           const request = TestUtils.createRequest({
-            'date-year': '2021',
+            'date-year': '2025',
             'date-month': '09',
             'date-day': '12',
             'time-hour': '1',
@@ -33,7 +33,7 @@ describe(ScheduleAppointmentForm, () => {
           const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
 
           expect(data.paramsForUpdate).toEqual({
-            appointmentTime: '2021-09-12T12:05:00.000Z',
+            appointmentTime: '2025-09-12T12:05:00.000Z',
             durationInMinutes: 90,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
@@ -46,7 +46,7 @@ describe(ScheduleAppointmentForm, () => {
       describe('with an other locations appointment', () => {
         it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
           const request = TestUtils.createRequest({
-            'date-year': '2021',
+            'date-year': '2025',
             'date-month': '09',
             'date-day': '12',
             'time-hour': '1',
@@ -66,7 +66,7 @@ describe(ScheduleAppointmentForm, () => {
           const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
 
           expect(data.paramsForUpdate).toEqual({
-            appointmentTime: '2021-09-12T12:05:00.000Z',
+            appointmentTime: '2025-09-12T12:05:00.000Z',
             durationInMinutes: 90,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -84,7 +84,7 @@ describe(ScheduleAppointmentForm, () => {
         describe('with a missing second address line', () => {
           it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
             const request = TestUtils.createRequest({
-              'date-year': '2021',
+              'date-year': '2025',
               'date-month': '09',
               'date-day': '12',
               'time-hour': '1',
@@ -102,7 +102,7 @@ describe(ScheduleAppointmentForm, () => {
 
             const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
             expect(data.paramsForUpdate).toEqual({
-              appointmentTime: '2021-09-12T12:05:00.000Z',
+              appointmentTime: '2025-09-12T12:05:00.000Z',
               durationInMinutes: 90,
               sessionType: 'ONE_TO_ONE',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -121,7 +121,7 @@ describe(ScheduleAppointmentForm, () => {
       describe('with a delius office location appointment', () => {
         it('returns a valid appointment with an office location code', async () => {
           const request = TestUtils.createRequest({
-            'date-year': '2021',
+            'date-year': '2025',
             'date-month': '09',
             'date-day': '12',
             'time-hour': '1',
@@ -137,7 +137,7 @@ describe(ScheduleAppointmentForm, () => {
           const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
 
           expect(data.paramsForUpdate).toEqual({
-            appointmentTime: '2021-09-12T12:05:00.000Z',
+            appointmentTime: '2025-09-12T12:05:00.000Z',
             durationInMinutes: 90,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
@@ -197,7 +197,7 @@ describe(ScheduleAppointmentForm, () => {
         describe('having an empty office location selection', () => {
           it('returns an error message for missing office location', async () => {
             const request = TestUtils.createRequest({
-              'date-year': '2021',
+              'date-year': '2025',
               'date-month': '09',
               'date-day': '12',
               'time-hour': '1',
@@ -226,7 +226,7 @@ describe(ScheduleAppointmentForm, () => {
         describe('having an invalid office location selection', () => {
           it('returns an error message for invalid office location', async () => {
             const request = TestUtils.createRequest({
-              'date-year': '2021',
+              'date-year': '2025',
               'date-month': '09',
               'date-day': '12',
               'time-hour': '1',

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
@@ -17,12 +17,16 @@ export default class ScheduleAppointmentForm {
   constructor(private readonly request: Request, private readonly deliusOfficeLocations: DeliusOfficeLocation[]) {}
 
   async data(): Promise<FormData<AppointmentSchedulingDetails>> {
+    const startOfToday = new Date()
+    startOfToday.setHours(0, 0, 0, 0)
+
     const [dateResult, durationResult, sessionTypeResult, appointmentDeliveryType] = await Promise.all([
       new TwelveHourBritishDateTimeInput(
         this.request,
         'date',
         'time',
-        errorMessages.scheduleAppointment.time
+        errorMessages.scheduleAppointment.time,
+        startOfToday
       ).validate(),
       new DurationInput(this.request, 'duration', errorMessages.scheduleAppointment.duration).validate(),
       FormUtils.runValidations({ request: this.request, validations: this.validateSessionType() }),

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -108,6 +108,7 @@ export default {
         invalidTime: 'The session time must be a real time',
       },
       invalidTime: 'The session time must exist on the session date',
+      pastTime: 'The session cannot be scheduled in the past',
     },
     duration: {
       empty: 'Enter a duration',


### PR DESCRIPTION
## What does this pull request do?

Add form validation for appointment scheduling which validates the appointment time is not before *today*.

## What is the intent behind these changes?
The reason for this is that the API does not currently support appointments before today, and if you
continue to submit the form you end up with an error page with a less useful error message. This
change brings the error to the users attention sooner so it can be corrected without the pain of
confirming and then being presented with an error page.
