### PR TITLE
Revert "Bump helmet from 4.6.0 to 5.0.1" until we review new defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "express-validator": "^6.14.0",
         "govuk-elements-sass": "^3.1.3",
         "govuk-frontend": "^4.0.0",
-        "helmet": "^5.0.1",
+        "helmet": "^4.1.1",
         "http-errors": "^2.0.0",
         "indefinite": "^2.4.1",
         "joi": "^17.5.0",
@@ -9304,11 +9304,11 @@
       }
     },
     "node_modules/helmet": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-5.0.1.tgz",
-      "integrity": "sha512-iyYpGYH2nbQVaQtauYDnemWg45S2RyGvJ+iKj+V9jp7Dc1NTtAJHmD+hFOSYS7Xdwe1GeyVEYSydggXLOg6TKQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
+      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/hexoid": {
@@ -26729,9 +26729,9 @@
       "dev": true
     },
     "helmet": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-5.0.1.tgz",
-      "integrity": "sha512-iyYpGYH2nbQVaQtauYDnemWg45S2RyGvJ+iKj+V9jp7Dc1NTtAJHmD+hFOSYS7Xdwe1GeyVEYSydggXLOg6TKQ=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
+      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg=="
     },
     "hexoid": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "express-validator": "^6.14.0",
     "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^4.0.0",
-    "helmet": "^5.0.1",
+    "helmet": "^4.1.1",
     "http-errors": "^2.0.0",
     "indefinite": "^2.4.1",
     "joi": "^17.5.0",


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-interventions-ui#1135

helmet 5.0 has breaking configuration changes and I have _no idea_ how it would actually impact production, so I'm reverting out of caution