### PR TITLE
allow action plan sessions to be scheduled in the past

### DIFF
--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -286,7 +286,7 @@ export default class AppointmentsController {
     let serverError: FormValidationError | null = null
 
     if (req.method === 'POST') {
-      const data = await new ScheduleAppointmentForm(req, deliusOfficeLocations).data()
+      const data = await new ScheduleAppointmentForm(req, deliusOfficeLocations, true).data()
 
       if (data.error) {
         res.status(400)

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
@@ -14,7 +14,11 @@ import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
 import FormUtils from '../../utils/formUtils'
 
 export default class ScheduleAppointmentForm {
-  constructor(private readonly request: Request, private readonly deliusOfficeLocations: DeliusOfficeLocation[]) {}
+  constructor(
+    private readonly request: Request,
+    private readonly deliusOfficeLocations: DeliusOfficeLocation[],
+    private readonly allowPastAppointments = false
+  ) {}
 
   async data(): Promise<FormData<AppointmentSchedulingDetails>> {
     const startOfToday = new Date()
@@ -26,7 +30,7 @@ export default class ScheduleAppointmentForm {
         'date',
         'time',
         errorMessages.scheduleAppointment.time,
-        startOfToday
+        this.allowPastAppointments ? null : startOfToday
       ).validate(),
       new DurationInput(this.request, 'duration', errorMessages.scheduleAppointment.duration).validate(),
       FormUtils.runValidations({ request: this.request, validations: this.validateSessionType() }),


### PR DESCRIPTION
## What does this pull request do?

allow action plan sessions to be scheduled in the past

## What does this pull request NOT do?

allow SAAs to be scheduled in the past.

## What is the intent behind these changes?

allow SPs to record information about sessions in the past.
