### PR TITLE
add missing return after redirect for saa behaviour feedback

### DIFF
--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -585,8 +585,10 @@ export default class AppointmentsController {
         }
 
         res.redirect(redirectUrl)
+        return
       }
     }
+
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
     const presenter = new InitialAssessmentBehaviourFeedbackPresenter(
       appointment,


### PR DESCRIPTION
## What does this pull request do?

add missing return after redirect for saa behaviour feedback

## What is the intent behind these changes?

stop `Cannot set headers after they are sent to the client` errors
