### PR TITLE
do not hide full risk details for PP referral view

### DIFF
--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -135,7 +135,7 @@ export default class ShowReferralPresenter {
   }
 
   get canShowFullSupplementaryRiskInformation(): boolean {
-    if (this.userType === 'probation-practitioner' || this.riskInformation.redactedRisk === undefined) {
+    if (this.riskInformation.redactedRisk === undefined) {
       return false
     }
     return config.apis.assessRisksAndNeedsApi.riskSummaryEnabled


### PR DESCRIPTION
## What does this pull request do?

https://trello.com/c/p5ZS3odg/228-pp-view-of-referral-details-doesnt-show-pps-submitted-risk-information

bugfix - do not hide full risk details for PP referral view

## What is the intent behind these changes?

show PP the same view of the risks as SPs get 
