### PR TITLE
Replace 'service user' in appointment feedback form

### DIFF
--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackForm.test.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackForm.test.ts
@@ -29,7 +29,7 @@ describe(AttendanceFeedbackForm, () => {
         expect(data.error?.errors).toContainEqual({
           errorSummaryLinkedField: 'attended',
           formFields: ['attended'],
-          message: 'Select whether the service user attended or not',
+          message: 'Select whether they attended or not',
         })
       })
     })

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackForm.test.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackForm.test.ts
@@ -26,7 +26,7 @@ describe(BehaviourFeedbackForm, () => {
         expect(data.error?.errors).toContainEqual({
           errorSummaryLinkedField: 'behaviour-description',
           formFields: ['behaviour-description'],
-          message: "Enter a description of the service user's behaviour",
+          message: "Enter a description of their behaviour",
         })
         expect(data.error?.errors).toContainEqual({
           errorSummaryLinkedField: 'notify-probation-practitioner',
@@ -47,7 +47,7 @@ describe(BehaviourFeedbackForm, () => {
           {
             errorSummaryLinkedField: 'behaviour-description',
             formFields: ['behaviour-description'],
-            message: "Enter a description of the service user's behaviour",
+            message: "Enter a description of their behaviour",
           },
         ])
       })

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackForm.test.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackForm.test.ts
@@ -26,7 +26,7 @@ describe(BehaviourFeedbackForm, () => {
         expect(data.error?.errors).toContainEqual({
           errorSummaryLinkedField: 'behaviour-description',
           formFields: ['behaviour-description'],
-          message: "Enter a description of their behaviour",
+          message: 'Enter a description of their behaviour',
         })
         expect(data.error?.errors).toContainEqual({
           errorSummaryLinkedField: 'notify-probation-practitioner',
@@ -47,7 +47,7 @@ describe(BehaviourFeedbackForm, () => {
           {
             errorSummaryLinkedField: 'behaviour-description',
             formFields: ['behaviour-description'],
-            message: "Enter a description of their behaviour",
+            message: 'Enter a description of their behaviour',
           },
         ])
       })

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -90,7 +90,7 @@ export default {
     empty: 'Select whether they attended or not',
   },
   appointmentBehaviour: {
-    descriptionEmpty: "Enter a description of their behaviour",
+    descriptionEmpty: 'Enter a description of their behaviour',
     notifyProbationPractitionerNotSelected: 'Select whether to notify the probation practitioner or not',
   },
   scheduleAppointment: {

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -87,10 +87,10 @@ export default {
     notConfirmed: 'Select the checkbox to confirm before you approve the action plan',
   },
   attendedAppointment: {
-    empty: 'Select whether the service user attended or not',
+    empty: 'Select whether they attended or not',
   },
   appointmentBehaviour: {
-    descriptionEmpty: "Enter a description of the service user's behaviour",
+    descriptionEmpty: "Enter a description of their behaviour",
     notifyProbationPractitionerNotSelected: 'Select whether to notify the probation practitioner or not',
   },
   scheduleAppointment: {

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanSessions.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanSessions.njk
@@ -6,7 +6,7 @@
 {% block formPart %}
     <h3 class="govuk-heading-m">Add number of sessions for {{ presenter.serviceUser.firstName | capitalize }}'s action plan</h3>
 
-    <p class="govuk-body">This will be shared with the probation practitioner for approval. The first version of the action plan must be submitted within 5 working days of the initial assessment.</p>
+    <p class="govuk-body">This will be shared with the probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
 
     {{ govukInput(numberOfSessionsInputArgs) }}
     {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -7,7 +7,7 @@
 {% set pageSubTitle = "Add activity" %}
 
 {% block formSection %}
-  <p class="govuk-body-m">This will be shared with the service user's probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
+  <p class="govuk-body-m">This will be shared with the probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
 
   <h2 class="govuk-heading-m">{{ presenter.text.referredOutcomesHeader }}</h2>
 

--- a/server/views/serviceProviderReferrals/actionPlan/numberOfSessions.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/numberOfSessions.njk
@@ -9,7 +9,7 @@
 {% block formSection %}
     <h3 class="govuk-heading-m">Add number of sessions for {{ presenter.text.serviceUserFirstName | capitalize }}’s action plan</h3>
 
-    <p class="govuk-body">This will be shared with the service user's probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
+    <p class="govuk-body">This will be shared with the probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
 
       <form method="post" novalidate>
         <input type="hidden" name="_csrf" value="{{csrfToken}}">


### PR DESCRIPTION
## What does this pull request do?
Change instances of service user.  https://trello.com/c/54z7DeHq/8-remove-use-of-service-user-across-the-service

## What is the intent behind these changes?
See card