### PR TITLE
Allow SAAs to be scheduled in the past

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1970,8 +1970,32 @@ describe('Service provider referrals dashboard', () => {
             cy.contains('Midnight to 1:15am')
             cy.contains('Phone call')
 
+            cy.get('button').contains('Confirm').click()
+
+            // Attendance page
+            cy.contains('Yes').click()
+            cy.contains("Add additional information about Alex's attendance").type('Alex attended the session')
+            cy.contains('Save and continue').click()
+
+            cy.contains('Add behaviour feedback')
+
+            cy.contains("Describe Alex's behaviour in the assessment appointment").type('Alex was well behaved')
+            cy.get('input[name="notify-probation-practitioner"][value="no"]').click()
+
+            cy.contains('Save and continue').click()
+
+            cy.contains('Confirm feedback')
+            cy.contains('Alex attended the session')
+            cy.contains('Yes, they were on time')
+            cy.contains('Alex was well behaved')
+            cy.contains('No')
+
+            const time = new Date()
+            time.setHours(0)
+            time.setMinutes(15)
+
             const scheduledAppointment = initialAssessmentAppointmentFactory.build({
-              appointmentTime: '2025-03-24T09:02:02Z',
+              appointmentTime: time.toString(),
               durationInMinutes: 75,
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
               appointmentDeliveryAddress: {
@@ -1981,12 +2005,27 @@ describe('Service provider referrals dashboard', () => {
                 county: 'Lancashire',
                 postCode: 'SY4 0RE',
               },
+              sessionFeedback: {
+                attendance: {
+                  attended: 'yes',
+                  additionalAttendanceInformation: 'Alex attended the session',
+                },
+                behaviour: {
+                  behaviourDescription: 'Alex was well behaved',
+                  notifyProbationPractitioner: false,
+                },
+                submitted: true,
+                submittedBy: {
+                  firstName: 'Case',
+                  lastName: 'Worker',
+                  username: 'case.worker',
+                },
+              },
             })
+
             cy.stubScheduleSupplierAssessmentAppointment(supplierAssessment.id, scheduledAppointment)
-
-            cy.get('button').contains('Confirm').click()
-
-            cy.contains('Initial assessment appointment added')
+            cy.get('form').contains('Confirm').click()
+            cy.contains('Initial assessment added')
           })
         })
         describe('that happened before today', () => {

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -328,7 +328,7 @@ describe('Scheduling a supplier assessment appointment', () => {
     it('updates the draft booking, schedules the appointment on the interventions service, deletes the draft booking, and redirects to the confirmation page', async () => {
       const draftBooking = draftAppointmentBookingFactory.build({
         data: {
-          appointmentTime: '2021-03-24T09:02:00.000Z',
+          appointmentTime: '3000-03-24T09:02:00.000Z',
           durationInMinutes: 75,
           appointmentDeliveryType: 'PHONE_CALL',
           appointmentDeliveryAddress: null,
@@ -361,7 +361,7 @@ describe('Scheduling a supplier assessment appointment', () => {
         'token',
         supplierAssessment.id,
         {
-          appointmentTime: '2021-03-24T09:02:00.000Z',
+          appointmentTime: '3000-03-24T09:02:00.000Z',
           durationInMinutes: 75,
           appointmentDeliveryType: 'PHONE_CALL',
           appointmentDeliveryAddress: null,
@@ -376,7 +376,7 @@ describe('Scheduling a supplier assessment appointment', () => {
       it('redirects to the booking form, passing a clash=true parameter, and does not delete the draft booking', async () => {
         const draftBooking = draftAppointmentBookingFactory.build({
           data: {
-            appointmentTime: '2021-03-24T09:02:00.000Z',
+            appointmentTime: '3000-03-24T09:02:00.000Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             appointmentDeliveryAddress: null,
@@ -406,7 +406,7 @@ describe('Scheduling a supplier assessment appointment', () => {
       it('renders an error message, and does not delete the draft booking', async () => {
         const draftBooking = draftAppointmentBookingFactory.build({
           data: {
-            appointmentTime: '2021-03-24T09:02:00.000Z',
+            appointmentTime: '3000-03-24T09:02:00.000Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             appointmentDeliveryAddress: null,

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -448,7 +448,6 @@ export default class AppointmentsController {
       this.interventionsService.getSupplierAssessment(accessToken, referralId),
     ])
     const appointment = await this.getSupplierAssessmentAppointmentFromDraftOrService(req, res, supplierAssessment)
-    // return because draft service already renders page.
 
     if (appointment === null) {
       throw new Error('Attempting to add supplier assessment attendance feedback without a current appointment')
@@ -513,6 +512,7 @@ export default class AppointmentsController {
         }
 
         res.redirect(`${basePath}/${redirectPath}`)
+        return
       }
     }
 

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -192,33 +192,33 @@ export default class AppointmentsController {
       res.redirect(
         `/service-provider/referrals/${req.params.id}/supplier-assessment/post-assessment-feedback/edit/${draft.id}/attendance`
       )
-    } else {
-      try {
-        await this.interventionsService.scheduleSupplierAssessmentAppointment(
-          res.locals.user.token.accessToken,
-          supplierAssessment.id,
-          draft.data
+      return
+    }
+    try {
+      await this.interventionsService.scheduleSupplierAssessmentAppointment(
+        res.locals.user.token.accessToken,
+        supplierAssessment.id,
+        draft.data
+      )
+    } catch (e) {
+      const interventionsServiceError = e as InterventionsServiceError
+      if (interventionsServiceError.status === 409) {
+        res.redirect(
+          `/service-provider/referrals/${req.params.id}/supplier-assessment/schedule/${draftBookingId}/details?clash=true`
         )
-      } catch (e) {
-        const interventionsServiceError = e as InterventionsServiceError
-        if (interventionsServiceError.status === 409) {
-          res.redirect(
-            `/service-provider/referrals/${req.params.id}/supplier-assessment/schedule/${draftBookingId}/details?clash=true`
-          )
-          return
-        }
-
-        throw e
+        return
       }
 
-      await this.draftsService.deleteDraft(draft.id, { userId: res.locals.user.userId })
-
-      const successfulRedirectPath = hasExistingScheduledAppointment
-        ? 'rescheduled-confirmation'
-        : 'scheduled-confirmation'
-
-      res.redirect(`/service-provider/referrals/${referralId}/supplier-assessment/${successfulRedirectPath}`)
+      throw e
     }
+
+    await this.draftsService.deleteDraft(draft.id, { userId: res.locals.user.userId })
+
+    const successfulRedirectPath = hasExistingScheduledAppointment
+      ? 'rescheduled-confirmation'
+      : 'scheduled-confirmation'
+
+    res.redirect(`/service-provider/referrals/${referralId}/supplier-assessment/${successfulRedirectPath}`)
   }
 
   async showSupplierAssessmentAppointmentConfirmation(

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -658,7 +658,11 @@ export default class AppointmentsController {
           appointmentDeliveryAddress: draftAppointment.appointmentDeliveryAddress,
           npsOfficeCode: draftAppointment.npsOfficeCode,
           appointmentAttendance: { ...draftAppointment.sessionFeedback.attendance },
-          appointmentBehaviour: { ...draftAppointment.sessionFeedback.behaviour },
+          appointmentBehaviour:
+            draftAppointment.sessionFeedback.behaviour.behaviourDescription ||
+            draftAppointment.sessionFeedback.behaviour.notifyProbationPractitioner
+              ? { ...draftAppointment.sessionFeedback.behaviour }
+              : null,
         }
         await this.interventionsService.scheduleAndSubmitSupplierAssessmentAppointmentWithFeedback(
           accessToken,

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -523,6 +523,7 @@ export default class AppointmentsController {
       serviceUser,
       appointmentSummary,
       referralId,
+      draftBookingId,
       formError,
       userInputData
     )
@@ -591,6 +592,7 @@ export default class AppointmentsController {
       appointment,
       serviceUser,
       referralId,
+      draftBookingId,
       formError,
       userInputData
     )

--- a/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.ts
@@ -11,6 +11,7 @@ export default class InitialAssessmentAttendanceFeedbackPresenter extends Attend
     private readonly serviceUser: DeliusServiceUser,
     readonly appointmentSummary: AppointmentSummary,
     private readonly referralId: string | null = null,
+    private readonly draftId: string | null = null,
     error: FormValidationError | null = null,
     userInputData: Record<string, unknown> | null = null
   ) {
@@ -25,5 +26,15 @@ export default class InitialAssessmentAttendanceFeedbackPresenter extends Attend
     )
   }
 
-  readonly backLinkHref = this.referralId ? `/service-provider/referrals/${this.referralId}/progress` : null
+  get getBackLinkHref(): string | null {
+    if (this.draftId && this.referralId) {
+      return `/service-provider/referrals/${this.referralId}/supplier-assessment/schedule/${this.draftId}/check-answers`
+    }
+    if (this.referralId) {
+      return `/service-provider/referrals/${this.referralId}/progress`
+    }
+    return null
+  }
+
+  readonly backLinkHref = this.getBackLinkHref
 }

--- a/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.ts
@@ -9,6 +9,7 @@ export default class InitialAssessmentBehaviourFeedbackPresenter {
     private readonly appointment: InitialAssessmentAppointment,
     private readonly serviceUser: DeliusServiceUser,
     private readonly referralId: string | null = null,
+    private readonly draftId: string | undefined = undefined,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
@@ -19,9 +20,15 @@ export default class InitialAssessmentBehaviourFeedbackPresenter {
     title: `Add behaviour feedback`,
   }
 
-  readonly backLinkHref = this.referralId
-    ? `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/attendance`
-    : null
+  get backLinkHref(): string | null {
+    if (this.referralId) {
+      if (this.draftId) {
+        return `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/edit/${this.draftId}/attendance`
+      }
+      return `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/attendance`
+    }
+    return null
+  }
 
   readonly inputsPresenter = new BehaviourFeedbackInputsPresenter(this.appointment, this.error, this.userInputData)
 }

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
@@ -22,8 +22,14 @@ export default class InitialAssessmentFeedbackCheckAnswersPresenter extends Chec
     ? `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/edit/${this.draftId}/submit`
     : `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/submit`
 
-  readonly backLinkHref =
-    this.appointment.sessionFeedback.attendance.attended === 'no'
+  get backLinkHref(): string {
+    if (this.draftId) {
+      return this.appointment.sessionFeedback.attendance.attended === 'no'
+        ? `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/edit/${this.draftId}/attendance`
+        : `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/edit/${this.draftId}/behaviour`
+    }
+    return this.appointment.sessionFeedback.attendance.attended === 'no'
       ? `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/attendance`
       : `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/behaviour`
+  }
 }

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
@@ -11,13 +11,16 @@ export default class InitialAssessmentFeedbackCheckAnswersPresenter extends Chec
     appointment: InitialAssessmentAppointment,
     private readonly serviceUser: DeliusServiceUser,
     private readonly referralId: string,
-    readonly appointmentSummary: AppointmentSummary
+    readonly appointmentSummary: AppointmentSummary,
+    private readonly draftId: string | undefined = undefined
   ) {
     super(appointment, appointmentSummary)
     this.feedbackAnswersPresenter = new FeedbackAnswersPresenter(appointment, serviceUser)
   }
 
-  readonly submitHref = `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/submit`
+  readonly submitHref = this.draftId
+    ? `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/edit/${this.draftId}/submit`
+    : `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/submit`
 
   readonly backLinkHref =
     this.appointment.sessionFeedback.attendance.attended === 'no'

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -207,6 +207,11 @@ export default function serviceProviderRoutes(router: Router, services: Services
   get(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/attendance', (req, res) =>
     appointmentsController.addSupplierAssessmentAttendanceFeedback(req, res)
   )
+  get(
+    router,
+    '/referrals/:id/supplier-assessment/post-assessment-feedback/edit/:draftBookingId/attendance',
+    (req, res) => appointmentsController.addSupplierAssessmentAttendanceFeedback(req, res)
+  )
   post(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/attendance', (req, res) =>
     appointmentsController.addSupplierAssessmentAttendanceFeedback(req, res)
   )

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -215,16 +215,39 @@ export default function serviceProviderRoutes(router: Router, services: Services
   post(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/attendance', (req, res) =>
     appointmentsController.addSupplierAssessmentAttendanceFeedback(req, res)
   )
+  post(
+    router,
+    '/referrals/:id/supplier-assessment/post-assessment-feedback/edit/:draftBookingId/attendance',
+    (req, res) => appointmentsController.addSupplierAssessmentAttendanceFeedback(req, res)
+  )
   get(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/behaviour', (req, res) =>
     appointmentsController.addSupplierAssessmentBehaviourFeedback(req, res)
+  )
+  get(
+    router,
+    '/referrals/:id/supplier-assessment/post-assessment-feedback/edit/:draftBookingId/behaviour',
+    (req, res) => appointmentsController.addSupplierAssessmentBehaviourFeedback(req, res)
   )
   post(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/behaviour', (req, res) =>
     appointmentsController.addSupplierAssessmentBehaviourFeedback(req, res)
   )
+  post(
+    router,
+    '/referrals/:id/supplier-assessment/post-assessment-feedback/edit/:draftBookingId/behaviour',
+    (req, res) => appointmentsController.addSupplierAssessmentBehaviourFeedback(req, res)
+  )
   get(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/check-your-answers', (req, res) =>
     appointmentsController.checkSupplierAssessmentFeedbackAnswers(req, res)
   )
+  get(
+    router,
+    '/referrals/:id/supplier-assessment/post-assessment-feedback/edit/:draftBookingId/check-your-answers',
+    (req, res) => appointmentsController.checkSupplierAssessmentFeedbackAnswers(req, res)
+  )
   post(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/submit', (req, res) =>
+    appointmentsController.submitSupplierAssessmentFeedback(req, res)
+  )
+  post(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/edit/:draftBookingId/submit', (req, res) =>
     appointmentsController.submitSupplierAssessmentFeedback(req, res)
   )
   get(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/confirmation', (req, res) =>

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -569,6 +569,19 @@ export default class InterventionsService {
     })) as SupplierAssessment
   }
 
+  async scheduleAndSubmitSupplierAssessmentAppointmentWithFeedback(
+    token: string,
+    supplierAssessmentId: string,
+    appointmentUpdate: CreateAppointmentSchedulingAndFeedback
+  ): Promise<InitialAssessmentAppointment> {
+    const restClient = this.createRestClient(token)
+    return (await restClient.put({
+      path: `/supplier-assessment/${supplierAssessmentId}/schedule-appointment`,
+      headers: { Accept: 'application/json' },
+      data: { ...appointmentUpdate },
+    })) as InitialAssessmentAppointment
+  }
+
   async scheduleSupplierAssessmentAppointment(
     token: string,
     supplierAssessmentId: string,


### PR DESCRIPTION
## What does this pull request do?

Updates the supplier assessment flow to allow for past appointments. This will then continue to ask for feedback at the same time.

## What is the intent behind these changes?

To allow past supplier assessment appointments to be created.
