### PR TITLE
add backlink on action plan activity 1 page to take back to progress page

### DIFF
--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.test.ts
@@ -160,4 +160,32 @@ describe(AddActionPlanActivitiesPresenter, () => {
       expect(presenter.existingActivity).toEqual(actionPlan.activities[0])
     })
   })
+
+  describe('backlink', () => {
+    it('returns to progress page for 1st activity', () => {
+      const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
+      const activityNumber = 1
+      const presenter = new AddActionPlanActivitiesPresenter(
+        sentReferral,
+        serviceCategories,
+        actionPlan,
+        activityNumber
+      )
+      expect(presenter.backLinkHref).toEqual(`/service-provider/referrals/${sentReferral.id}/progress`)
+    })
+
+    it('returns to previous add activity page for an activity later than the 1st', () => {
+      const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
+      const activityNumber = 2
+      const presenter = new AddActionPlanActivitiesPresenter(
+        sentReferral,
+        serviceCategories,
+        actionPlan,
+        activityNumber
+      )
+      expect(presenter.backLinkHref).toEqual(
+        `/service-provider/action-plan/${actionPlan.id}/add-activity/${activityNumber - 1}`
+      )
+    })
+  })
 })

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
@@ -35,6 +35,12 @@ export default class AddActionPlanActivitiesPresenter {
     referredOutcomesHeader: `Referred outcomes for ${this.sentReferral.referral.serviceUser.firstName}`,
   }
 
+  get backLinkHref(): string {
+    return this.activityNumber === 1
+      ? `/service-provider/referrals/${this.referralId}/progress`
+      : `/service-provider/action-plan/${this.actionPlanId}/add-activity/${this.activityNumber - 1}`
+  }
+
   get existingActivity(): Activity | null {
     return this.actionPlanPresenter.orderedActivities[this.activityNumber - 1] || null
   }

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesPresenter.ts
@@ -20,6 +20,8 @@ export default class AddActionPlanActivitiesPresenter {
 
   readonly actionPlanId = this.actionPlan.id
 
+  readonly referralId = this.sentReferral.id
+
   readonly saveAndContinueFormAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activities`
 
   readonly addActivityAction = `/service-provider/action-plan/${this.actionPlan.id}/add-activity/${this.activityNumber}`

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesView.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesView.ts
@@ -6,15 +6,14 @@ export default class AddActionPlanActivitiesView {
   constructor(private readonly presenter: AddActionPlanActivitiesPresenter) {}
 
   private get backLinkArgs(): BackLinkArgs | null {
-    if (this.presenter.activityNumber === 1) {
-      return null
-    }
-
     return {
       text: 'Back',
-      href: `/service-provider/action-plan/${this.presenter.actionPlanId}/add-activity/${
-        this.presenter.activityNumber - 1
-      }`,
+      href:
+        this.presenter.activityNumber === 1
+          ? `/service-provider/referrals/${this.presenter.referralId}/progress`
+          : `/service-provider/action-plan/${this.presenter.actionPlanId}/add-activity/${
+              this.presenter.activityNumber - 1
+            }`,
     }
   }
 

--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesView.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesView.ts
@@ -5,15 +5,10 @@ import { BackLinkArgs } from '../../../../utils/govukFrontendTypes'
 export default class AddActionPlanActivitiesView {
   constructor(private readonly presenter: AddActionPlanActivitiesPresenter) {}
 
-  private get backLinkArgs(): BackLinkArgs | null {
+  private get backLinkArgs(): BackLinkArgs {
     return {
       text: 'Back',
-      href:
-        this.presenter.activityNumber === 1
-          ? `/service-provider/referrals/${this.presenter.referralId}/progress`
-          : `/service-provider/action-plan/${this.presenter.actionPlanId}/add-activity/${
-              this.presenter.activityNumber - 1
-            }`,
+      href: this.presenter.backLinkHref,
     }
   }
 


### PR DESCRIPTION
## What does this pull request do?

Adds a backlink to the create action plan page. (add activity 1). This will take the user back to the progress page for the given referral.

## What is the intent behind these changes?

Currently there is no backlink on the add activity 1 page. This change is adding that back in, whilst maintaining the subsequent add activity pages.
