### PR TITLE
ensure that sessions on the action plan progress page are always pulled from the latest approved action plan

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -45,6 +45,7 @@ describe('Probation Practitioner monitor journey', () => {
           cy.stubGetIntervention(intervention.id, intervention)
           cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUserFactory.build())
           cy.stubGetSupplierAssessment(referral.id, supplierAssessment)
+          cy.stubGetApprovedActionPlanSummaries(referral.id, [])
 
           cy.login()
 
@@ -85,6 +86,7 @@ describe('Probation Practitioner monitor journey', () => {
           cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUserFactory.build())
           cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
           cy.stubGetSupplierAssessment(referral.id, supplierAssessment)
+          cy.stubGetApprovedActionPlanSummaries(referral.id, [])
 
           cy.login()
 
@@ -127,6 +129,7 @@ describe('Probation Practitioner monitor journey', () => {
           cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUserFactory.build())
           cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
           cy.stubGetSupplierAssessment(referral.id, supplierAssessment)
+          cy.stubGetApprovedActionPlanSummaries(referral.id, [])
 
           cy.login()
 
@@ -151,7 +154,7 @@ describe('Probation Practitioner monitor journey', () => {
         surname: 'Smith',
         username: 'john.smith',
       })
-      const actionPlan = actionPlanFactory.submitted().build({
+      const actionPlan = actionPlanFactory.approved().build({
         referralId: referralParams.id,
         numberOfSessions: 4,
       })
@@ -193,6 +196,14 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetUserByUsername(probationPractitioner.username, probationPractitioner)
       cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
       cy.stubGetAuthUserByUsername(assignedReferral.assignedTo.username, hmppsAuthUserFactory.build())
+
+      cy.stubGetApprovedActionPlanSummaries(assignedReferral.id, [
+        {
+          id: actionPlan.id,
+          submittedAt: actionPlan.submittedAt,
+          approvedAt: actionPlan.approvedAt,
+        },
+      ])
 
       cy.stubGetActionPlanAppointments(actionPlan.id, appointments)
       cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointments[0])
@@ -249,7 +260,7 @@ describe('Probation Practitioner monitor journey', () => {
         surname: 'Smith',
         username: 'john.smith',
       })
-      const actionPlan = actionPlanFactory.submitted().build({
+      const actionPlan = actionPlanFactory.approved().build({
         referralId: referralParams.id,
         numberOfSessions: 4,
       })
@@ -289,6 +300,13 @@ describe('Probation Practitioner monitor journey', () => {
         }),
       ]
 
+      cy.stubGetApprovedActionPlanSummaries(assignedReferral.id, [
+        {
+          id: actionPlan.id,
+          submittedAt: actionPlan.submittedAt,
+          approvedAt: actionPlan.approvedAt,
+        },
+      ])
       cy.stubGetActionPlanAppointments(actionPlan.id, appointmentsWithSubmittedFeedback)
       cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointmentsWithSubmittedFeedback[0])
 
@@ -324,28 +342,6 @@ describe('Probation Practitioner monitor journey', () => {
         numberOfSessions: 4,
       })
 
-      const appointments = [
-        actionPlanAppointmentFactory.attended('yes').build({
-          sessionNumber: 1,
-          appointmentTime: '2021-03-24T09:02:02Z',
-          durationInMinutes: 75,
-        }),
-        actionPlanAppointmentFactory.attended('no').build({
-          sessionNumber: 2,
-          appointmentTime: '2021-04-30T09:02:02Z',
-          durationInMinutes: 75,
-        }),
-        actionPlanAppointmentFactory.build({
-          sessionNumber: 3,
-          appointmentTime: '2021-05-31T09:02:02Z',
-          durationInMinutes: 75,
-        }),
-        actionPlanAppointmentFactory.build({
-          sessionNumber: 4,
-          durationInMinutes: 75,
-        }),
-      ]
-
       const assignedReferral = sentReferralFactory.assigned().build({
         ...referralParams,
         assignedTo: { username: probationPractitioner.username },
@@ -364,10 +360,7 @@ describe('Probation Practitioner monitor journey', () => {
         { code: 'MIS', description: 'Referral was made by mistake' },
         { code: 'MOV', description: 'Service user has moved out of delivery area' },
       ])
-
-      cy.stubGetActionPlanAppointments(actionPlan.id, appointments)
-      cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointments[0])
-      cy.stubGetActionPlanAppointment(actionPlan.id, 2, appointments[1])
+      cy.stubGetApprovedActionPlanSummaries(assignedReferral.id, [])
 
       cy.login()
 
@@ -447,6 +440,7 @@ describe('Probation Practitioner monitor journey', () => {
       cy.stubGetServiceUserByCRN(referral.referral.serviceUser.crn, deliusServiceUserFactory.build())
       cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
       cy.stubGetSupplierAssessment(referral.id, supplierAssessment)
+      cy.stubGetApprovedActionPlanSummaries(referral.id, [])
 
       cy.login()
 

--- a/integration_tests/integration/probationPractitionerReferrals.spec.js
+++ b/integration_tests/integration/probationPractitionerReferrals.spec.js
@@ -196,6 +196,7 @@ describe('Probation practitioner referrals dashboard', () => {
         const deliusUser = deliusUserFactory.build()
         cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
         cy.stubGetIntervention(intervention.id, intervention)
+        cy.stubGetApprovedActionPlanSummaries(assignedReferral.id, [])
         cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUserFactory.build())
         cy.stubGetExpandedServiceUserByCRN(
           assignedReferral.referral.serviceUser.crn,

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -163,6 +163,7 @@ describe('GET /probation-practitioner/referrals/:id/progress', () => {
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessment)
     hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    interventionsService.getApprovedActionPlanSummaries.mockResolvedValue([])
 
     communityApiService.getServiceUserByCRN.mockResolvedValue(serviceUser)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -318,6 +318,7 @@ describe('GET /service-provider/referrals/:id/progress', () => {
     interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessmentFactory.build())
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
     hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    interventionsService.getApprovedActionPlanSummaries.mockResolvedValue([])
 
     await request(app)
       .get(`/service-provider/referrals/${sentReferral.id}/progress`)

--- a/server/utils/actionPlanUtils.test.ts
+++ b/server/utils/actionPlanUtils.test.ts
@@ -1,0 +1,21 @@
+import ActionPlanUtils from './actionPlanUtils'
+import Factory from '../../testutils/factories/approvedActionPlanSummary'
+
+describe(ActionPlanUtils, () => {
+  describe('getLatestApprovedActionPlanSummary', () => {
+    it('returns null for an empty list', () => {
+      const latest = ActionPlanUtils.getLatestApprovedActionPlanSummary([])
+      expect(latest).toBeNull()
+    })
+
+    it('returns the latest action plan summary', () => {
+      const latest = ActionPlanUtils.getLatestApprovedActionPlanSummary([
+        Factory.build({ approvedAt: '2021-01-01T12:12:12+00:00' }),
+        Factory.build({ approvedAt: '2021-01-02T14:00:00+00:00' }), // newest
+        Factory.build({ approvedAt: '2021-01-02T12:12:12+00:00' }),
+        Factory.build({ approvedAt: '2020-01-02T12:12:12+00:00' }), // oldest
+      ])
+      expect(latest?.approvedAt).toEqual('2021-01-02T14:00:00+00:00')
+    })
+  })
+})

--- a/server/utils/actionPlanUtils.ts
+++ b/server/utils/actionPlanUtils.ts
@@ -1,0 +1,13 @@
+import ApprovedActionPlanSummary from '../models/approvedActionPlanSummary'
+
+export default class ActionPlanUtils {
+  static getLatestApprovedActionPlanSummary(
+    actionPlanSummaries: ApprovedActionPlanSummary[]
+  ): ApprovedActionPlanSummary | null {
+    return (
+      actionPlanSummaries.sort((a, b) => {
+        return new Date(a.approvedAt) >= new Date(b.approvedAt) ? -1 : 1
+      })?.[0] ?? null
+    )
+  }
+}


### PR DESCRIPTION
https://trello.com/c/xN23pxkV/175-bug-fix-sessions-disppears-when-action-plan-is-in-draft-state

## What does this pull request do?

ensure that sessions on the action plan progress page are always pulled from the latest approved action plan

## What is the intent behind these changes?

stop sessions going missing when the SP creates a new draft action plan
