### PR TITLE
add double click prevention to all buttons

### DIFF
--- a/server/views/appointments/feedback/shared/postSessionAttendanceFeedback.njk
+++ b/server/views/appointments/feedback/shared/postSessionAttendanceFeedback.njk
@@ -18,6 +18,6 @@
 
     {{ govukTextarea(textAreaArgs) }}
 
-    {{ govukButton({ text: "Save and continue" }) }}
+    {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
   </form>
 {% endblock %}

--- a/server/views/appointments/feedback/shared/postSessionBehaviourFeedback.njk
+++ b/server/views/appointments/feedback/shared/postSessionBehaviourFeedback.njk
@@ -15,6 +15,6 @@
 
     {{ govukRadios(radioButtonArgs) }}
 
-    {{ govukButton({ text: "Save and continue" }) }}
+    {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
   </form>
 {% endblock %}

--- a/server/views/caseNotes/addNewCaseNote.njk
+++ b/server/views/caseNotes/addNewCaseNote.njk
@@ -26,7 +26,7 @@
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukInput(subjectInputArgs) }}
         {{ govukTextarea(bodyInputArgs) }}
-        {{ govukButton({ text: "Continue" }) }}
+        {{ govukButton({ text: "Continue" , preventDoubleClick: true}) }}
       </form>
     </div>
   </div>

--- a/server/views/caseNotes/checkAnswers.njk
+++ b/server/views/caseNotes/checkAnswers.njk
@@ -16,6 +16,6 @@
 
     <form method="post" action="{{ presenter.submitHref }}">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
-        {{ govukButton({ text: "Confirm case note" }) }}
+        {{ govukButton({ text: "Confirm case note", preventDoubleClick: true }) }}
     </form>
 {% endblock %}

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -32,7 +32,7 @@
         {{ govukCheckboxes(pccRegionCheckboxArgs) }}
         {{ govukCheckboxes(genderCheckboxArgs) }}
         {{ govukCheckboxes(ageCheckboxArgs) }}
-        {{ govukButton({ text: "Filter results" }) }}
+        {{ govukButton({ text: "Filter results", preventDoubleClick: true }) }}
       </form>
 
     </div>

--- a/server/views/makeAReferral/completionDeadline.njk
+++ b/server/views/makeAReferral/completionDeadline.njk
@@ -19,7 +19,7 @@
 
         {{ govukDateInput(dateInputArgs) }}
 
-        {{ govukButton({ text: "Save and continue" }) }}
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/server/views/makeAReferral/enforceableDays.njk
+++ b/server/views/makeAReferral/enforceableDays.njk
@@ -21,7 +21,7 @@
 
         {{ govukInput(maximumEnforceableDaysInputArgs) }}
 
-        {{ govukButton({ text: "Save and continue" }) }}
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/server/views/makeAReferral/needsAndRequirements.njk
+++ b/server/views/makeAReferral/needsAndRequirements.njk
@@ -36,7 +36,7 @@
         {% endset -%}
         {{ govukRadios(responsibilitiesRadiosArgs(whenUnavailableHtml)) }}
 
-        {{ govukButton({ text: "Save and continue" }) }}
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/server/views/makeAReferral/relevantSentence.njk
+++ b/server/views/makeAReferral/relevantSentence.njk
@@ -19,7 +19,7 @@
 
         {{ govukRadios(radioButtonArgs) }}
 
-        {{ govukButton({ text: "Save and continue" }) }}
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/server/views/makeAReferral/riskInformation.njk
+++ b/server/views/makeAReferral/riskInformation.njk
@@ -26,7 +26,7 @@
 
         {{ govukTextarea(additionalRiskInformationTextareaArgs) }}
 
-        {{ govukButton({ text: "Save and continue" }) }}
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/server/views/probationPractitionerReferrals/referralCancellationReason.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationReason.njk
@@ -24,7 +24,7 @@
         {{ govukRadios(referralCancellationRadiosArgs) }}
         {{ govukTextarea(additionalCommentsTextareaArgs) }}
 
-        {{ govukButton({ text: "Continue" }) }}
+        {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/server/views/reporting/performanceReport/reportingForm.njk
+++ b/server/views/reporting/performanceReport/reportingForm.njk
@@ -29,7 +29,7 @@
         {{ govukDateInput(fromDateInputArgs) }}
         {{ govukDateInput(toDateInputArgs) }}
 
-        {{ govukButton({ text: "Request data" }) }}
+        {{ govukButton({ text: "Request data", preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanSessions.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanSessions.njk
@@ -9,5 +9,5 @@
     <p class="govuk-body">This will be shared with the service user's probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
 
     {{ govukInput(numberOfSessionsInputArgs) }}
-    {{ govukButton({ text: "Save and continue" }) }}
+    {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
 {% endblock %}

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -34,6 +34,6 @@
 
   <form method="post" action="{{ presenter.saveAndContinueFormAction }}">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    {{ govukButton({ text: "Continue without adding other activities" }) }}
+    {{ govukButton({ text: "Continue without adding other activities", preventDoubleClick: true }) }}
   </form>
 {% endblock %}

--- a/server/views/serviceProviderReferrals/actionPlan/numberOfSessions.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/numberOfSessions.njk
@@ -14,6 +14,6 @@
       <form method="post" novalidate>
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukInput(numberOfSessionsInputArgs) }}
-        {{ govukButton({ text: "Save and continue" }) }}
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
       </form>
 {% endblock %}

--- a/server/views/serviceProviderReferrals/endOfServiceReport/furtherInformation.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/furtherInformation.njk
@@ -12,6 +12,6 @@
 
     {{ govukTextarea(furtherInformationTextareaArgs) }}
 
-    {{ govukButton({ text: "Save and continue" }) }}
+    {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
   </form>
 {% endblock %}

--- a/server/views/serviceProviderReferrals/endOfServiceReport/outcome.njk
+++ b/server/views/serviceProviderReferrals/endOfServiceReport/outcome.njk
@@ -25,6 +25,6 @@
     {{ govukTextarea(progressionCommentsTextareaArgs) }}
     {{ govukTextarea(additionalTaskCommentsTextareaArgs) }}
 
-    {{ govukButton({ text: "Save and continue" }) }}
+    {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
   </form>
 {% endblock %}

--- a/server/views/serviceProviderReferrals/reviewActionPlan.njk
+++ b/server/views/serviceProviderReferrals/reviewActionPlan.njk
@@ -39,6 +39,6 @@
 
   <form method="post" action="{{ presenter.submitFormAction }}">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
-    {{ govukButton({ text: "Submit for approval" }) }}
+    {{ govukButton({ text: "Submit for approval", preventDoubleClick: true }) }}
   </form>
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds double click prevention to the end of service outcome form.

## What is the intent behind these changes?

There is currently a live issue where multiple patch requests are sent to the service in the case of double clicking. This results in duplicate key errors.
