### PR TITLE
Upgrade base image to use alpine 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUILD_NUMBER
 ARG GIT_REF
 
-FROM node:14-alpine3.13 as base
+FROM node:14-alpine3.15 as base
 
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 


### PR DESCRIPTION


## What does this pull request do?

Upgrade base image to use alpine 3.15

## What is the intent behind these changes?

Alpine 3.13 ends support on 2022-11-01, 3.15 ends support on 2023-11-01
