### PR TITLE
show previously approved action plans on referral progress screen

### DIFF
--- a/assets/sass/components/_button-link.scss
+++ b/assets/sass/components/_button-link.scss
@@ -15,6 +15,12 @@
   }
 }
 
+.govuk-table {
+  .button-link {
+    @include button-link;
+  }
+}
+
 .form-input-reset {
   button {
     @include button-link;

--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -215,7 +215,7 @@ describe('Probation Practitioner monitor journey', () => {
 
       cy.get('h1').contains('Accommodation progress')
 
-      cy.get('table')
+      cy.get('[data-cy=session-table]')
         .getTable()
         .should('deep.equal', [
           {
@@ -554,7 +554,7 @@ describe('Probation Practitioner monitor journey', () => {
 
       cy.stubGetActionPlan(actionPlanId, approvedActionPlan)
       cy.contains('Return to intervention progress').click()
-      cy.contains('Action plan status').next().contains('Approved')
+      cy.get('#action-plan-status').contains('Approved')
 
       cy.contains('View action plan').click()
       cy.contains('Action plan versions')

--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -710,6 +710,7 @@ describe('Service provider referrals dashboard', () => {
     it('User edits an unapproved action plan and submits it for approval', () => {
       const activityId = '1'
       const submittedActionPlan = actionPlanFactory.submitted(assignedReferral.id).build({
+        referralId: assignedReferral.id,
         id: actionPlanId,
         activities: [actionPlanActivityFactory.build({ id: activityId, description: 'First activity version 1' })],
         submittedAt: '2021-08-19T11:03:47.061Z',
@@ -781,6 +782,7 @@ describe('Service provider referrals dashboard', () => {
     it('User edits an approved action plan and submits it for approval', () => {
       const activityId = '1'
       const approvedActionPlan = actionPlanFactory.approved(assignedReferral.id).build({
+        referralId: assignedReferral.id,
         id: actionPlanId,
         activities: [actionPlanActivityFactory.build({ id: activityId, description: 'First activity version 1' })],
         submittedAt: '2021-08-19T11:03:47.061Z',
@@ -799,8 +801,6 @@ describe('Service provider referrals dashboard', () => {
       cy.get('#action-plan-status').contains('Approved')
       cy.contains('19 August 2021')
       cy.contains('View action plan').click()
-
-      cy.location('pathname').should('equal', `/service-provider/referrals/${assignedReferral.id}/action-plan`)
 
       cy.contains('Create action plan').click()
       cy.contains('Are you sure you want to create a new action plan?')

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -13,7 +13,15 @@ describe(InterventionProgressPresenter, () => {
       const referral = sentReferralFactory.build()
       const intervention = interventionFactory.build()
       const supplierAssessment = supplierAssessmentFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null
+      )
 
       expect(presenter.sessionTableRows).toEqual([])
     })
@@ -28,6 +36,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           [actionPlanAppointmentFactory.newlyCreated().build()],
           null,
+          [],
           supplierAssessment,
           null
         )
@@ -62,6 +71,7 @@ describe(InterventionProgressPresenter, () => {
               }),
             ],
             null,
+            [],
             supplierAssessment,
             null
           )
@@ -95,6 +105,7 @@ describe(InterventionProgressPresenter, () => {
               }),
             ],
             null,
+            [],
             supplierAssessment,
             null
           )
@@ -127,6 +138,7 @@ describe(InterventionProgressPresenter, () => {
               actionPlanAppointmentFactory.attended('late').build({ sessionNumber: 2 }),
             ],
             null,
+            [],
             supplierAssessment,
             null
           )
@@ -169,6 +181,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             [actionPlanAppointmentFactory.attended('no').build()],
             null,
+            [],
             supplierAssessment,
             null
           )
@@ -197,7 +210,15 @@ describe(InterventionProgressPresenter, () => {
         const referral = sentReferralFactory.build()
         const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
         const supplierAssessment = supplierAssessmentFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [],
+          null,
+          [],
+          supplierAssessment,
+          null
+        )
 
         expect(presenter.text).toMatchObject({
           title: 'Accommodation progress',
@@ -211,7 +232,15 @@ describe(InterventionProgressPresenter, () => {
       const referral = sentReferralFactory.build()
       const intervention = interventionFactory.build()
       const supplierAssessment = supplierAssessmentFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null
+      )
 
       expect(presenter.referralCancellationHref).toEqual(
         `/probation-practitioner/referrals/${referral.id}/cancellation/start`
@@ -226,7 +255,15 @@ describe(InterventionProgressPresenter, () => {
         const intervention = interventionFactory.build()
         const supplierAssessment = supplierAssessmentFactory.justCreated.build()
 
-        const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [],
+          null,
+          [],
+          supplierAssessment,
+          null
+        )
 
         expect(presenter.referralAssigned).toEqual(false)
       })
@@ -244,6 +281,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           [],
           null,
+          [],
           supplierAssessment,
           assignee
         )
@@ -258,7 +296,15 @@ describe(InterventionProgressPresenter, () => {
       const referral = sentReferralFactory.endRequested().build()
       const intervention = interventionFactory.build()
       const supplierAssessment = supplierAssessmentFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null
+      )
 
       expect(presenter.referralEndRequested).toEqual(true)
     })
@@ -268,7 +314,15 @@ describe(InterventionProgressPresenter, () => {
       const intervention = interventionFactory.build()
       const supplierAssessment = supplierAssessmentFactory.build()
 
-      const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null
+      )
 
       expect(presenter.referralEndRequested).toEqual(false)
     })
@@ -279,7 +333,15 @@ describe(InterventionProgressPresenter, () => {
       const referral = sentReferralFactory.endRequested().build({ endRequestedAt: '2021-04-28T20:45:21.986389Z' })
       const intervention = interventionFactory.build()
       const supplierAssessment = supplierAssessmentFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null
+      )
 
       expect(presenter.referralEndRequestedText).toEqual('You requested to end this service on 28 April 2021.')
     })
@@ -289,7 +351,15 @@ describe(InterventionProgressPresenter, () => {
       const intervention = interventionFactory.build()
       const supplierAssessment = supplierAssessmentFactory.build()
 
-      const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null
+      )
 
       expect(presenter.referralEndRequestedText).toEqual('')
     })
@@ -305,6 +375,7 @@ describe(InterventionProgressPresenter, () => {
           interventionFactory.build(),
           [],
           null,
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -322,6 +393,7 @@ describe(InterventionProgressPresenter, () => {
           interventionFactory.build(),
           [],
           null,
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -339,6 +411,7 @@ describe(InterventionProgressPresenter, () => {
           interventionFactory.build(),
           [],
           null,
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -354,7 +427,15 @@ describe(InterventionProgressPresenter, () => {
         const referral = sentReferralFactory.build({ endOfServiceReport: null })
         const intervention = interventionFactory.build()
         const supplierAssessment = supplierAssessmentFactory.build()
-        const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [],
+          null,
+          [],
+          supplierAssessment,
+          null
+        )
 
         expect(presenter.hasEndOfServiceReport).toEqual(false)
       })
@@ -372,6 +453,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             [],
             null,
+            [],
             supplierAssessment,
             null
           )
@@ -392,6 +474,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             [],
             null,
+            [],
             supplierAssessment,
             null
           )
@@ -407,7 +490,15 @@ describe(InterventionProgressPresenter, () => {
       const referral = sentReferralFactory.build()
       const intervention = interventionFactory.build()
       const supplierAssessment = supplierAssessmentFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null
+      )
 
       expect(presenter.endOfServiceReportTableHeaders).toEqual(['Caseworker', 'Status', 'Action'])
     })
@@ -422,7 +513,15 @@ describe(InterventionProgressPresenter, () => {
       })
       const intervention = interventionFactory.build()
       const supplierAssessment = supplierAssessmentFactory.build()
-      const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null
+      )
 
       expect(presenter.endOfServiceReportTableRows).toEqual([
         {
@@ -444,7 +543,15 @@ describe(InterventionProgressPresenter, () => {
         const intervention = interventionFactory.build()
         const supplierAssessment = supplierAssessmentFactory.justCreated.build()
 
-        const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [],
+          null,
+          [],
+          supplierAssessment,
+          null
+        )
 
         expect(presenter.shouldDisplaySupplierAssessmentSummaryList).toEqual(false)
       })
@@ -456,7 +563,15 @@ describe(InterventionProgressPresenter, () => {
         const intervention = interventionFactory.build()
         const supplierAssessment = supplierAssessmentFactory.justCreated.build()
 
-        const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [],
+          null,
+          [],
+          supplierAssessment,
+          null
+        )
 
         expect(presenter.shouldDisplaySupplierAssessmentSummaryList).toEqual(true)
       })
@@ -476,6 +591,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             [],
             null,
+            [],
             supplierAssessment,
             null
           )
@@ -497,6 +613,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             [],
             null,
+            [],
             supplierAssessment,
             hmppsAuthUserFactory.build()
           )
@@ -521,6 +638,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             [],
             null,
+            [],
             supplierAssessment,
             null
           )
@@ -541,6 +659,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             [],
             null,
+            [],
             supplierAssessment,
             null
           )
@@ -556,7 +675,15 @@ describe(InterventionProgressPresenter, () => {
         const intervention = interventionFactory.build()
         const supplierAssessment = supplierAssessmentFactory.withAttendedAppointment.build()
 
-        const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [],
+          null,
+          [],
+          supplierAssessment,
+          null
+        )
 
         expect(presenter.supplierAssessmentMessage).toEqual(
           'The initial assessment has been delivered and feedback added.'
@@ -570,7 +697,15 @@ describe(InterventionProgressPresenter, () => {
         const intervention = interventionFactory.build()
         const supplierAssessment = supplierAssessmentFactory.withNonAttendedAppointment.build()
 
-        const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [],
+          null,
+          [],
+          supplierAssessment,
+          null
+        )
 
         expect(presenter.supplierAssessmentMessage).toEqual(
           'The initial assessment has been delivered and feedback added.'
@@ -586,7 +721,15 @@ describe(InterventionProgressPresenter, () => {
         const intervention = interventionFactory.build()
         const supplierAssessment = supplierAssessmentFactory.justCreated.build()
 
-        const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [],
+          null,
+          [],
+          supplierAssessment,
+          null
+        )
 
         expect(presenter.assignedCaseworkerFullName).toEqual(null)
       })
@@ -604,6 +747,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           [],
           null,
+          [],
           supplierAssessment,
           assignee
         )
@@ -620,7 +764,15 @@ describe(InterventionProgressPresenter, () => {
         const intervention = interventionFactory.build()
         const supplierAssessment = supplierAssessmentFactory.justCreated.build()
 
-        const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [],
+          null,
+          [],
+          supplierAssessment,
+          null
+        )
 
         expect(presenter.assignedCaseworkerEmail).toEqual(null)
       })
@@ -638,6 +790,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           [],
           null,
+          [],
           supplierAssessment,
           assignee
         )
@@ -654,7 +807,15 @@ describe(InterventionProgressPresenter, () => {
         const intervention = interventionFactory.build()
         const supplierAssessment = supplierAssessmentFactory.justCreated.build()
 
-        const presenter = new InterventionProgressPresenter(referral, intervention, [], null, supplierAssessment, null)
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          [],
+          null,
+          [],
+          supplierAssessment,
+          null
+        )
 
         expect(presenter.supplierAssessmentLink).toBeNull()
       })
@@ -674,6 +835,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             [],
             null,
+            [],
             supplierAssessment,
             assignee
           )
@@ -698,6 +860,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             [],
             null,
+            [],
             supplierAssessment,
             assignee
           )
@@ -722,6 +885,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           [],
           null,
+          [],
           supplierAssessment,
           assignee
         )
@@ -745,6 +909,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           [],
           null,
+          [],
           supplierAssessment,
           assignee
         )

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -9,8 +9,9 @@ import Intervention from '../../models/intervention'
 import SupplierAssessment from '../../models/supplierAssessment'
 import SupplierAssessmentDecorator from '../../decorators/supplierAssessmentDecorator'
 import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
-import ActionPlanSummaryPresenter from '../shared/action-plan/actionPlanSummaryPresenter'
 import { ActionPlanAppointment } from '../../models/appointment'
+import ActionPlanProgressPresenter from '../shared/action-plan/actionPlanProgressPresenter'
+import ApprovedActionPlanSummary from '../../models/approvedActionPlanSummary'
 
 interface ProgressSessionTableRow {
   sessionNumber: number
@@ -35,13 +36,14 @@ enum SupplierAssessmentStatus {
 export default class InterventionProgressPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
 
-  actionPlanSummaryPresenter: ActionPlanSummaryPresenter
+  actionPlanProgressPresenter: ActionPlanProgressPresenter
 
   constructor(
     private readonly referral: SentReferral,
     private readonly intervention: Intervention,
     private readonly actionPlanAppointments: ActionPlanAppointment[],
     private readonly actionPlan: ActionPlan | null,
+    private readonly approvedActionPlanSummaries: ApprovedActionPlanSummary[],
     private readonly supplierAssessment: SupplierAssessment,
     private readonly assignee: AuthUserDetails | null
   ) {
@@ -50,7 +52,12 @@ export default class InterventionProgressPresenter {
       referral.id,
       'probation-practitioner'
     )
-    this.actionPlanSummaryPresenter = new ActionPlanSummaryPresenter(referral, actionPlan, 'probation-practitioner')
+    this.actionPlanProgressPresenter = new ActionPlanProgressPresenter(
+      referral.id,
+      actionPlan,
+      approvedActionPlanSummaries,
+      'probation-practitioner'
+    )
   }
 
   get referralAssigned(): boolean {

--- a/server/routes/probationPractitionerReferrals/interventionProgressView.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressView.ts
@@ -2,13 +2,13 @@ import { TagArgs, TableArgs, SummaryListArgs } from '../../utils/govukFrontendTy
 import ViewUtils from '../../utils/viewUtils'
 
 import InterventionProgressPresenter from './interventionProgressPresenter'
-import ActionPlanSummaryView from '../shared/action-plan/actionPlanSummaryView'
+import ActionPlanProgressView from '../shared/action-plan/actionPlanProgressView'
 
 export default class InterventionProgressView {
-  actionPlanSummaryView: ActionPlanSummaryView
+  actionPlanProgressView: ActionPlanProgressView
 
   constructor(private readonly presenter: InterventionProgressPresenter) {
-    this.actionPlanSummaryView = new ActionPlanSummaryView(presenter.actionPlanSummaryPresenter, true)
+    this.actionPlanProgressView = new ActionPlanProgressView(presenter.actionPlanProgressPresenter)
   }
 
   private supplierAssessmentSummaryListArgs(tagMacro: (args: TagArgs) => string): SummaryListArgs | null {
@@ -51,6 +51,7 @@ export default class InterventionProgressView {
           { html: row.link === null ? '' : ViewUtils.linkHtml([row.link]) },
         ]
       }),
+      attributes: { 'data-cy': 'session-table' },
     }
   }
 
@@ -84,7 +85,7 @@ export default class InterventionProgressView {
         supplierAssessmentSummaryListArgs: this.supplierAssessmentSummaryListArgs.bind(this),
         sessionTableArgs: this.sessionTableArgs.bind(this),
         endOfServiceReportTableArgs: this.endOfServiceReportTableArgs.bind(this),
-        actionPlanSummaryListArgs: this.actionPlanSummaryView.summaryListArgs.bind(this.actionPlanSummaryView),
+        actionPlanTableArgs: this.actionPlanProgressView.tableArgs.bind(this.actionPlanProgressView),
       },
     ]
   }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -148,6 +148,7 @@ export default class ProbationPractitionerReferralsController {
       intervention,
       actionPlanAppointments,
       actionPlan,
+      approvedActionPlanSummaries,
       supplierAssessment,
       assignee
     )

--- a/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationPresenter.test.ts
@@ -1,15 +1,13 @@
 import actionPlanFactory from '../../../../../testutils/factories/actionPlan'
-import sentReferralFactory from '../../../../../testutils/factories/sentReferral'
 import ActionPlanEditConfirmationPresenter from './actionPlanEditConfirmationPresenter'
 
 describe(ActionPlanEditConfirmationPresenter, () => {
   describe('text', () => {
     describe('when editing an approved action plan', () => {
       it('contains the correct warning message to the user', () => {
-        const sentReferral = sentReferralFactory.build()
         const approvedActionPlan = actionPlanFactory.approved().build()
 
-        const presenter = new ActionPlanEditConfirmationPresenter(sentReferral, approvedActionPlan)
+        const presenter = new ActionPlanEditConfirmationPresenter(approvedActionPlan)
 
         expect(presenter.text.title).toEqual('Are you sure you want to create a new action plan?')
         expect(presenter.text.note).toEqual(
@@ -20,10 +18,9 @@ describe(ActionPlanEditConfirmationPresenter, () => {
 
     describe('when editing a not-yet-approved action plan', () => {
       it('contains the correct warning message to the user', () => {
-        const sentReferral = sentReferralFactory.build()
         const approvedActionPlan = actionPlanFactory.submitted().build()
 
-        const presenter = new ActionPlanEditConfirmationPresenter(sentReferral, approvedActionPlan)
+        const presenter = new ActionPlanEditConfirmationPresenter(approvedActionPlan)
 
         expect(presenter.text.title).toEqual(
           'Are you sure you want to change the action plan while it is being reviewed?'

--- a/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationPresenter.ts
+++ b/server/routes/service-provider/action-plan/edit/actionPlanEditConfirmationPresenter.ts
@@ -1,17 +1,16 @@
 import ActionPlan from '../../../../models/actionPlan'
-import SentReferral from '../../../../models/sentReferral'
 import ActionPlanSummaryPresenter from '../../../shared/action-plan/actionPlanSummaryPresenter'
 
 export default class ActionPlanEditConfirmationPresenter {
   actionPlanSummaryPresenter: ActionPlanSummaryPresenter
 
-  constructor(private readonly sentReferral: SentReferral, private readonly actionPlan: ActionPlan) {
-    this.actionPlanSummaryPresenter = new ActionPlanSummaryPresenter(sentReferral, actionPlan, 'service-provider')
+  constructor(private readonly actionPlan: ActionPlan) {
+    this.actionPlanSummaryPresenter = new ActionPlanSummaryPresenter(actionPlan, 'service-provider')
   }
 
-  readonly viewActionPlanUrl = `/service-provider/referrals/${this.sentReferral.id}/action-plan`
+  readonly viewActionPlanUrl = `/service-provider/referrals/${this.actionPlan.referralId}/action-plan`
 
-  readonly editConfirmAction = `/service-provider/referrals/${this.sentReferral.id}/action-plan/edit`
+  readonly editConfirmAction = `/service-provider/referrals/${this.actionPlan.referralId}/action-plan/edit`
 
   get text(): { title: string; note: string } {
     if (this.actionPlanSummaryPresenter.actionPlanApproved) {

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -20,6 +20,7 @@ describe(InterventionProgressPresenter, () => {
         intervention,
         null,
         [],
+        [],
         supplierAssessmentFactory.build(),
         null
       )
@@ -33,6 +34,7 @@ describe(InterventionProgressPresenter, () => {
         referral,
         intervention,
         null,
+        [],
         [],
         supplierAssessmentFactory.build(),
         null
@@ -51,6 +53,7 @@ describe(InterventionProgressPresenter, () => {
         intervention,
         null,
         [],
+        [],
         supplierAssessmentFactory.build(),
         null
       )
@@ -66,6 +69,7 @@ describe(InterventionProgressPresenter, () => {
         referral,
         intervention,
         null,
+        [],
         [],
         supplierAssessmentFactory.build(),
         null
@@ -86,6 +90,7 @@ describe(InterventionProgressPresenter, () => {
         intervention,
         null,
         [],
+        [],
         supplierAssessmentFactory.build(),
         null
       )
@@ -102,6 +107,7 @@ describe(InterventionProgressPresenter, () => {
           referral,
           intervention,
           actionPlan,
+          [],
           [
             actionPlanAppointmentFactory.build({ sessionNumber: 2 }),
             actionPlanAppointmentFactory.build({ sessionNumber: 3 }),
@@ -123,6 +129,7 @@ describe(InterventionProgressPresenter, () => {
           referral,
           intervention,
           actionPlan,
+          [],
           [actionPlanAppointmentFactory.newlyCreated().build()],
           supplierAssessmentFactory.build(),
           null
@@ -152,6 +159,7 @@ describe(InterventionProgressPresenter, () => {
           referral,
           intervention,
           actionPlan,
+          [],
           [
             actionPlanAppointmentFactory.build({
               sessionNumber: 1,
@@ -192,6 +200,7 @@ describe(InterventionProgressPresenter, () => {
             referral,
             intervention,
             actionPlan,
+            [],
             [
               actionPlanAppointmentFactory.attended('yes').build({ sessionNumber: 1 }),
               actionPlanAppointmentFactory.attended('late').build({ sessionNumber: 2 }),
@@ -236,6 +245,7 @@ describe(InterventionProgressPresenter, () => {
             referral,
             intervention,
             actionPlan,
+            [],
             [actionPlanAppointmentFactory.attended('no').build()],
             supplierAssessmentFactory.build(),
             null
@@ -269,6 +279,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           null,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -289,6 +300,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             null,
             [],
+            [],
             supplierAssessmentFactory.build(),
             null
           )
@@ -307,6 +319,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             null,
             [],
+            [],
             supplierAssessmentFactory.build(),
             null
           )
@@ -324,6 +337,7 @@ describe(InterventionProgressPresenter, () => {
             referral,
             intervention,
             null,
+            [],
             [],
             supplierAssessmentFactory.build(),
             null
@@ -347,6 +361,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           actionPlan,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -366,6 +381,7 @@ describe(InterventionProgressPresenter, () => {
           referral,
           intervention,
           actionPlan,
+          [],
           [],
           supplierAssessmentFactory.build(),
           assignee
@@ -388,6 +404,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           actionPlan,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -407,6 +424,7 @@ describe(InterventionProgressPresenter, () => {
           referral,
           intervention,
           actionPlan,
+          [],
           [],
           supplierAssessmentFactory.build(),
           assignee
@@ -429,6 +447,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           actionPlan,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -449,6 +468,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           actionPlan,
           [],
+          [],
           supplierAssessmentFactory.build(),
           assignee
         )
@@ -468,6 +488,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           null,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -486,6 +507,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           null,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -503,6 +525,7 @@ describe(InterventionProgressPresenter, () => {
           referral,
           intervention,
           null,
+          [],
           [],
           supplierAssessmentFactory.build(),
           null
@@ -523,6 +546,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           null,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -542,6 +566,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             null,
             [],
+            [],
             supplierAssessmentFactory.build(),
             null
           )
@@ -559,6 +584,7 @@ describe(InterventionProgressPresenter, () => {
             referral,
             intervention,
             null,
+            [],
             [],
             supplierAssessmentFactory.build(),
             null
@@ -580,6 +606,7 @@ describe(InterventionProgressPresenter, () => {
             intervention,
             null,
             [],
+            [],
             supplierAssessmentFactory.build(),
             null
           )
@@ -600,6 +627,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           null,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -618,6 +646,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           null,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -635,6 +664,7 @@ describe(InterventionProgressPresenter, () => {
           referral,
           intervention,
           null,
+          [],
           [],
           supplierAssessmentFactory.build(),
           null
@@ -655,6 +685,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           null,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -673,6 +704,7 @@ describe(InterventionProgressPresenter, () => {
           intervention,
           null,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -690,6 +722,7 @@ describe(InterventionProgressPresenter, () => {
           referral,
           intervention,
           null,
+          [],
           [],
           supplierAssessmentFactory.build(),
           null
@@ -716,6 +749,7 @@ describe(InterventionProgressPresenter, () => {
           interventionFactory.build(),
           null,
           [],
+          [],
           supplierAssessmentFactory.build({ appointments: [firstScheduledAppointment, secondScheduledAppointment] }),
           null
         )
@@ -734,6 +768,7 @@ describe(InterventionProgressPresenter, () => {
           interventionFactory.build(),
           null,
           [],
+          [],
           supplierAssessmentWithNoAppointmentScheduled,
           null
         )
@@ -751,6 +786,7 @@ describe(InterventionProgressPresenter, () => {
             referral,
             interventionFactory.build(),
             null,
+            [],
             [],
             supplierAssessmentFactory.build({ appointments: [] }),
             null
@@ -777,6 +813,7 @@ describe(InterventionProgressPresenter, () => {
               interventionFactory.build(),
               null,
               [],
+              [],
               supplierAssessmentFactory.withAnAppointment(appointment).build(),
               null
             )
@@ -799,6 +836,7 @@ describe(InterventionProgressPresenter, () => {
               referral,
               interventionFactory.build(),
               null,
+              [],
               [],
               supplierAssessmentFactory.withAnAppointment(appointment).build(),
               null
@@ -824,6 +862,7 @@ describe(InterventionProgressPresenter, () => {
             interventionFactory.build(),
             null,
             [],
+            [],
             supplierAssessmentFactory.withAnAppointment(appointment).build(),
             null
           )
@@ -847,6 +886,7 @@ describe(InterventionProgressPresenter, () => {
               referral,
               interventionFactory.build(),
               null,
+              [],
               [],
               supplierAssessmentFactory.withAnAppointment(appointment).build({ currentAppointmentId: appointment.id }),
               null
@@ -875,6 +915,7 @@ describe(InterventionProgressPresenter, () => {
               interventionFactory.build(),
               null,
               [],
+              [],
               supplierAssessmentFactory.build({ appointments: [appointment] }),
               null
             )
@@ -901,6 +942,7 @@ describe(InterventionProgressPresenter, () => {
           interventionFactory.build(),
           null,
           [],
+          [],
           supplierAssessmentFactory.build(),
           null
         )
@@ -921,6 +963,7 @@ describe(InterventionProgressPresenter, () => {
             interventionFactory.build(),
             null,
             [],
+            [],
             supplierAssessmentFactory.withAnAppointment(initialAssessmentAppointmentFactory.inThePast.build()).build(),
             null
           )
@@ -939,6 +982,7 @@ describe(InterventionProgressPresenter, () => {
             referral,
             interventionFactory.build(),
             null,
+            [],
             [],
             supplierAssessmentFactory
               .withAnAppointment(initialAssessmentAppointmentFactory.inTheFuture.build())
@@ -962,6 +1006,7 @@ describe(InterventionProgressPresenter, () => {
           interventionFactory.build(),
           null,
           [],
+          [],
           supplierAssessmentFactory.withAttendedAppointment.build(),
           null
         )
@@ -980,6 +1025,7 @@ describe(InterventionProgressPresenter, () => {
           referral,
           interventionFactory.build(),
           null,
+          [],
           [],
           supplierAssessmentFactory.withNonAttendedAppointment.build(),
           null

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -8,9 +8,10 @@ import SessionStatusPresenter from '../shared/sessionStatusPresenter'
 import Intervention from '../../models/intervention'
 import SupplierAssessment from '../../models/supplierAssessment'
 import SupplierAssessmentDecorator from '../../decorators/supplierAssessmentDecorator'
-import ActionPlanSummaryPresenter from '../shared/action-plan/actionPlanSummaryPresenter'
 import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../models/appointment'
 import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
+import ActionPlanProgressPresenter from '../shared/action-plan/actionPlanProgressPresenter'
+import ApprovedActionPlanSummary from '../../models/approvedActionPlanSummary'
 
 interface EndedFields {
   endRequestedAt: string | null
@@ -40,12 +41,13 @@ interface SupplierAssessmentTableRow {
 export default class InterventionProgressPresenter {
   referralOverviewPagePresenter: ReferralOverviewPagePresenter
 
-  actionPlanSummaryPresenter: ActionPlanSummaryPresenter
+  actionPlanProgressPresenter: ActionPlanProgressPresenter
 
   constructor(
     private readonly referral: SentReferral,
     private readonly intervention: Intervention,
     private readonly actionPlan: ActionPlan | null,
+    private readonly approvedActionPlanSummaries: ApprovedActionPlanSummary[],
     private readonly actionPlanAppointments: ActionPlanAppointment[],
     private readonly supplierAssessment: SupplierAssessment,
     private readonly assignee: AuthUserDetails | null
@@ -56,7 +58,12 @@ export default class InterventionProgressPresenter {
       referral.id,
       subNavUrlPrefix
     )
-    this.actionPlanSummaryPresenter = new ActionPlanSummaryPresenter(referral, actionPlan, 'service-provider')
+    this.actionPlanProgressPresenter = new ActionPlanProgressPresenter(
+      referral.id,
+      actionPlan,
+      approvedActionPlanSummaries,
+      'service-provider'
+    )
   }
 
   get referralAssigned(): boolean {

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -9,13 +9,13 @@ import {
 import ViewUtils from '../../utils/viewUtils'
 import InterventionProgressPresenter from './interventionProgressPresenter'
 import DateUtils from '../../utils/dateUtils'
-import ActionPlanSummaryView from '../shared/action-plan/actionPlanSummaryView'
+import ActionPlanProgressView from '../shared/action-plan/actionPlanProgressView'
 
 export default class InterventionProgressView {
-  actionPlanSummaryView: ActionPlanSummaryView
+  actionPlanProgressView: ActionPlanProgressView
 
   constructor(private readonly presenter: InterventionProgressPresenter) {
-    this.actionPlanSummaryView = new ActionPlanSummaryView(presenter.actionPlanSummaryPresenter, true)
+    this.actionPlanProgressView = new ActionPlanProgressView(presenter.actionPlanProgressPresenter)
   }
 
   get cancelledReferralNotificationBannerArgs(): NotificationBannerArgs {
@@ -144,7 +144,7 @@ export default class InterventionProgressView {
         subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
         supplierAssessmentAppointmentsTableArgs: this.supplierAssessmentAppointmentsTableArgs.bind(this),
         supplierAssessmentMessage: this.presenter.supplierAssessmentMessage,
-        actionPlanSummaryListArgs: this.actionPlanSummaryView.summaryListArgs.bind(this.actionPlanSummaryView),
+        actionPlanTableArgs: this.actionPlanProgressView.tableArgs.bind(this.actionPlanProgressView),
         sessionTableArgs: this.sessionTableArgs.bind(this),
         backLinkArgs: this.backLinkArgs,
         endOfServiceReportSummaryListArgs: this.endOfServiceReportSummaryListArgs.bind(this),

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -217,6 +217,7 @@ export default class ServiceProviderReferralsController {
       sentReferral,
       intervention,
       actionPlan,
+      approvedActionPlanSummaries,
       actionPlanAppointments,
       supplierAssessment,
       assignee
@@ -821,7 +822,7 @@ export default class ServiceProviderReferralsController {
       await this.interventionsService.getActionPlan(accessToken, sentReferral.actionPlanId),
     ])
 
-    const presenter = new ActionPlanEditConfirmationPresenter(sentReferral, actionPlan)
+    const presenter = new ActionPlanEditConfirmationPresenter(actionPlan)
     const view = new ActionPlanEditConfirmationView(presenter)
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }

--- a/server/routes/shared/action-plan/actionPlanPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.ts
@@ -20,7 +20,7 @@ export default class ActionPlanPresenter {
     private readonly validationError: FormValidationError | null = null,
     private readonly approvedActionPlanSummaries: ApprovedActionPlanSummary[] = []
   ) {
-    this.actionPlanSummaryPresenter = new ActionPlanSummaryPresenter(referral, actionPlan, userType)
+    this.actionPlanSummaryPresenter = new ActionPlanSummaryPresenter(actionPlan, userType)
   }
 
   readonly text = {

--- a/server/routes/shared/action-plan/actionPlanProgressPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanProgressPresenter.test.ts
@@ -1,0 +1,71 @@
+import actionPlanFactory from '../../../../testutils/factories/actionPlan'
+import referralFactory from '../../../../testutils/factories/sentReferral'
+import ActionPlanProgressPresenter from './actionPlanProgressPresenter'
+
+describe(ActionPlanProgressPresenter, () => {
+  const referral = referralFactory.build()
+  describe('createNewActionPlanUrl', () => {
+    it('returns the relative URL for creating a draft action plan', () => {
+      const presenter = new ActionPlanProgressPresenter(referral.id, null, [], 'service-provider')
+
+      expect(presenter.createNewActionPlanUrl).toEqual(`/service-provider/referrals/${referral.id}/action-plan`)
+    })
+  })
+
+  describe('continueInProgressActionPlanUrl', () => {
+    it('returns the relative URL for continuing a draft action plan', () => {
+      const actionPlan = actionPlanFactory.justCreated(referral.id).build()
+      const presenter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'probation-practitioner')
+
+      expect(presenter.continueInProgressActionPlanUrl).toEqual(
+        `/service-provider/action-plan/${actionPlan.id}/add-activity/1`
+      )
+    })
+  })
+
+  describe('viewCurrentActionPlanUrl', () => {
+    it('returns the relative URL for viewing the current action plan', () => {
+      const actionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+      const presenter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'probation-practitioner')
+
+      expect(presenter.viewCurrentActionPlanUrl).toEqual(`/probation-practitioner/referrals/${referral.id}/action-plan`)
+    })
+  })
+
+  describe('includeCurrentActionPlanRow', () => {
+    it('returns false if the current action plan is approved', () => {
+      const actionPlan = actionPlanFactory.approved().build({ referralId: referral.id })
+      const spPresenter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'service-provider')
+      const ppPresenter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'probation-practitioner')
+
+      expect(spPresenter.includeCurrentActionPlanRow).toEqual(false)
+      expect(ppPresenter.includeCurrentActionPlanRow).toEqual(false)
+    })
+
+    it('returns false for PPs if the referral has not been created', () => {
+      const spPresenter = new ActionPlanProgressPresenter(referral.id, null, [], 'service-provider')
+      const ppPresemnter = new ActionPlanProgressPresenter(referral.id, null, [], 'probation-practitioner')
+
+      expect(spPresenter.includeCurrentActionPlanRow).toEqual(true)
+      expect(ppPresemnter.includeCurrentActionPlanRow).toEqual(false)
+    })
+
+    it('returns false for PPs if the referral is not submitted', () => {
+      const actionPlan = actionPlanFactory.justCreated(referral.id).build()
+      const spPresenter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'service-provider')
+      const ppPresemnter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'probation-practitioner')
+
+      expect(spPresenter.includeCurrentActionPlanRow).toEqual(true)
+      expect(ppPresemnter.includeCurrentActionPlanRow).toEqual(false)
+    })
+
+    it('returns true for submitted action plans', () => {
+      const actionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+      const spPresenter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'service-provider')
+      const ppPresemnter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'probation-practitioner')
+
+      expect(spPresenter.includeCurrentActionPlanRow).toEqual(true)
+      expect(ppPresemnter.includeCurrentActionPlanRow).toEqual(true)
+    })
+  })
+})

--- a/server/routes/shared/action-plan/actionPlanProgressPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanProgressPresenter.test.ts
@@ -42,30 +42,40 @@ describe(ActionPlanProgressPresenter, () => {
       expect(ppPresenter.includeCurrentActionPlanRow).toEqual(false)
     })
 
-    it('returns false for PPs if the referral has not been created', () => {
+    it('returns true if the referral has not been created', () => {
       const spPresenter = new ActionPlanProgressPresenter(referral.id, null, [], 'service-provider')
-      const ppPresemnter = new ActionPlanProgressPresenter(referral.id, null, [], 'probation-practitioner')
+      const ppPresenter = new ActionPlanProgressPresenter(referral.id, null, [], 'probation-practitioner')
 
       expect(spPresenter.includeCurrentActionPlanRow).toEqual(true)
-      expect(ppPresemnter.includeCurrentActionPlanRow).toEqual(false)
+      expect(ppPresenter.includeCurrentActionPlanRow).toEqual(true)
     })
 
     it('returns false for PPs if the referral is not submitted', () => {
       const actionPlan = actionPlanFactory.justCreated(referral.id).build()
       const spPresenter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'service-provider')
-      const ppPresemnter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'probation-practitioner')
+      const ppPresenter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'probation-practitioner')
 
       expect(spPresenter.includeCurrentActionPlanRow).toEqual(true)
-      expect(ppPresemnter.includeCurrentActionPlanRow).toEqual(false)
+      expect(ppPresenter.includeCurrentActionPlanRow).toEqual(false)
     })
 
-    it('returns true for submitted action plans', () => {
+    it('returns true for submitted but not approved action plans', () => {
       const actionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
       const spPresenter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'service-provider')
-      const ppPresemnter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'probation-practitioner')
+      const ppPresenter = new ActionPlanProgressPresenter(referral.id, actionPlan, [], 'probation-practitioner')
 
       expect(spPresenter.includeCurrentActionPlanRow).toEqual(true)
-      expect(ppPresemnter.includeCurrentActionPlanRow).toEqual(true)
+      expect(ppPresenter.includeCurrentActionPlanRow).toEqual(true)
+    })
+  })
+
+  describe('includeCreateActionPlanButton', () => {
+    it('returns true for SPs and false for PPs', () => {
+      const spPresenter = new ActionPlanProgressPresenter(referral.id, null, [], 'service-provider')
+      const ppPresenter = new ActionPlanProgressPresenter(referral.id, null, [], 'probation-practitioner')
+
+      expect(spPresenter.includeCreateActionPlanButton).toEqual(true)
+      expect(ppPresenter.includeCreateActionPlanButton).toEqual(false)
     })
   })
 })

--- a/server/routes/shared/action-plan/actionPlanProgressPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanProgressPresenter.ts
@@ -1,0 +1,38 @@
+import ActionPlan from '../../../models/actionPlan'
+import ApprovedActionPlanSummary from '../../../models/approvedActionPlanSummary'
+import ActionPlanSummaryPresenter from './actionPlanSummaryPresenter'
+
+export default class ActionPlanProgressPresenter {
+  currentActionPlanSummaryPresenter: ActionPlanSummaryPresenter
+
+  constructor(
+    private readonly referralId: string,
+    private readonly currentActionPlan: ActionPlan | null,
+    readonly approvedActionPlanSummaries: ApprovedActionPlanSummary[],
+    readonly userType: 'service-provider' | 'probation-practitioner'
+  ) {
+    this.currentActionPlanSummaryPresenter = new ActionPlanSummaryPresenter(currentActionPlan, userType)
+  }
+
+  readonly tableHeaders = ['Version', 'Status', 'Submitted', 'Approved', 'Action']
+
+  readonly viewCurrentActionPlanUrl = `/${this.userType}/referrals/${this.referralId}/action-plan`
+
+  readonly createNewActionPlanUrl = `/service-provider/referrals/${this.referralId}/action-plan`
+
+  readonly continueInProgressActionPlanUrl = `/service-provider/action-plan/${this.currentActionPlan?.id}/add-activity/1`
+
+  get includeCurrentActionPlanRow(): boolean {
+    // if the current action plan is approved, it will be rendered from `approvedActionPlanSummaries`
+    if (this.currentActionPlanSummaryPresenter.actionPlanApproved) {
+      return false
+    }
+
+    // PPs should never see unsubmitted action plans
+    if (this.userType === 'probation-practitioner' && !this.currentActionPlanSummaryPresenter.actionPlanSubmitted) {
+      return false
+    }
+
+    return true
+  }
+}

--- a/server/routes/shared/action-plan/actionPlanProgressPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanProgressPresenter.ts
@@ -28,11 +28,19 @@ export default class ActionPlanProgressPresenter {
       return false
     }
 
-    // PPs should never see unsubmitted action plans
-    if (this.userType === 'probation-practitioner' && !this.currentActionPlanSummaryPresenter.actionPlanSubmitted) {
+    // PPs should never see draft action plans
+    if (
+      this.userType === 'probation-practitioner' &&
+      this.currentActionPlanSummaryPresenter.actionPlanCreated &&
+      !this.currentActionPlanSummaryPresenter.actionPlanSubmitted
+    ) {
       return false
     }
 
     return true
+  }
+
+  get includeCreateActionPlanButton(): boolean {
+    return this.userType === 'service-provider'
   }
 }

--- a/server/routes/shared/action-plan/actionPlanProgressView.ts
+++ b/server/routes/shared/action-plan/actionPlanProgressView.ts
@@ -50,7 +50,7 @@ export default class ActionPlanProgressView {
     const currentActionPlanSummary = this.presenter.currentActionPlanSummaryPresenter
     const row: TableArgsCell[] = [
       {
-        text: (this.presenter.approvedActionPlanSummaries.length + 1).toString(),
+        text: '',
         classes: 'action-plan-version',
       },
       {
@@ -73,13 +73,15 @@ export default class ActionPlanProgressView {
       row.push({
         html: `<a href="${this.presenter.continueInProgressActionPlanUrl}" class="govuk-link">Continue action plan</a>`,
       })
-    } else {
+    } else if (this.presenter.includeCreateActionPlanButton) {
       row.push({
         html: `<form method="post" action="${ViewUtils.escape(this.presenter.createNewActionPlanUrl)}">
                <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken!)}">
                <button class="button-link" data-module="govuk-button" data-prevent-double-click="true">Create action plan</button>
                </form>`,
       })
+    } else {
+      row.push({ text: '' })
     }
 
     return row

--- a/server/routes/shared/action-plan/actionPlanProgressView.ts
+++ b/server/routes/shared/action-plan/actionPlanProgressView.ts
@@ -1,0 +1,87 @@
+import { TableArgs, TableArgsCell, TagArgs } from '../../../utils/govukFrontendTypes'
+import ActionPlanProgressPresenter from './actionPlanProgressPresenter'
+import ActionPlanUtils, { ActionPlanStatus } from '../../../utils/actionPlanUtils'
+import DateUtils from '../../../utils/dateUtils'
+import ViewUtils from '../../../utils/viewUtils'
+
+export default class ActionPlanProgressView {
+  constructor(private readonly presenter: ActionPlanProgressPresenter) {}
+
+  tableArgs(tagMacro: (args: TagArgs) => string, csrfToken?: string): TableArgs {
+    const rows: TableArgsCell[][] = []
+
+    if (this.presenter.includeCurrentActionPlanRow) {
+      rows.push(this.getCurrentActionPlanRow(tagMacro, csrfToken))
+    }
+
+    rows.push(
+      ...this.presenter.approvedActionPlanSummaries.map((summary, i) => [
+        {
+          text: (this.presenter.approvedActionPlanSummaries.length - i).toString(),
+          classes: 'action-plan-version',
+        },
+        {
+          text: tagMacro(ActionPlanUtils.actionPlanTagArgs(ActionPlanStatus.Approved)),
+          classes: 'action-plan-status',
+        },
+        {
+          text: DateUtils.formattedDate(summary.submittedAt),
+          classes: 'action-plan-submitted-date',
+        },
+        {
+          text: DateUtils.formattedDate(summary.approvedAt),
+          classes: 'action-plan-approved-date',
+        },
+        {
+          html: `<a href="/${this.presenter.userType}/action-plan/${summary.id}" class="govuk-link">View action plan</a>`,
+        },
+      ])
+    )
+
+    return {
+      head: this.presenter.tableHeaders.map(header => {
+        return { text: header }
+      }),
+      rows,
+    }
+  }
+
+  private getCurrentActionPlanRow(tagMacro: (args: TagArgs) => string, csrfToken?: string): TableArgsCell[] {
+    const currentActionPlanSummary = this.presenter.currentActionPlanSummaryPresenter
+    const row: TableArgsCell[] = [
+      {
+        text: (this.presenter.approvedActionPlanSummaries.length + 1).toString(),
+        classes: 'action-plan-version',
+      },
+      {
+        text: tagMacro(ActionPlanUtils.actionPlanTagArgs(currentActionPlanSummary.actionPlanStatus)),
+        classes: 'action-plan-status',
+      },
+      {
+        text: currentActionPlanSummary.text.actionPlanSubmittedDate,
+        classes: 'action-plan-submitted-date',
+      },
+      {
+        text: currentActionPlanSummary.text.actionPlanApprovalDate,
+        classes: 'action-plan-approved-date',
+      },
+    ]
+
+    if (currentActionPlanSummary.actionPlanSubmitted) {
+      row.push({ html: `<a href="${this.presenter.viewCurrentActionPlanUrl}" class="govuk-link">View action plan</a>` })
+    } else if (currentActionPlanSummary.actionPlanCreated) {
+      row.push({
+        html: `<a href="${this.presenter.continueInProgressActionPlanUrl}" class="govuk-link">Continue action plan</a>`,
+      })
+    } else {
+      row.push({
+        html: `<form method="post" action="${ViewUtils.escape(this.presenter.createNewActionPlanUrl)}">
+               <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken!)}">
+               <button class="button-link" data-module="govuk-button" data-prevent-double-click="true">Create action plan</button>
+               </form>`,
+      })
+    }
+
+    return row
+  }
+}

--- a/server/routes/shared/action-plan/actionPlanSummaryPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanSummaryPresenter.test.ts
@@ -1,59 +1,46 @@
 import actionPlanFactory from '../../../../testutils/factories/actionPlan'
-import referralFactory from '../../../../testutils/factories/sentReferral'
 import ActionPlanSummaryPresenter from './actionPlanSummaryPresenter'
 
 describe(ActionPlanSummaryPresenter, () => {
-  const referral = referralFactory.build()
-  describe('createActionPlanFormAction', () => {
-    it('returns the relative URL for creating a draft action plan', () => {
-      const actionPlan = actionPlanFactory.approved().build({ referralId: referral.id })
-      const presenter = new ActionPlanSummaryPresenter(referral, actionPlan, 'service-provider')
-
-      expect(presenter.createActionPlanFormAction).toEqual(
-        `/service-provider/referrals/${actionPlan.referralId}/action-plan`
-      )
-    })
-  })
-
   describe('actionPlanStatus', () => {
     describe('when there is no action plan', () => {
       it('returns the correct status', () => {
-        const presenter = new ActionPlanSummaryPresenter(referral, null, 'service-provider')
-        expect(presenter.text.actionPlanStatus).toEqual('Not submitted')
+        const presenter = new ActionPlanSummaryPresenter(null, 'service-provider')
+        expect(presenter.actionPlanStatus).toEqual('Not submitted')
       })
     })
 
     describe('when the action plan has not been submitted', () => {
       it('returns the correct status for service providers', () => {
-        const actionPlan = actionPlanFactory.notSubmitted().build({ referralId: referral.id })
-        const presenter = new ActionPlanSummaryPresenter(referral, actionPlan, 'service-provider')
+        const actionPlan = actionPlanFactory.notSubmitted().build()
+        const presenter = new ActionPlanSummaryPresenter(actionPlan, 'service-provider')
 
-        expect(presenter.text.actionPlanStatus).toEqual('In draft')
+        expect(presenter.actionPlanStatus).toEqual('In draft')
       })
 
       it('returns the correct status for probation practitioners', () => {
-        const actionPlan = actionPlanFactory.notSubmitted().build({ referralId: referral.id })
-        const presenter = new ActionPlanSummaryPresenter(referral, actionPlan, 'probation-practitioner')
+        const actionPlan = actionPlanFactory.notSubmitted().build()
+        const presenter = new ActionPlanSummaryPresenter(actionPlan, 'probation-practitioner')
 
-        expect(presenter.text.actionPlanStatus).toEqual('Not submitted')
+        expect(presenter.actionPlanStatus).toEqual('Not submitted')
       })
     })
 
     describe('when the action plan has been submitted', () => {
       it('returns the correct status', () => {
-        const actionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
-        const presenter = new ActionPlanSummaryPresenter(referral, actionPlan, 'service-provider')
+        const actionPlan = actionPlanFactory.submitted().build()
+        const presenter = new ActionPlanSummaryPresenter(actionPlan, 'service-provider')
 
-        expect(presenter.text.actionPlanStatus).toEqual('Awaiting approval')
+        expect(presenter.actionPlanStatus).toEqual('Awaiting approval')
       })
     })
 
     describe('when the action plan has been approved', () => {
       it('returns the correct status', () => {
-        const actionPlan = actionPlanFactory.approved().build({ referralId: referral.id })
-        const presenter = new ActionPlanSummaryPresenter(referral, actionPlan, 'service-provider')
+        const actionPlan = actionPlanFactory.approved().build()
+        const presenter = new ActionPlanSummaryPresenter(actionPlan, 'service-provider')
 
-        expect(presenter.text.actionPlanStatus).toEqual('Approved')
+        expect(presenter.actionPlanStatus).toEqual('Approved')
       })
     })
   })
@@ -61,7 +48,7 @@ describe(ActionPlanSummaryPresenter, () => {
   describe('actionPlanCreated', () => {
     describe('when there is no action plan', () => {
       it('returns false', () => {
-        const presenter = new ActionPlanSummaryPresenter(referral, null, 'service-provider')
+        const presenter = new ActionPlanSummaryPresenter(null, 'service-provider')
 
         expect(presenter.actionPlanCreated).toEqual(false)
       })
@@ -69,8 +56,8 @@ describe(ActionPlanSummaryPresenter, () => {
 
     describe('when there is an action plan', () => {
       it('returns true', () => {
-        const actionPlan = actionPlanFactory.notSubmitted().build({ referralId: referral.id })
-        const presenter = new ActionPlanSummaryPresenter(referral, actionPlan, 'service-provider')
+        const actionPlan = actionPlanFactory.notSubmitted().build()
+        const presenter = new ActionPlanSummaryPresenter(actionPlan, 'service-provider')
 
         expect(presenter.actionPlanCreated).toEqual(true)
       })

--- a/server/routes/shared/action-plan/actionPlanSummaryPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanSummaryPresenter.ts
@@ -1,39 +1,29 @@
 import ActionPlan from '../../../models/actionPlan'
 import DateUtils from '../../../utils/dateUtils'
-import SentReferral from '../../../models/sentReferral'
+import { ActionPlanStatus } from '../../../utils/actionPlanUtils'
 
 export default class ActionPlanSummaryPresenter {
   constructor(
-    private readonly referral: SentReferral,
     private readonly actionPlan: ActionPlan | null,
-    readonly userType: 'service-provider' | 'probation-practitioner'
+    private readonly userType: 'service-provider' | 'probation-practitioner'
   ) {}
 
-  readonly viewActionPlanUrl = `/${this.userType}/referrals/${this.referral.id}/action-plan`
-
-  readonly createActionPlanFormAction = `/service-provider/referrals/${this.referral.id}/action-plan`
-
-  // this url is used to pick up action plan creation after it has been started.
-  readonly actionPlanFormUrl =
-    this.actionPlan !== null ? `/service-provider/action-plan/${this.actionPlan.id}/add-activity/1` : ''
-
   readonly text = {
-    actionPlanStatus: this.actionPlanStatus,
     actionPlanSubmittedDate: this.actionPlan?.submittedAt ? DateUtils.formattedDate(this.actionPlan?.submittedAt) : '',
     actionPlanApprovalDate: this.actionPlan?.approvedAt ? DateUtils.formattedDate(this.actionPlan?.approvedAt) : '',
   }
 
-  private get actionPlanStatus(): string {
+  get actionPlanStatus(): ActionPlanStatus {
     if (this.actionPlanApproved) {
-      return 'Approved'
+      return ActionPlanStatus.Approved
     }
     if (this.actionPlanUnderReview) {
-      return 'Awaiting approval'
+      return ActionPlanStatus.AwaitingApproval
     }
     if (this.actionPlanCreated && this.userType === 'service-provider') {
-      return 'In draft'
+      return ActionPlanStatus.InDraft
     }
-    return 'Not submitted'
+    return ActionPlanStatus.NotSubmitted
   }
 
   get actionPlanCreated(): boolean {

--- a/server/routes/shared/action-plan/actionPlanSummaryView.ts
+++ b/server/routes/shared/action-plan/actionPlanSummaryView.ts
@@ -1,33 +1,16 @@
 import { SummaryListArgs, SummaryListArgsRow, TagArgs } from '../../../utils/govukFrontendTypes'
-import ViewUtils from '../../../utils/viewUtils'
 import ActionPlanSummaryPresenter from './actionPlanSummaryPresenter'
+import ActionPlanUtils from '../../../utils/actionPlanUtils'
 
 export default class ActionPlanSummaryView {
-  constructor(private readonly presenter: ActionPlanSummaryPresenter, private readonly includeTodo: boolean) {}
+  constructor(private readonly presenter: ActionPlanSummaryPresenter) {}
 
-  private get actionPlanTagClass(): string {
-    switch (this.presenter.text.actionPlanStatus) {
-      case 'Approved':
-        return 'govuk-tag--green'
-      case 'Awaiting approval':
-        return 'govuk-tag--red'
-      case 'In draft':
-        return 'govuk-tag--yellow'
-      default:
-        return 'govuk-tag--grey'
-    }
-  }
-
-  summaryListArgs(tagMacro: (args: TagArgs) => string, csrfToken?: string): SummaryListArgs {
+  summaryListArgs(tagMacro: (args: TagArgs) => string): SummaryListArgs {
     const rows: SummaryListArgsRow[] = [
       {
         key: { text: 'Action plan status' },
         value: {
-          text: tagMacro({
-            text: this.presenter.text.actionPlanStatus,
-            classes: this.actionPlanTagClass,
-            attributes: { id: 'action-plan-status' },
-          }),
+          text: tagMacro(ActionPlanUtils.actionPlanTagArgs(this.presenter.actionPlanStatus)),
         },
       },
     ]
@@ -47,38 +30,6 @@ export default class ActionPlanSummaryView {
         key: { text: 'Approval date' },
         value: { text: this.presenter.text.actionPlanApprovalDate },
       })
-    }
-
-    if (this.includeTodo) {
-      if (this.presenter.actionPlanSubmitted) {
-        rows.push({
-          key: { text: 'Action' },
-          value: {
-            html: `<a href="${this.presenter.viewActionPlanUrl}" class="govuk-link">View action plan</a>`,
-          },
-        })
-      } else if (this.presenter.userType === 'service-provider') {
-        if (!this.presenter.actionPlanCreated) {
-          rows.push({
-            key: { text: 'Action' },
-            value: {
-              html: `<form method="post" action="${ViewUtils.escape(this.presenter.createActionPlanFormAction)}">
-                     <input type="hidden" name="_csrf" value="${ViewUtils.escape(csrfToken!)}">
-                     <button data-module="govuk-button" data-prevent-double-click="true">
-                       Create action plan
-                     </button>
-                     </form>`,
-            },
-          })
-        } else if (!this.presenter.actionPlanSubmitted) {
-          rows.push({
-            key: { text: 'Action' },
-            value: {
-              html: `<a href="${this.presenter.actionPlanFormUrl}" class="govuk-link">Complete action plan</a>`,
-            },
-          })
-        }
-      }
     }
 
     return { rows }

--- a/server/routes/shared/action-plan/actionPlanView.ts
+++ b/server/routes/shared/action-plan/actionPlanView.ts
@@ -7,7 +7,7 @@ export default class ActionPlanView {
   actionPlanSummaryView: ActionPlanSummaryView
 
   constructor(private readonly presenter: ActionPlanPresenter) {
-    this.actionPlanSummaryView = new ActionPlanSummaryView(presenter.actionPlanSummaryPresenter, false)
+    this.actionPlanSummaryView = new ActionPlanSummaryView(presenter.actionPlanSummaryPresenter)
   }
 
   private readonly backLinkArgs = {

--- a/server/utils/actionPlanUtils.ts
+++ b/server/utils/actionPlanUtils.ts
@@ -1,4 +1,12 @@
 import ApprovedActionPlanSummary from '../models/approvedActionPlanSummary'
+import { TagArgs } from './govukFrontendTypes'
+
+export enum ActionPlanStatus {
+  Approved = 'Approved',
+  AwaitingApproval = 'Awaiting approval',
+  InDraft = 'In draft',
+  NotSubmitted = 'Not submitted',
+}
 
 export default class ActionPlanUtils {
   static getLatestApprovedActionPlanSummary(
@@ -9,5 +17,26 @@ export default class ActionPlanUtils {
         return new Date(a.approvedAt) >= new Date(b.approvedAt) ? -1 : 1
       })?.[0] ?? null
     )
+  }
+
+  private static actionPlanTagClass(actionPlanStatus: ActionPlanStatus): string {
+    switch (actionPlanStatus) {
+      case ActionPlanStatus.Approved:
+        return 'govuk-tag--green'
+      case ActionPlanStatus.AwaitingApproval:
+        return 'govuk-tag--red'
+      case ActionPlanStatus.InDraft:
+        return 'govuk-tag--yellow'
+      default:
+        return 'govuk-tag--grey'
+    }
+  }
+
+  static actionPlanTagArgs(status: ActionPlanStatus): TagArgs {
+    return {
+      text: status,
+      classes: ActionPlanUtils.actionPlanTagClass(status),
+      attributes: { id: 'action-plan-status' },
+    }
   }
 }

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -28,7 +28,7 @@
     This is the action plan created by the service provider. When there are changes submitted by the service provider, you will need to review it and decide if you want to approve it.
   </p>
 
-  {{ govukSummaryList(actionPlanSummaryListArgs(govukTag)) }}
+  {{ govukTable(actionPlanTableArgs(govukTag)) }}
 
   <h2 class="govuk-heading-m">Intervention sessions</h2>
   <p class="govuk-body">

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -40,7 +40,7 @@
       Please complete the service user’s action plan and submit it to the probation practitioner for approval.
     </p>
 
-    {{ govukSummaryList(actionPlanSummaryListArgs(govukTag, csrfToken)) }}
+    {{ govukTable(actionPlanTableArgs(govukTag, csrfToken)) }}
 
   {% else %}
     <p class="govuk-body">


### PR DESCRIPTION
https://trello.com/c/hTuiKyOn/173-add-action-plan-versions-table-on-referral-progress-page

## What does this pull request do?

Provides a full historical context of previously approved action plans on the referral progress page (for SPs and PPs). e.g. 

<img width="852" alt="Screenshot 2022-02-04 at 00 55 05" src="https://user-images.githubusercontent.com/63233073/152454427-9a63e274-de2d-4f5d-8979-10e979be835c.png">

## What is the intent behind these changes?

improve clarity about the current action plan and previous versions
