### PR TITLE
Handle delius conflicts on appointments in the past

### DIFF
--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -491,26 +491,6 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubRecordAndSubmitActionPlanAppointmentWithFeedback = async (
-    actionPlanId: string,
-    session: number,
-    responseJson: unknown
-  ): Promise<unknown> => {
-    return this.wiremock.stubFor({
-      request: {
-        method: 'POST',
-        urlPattern: `${this.mockPrefix}/action-plan/${actionPlanId}/appointment/${session}`,
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        jsonBody: responseJson,
-      },
-    })
-  }
-
   stubCreateDraftEndOfServiceReport = async (responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -1776,7 +1776,7 @@ describe('Adding post delivery session feedback', () => {
           `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/confirmation`
         )
 
-      expect(interventionsService.recordAndSubmitActionPlanAppointmentWithFeedback).toHaveBeenCalledWith(
+      expect(interventionsService.updateActionPlanAppointment).toHaveBeenCalledWith(
         'token',
         actionPlanId,
         sessionNumber,

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -1,5 +1,6 @@
 import { Express } from 'express'
 import request from 'supertest'
+import createError from 'http-errors'
 import actionPlanFactory from '../../../testutils/factories/actionPlan'
 import actionPlanAppointmentFactory from '../../../testutils/factories/actionPlanAppointment'
 import { createDraftFactory } from '../../../testutils/factories/draft'
@@ -1791,6 +1792,30 @@ describe('Adding post delivery session feedback', () => {
           appointmentBehaviour: { ...draftAppointment!.sessionFeedback!.behaviour },
         }
       )
+    })
+
+    it('redirects back to the appointment booking form if a 409 conflict is return from interventions service', async () => {
+      const actionPlanId = '91e7ceab-74fd-45d8-97c8-ec58844618dd'
+      const sessionNumber = 2
+
+      const draftAppointment: DraftAppointment = draftAppointmentFactory.withSubmittedFeedback().build()
+      const draftAppointmentResult = draftAppointmentBookingFactory.build({
+        data: draftAppointment,
+      })
+      draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
+      interventionsService.updateActionPlanAppointment.mockImplementation(() => {
+        throw createError(409)
+      })
+
+      await request(app)
+        .post(
+          `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/submit`
+        )
+        .expect(302)
+        .expect(
+          'Location',
+          `/service-provider/action-plan/${actionPlanId}/sessions/${sessionNumber}/edit/${draftAppointmentResult.id}/details?clash=true`
+        )
     })
   })
 

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -387,28 +387,42 @@ export default class AppointmentsController {
         `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/edit/${draft.id}/attendance`
       )
     } else {
-      try {
-        await this.interventionsService.updateActionPlanAppointment(
-          accessToken,
-          actionPlanId,
-          sessionNumber,
-          appointmentScheduleDetails
-        )
-      } catch (e) {
-        const interventionsServiceError = e as InterventionsServiceError
-        if (interventionsServiceError.status === 409) {
-          res.redirect(
-            `/service-provider/action-plan/${actionPlanId}/sessions/${sessionNumber}/edit/${draftBookingId}/details?clash=true`
-          )
-          return
-        }
+      const success = await this.updateSessionAppointmentAndCheckForConflicts(
+        accessToken,
+        actionPlanId,
+        sessionNumber,
+        appointmentScheduleDetails
+      )
 
-        throw e
+      if (success === false) {
+        res.redirect(
+          `/service-provider/action-plan/${actionPlanId}/sessions/${sessionNumber}/edit/${draftBookingId}/details?clash=true`
+        )
+        return
       }
 
       await this.draftsService.deleteDraft(draft.id, { userId: res.locals.user.userId })
       res.redirect(`/service-provider/referrals/${actionPlan.referralId}/progress`)
     }
+  }
+
+  // returns true on success, false on conflict
+  private async updateSessionAppointmentAndCheckForConflicts(
+    accessToken: string,
+    actionPlanId: string,
+    sessionNumber: number,
+    data: AppointmentSchedulingDetails
+  ): Promise<boolean> {
+    try {
+      await this.interventionsService.updateActionPlanAppointment(accessToken, actionPlanId, sessionNumber, data)
+    } catch (e) {
+      const interventionsServiceError = e as InterventionsServiceError
+      if (interventionsServiceError.status === 409) {
+        return false
+      }
+      throw e
+    }
+    return true
   }
 
   async addSupplierAssessmentAttendanceFeedback(req: Request, res: Response): Promise<void> {
@@ -830,12 +844,20 @@ export default class AppointmentsController {
           appointmentAttendance: { ...draftAppointment.sessionFeedback.attendance },
           appointmentBehaviour: { ...draftAppointment.sessionFeedback.behaviour },
         }
-        await this.interventionsService.updateActionPlanAppointment(
+
+        const success = await this.updateSessionAppointmentAndCheckForConflicts(
           accessToken,
           actionPlanId,
           Number(sessionNumber),
           data
         )
+        if (success === false) {
+          res.redirect(
+            `/service-provider/action-plan/${actionPlanId}/sessions/${sessionNumber}/edit/${draftBookingId}/details?clash=true`
+          )
+          return
+        }
+
         await this.draftsService.deleteDraft(draft.id, { userId: res.locals.user.userId })
       } else {
         throw new Error('Draft appointment data is missing.')

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -830,7 +830,7 @@ export default class AppointmentsController {
           appointmentAttendance: { ...draftAppointment.sessionFeedback.attendance },
           appointmentBehaviour: { ...draftAppointment.sessionFeedback.behaviour },
         }
-        await this.interventionsService.recordAndSubmitActionPlanAppointmentWithFeedback(
+        await this.interventionsService.updateActionPlanAppointment(
           accessToken,
           actionPlanId,
           Number(sessionNumber),

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2835,7 +2835,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         })
 
         expect(
-          await interventionsService.recordAndSubmitActionPlanAppointmentWithFeedback(
+          await interventionsService.updateActionPlanAppointment(
             serviceProviderToken,
             '345059d4-1697-467b-8914-fedec9957279',
             2,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -433,27 +433,13 @@ export default class InterventionsService {
     token: string,
     actionPlanId: string,
     sessionNumber: number,
-    appointmentUpdate: AppointmentSchedulingDetails
+    appointmentUpdate: AppointmentSchedulingDetails | CreateAppointmentSchedulingAndFeedback
   ): Promise<ActionPlanAppointment> {
     const restClient = this.createRestClient(token)
     return (await restClient.patch({
       path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}`,
       headers: { Accept: 'application/json' },
       data: { ...appointmentUpdate },
-    })) as ActionPlanAppointment
-  }
-
-  async recordAndSubmitActionPlanAppointmentWithFeedback(
-    token: string,
-    actionPlanId: string,
-    sessionNumber: number,
-    appointmentDetails: CreateAppointmentSchedulingAndFeedback
-  ): Promise<ActionPlanAppointment> {
-    const restClient = this.createRestClient(token)
-    return (await restClient.patch({
-      path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}`,
-      headers: { Accept: 'application/json' },
-      data: { ...appointmentDetails },
     })) as ActionPlanAppointment
   }
 


### PR DESCRIPTION
## What does this pull request do?

Handle delius conflicts on appointments in the past

## What is the intent behind these changes?

stop unhandled errors occuring when you submit confirmation for appointments in the past (with feedback) that cause conflicts on delius).
