### PR TITLE
enable feature flags for post-approved action plan modification in preprod and prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -13,3 +13,5 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
     GA_ID: G-08D8T0RZZR
     FEATURE_SP_REPORTING_ENABLED: true
+    FEATURE_PREVIOUSLY_APPROVED_ACTION_PLANS: true
+

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,3 +13,5 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
     GA_ID: G-THWB3S7TLX
     FEATURE_SP_REPORTING_ENABLED: true
+    FEATURE_PREVIOUSLY_APPROVED_ACTION_PLANS: true
+


### PR DESCRIPTION
https://trello.com/c/Nm149wsF/83-enable-feature-for-creating-a-new-action-plan-after-a-previous-one-has-been-approved

## What does this pull request do?

enable feature flags for post-approved action plan modification in preprod and prod

## What is the intent behind these changes?

enable this functionality for end users
