### PR TITLE
Switch to the new cluster on production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ workflows:
             - approve_prod
           context:
             - hmpps-common-vars
-            - hmpps-interventions-ui-prod
+            - hmpps-interventions-prod-deploy
       - tag_pact_version:
           name: "tag_pact_version_prod"
           tag: "deployed:prod"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,6 +1,7 @@
 generic-service:
   ingress:
     host: refer-monitor-intervention.service.justice.gov.uk
+    contextColour: green
     tlsSecretName: tls-certificate
     modsecurity_enabled: true
   env:
@@ -14,4 +15,3 @@ generic-service:
     GA_ID: G-THWB3S7TLX
     FEATURE_SP_REPORTING_ENABLED: true
     FEATURE_PREVIOUSLY_APPROVED_ACTION_PLANS: true
-


### PR DESCRIPTION


## What does this pull request do?

Switch to the new cluster on production

`green` means 100% new cluster
`blue` (or missing) means 100% old cluster

## What is the intent behind these changes?

Completes the migration to the new cloud platform cluster
