### PR TITLE
pass query param to specify the page the case note was located on to redirect back to via backlink

### DIFF
--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -293,21 +293,5 @@ describe.each([
           expect(res.text).toContain('firstName lastName')
         })
     })
-    it('incorrect backlink page should throw an error', async () => {
-      const caseNote = caseNoteFactory.build({
-        subject: 'case note subject text',
-        body: 'case note body text',
-        sentAt: '2021-01-01T09:45:21.986389Z',
-      })
-      const userDetails = userDetailsFactory.build({ name: 'firstName lastName' })
-      interventionsService.getCaseNote.mockResolvedValue(caseNote)
-      hmppsAuthService.getUserDetailsByUsername.mockResolvedValue(userDetails)
-      await request(app)
-        .get(`/${user.userType}/case-note/${caseNote.id}?backlinkPageNumber=abc`)
-        .expect(500)
-        .expect(res => {
-          expect(res.text).toContain('Incorrect url.')
-        })
-    })
   })
 })

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -293,5 +293,21 @@ describe.each([
           expect(res.text).toContain('firstName lastName')
         })
     })
+    it('incorrect backlink page should throw an error', async () => {
+      const caseNote = caseNoteFactory.build({
+        subject: 'case note subject text',
+        body: 'case note body text',
+        sentAt: '2021-01-01T09:45:21.986389Z',
+      })
+      const userDetails = userDetailsFactory.build({ name: 'firstName lastName' })
+      interventionsService.getCaseNote.mockResolvedValue(caseNote)
+      hmppsAuthService.getUserDetailsByUsername.mockResolvedValue(userDetails)
+      await request(app)
+        .get(`/${user.userType}/case-note/${caseNote.id}?backlinkPageNumber=abc`)
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain('Incorrect url.')
+        })
+    })
   })
 })

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -135,7 +135,7 @@ export default class CaseNotesController {
     const { accessToken } = res.locals.user.token
     const { caseNoteId } = req.params
     const backlinkPageNumber = req.query.backlinkPageNumber as string
-    if (!Number(backlinkPageNumber)) {
+    if (backlinkPageNumber && !Number(backlinkPageNumber)) {
       // This is to prevent the url being manipulated.
       throw createError(500, `The page number for a case not backlink should only ever be a number.`, {
         userMessage: 'Incorrect url.',

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -134,13 +134,20 @@ export default class CaseNotesController {
   ): Promise<void> {
     const { accessToken } = res.locals.user.token
     const { caseNoteId } = req.params
+    const backlinkPageNumber = req.query.backlinkPageNumber as string
+    if (!Number(backlinkPageNumber)) {
+      // This is to prevent the url being manipulated.
+      throw createError(500, `The page number for a case not backlink should only ever be a number.`, {
+        userMessage: 'Incorrect url.',
+      })
+    }
     const caseNote = await this.interventionsService.getCaseNote(accessToken, caseNoteId)
     const sentByUserDetails = await this.hmppsAuthService.getUserDetailsByUsername(
       accessToken,
       caseNote.sentBy.username
     )
     const sentByUserName = sentByUserDetails.name
-    const presenter = new CaseNotePresenter(caseNote, sentByUserName, loggedInUserType)
+    const presenter = new CaseNotePresenter(caseNote, sentByUserName, loggedInUserType, backlinkPageNumber)
     const view = new CaseNoteView(presenter)
     ControllerUtils.renderWithLayout(res, view, null)
   }

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -134,7 +134,10 @@ export default class CaseNotesController {
   ): Promise<void> {
     const { accessToken } = res.locals.user.token
     const { caseNoteId } = req.params
-    const backlinkPageNumber = Number(req.query.backlinkPageNumber) ?? null
+
+    const parsedBacklinkPageNumber = Number(req.query.backlinkPageNumber)
+    const backlinkPageNumber =
+      Number.isNaN(parsedBacklinkPageNumber) || parsedBacklinkPageNumber < 1 ? null : parsedBacklinkPageNumber
 
     const caseNote = await this.interventionsService.getCaseNote(accessToken, caseNoteId)
     const sentByUserDetails = await this.hmppsAuthService.getUserDetailsByUsername(

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -134,13 +134,8 @@ export default class CaseNotesController {
   ): Promise<void> {
     const { accessToken } = res.locals.user.token
     const { caseNoteId } = req.params
-    const backlinkPageNumber = req.query.backlinkPageNumber as string
-    if (backlinkPageNumber && !Number(backlinkPageNumber)) {
-      // This is to prevent the url being manipulated.
-      throw createError(500, `The page number for a case not backlink should only ever be a number.`, {
-        userMessage: 'Incorrect url.',
-      })
-    }
+    const backlinkPageNumber = Number(req.query.backlinkPageNumber) ?? null
+
     const caseNote = await this.interventionsService.getCaseNote(accessToken, caseNoteId)
     const sentByUserDetails = await this.hmppsAuthService.getUserDetailsByUsername(
       accessToken,

--- a/server/routes/caseNotes/view/caseNotePresenter.test.ts
+++ b/server/routes/caseNotes/view/caseNotePresenter.test.ts
@@ -8,7 +8,7 @@ describe('CaseNotePresenter', () => {
         caseNoteFactory.build({ referralId: '8b588c52-91fd-48fa-89fe-6438748bceda' }),
         'firstName lastName',
         'service-provider',
-        '2'
+        2
       )
       expect(presenter.backLinkHref).toEqual(
         '/service-provider/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/case-notes?page=2'
@@ -20,7 +20,7 @@ describe('CaseNotePresenter', () => {
         caseNoteFactory.build({ referralId: '8b588c52-91fd-48fa-89fe-6438748bceda' }),
         'firstName lastName',
         'probation-practitioner',
-        '1'
+        1
       )
       expect(presenter.backLinkHref).toEqual(
         '/probation-practitioner/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/case-notes?page=1'
@@ -38,7 +38,7 @@ describe('CaseNotePresenter', () => {
         }),
         'firstName lastName',
         'probation-practitioner',
-        '1'
+        1
       )
       expect(presenter.caseNoteSummary.subject).toEqual('Case note subject')
       expect(presenter.caseNoteSummary.body).toEqual('Case note body text')

--- a/server/routes/caseNotes/view/caseNotePresenter.test.ts
+++ b/server/routes/caseNotes/view/caseNotePresenter.test.ts
@@ -7,10 +7,11 @@ describe('CaseNotePresenter', () => {
       const presenter = new CaseNotePresenter(
         caseNoteFactory.build({ referralId: '8b588c52-91fd-48fa-89fe-6438748bceda' }),
         'firstName lastName',
-        'service-provider'
+        'service-provider',
+        '2'
       )
       expect(presenter.backLinkHref).toEqual(
-        '/service-provider/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/case-notes'
+        '/service-provider/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/case-notes?page=2'
       )
     })
 
@@ -18,10 +19,11 @@ describe('CaseNotePresenter', () => {
       const presenter = new CaseNotePresenter(
         caseNoteFactory.build({ referralId: '8b588c52-91fd-48fa-89fe-6438748bceda' }),
         'firstName lastName',
-        'probation-practitioner'
+        'probation-practitioner',
+        '1'
       )
       expect(presenter.backLinkHref).toEqual(
-        '/probation-practitioner/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/case-notes'
+        '/probation-practitioner/referrals/8b588c52-91fd-48fa-89fe-6438748bceda/case-notes?page=1'
       )
     })
   })
@@ -35,7 +37,8 @@ describe('CaseNotePresenter', () => {
           sentAt: '2021-01-01T09:45:21.986389Z',
         }),
         'firstName lastName',
-        'probation-practitioner'
+        'probation-practitioner',
+        '1'
       )
       expect(presenter.caseNoteSummary.subject).toEqual('Case note subject')
       expect(presenter.caseNoteSummary.body).toEqual('Case note body text')

--- a/server/routes/caseNotes/view/caseNotePresenter.ts
+++ b/server/routes/caseNotes/view/caseNotePresenter.ts
@@ -20,7 +20,7 @@ export default class CaseNotePresenter {
   // There is the chance that further case notes are added which pushes the selected case note onto another page.
   // The backlink will now take them to the page they came from, but potentially not the page the case note now lives.
   backLinkHref = `/${this.loggedInUserType}/referrals/${this.caseNote.referralId}/case-notes${
-    Number(this.backlinkPageNumber) ? `?page=${this.backlinkPageNumber}` : ''
+    this.backlinkPageNumber !== null ? `?page=${this.backlinkPageNumber}` : ''
   }`
 
   readonly caseNoteSummary: CaseNoteSummary = {

--- a/server/routes/caseNotes/view/caseNotePresenter.ts
+++ b/server/routes/caseNotes/view/caseNotePresenter.ts
@@ -14,12 +14,14 @@ export default class CaseNotePresenter {
     private caseNote: CaseNote,
     private sentByUserName: string,
     public loggedInUserType: 'service-provider' | 'probation-practitioner',
-    private backlinkPageNumber: string
+    private backlinkPageNumber: number | null
   ) {}
 
   // There is the chance that further case notes are added which pushes the selected case note onto another page.
   // The backlink will now take them to the page they came from, but potentially not the page the case note now lives.
-  backLinkHref = `/${this.loggedInUserType}/referrals/${this.caseNote.referralId}/case-notes?page=${this.backlinkPageNumber}`
+  backLinkHref = `/${this.loggedInUserType}/referrals/${this.caseNote.referralId}/case-notes${
+    Number(this.backlinkPageNumber) ? `?page=${this.backlinkPageNumber}` : ''
+  }`
 
   readonly caseNoteSummary: CaseNoteSummary = {
     subject: this.caseNote.subject,

--- a/server/routes/caseNotes/view/caseNotePresenter.ts
+++ b/server/routes/caseNotes/view/caseNotePresenter.ts
@@ -13,10 +13,13 @@ export default class CaseNotePresenter {
   constructor(
     private caseNote: CaseNote,
     private sentByUserName: string,
-    public loggedInUserType: 'service-provider' | 'probation-practitioner'
+    public loggedInUserType: 'service-provider' | 'probation-practitioner',
+    private backlinkPageNumber: string
   ) {}
 
-  backLinkHref = `/${this.loggedInUserType}/referrals/${this.caseNote.referralId}/case-notes`
+  // There is the chance that further case notes are added which pushes the selected case note onto another page.
+  // The backlink will now take them to the page they came from, but potentially not the page the case note now lives.
+  backLinkHref = `/${this.loggedInUserType}/referrals/${this.caseNote.referralId}/case-notes?page=${this.backlinkPageNumber}`
 
   readonly caseNoteSummary: CaseNoteSummary = {
     subject: this.caseNote.subject,

--- a/server/routes/caseNotes/viewAll/caseNotesPresenter.test.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesPresenter.test.ts
@@ -66,7 +66,7 @@ describe('CaseNotesPresenter', () => {
         'service-provider'
       )
       expect(presenter.tableRows[0].caseNoteLink).toEqual(
-        '/service-provider/case-note/025a807d-a631-4559-be74-664ba62db279'
+        '/service-provider/case-note/025a807d-a631-4559-be74-664ba62db279?backlinkPageNumber=1'
       )
       presenter = new CaseNotesPresenter(
         referralId,
@@ -77,7 +77,7 @@ describe('CaseNotesPresenter', () => {
         'probation-practitioner'
       )
       expect(presenter.tableRows[0].caseNoteLink).toEqual(
-        '/probation-practitioner/case-note/025a807d-a631-4559-be74-664ba62db279'
+        '/probation-practitioner/case-note/025a807d-a631-4559-be74-664ba62db279?backlinkPageNumber=1'
       )
     })
 

--- a/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
@@ -43,6 +43,8 @@ export default class CaseNotesPresenter {
     title: `${utils.convertToTitleCase(this.intervention.contractType.name)}: case notes`,
   }
 
+  readonly backlinkPageNumber = this.caseNotes.number + 1
+
   readonly hrefBackLink = `/${this.loggedInUserType}/dashboard`
 
   readonly hrefCaseNoteStart = `/${this.loggedInUserType}/referrals/${this.referralId}/add-case-note/start`
@@ -65,7 +67,8 @@ export default class CaseNotesPresenter {
       sentByUserType: caseNote.sentBy.authSource === 'delius' ? 'probation practitioner' : 'service provider',
       subject: caseNote.subject,
       body: caseNote.body,
-      caseNoteLink: `/${this.loggedInUserType}/case-note/${caseNote.id}`,
+      // caseNoteLink: `/${this.loggedInUserType}/case-note/${caseNote.id}`,
+      caseNoteLink: `/${this.loggedInUserType}/case-note/${caseNote.id}?backlinkPageNumber=${this.backlinkPageNumber}`,
     }
   })
 }

--- a/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
@@ -67,7 +67,6 @@ export default class CaseNotesPresenter {
       sentByUserType: caseNote.sentBy.authSource === 'delius' ? 'probation practitioner' : 'service provider',
       subject: caseNote.subject,
       body: caseNote.body,
-      // caseNoteLink: `/${this.loggedInUserType}/case-note/${caseNote.id}`,
       caseNoteLink: `/${this.loggedInUserType}/case-note/${caseNote.id}?backlinkPageNumber=${this.backlinkPageNumber}`,
     }
   })


### PR DESCRIPTION
## What does this pull request do?

Adds a new query param to the case note url so that the backlink can redirect to the page it was selected from.

## What is the intent behind these changes?

Currently the backlink on a case note page redirects back to the very first page. This should now redirect to the page the case note was selected from.
