### PR TITLE
trim whitespace characters from postcode inputs before posting to interventions API

### DIFF
--- a/server/utils/forms/inputs/addressInput.test.ts
+++ b/server/utils/forms/inputs/addressInput.test.ts
@@ -51,19 +51,21 @@ describe(AddressInput, () => {
             'method-other-location-address-postcode': postCode,
           }
         }
-        async function validatePostCode(postCode: string): Promise<void> {
-          const request = TestUtils.createRequest(createRequest(postCode))
+        async function validatePostCode(input: string, expected: string): Promise<void> {
+          const request = TestUtils.createRequest(createRequest(input))
           const result = await new AddressInput(request, 'method-other-location', errorMessages).validate()
-          expect(result.value?.postCode).toEqual(postCode)
+          expect(result.value?.postCode).toEqual(expected)
         }
         it('returns an address value when all postcode is valid', async () => {
-          await validatePostCode('aa9a 9aa')
-          await validatePostCode('a9a 9aa')
-          await validatePostCode('a9 9aa')
-          await validatePostCode('a99 9aa')
-          await validatePostCode('aa9 9aa')
-          await validatePostCode('aa99 9aa')
-          await validatePostCode(' aa999aa ')
+          await validatePostCode('aa9a 9aa', 'aa9a 9aa')
+          await validatePostCode('a9a 9aa', 'a9a 9aa')
+          await validatePostCode('a9 9aa', 'a9 9aa')
+          await validatePostCode('a99 9aa', 'a99 9aa')
+          await validatePostCode('aa9 9aa', 'aa9 9aa')
+          await validatePostCode('aa99 9aa', 'aa99 9aa')
+          await validatePostCode(' aa999aa ', 'aa999aa')
+          // unicode whitespace characters
+          await validatePostCode(' aa9 9aa  ', 'aa9 9aa')
         })
       })
     })

--- a/server/utils/forms/inputs/addressInput.ts
+++ b/server/utils/forms/inputs/addressInput.ts
@@ -57,7 +57,8 @@ export default class AddressInput {
         .withMessage(this.errorMessages.postCodeEmpty),
 
       ExpressValidator.body(this.keys.postCode)
-        .matches(/^\s*[A-Za-z]{1,2}\d[A-Za-z\d]? ?\d[A-Za-z]{2}\s*$/)
+        .trim()
+        .matches(/^[A-Za-z]{1,2}\d[A-Za-z\d]? ?\d[A-Za-z]{2}$/)
         .withMessage(this.errorMessages.postCodeInvalid),
     ]
   }


### PR DESCRIPTION
## What does this pull request do?

trim whitespace characters from postcode inputs before posting to interventions API

## What is the intent behind these changes?

it's possible to get unhandled errors in the UI by pasting whitespace unicode characters in postcodes that pass the UI-side validation checks but not the API side validation checks.
