### PR TITLE
use user id instead of username to look up service provider users in hmpps auth

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -75,7 +75,7 @@ describe('Probation Practitioner monitor journey', () => {
               interventionId: intervention.id,
               serviceCategoryIds: [serviceCategory.id],
             },
-            assignedTo: { username: hmppsAuthUser.username },
+            assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId },
           })
 
           const supplierAssessment = supplierAssessmentFactory.justCreated.build()
@@ -83,7 +83,7 @@ describe('Probation Practitioner monitor journey', () => {
           cy.stubGetSentReferral(referral.id, referral)
           cy.stubGetIntervention(intervention.id, intervention)
           cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUserFactory.build())
-          cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+          cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
           cy.stubGetSupplierAssessment(referral.id, supplierAssessment)
 
           cy.login()
@@ -117,7 +117,7 @@ describe('Probation Practitioner monitor journey', () => {
               interventionId: intervention.id,
               serviceCategoryIds: [serviceCategory.id],
             },
-            assignedTo: { username: hmppsAuthUser.username },
+            assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId },
           })
 
           const supplierAssessment = supplierAssessmentFactory.withSingleAppointment.build()
@@ -125,7 +125,7 @@ describe('Probation Practitioner monitor journey', () => {
           cy.stubGetSentReferral(referral.id, referral)
           cy.stubGetIntervention(intervention.id, intervention)
           cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUserFactory.build())
-          cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+          cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
           cy.stubGetSupplierAssessment(referral.id, supplierAssessment)
 
           cy.login()
@@ -192,7 +192,7 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetExpandedServiceUserByCRN(assignedReferral.referral.serviceUser.crn, expandedDeliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
       cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
-      cy.stubGetAuthUserByUsername(assignedReferral.assignedTo.username, hmppsAuthUserFactory.build())
+      cy.stubGetAuthUserByUserId(assignedReferral.assignedTo.userId, hmppsAuthUserFactory.build())
 
       cy.stubGetActionPlanAppointments(actionPlan.id, appointments)
       cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointments[0])
@@ -267,8 +267,8 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
       cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
-      cy.stubGetAuthUserByUsername(
-        assignedReferral.assignedTo.username,
+      cy.stubGetAuthUserByUserId(
+        assignedReferral.assignedTo.userId,
         hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', email: 'john.smith@email.com' })
       )
 
@@ -359,7 +359,7 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
       cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
-      cy.stubGetAuthUserByUsername(assignedReferral.assignedTo.username, hmppsAuthUserFactory.build())
+      cy.stubGetAuthUserByUserId(assignedReferral.assignedTo.userId, hmppsAuthUserFactory.build())
       cy.stubGetReferralCancellationReasons([
         { code: 'MIS', description: 'Referral was made by mistake' },
         { code: 'MOV', description: 'Service user has moved out of delivery area' },
@@ -422,7 +422,7 @@ describe('Probation Practitioner monitor journey', () => {
           interventionId: intervention.id,
           serviceCategoryIds: [serviceCategory.id],
         },
-        assignedTo: { username: hmppsAuthUser.username },
+        assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId },
       })
 
       const appointment = initialAssessmentAppointmentFactory.build({
@@ -445,7 +445,7 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetSentReferral(referral.id, referral)
       cy.stubGetIntervention(intervention.id, intervention)
       cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUserFactory.build())
-      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
       cy.stubGetSupplierAssessment(referral.id, supplierAssessment)
 
       cy.login()
@@ -492,7 +492,7 @@ describe('Probation Practitioner monitor journey', () => {
           serviceCategoryIds: [serviceCategory.id],
         },
         actionPlanId,
-        assignedTo: { username: hmppsAuthUser.username },
+        assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId },
       })
 
       const appointment = initialAssessmentAppointmentFactory.attended().build()
@@ -527,7 +527,7 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetSentReferral(referral.id, referral)
       cy.stubGetIntervention(intervention.id, intervention)
       cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUserFactory.build())
-      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
       cy.stubGetSupplierAssessment(referral.id, supplierAssessment)
       cy.stubGetActionPlanAppointments(actionPlanId, actionPlanAppointmentFactory.buildList(4))
       cy.stubGetActionPlan(actionPlanId, actionPlan)
@@ -604,7 +604,7 @@ describe('Probation Practitioner monitor journey', () => {
           serviceCategoryIds: [serviceCategory.id],
         },
         actionPlanId,
-        assignedTo: { username: hmppsAuthUser.username },
+        assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId },
       })
 
       const appointment = initialAssessmentAppointmentFactory.attended().build()
@@ -654,7 +654,7 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetSentReferral(referral.id, referral)
       cy.stubGetIntervention(intervention.id, intervention)
       cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUserFactory.build())
-      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
       cy.stubGetSupplierAssessment(referral.id, supplierAssessment)
       cy.stubGetActionPlanAppointments(actionPlanId, actionPlanAppointmentFactory.buildList(4))
       cy.stubGetActionPlan(actionPlanId, approvedActionPlan)

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -187,7 +187,7 @@ describe('Probation practitioner referrals dashboard', () => {
           email: 'john.smith@example.com',
         })
         assignedReferral = sentReferralFactory.build({
-          assignedTo: { username: hmppsAuthUser.username },
+          assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId },
           referral: {
             interventionId: intervention.id,
             serviceUser: { firstName: 'Jenny', lastName: 'Jones', crn: 'X123456' },
@@ -209,7 +209,7 @@ describe('Probation practitioner referrals dashboard', () => {
         )
 
         cy.stubGetAuthUserByEmailAddress([hmppsAuthUser])
-        cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+        cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
       })
 
       describe('when the referral has been assigned and the appointment scheduled', () => {

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -318,7 +318,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetExpandedServiceUserByCRN(referral.referral.serviceUser.crn, expandedDeliusServiceUser)
       cy.stubGetAuthUserByEmailAddress([hmppsAuthUser])
-      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
       cy.stubAssignSentReferral(referral.id, referral)
       cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
       cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
@@ -344,9 +344,11 @@ describe('Service provider referrals dashboard', () => {
       cy.get('h1').contains('Confirm the Accommodation referral assignment')
       cy.contains('John Smith')
 
-      const assignedReferral = sentReferralFactory
-        .assigned()
-        .build({ ...referralParams, id: referral.id, assignedTo: { username: hmppsAuthUser.username } })
+      const assignedReferral = sentReferralFactory.assigned().build({
+        ...referralParams,
+        id: referral.id,
+        assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId },
+      })
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetSentReferralsForUserToken([assignedReferral])
       referralSummary = serviceProviderSentReferralSummaryFactory
@@ -391,9 +393,10 @@ describe('Service provider referrals dashboard', () => {
         username: 'john.smith',
         email: 'john.smith@example.com',
       })
-      const referral = sentReferralFactory
-        .assigned()
-        .build({ ...referralParams, assignedTo: { username: currentAssignee.username } })
+      const referral = sentReferralFactory.assigned().build({
+        ...referralParams,
+        assignedTo: { username: currentAssignee.username, userId: currentAssignee.userId },
+      })
       const deliusUser = deliusUserFactory.build()
       const deliusServiceUser = deliusServiceUserFactory.build()
       const expandedDeliusServiceUser = expandedDeliusServiceUserFactory.build({ ...deliusServiceUser })
@@ -411,7 +414,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetExpandedServiceUserByCRN(referral.referral.serviceUser.crn, expandedDeliusServiceUser)
       cy.stubGetAuthUserByEmailAddress([currentAssignee])
-      cy.stubGetAuthUserByUsername(currentAssignee.username, currentAssignee)
+      cy.stubGetAuthUserByUserId(currentAssignee.userId, currentAssignee)
       cy.stubAssignSentReferral(referral.id, referral)
       cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
       cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
@@ -432,7 +435,7 @@ describe('Service provider referrals dashboard', () => {
         email: 'anna.dawkins@example.com',
       })
       cy.stubGetAuthUserByEmailAddress([newAssignee])
-      cy.stubGetAuthUserByUsername(newAssignee.username, newAssignee)
+      cy.stubGetAuthUserByUserId(newAssignee.userId, newAssignee)
 
       cy.get('#email').type('anna.dawkins@example.com')
       cy.contains('Save and continue').click()
@@ -446,7 +449,7 @@ describe('Service provider referrals dashboard', () => {
 
       const reAssignedReferral = sentReferralFactory
         .assigned()
-        .build({ ...referral, assignedTo: { username: newAssignee.username } })
+        .build({ ...referral, assignedTo: { username: newAssignee.username, userId: newAssignee.userId } })
       referralSummary = serviceProviderSentReferralSummaryFactory
         .fromReferralAndIntervention(reAssignedReferral, intervention)
         .withAssignedUser(newAssignee.username)
@@ -505,7 +508,7 @@ describe('Service provider referrals dashboard', () => {
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
     const assignedReferral = sentReferralFactory
       .assigned()
-      .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username } })
+      .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId } })
     const draftActionPlan = actionPlanFactory.justCreated(assignedReferral.id).build()
     const actionPlanAppointments = [
       actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 1 }),
@@ -528,7 +531,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
     cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
     cy.stubGetUserByUsername(deliusUser.username, deliusUser)
-    cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+    cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
     cy.stubGetActionPlanAppointments(draftActionPlan.id, actionPlanAppointments)
     cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
 
@@ -639,9 +642,11 @@ describe('Service provider referrals dashboard', () => {
       const deliusServiceUser = deliusServiceUserFactory.build()
       const deliusUser = deliusUserFactory.build()
       const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
-      const assignedReferral = sentReferralFactory
-        .assigned()
-        .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username }, actionPlanId })
+      const assignedReferral = sentReferralFactory.assigned().build({
+        ...referralParams,
+        assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId },
+        actionPlanId,
+      })
 
       const activityId = '1'
       const submittedActionPlan = actionPlanFactory.submitted(assignedReferral.id).build({
@@ -663,7 +668,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(deliusUser.username, deliusUser)
-      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
       cy.stubGetActionPlanAppointments(submittedActionPlan.id, [])
       cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
 
@@ -746,9 +751,11 @@ describe('Service provider referrals dashboard', () => {
       const deliusServiceUser = deliusServiceUserFactory.build()
       const deliusUser = deliusUserFactory.build()
       const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
-      const assignedReferral = sentReferralFactory
-        .assigned()
-        .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username }, actionPlanId })
+      const assignedReferral = sentReferralFactory.assigned().build({
+        ...referralParams,
+        assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId },
+        actionPlanId,
+      })
 
       const activityId = '1'
       const approvedActionPlan = actionPlanFactory.approved(assignedReferral.id).build({
@@ -770,7 +777,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(deliusUser.username, deliusUser)
-      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
       cy.stubGetActionPlanAppointments(approvedActionPlan.id, [])
       cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
 
@@ -1298,7 +1305,7 @@ describe('Service provider referrals dashboard', () => {
 
       const assignedReferral = sentReferralFactory.assigned().build({
         ...referralParams,
-        assignedTo: { username: serviceProvider.username },
+        assignedTo: { username: serviceProvider.username, userId: serviceProvider.userId },
         actionPlanId: actionPlan.id,
       })
 
@@ -1311,7 +1318,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
       cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
-      cy.stubGetAuthUserByUsername(serviceProvider.username, serviceProvider)
+      cy.stubGetAuthUserByUserId(serviceProvider.userId, serviceProvider)
 
       cy.stubGetActionPlanAppointments(actionPlan.id, appointments)
       cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointments[0])
@@ -1458,7 +1465,7 @@ describe('Service provider referrals dashboard', () => {
 
       const assignedReferral = sentReferralFactory.assigned().build({
         ...referralParams,
-        assignedTo: { username: serviceProvider.username },
+        assignedTo: { username: serviceProvider.username, userId: serviceProvider.userId },
         actionPlanId: actionPlan.id,
       })
 
@@ -1471,7 +1478,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
       cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
-      cy.stubGetAuthUserByUsername(serviceProvider.username, serviceProvider)
+      cy.stubGetAuthUserByUserId(serviceProvider.userId, serviceProvider)
 
       cy.stubGetActionPlanAppointments(actionPlan.id, appointments)
       cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointments[0])
@@ -1613,7 +1620,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointmentsWithSubmittedFeedback[0])
       cy.stubGetServiceUserByCRN(crn, deliusServiceUser)
       cy.stubGetSupplierAssessment(referralParams.id, supplierAssessmentFactory.build())
-      cy.stubGetAuthUserByUsername(serviceProvider.username, serviceProvider)
+      cy.stubGetAuthUserByUserId(serviceProvider.userId, serviceProvider)
     })
 
     it('allows users to know if, when and why an intervention was cancelled', () => {
@@ -1653,7 +1660,7 @@ describe('Service provider referrals dashboard', () => {
     it('allows users to click through to a page to view session feedback', () => {
       const assignedReferral = sentReferralFactory.assigned().build({
         ...referralParams,
-        assignedTo: { username: serviceProvider.username },
+        assignedTo: { username: serviceProvider.username, userId: serviceProvider.userId },
         actionPlanId: actionPlan.id,
       })
       cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
@@ -1714,7 +1721,7 @@ describe('Service provider referrals dashboard', () => {
     const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
     const referral = sentReferralFactory
       .assigned()
-      .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username } })
+      .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId } })
     const actionPlan = actionPlanFactory.submitted(referral.id).build()
     referral.actionPlanId = actionPlan.id
 
@@ -1726,7 +1733,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
       cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
       cy.stubGetUserByUsername(deliusUser.username, deliusUser)
-      cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+      cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
       cy.stubGetSupplierAssessment(referral.id, supplierAssessmentFactory.build())
       cy.stubGetActionPlanAppointments(actionPlan.id, [])
     })
@@ -1937,7 +1944,7 @@ describe('Service provider referrals dashboard', () => {
         cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUser)
         cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
         cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
-        cy.stubGetAuthUserByUsername(serviceProvider.username, serviceProvider)
+        cy.stubGetAuthUserByUserId(serviceProvider.userId, serviceProvider)
 
         cy.login()
       })
@@ -2256,7 +2263,7 @@ describe('Service provider referrals dashboard', () => {
       })
       const sentReferral = sentReferralFactory.assigned().build({
         id: 'f437a412-078f-4bbf-82d8-569c2eb9ddb9',
-        assignedTo: { username: serviceProvider.username },
+        assignedTo: { username: serviceProvider.username, userId: serviceProvider.userId },
         referral: { serviceCategoryIds: [serviceCategory.id], interventionId: intervention.id },
       })
 
@@ -2268,7 +2275,7 @@ describe('Service provider referrals dashboard', () => {
         cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
         cy.stubGetSentReferral(sentReferral.id, sentReferral)
         cy.stubGetServiceUserByCRN(sentReferral.referral.serviceUser.crn, deliusServiceUser)
-        cy.stubGetAuthUserByUsername(serviceProvider.username, serviceProvider)
+        cy.stubGetAuthUserByUserId(serviceProvider.userId, serviceProvider)
       })
 
       describe('when user records the attendance as not attended', () => {
@@ -2342,7 +2349,7 @@ describe('Service provider referrals dashboard', () => {
             lastName: 'Smith',
             username: 'john.smith',
           })
-          cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+          cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
           const submittedAppointment = initialAssessmentAppointmentFactory.build({
             appointmentTime: '2021-03-24T09:02:02Z',
             durationInMinutes: 75,
@@ -2353,7 +2360,7 @@ describe('Service provider referrals dashboard', () => {
                 additionalAttendanceInformation: 'Alex did not attend this session',
               },
               submitted: true,
-              submittedBy: { username: hmppsAuthUser.username, userId: hmppsAuthUser.username, authSource: 'auth' },
+              submittedBy: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId, authSource: 'auth' },
             },
           })
           supplierAssessment = supplierAssessmentFactory.build({
@@ -2382,7 +2389,7 @@ describe('Service provider referrals dashboard', () => {
             lastName: 'Smith',
             username: 'john.smith',
           })
-          cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+          cy.stubGetAuthUserByUserId(hmppsAuthUser.userId, hmppsAuthUser)
 
           const unattendedAppointment = initialAssessmentAppointmentFactory.build({
             appointmentTime: '2025-03-24T09:02:02Z',
@@ -2394,7 +2401,7 @@ describe('Service provider referrals dashboard', () => {
                 additionalAttendanceInformation: 'Alex did not attend the session',
               },
               submitted: true,
-              submittedBy: { username: hmppsAuthUser.username, userId: hmppsAuthUser.username, authSource: 'auth' },
+              submittedBy: { username: hmppsAuthUser.username, userId: hmppsAuthUser.userId, authSource: 'auth' },
             },
           })
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -25,8 +25,8 @@ export default on => {
     stubGetAuthUserByEmailAddress: arg => {
       return auth.stubGetSPUserByEmailAddress(arg.responseJson)
     },
-    stubGetAuthUserByUsername: arg => {
-      return auth.stubGetSPUserByUsername(arg.username, arg.responseJson)
+    stubGetAuthUserByUserId: arg => {
+      return auth.stubGetSPUserByUserId(arg.userId, arg.responseJson)
     },
 
     stubServiceProviderAuthUser: auth.stubServiceProviderUser,

--- a/integration_tests/support/commands.js
+++ b/integration_tests/support/commands.js
@@ -13,8 +13,8 @@ Cypress.Commands.add('stubGetAuthUserByEmailAddress', responseJson => {
   cy.task('stubGetAuthUserByEmailAddress', { responseJson })
 })
 
-Cypress.Commands.add('stubGetAuthUserByUsername', (username, responseJson) => {
-  cy.task('stubGetAuthUserByUsername', { username, responseJson })
+Cypress.Commands.add('stubGetAuthUserByUserId', (userId, responseJson) => {
+  cy.task('stubGetAuthUserByUserId', { userId, responseJson })
 })
 
 Cypress.Commands.add('withinFieldsetThatContains', (text, action) => {

--- a/mockApis/auth.ts
+++ b/mockApis/auth.ts
@@ -182,11 +182,11 @@ export default class AuthServiceMocks {
     })
   }
 
-  stubGetSPUserByUsername = async (username: string, responseJson: Record<string, unknown>): Promise<unknown> => {
+  stubGetSPUserByUserId = async (userId: string, responseJson: Record<string, unknown>): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/auth/api/authuser/${username}`,
+        urlPattern: `/auth/api/authuser/id/${userId}`,
       },
       response: {
         status: 200,

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -141,7 +141,7 @@ describe('Scheduling a supplier assessment appointment', () => {
         )
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
-        hmppsAuthService.getSPUserByUsername.mockResolvedValue(
+        hmppsAuthService.getSPUserByUserId.mockResolvedValue(
           hmppsAuthUserFactory.build({ firstName: 'caseWorkerFirstName', lastName: 'caseWorkerLastName' })
         )
 
@@ -1992,7 +1992,7 @@ describe('Adding post delivery session feedback', () => {
           interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
           interventionsService.getSentReferral.mockResolvedValue(referral)
           interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
-          hmppsAuthService.getSPUserByUsername.mockResolvedValue(
+          hmppsAuthService.getSPUserByUserId.mockResolvedValue(
             hmppsAuthUserFactory.build({
               firstName: 'caseworkerFirstName',
               lastName: 'caseworkerLastName',
@@ -2051,7 +2051,7 @@ describe('Adding post delivery session feedback', () => {
           interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
           interventionsService.getSentReferral.mockResolvedValue(referral)
           interventionsService.getActionPlanAppointment.mockResolvedValue(appointmentWithSubmittedFeedback)
-          hmppsAuthService.getSPUserByUsername.mockResolvedValue(
+          hmppsAuthService.getSPUserByUserId.mockResolvedValue(
             hmppsAuthUserFactory.build({
               firstName: 'caseworkerFirstName',
               lastName: 'caseworkerLastName',

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -878,14 +878,14 @@ export default class AppointmentsController {
     )
   }
 
-  private async getCaseWorker(accessToken: string, username: string): Promise<AuthUserDetails | string> {
+  private async getCaseWorker(accessToken: string, userId: string): Promise<AuthUserDetails | null> {
     try {
-      return this.hmppsAuthService.getSPUserByUsername(accessToken, username)
+      return this.hmppsAuthService.getSPUserByUserId(accessToken, userId)
     } catch (e) {
       const interventionsServiceError = e as InterventionsServiceError
       if (interventionsServiceError.status === 404) {
-        logger.warn(`Auth user details not found for user ${username}".`)
-        return username
+        logger.warn({ userId }, 'Auth user details not found for user')
+        return null
       }
       throw e
     }
@@ -895,16 +895,16 @@ export default class AppointmentsController {
     accessToken: string,
     referral: SentReferral
   ): Promise<AuthUserDetails | string | null> {
-    const assignedToUsername = referral.assignedTo?.username
-    return assignedToUsername ? this.getCaseWorker(accessToken, assignedToUsername) : null
+    const assignee = referral.assignedTo
+    return assignee ? this.getCaseWorker(accessToken, assignee.userId) || assignee.username : null
   }
 
   private async getFeedbackSubmittedByCaseworker(
     accessToken: string,
     appointment: ActionPlanAppointment | InitialAssessmentAppointment
   ): Promise<AuthUserDetails | string | null> {
-    const submittedByUsername = appointment?.sessionFeedback.submittedBy?.username
-    return submittedByUsername ? this.getCaseWorker(accessToken, submittedByUsername) : null
+    const submitter = appointment?.sessionFeedback.submittedBy
+    return submitter ? this.getCaseWorker(accessToken, submitter.userId) || submitter.username : null
   }
 
   private async createAppointmentSummary(

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -162,7 +162,7 @@ describe('GET /probation-practitioner/referrals/:id/progress', () => {
     interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessment)
-    hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    hmppsAuthService.getSPUserByUserId.mockResolvedValue(hmppsAuthUser)
 
     communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
 
@@ -263,7 +263,7 @@ describe('GET /probation-practitioner/referrals/:id/details', () => {
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
     communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(expandedDeliusServiceUser)
-    hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    hmppsAuthService.getSPUserByUserId.mockResolvedValue(hmppsAuthUser)
     communityApiService.getConvictionById.mockResolvedValue(conviction)
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
     assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
@@ -472,7 +472,7 @@ describe('GET /probation-practitioner/referrals/:id/supplier-assessment', () => 
       lastName: 'Johnson',
       username: 'liam.johnson',
     })
-    hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    hmppsAuthService.getSPUserByUserId.mockResolvedValue(hmppsAuthUser)
 
     const referral = sentReferralFactory.build({ assignedTo: { username: hmppsAuthUser.username } })
     interventionsService.getSentReferral.mockResolvedValue(referral)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -121,7 +121,7 @@ export default class ProbationPractitionerReferralsController {
       sentReferral.id
     )
     const assigneePromise = sentReferral.assignedTo
-      ? this.hmppsAuthService.getSPUserByUsername(res.locals.user.token.accessToken, sentReferral.assignedTo.username)
+      ? this.hmppsAuthService.getSPUserByUserId(res.locals.user.token.accessToken, sentReferral.assignedTo.userId)
       : Promise.resolve(null)
 
     const [intervention, actionPlan, serviceUser, supplierAssessment, assignee] = await Promise.all([
@@ -172,7 +172,7 @@ export default class ProbationPractitionerReferralsController {
     const assignee =
       sentReferral.assignedTo === null
         ? null
-        : await this.hmppsAuthService.getSPUserByUsername(
+        : await this.hmppsAuthService.getSPUserByUserId(
             res.locals.user.token.accessToken,
             sentReferral.assignedTo.username
           )

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -209,7 +209,7 @@ describe('GET /service-provider/referrals/:id/details', () => {
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     communityApiService.getUserByUsername.mockResolvedValue(deliusUser)
     communityApiService.getExpandedServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-    hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    hmppsAuthService.getSPUserByUserId.mockResolvedValue(hmppsAuthUser)
     communityApiService.getConvictionById.mockResolvedValue(conviction)
     assessRisksAndNeedsService.getSupplementaryRiskInformation.mockResolvedValue(supplementaryRiskInformation)
     assessRisksAndNeedsService.getRiskSummary.mockResolvedValue(riskSummary)
@@ -317,7 +317,7 @@ describe('GET /service-provider/referrals/:id/progress', () => {
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessmentFactory.build())
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-    hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    hmppsAuthService.getSPUserByUserId.mockResolvedValue(hmppsAuthUser)
 
     await request(app)
       .get(`/service-provider/referrals/${sentReferral.id}/progress`)
@@ -489,7 +489,7 @@ describe('GET /service-provider/referrals/:id/assignment/confirmation', () => {
 
     interventionsService.getIntervention.mockResolvedValue(intervention)
     interventionsService.getSentReferral.mockResolvedValue(referral)
-    hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    hmppsAuthService.getSPUserByUserId.mockResolvedValue(hmppsAuthUser)
 
     await request(app)
       .get(`/service-provider/referrals/${referral.id}/assignment/confirmation`)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -137,7 +137,7 @@ export default class ServiceProviderReferralsController {
     const assignee =
       sentReferral.assignedTo === null
         ? null
-        : await this.hmppsAuthService.getSPUserByUsername(accessToken, sentReferral.assignedTo.username)
+        : await this.hmppsAuthService.getSPUserByUserId(accessToken, sentReferral.assignedTo.userId)
 
     let formError: FormValidationError | null = null
     const error = req.query.error as string
@@ -205,9 +205,9 @@ export default class ServiceProviderReferralsController {
     const assignee =
       sentReferral.assignedTo === null
         ? null
-        : await this.hmppsAuthService.getSPUserByUsername(
+        : await this.hmppsAuthService.getSPUserByUserId(
             res.locals.user.token.accessToken,
-            sentReferral.assignedTo.username
+            sentReferral.assignedTo.userId
           )
 
     const presenter = new InterventionProgressPresenter(
@@ -328,7 +328,7 @@ export default class ServiceProviderReferralsController {
     }
 
     const [assignee, intervention, serviceUser] = await Promise.all([
-      this.hmppsAuthService.getSPUserByUsername(res.locals.user.token.accessToken, referral.assignedTo.username),
+      this.hmppsAuthService.getSPUserByUserId(res.locals.user.token.accessToken, referral.assignedTo.userId),
       this.interventionsService.getIntervention(res.locals.user.token.accessToken, referral.referral.interventionId),
       this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn),
     ])

--- a/server/services/hmppsAuthService.test.ts
+++ b/server/services/hmppsAuthService.test.ts
@@ -173,7 +173,7 @@ describe('hmppsAuthService', () => {
     })
   })
 
-  describe('getSPUserByUsername', () => {
+  describe('getSPUserByUserId', () => {
     it('should return the matching user from the API response', async () => {
       const response = {
         userId: '91229A16-B5F4-4784-942E-A484A97AC865',
@@ -188,11 +188,11 @@ describe('hmppsAuthService', () => {
       }
 
       fakeHmppsAuthApi
-        .get('/api/authuser/AUTH_ADM')
+        .get('/api/authuser/id/123456')
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(200, response)
 
-      const output = await hmppsAuthService.getSPUserByUsername(token.access_token, 'AUTH_ADM')
+      const output = await hmppsAuthService.getSPUserByUserId(token.access_token, '123456')
       expect(output).toEqual(response)
     })
   })

--- a/server/services/hmppsAuthService.ts
+++ b/server/services/hmppsAuthService.ts
@@ -75,10 +75,10 @@ export default class HmppsAuthService {
     return Promise.resolve(authUsers[0])
   }
 
-  async getSPUserByUsername(token: string, username: string): Promise<AuthUserDetails> {
-    logger.info(`Getting user detail by username: calling HMPPS Auth`)
+  async getSPUserByUserId(token: string, userId: string): Promise<AuthUserDetails> {
+    logger.info(`Getting user detail by user id: calling HMPPS Auth`)
     return (await this.restClient(token).get({
-      path: `/api/authuser/${username}`,
+      path: `/api/authuser/id/${userId}`,
     })) as AuthUserDetails
   }
 


### PR DESCRIPTION
## What does this pull request do?

user user id instead of username to look up service provider users in hmpps auth

depending on how the username is used, email address changes in hmpps auth can cause
pages to become broken entirely in the UI (for example where looking up a referral
assignee with an invalid or old username).

this change removes the old hmpps auth service method for looking up records by username,
and replaces it with the equivalent call to look up users using user id. there are lots
of changes to the integration tests, but it's mainly just find and replace.


## What is the intent behind these changes?

fix broken referrals for SP users that have changes their email address / username
