### PR TITLE
allow past appointments to record 'did not attend' by sending null in the feedback DTO

### DIFF
--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -842,7 +842,11 @@ export default class AppointmentsController {
           appointmentDeliveryAddress: draftAppointment.appointmentDeliveryAddress,
           npsOfficeCode: draftAppointment.npsOfficeCode,
           appointmentAttendance: { ...draftAppointment.sessionFeedback.attendance },
-          appointmentBehaviour: { ...draftAppointment.sessionFeedback.behaviour },
+          appointmentBehaviour:
+            draftAppointment.sessionFeedback.behaviour.behaviourDescription ||
+            draftAppointment.sessionFeedback.behaviour.notifyProbationPractitioner
+              ? { ...draftAppointment.sessionFeedback.behaviour }
+              : null,
         }
 
         const success = await this.updateSessionAppointmentAndCheckForConflicts(

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -107,7 +107,7 @@ export type CreateAppointmentSchedulingAndFeedback = AppointmentSchedulingDetail
   appointmentBehaviour: {
     behaviourDescription: string | null
     notifyProbationPractitioner: boolean | null
-  }
+  } | null
 }
 
 export default class InterventionsService {


### PR DESCRIPTION
https://trello.com/c/zvyg5T8r/216-submitting-feedback-for-an-appointment-in-the-past-with-did-not-attend-causes-unhandled-error

## What does this pull request do?

allow past appointments to record 'did not attend' by sending null in the feedback DTO.

this kind of a crappy fix that does not address the larger problem of too many overlapping types causing confusion. we need to address this tech debt properly. for now, this adds a little more tech debt, but unblocks the release (hopefully)

## What is the intent behind these changes?

allow past appointment feedback forms to be submitted with 'did not attend'
