### PR TITLE
add 'submittedAt' field to ApprovedActionPlanSummary

### DIFF
--- a/server/models/approvedActionPlanSummary.ts
+++ b/server/models/approvedActionPlanSummary.ts
@@ -1,4 +1,5 @@
 export default interface ApprovedActionPlanSummary {
   id: string
   approvedAt: string
+  submittedAt: string
 }

--- a/testutils/factories/approvedActionPlanSummary.ts
+++ b/testutils/factories/approvedActionPlanSummary.ts
@@ -4,4 +4,5 @@ import ApprovedActionPlanSummary from '../../server/models/approvedActionPlanSum
 export default Factory.define<ApprovedActionPlanSummary>(({ sequence }) => ({
   id: sequence.toString(),
   approvedAt: '2021-08-07T20:45:21.986389Z',
+  submittedAt: '2021-08-06T12:33:22.000000Z',
 }))


### PR DESCRIPTION
## What does this pull request do?

add 'submittedAt' field to ApprovedActionPlanSummary

## What is the intent behind these changes?

allows the UI consume this important piece of information from the API to populate better action plan summary tables.
