### PR TITLE
remove logic in action plan back link and always go back to intervention progress

### DIFF
--- a/server/routes/shared/action-plan/actionPlanView.ts
+++ b/server/routes/shared/action-plan/actionPlanView.ts
@@ -12,9 +12,7 @@ export default class ActionPlanView {
 
   private readonly backLinkArgs = {
     text: 'Back',
-    href: this.presenter.showPreviousActionPlanNotificationBanner
-      ? this.presenter.viewProbationPractitionerLatestActionPlanURL
-      : this.presenter.interventionProgressURL,
+    href: this.presenter.interventionProgressURL,
   }
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)


### PR DESCRIPTION
## What does this pull request do?
remove logic in action plan back link and always go back to intervention progress

this is somewhat temporary, since the other link can take users to the wrong page or
even to action plans that are unsubmitted. for now always going back to the intervention
progress is at least consistent.


## What is the intent behind these changes?
stop unexpected behaviour when clicking action plan back button
