### PR TITLE
handle timeout errors from superagent without getting errors thrown from 'http-error'

### DIFF
--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -53,6 +53,12 @@ export default class RestClient {
 
   private static createErrorFromCaughtValue(value: unknown): RestClientError {
     const error = value as SuperagentHttpError
+
+    // some errors thrown by superagent are not HttpError e.g. `RequestBase._timeoutError`
+    if (error.status === undefined) {
+      throw value
+    }
+
     return createError(error.status, error, { external: true })
   }
 


### PR DESCRIPTION
## What does this pull request do?

handle timeout errors from superagent without getting errors thrown from 'http-error'

## What is the intent behind these changes?

stop the logs being polluted with confusing errors from 'http-error'
