### PR TITLE
add endpoint for SPs to view action plans by id

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1488,6 +1488,30 @@ describe('GET /service-provider/end-of-service-report/:id/confirmation', () => {
   })
 })
 
+describe('GET /service-provider/action-plan/:id', () => {
+  it('returns details of the specified action plan', async () => {
+    const referral = sentReferralFactory.assigned().build()
+    const actionPlan = actionPlanFactory.approved().build({
+      submittedAt: '2021-12-12T09:30:00+00:00',
+    })
+    const serviceCategories = [serviceCategoryFactory.build({ name: 'accommodation' })]
+
+    interventionsService.getSentReferral.mockResolvedValue(referral)
+    interventionsService.getActionPlan.mockResolvedValue(actionPlan)
+    interventionsService.getServiceCategory.mockResolvedValue(serviceCategories[0])
+    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUserFactory.build())
+
+    await request(app)
+      .get(`/service-provider/action-plan/${actionPlan.id}`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('View action plan')
+        expect(res.text).toContain('Approved')
+        expect(res.text).toContain('12 December 2021')
+      })
+  })
+})
+
 describe('POST /service-provider/referrals/:id/action-plan/edit', () => {
   it('returns error if no existing action plan exists', async () => {
     const referral = sentReferralFactory.assigned().build()

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -271,6 +271,8 @@ export default function serviceProviderRoutes(router: Router, services: Services
     serviceProviderReferralsController.createNewDraftActionPlan(req, res)
   )
 
+  get(router, '/action-plan/:id', (req, res) => serviceProviderReferralsController.viewActionPlanById(req, res))
+
   const caseNotesController = new CaseNotesController(
     services.interventionsService,
     services.communityApiService,


### PR DESCRIPTION
## What does this pull request do?

add endpoint for SPs to view action plans by id

## What is the intent behind these changes?

allow SP to view action plans that aren't the most recent (i.e. using the id in the referral DTO
