### PR TITLE
edit risk information page style improvements

### DIFF
--- a/assets/sass/components/_button-link.scss
+++ b/assets/sass/components/_button-link.scss
@@ -14,3 +14,11 @@
     @include button-link;
   }
 }
+
+.form-input-reset {
+  button {
+    @include button-link;
+    @include govuk-link-common;
+    @include govuk-link-style-no-visited-state;
+  }
+}

--- a/server/views/makeAReferral/editRiskInformationOasys.njk
+++ b/server/views/makeAReferral/editRiskInformationOasys.njk
@@ -24,63 +24,79 @@
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         <h2 class="govuk-heading-m">Who is at risk</h2>
         {{ govukTextarea(whoIsAtRiskTextareaArgs) }}
-        <a id='revert-who-is-at-risk' class="govuk-link link link__right-justified">
+        <div class="form-input-reset govuk-!-text-align-right">
+        <button type="button" id='revert-who-is-at-risk'>
             Revert to original OASys information
-        </a>
+        </button>
+        </div>
         <hr/>
 
         <h2 class="govuk-heading-m">What is the nature of the risk</h2>
         {{ govukTextarea(natureOfRiskTextareaArgs) }}
-        <a id='revert-nature-of-risk' class="govuk-link link link__right-justified">
+        <div class="form-input-reset govuk-!-text-align-right">
+        <button type="button" id='revert-nature-of-risk'>
             Revert to original OASys information
-        </a>
+        </button>
+        </div>
         <hr/>
 
         <h2 class="govuk-heading-m">When is the risk likely to be greatest</h2>
         {{ govukTextarea(riskImminenceTextareaArgs) }}
-        <a id='revert-risk-imminence' class="govuk-link link link__right-justified">
+        <div class="form-input-reset govuk-!-text-align-right">
+        <button type="button" id='revert-risk-imminence'>
             Revert to original OASys information
-        </a>
+        </button>
+        </div>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to self-harm</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.selfHarm.label.class }}"> {{ riskInformation.riskToSelf.selfHarm.label.text }}</p>
         {{ govukTextarea(riskToSelfSelfHarmTextareaArgs) }}
-        <a id='revert-risk-to-self-self-harm' class="govuk-link link link__right-justified">
+        <div class="form-input-reset govuk-!-text-align-right">
+        <button type="button" id='revert-risk-to-self-self-harm'>
             Revert to original OASys information
-        </a>
+        </button>
+        </div>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to suicide</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.suicide.label.class }}"> {{ riskInformation.riskToSelf.suicide.label.text }}</p>
         {{ govukTextarea(riskToSelfSuicideTextareaArgs) }}
-        <a id='revert-risk-to-self-suicide' class="govuk-link link link__right-justified">
+        <div class="form-input-reset govuk-!-text-align-right">
+        <button type="button" id='revert-risk-to-self-suicide'>
             Revert to original OASys information
-        </a>
+        </button>
+        </div>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to coping in a hostel setting</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.hostelSetting.label.class }}"> {{ riskInformation.riskToSelf.hostelSetting.label.text }}</p>
         {{ govukTextarea(riskToSelfHostelSettingTextareaArgs) }}
-        <a id='revert-risk-to-self-hostel-setting' class="govuk-link link link__right-justified">
+        <div class="form-input-reset govuk-!-text-align-right">
+        <button type="button" id='revert-risk-to-self-hostel-setting'>
             Revert to original OASys information
-        </a>
+        </button>
+        </div>
         <hr/>
 
         <h2 class="govuk-heading-m">Concerns in relation to vulnerability</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.vulnerability.label.class }}"> {{ riskInformation.riskToSelf.vulnerability.label.text }}</p>
         {{ govukTextarea(riskToSelfVulnerabilityTextareaArgs) }}
-        <a id='revert-risk-to-self-vulnerability' class="govuk-link link link__right-justified">
+        <div class="form-input-reset govuk-!-text-align-right">
+        <button type="button" id='revert-risk-to-self-vulnerability'>
             Revert to original OASys information
-        </a>
+        </button>
+        </div>
         <hr/>
 
         <h2 class="govuk-heading-m">Additional information</h2>
         <p class="govuk-body {{ riskInformation.additionalRiskInformation.label.class }}">{{ riskInformation.additionalRiskInformation.label.text }}</p>
         {{ govukTextarea(additionalInformationTextareaArgs) }}
-        <a id='revert-additional-information' class="govuk-link link link__right-justified">
+        <div class="form-input-reset govuk-!-text-align-right">
+        <button type="button" id='revert-additional-information'>
             Revert to original OASys information
-        </a>
+        </button>
+        </div>
 
         {{ govukCheckboxes(confirmUnderstoodWarningCheckboxArgs) }}
         {{ govukButton({ text: "Save and continue" }) }}

--- a/server/views/makeAReferral/editRiskInformationOasys.njk
+++ b/server/views/makeAReferral/editRiskInformationOasys.njk
@@ -19,7 +19,7 @@
       {% endif %}
 
       <p class="govuk-body">Latest assessment: {{ latestAssessment }} </p>
-      <hr/>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         <h2 class="govuk-heading-m">Who is at risk</h2>
@@ -29,7 +29,7 @@
             Revert to original OASys information
         </button>
         </div>
-        <hr/>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         <h2 class="govuk-heading-m">What is the nature of the risk</h2>
         {{ govukTextarea(natureOfRiskTextareaArgs) }}
@@ -38,7 +38,7 @@
             Revert to original OASys information
         </button>
         </div>
-        <hr/>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         <h2 class="govuk-heading-m">When is the risk likely to be greatest</h2>
         {{ govukTextarea(riskImminenceTextareaArgs) }}
@@ -47,7 +47,7 @@
             Revert to original OASys information
         </button>
         </div>
-        <hr/>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         <h2 class="govuk-heading-m">Concerns in relation to self-harm</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.selfHarm.label.class }}"> {{ riskInformation.riskToSelf.selfHarm.label.text }}</p>
@@ -57,7 +57,7 @@
             Revert to original OASys information
         </button>
         </div>
-        <hr/>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         <h2 class="govuk-heading-m">Concerns in relation to suicide</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.suicide.label.class }}"> {{ riskInformation.riskToSelf.suicide.label.text }}</p>
@@ -67,7 +67,7 @@
             Revert to original OASys information
         </button>
         </div>
-        <hr/>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         <h2 class="govuk-heading-m">Concerns in relation to coping in a hostel setting</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.hostelSetting.label.class }}"> {{ riskInformation.riskToSelf.hostelSetting.label.text }}</p>
@@ -77,7 +77,7 @@
             Revert to original OASys information
         </button>
         </div>
-        <hr/>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         <h2 class="govuk-heading-m">Concerns in relation to vulnerability</h2>
         <p class="govuk-body {{ riskInformation.riskToSelf.vulnerability.label.class }}"> {{ riskInformation.riskToSelf.vulnerability.label.text }}</p>
@@ -87,7 +87,7 @@
             Revert to original OASys information
         </button>
         </div>
-        <hr/>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         <h2 class="govuk-heading-m">Additional information</h2>
         <p class="govuk-body {{ riskInformation.additionalRiskInformation.label.class }}">{{ riskInformation.additionalRiskInformation.label.text }}</p>
@@ -97,6 +97,7 @@
             Revert to original OASys information
         </button>
         </div>
+        <hr class="govuk-section-break govuk-section-break--m">
 
         {{ govukCheckboxes(confirmUnderstoodWarningCheckboxArgs) }}
         {{ govukButton({ text: "Save and continue" }) }}


### PR DESCRIPTION
https://trello.com/c/zKftrENN/231-cant-tab-into-revert-to-original-oasys-information

## What does this pull request do?

update the 'revert to oasys' links to use buttons under the hood - benefit is they are tabbable and appear as buttons on screen readers.

use govuk horizontal breaks - they are nicer looking and provide better spacing.

before: 
<img width="881" alt="Screenshot 2022-01-25 at 17 01 23" src="https://user-images.githubusercontent.com/63233073/151025090-abeff182-4846-4924-b87b-cf56fa0c3819.png">

after:
<img width="916" alt="Screenshot 2022-01-25 at 17 04 43" src="https://user-images.githubusercontent.com/63233073/151025112-2dd52203-666a-41b3-8cde-d042366b935d.png">


## What is the intent behind these changes?

improve accessability of the form
