### PR TITLE
Remove unused snyk file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.14.1
-
-# ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore:
-  SNYK-JS-LODASH-1040724:
-     - '*':
-         reason: Lodash vuln introduced by express-validator@6.8.0 with no upgrade path; will reassess in 1 month
-         expiry: 2021-03-16:00:00.000Z


### PR DESCRIPTION

## What does this pull request do?

Remove unused snyk file

Snyk has been removed in favour of trivy in e9c16be0bbe785b3042ce37dad0a3dfb400b3e14

## What is the intent behind these changes?

Remove unused files -- they only cause confusion as they imply snyk is used in some way
