### PR TITLE
ensure links to previously approved and 'current' action plans always point to the right pages

### DIFF
--- a/integration_tests/integration/monitor.spec.js
+++ b/integration_tests/integration/monitor.spec.js
@@ -684,7 +684,7 @@ describe('Probation Practitioner monitor journey', () => {
       cy.contains("You're looking at an older version of the action plan.")
       cy.contains('Achieve an older thing')
       cy.contains('Suggested number of sessions: 3')
-      cy.contains('View the current action plan').click()
+      cy.contains('View the latest approved action plan').click()
       cy.contains("You're looking at an older version of the action plan.").should('not.exist')
     })
   })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -54,6 +54,7 @@ import EndOfServiceReportPresenter from '../shared/endOfServiceReport/endOfServi
 import EndOfServiceReportView from '../shared/endOfServiceReport/endOfServiceReportView'
 import ServiceProviderSentReferralSummary from '../../models/serviceProviderSentReferralSummary'
 import ActionPlanUtils from '../../utils/actionPlanUtils'
+import SentReferral from '../../models/sentReferral'
 
 export interface DraftAssignmentData {
   email: string | null
@@ -771,19 +772,8 @@ export default class ServiceProviderReferralsController {
       })
     }
 
-    const [serviceCategories, actionPlan, serviceUser] = await Promise.all([
-      Promise.all(
-        sentReferral.referral.serviceCategoryIds.map(id =>
-          this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, id)
-        )
-      ),
-      this.interventionsService.getActionPlan(accessToken, sentReferral.actionPlanId),
-      this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
-    ])
-
-    const presenter = new ActionPlanPresenter(sentReferral, actionPlan, serviceCategories, 'service-provider')
-    const view = new ActionPlanView(presenter)
-    ControllerUtils.renderWithLayout(res, view, serviceUser)
+    const actionPlan = await this.interventionsService.getActionPlan(accessToken, sentReferral.actionPlanId)
+    return this.renderActionPlan(res, sentReferral, actionPlan)
   }
 
   async viewActionPlanById(req: Request, res: Response): Promise<void> {
@@ -793,16 +783,30 @@ export default class ServiceProviderReferralsController {
     const actionPlan = await this.interventionsService.getActionPlan(accessToken, id)
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, actionPlan.referralId)
 
-    const [serviceCategories, serviceUser] = await Promise.all([
+    return this.renderActionPlan(res, sentReferral, actionPlan)
+  }
+
+  private async renderActionPlan(res: Response, sentReferral: SentReferral, actionPlan: ActionPlan) {
+    const { accessToken } = res.locals.user.token
+
+    const [serviceCategories, serviceUser, approvedActionPlanSummaries] = await Promise.all([
       Promise.all(
         sentReferral.referral.serviceCategoryIds.map(it =>
           this.interventionsService.getServiceCategory(res.locals.user.token.accessToken, it)
         )
       ),
       this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn),
+      this.interventionsService.getApprovedActionPlanSummaries(accessToken, sentReferral.id),
     ])
 
-    const presenter = new ActionPlanPresenter(sentReferral, actionPlan, serviceCategories, 'service-provider')
+    const presenter = new ActionPlanPresenter(
+      sentReferral,
+      actionPlan,
+      serviceCategories,
+      'service-provider',
+      null,
+      approvedActionPlanSummaries
+    )
     const view = new ActionPlanView(presenter)
     ControllerUtils.renderWithLayout(res, view, serviceUser)
   }

--- a/server/routes/shared/action-plan/actionPlanPresenter.test.ts
+++ b/server/routes/shared/action-plan/actionPlanPresenter.test.ts
@@ -237,12 +237,12 @@ describe(InterventionProgressPresenter, () => {
         {
           approvalDate: '12 Jun 2021',
           versionNumber: 3,
-          href: `/probation-practitioner/referrals/${referralWithLatestActionPlan.id}/action-plan`,
+          href: `/service-provider/action-plan/${latestActionPlanId}`,
         },
         {
           approvalDate: '11 Jun 2021',
           versionNumber: 2,
-          href: `/probation-practitioner/action-plan/${otherActionPlanId}`,
+          href: `/service-provider/action-plan/${otherActionPlanId}`,
         },
         { approvalDate: '10 Jun 2021', versionNumber: 1, href: null },
       ])
@@ -304,8 +304,7 @@ describe(InterventionProgressPresenter, () => {
         referral,
         submittedActionPlan,
         serviceCategories,
-        'service-provider',
-        null
+        'service-provider'
       )
 
       expect(actionPlanPresenter.showActionPlanVersions).toEqual(false)
@@ -313,59 +312,46 @@ describe(InterventionProgressPresenter, () => {
   })
 
   describe('showPreviousActionPlanNotificationBanner', () => {
-    describe('when the user is an SP', () => {
-      it("returns false, as they can't view previous revisions", () => {
-        const actionPlan = actionPlanFactory.build()
-        const approvedActionPlanSummaries = approvedActionPlanSummaryFactory.buildList(3)
-
-        const actionPlanPresenter = new ActionPlanPresenter(
-          referral,
-          actionPlan,
-          serviceCategories,
-          'service-provider',
-          null,
-          approvedActionPlanSummaries
-        )
-
-        expect(actionPlanPresenter.showPreviousActionPlanNotificationBanner).toEqual(false)
-      })
-    })
-
-    describe('when the user is a PP', () => {
+    describe('for both SP and PP users', () => {
+      const users: ('service-provider' | 'probation-practitioner')[] = ['probation-practitioner', 'service-provider']
       it("returns false when the viewed action plan's ID matches the latest action plan's ID on the referral", () => {
         const referralWithLatestActionPlan = referralFactory.assigned().build({ actionPlanId: 'latest-id' })
         const latestActionPlan = actionPlanFactory.build({ id: 'latest-id' })
 
         const approvedActionPlanSummaries = approvedActionPlanSummaryFactory.buildList(3)
 
-        const actionPlanPresenter = new ActionPlanPresenter(
-          referralWithLatestActionPlan,
-          latestActionPlan,
-          serviceCategories,
-          'probation-practitioner',
-          null,
-          approvedActionPlanSummaries
-        )
+        users.forEach(userType => {
+          const actionPlanPresenter = new ActionPlanPresenter(
+            referralWithLatestActionPlan,
+            latestActionPlan,
+            serviceCategories,
+            userType,
+            null,
+            approvedActionPlanSummaries
+          )
 
-        expect(actionPlanPresenter.showPreviousActionPlanNotificationBanner).toEqual(false)
+          expect(actionPlanPresenter.showPreviousActionPlanNotificationBanner).toEqual(false)
+        })
       })
 
-      it("returns true when the viewed action plan's ID doesn't match the latest action plan's ID on the referral", () => {
+      it("returns true when the viewed action plan is approved and its ID doesn't match the latest approved action plan id", () => {
         const referralWithNewerActionPlan = referralFactory.assigned().build({ actionPlanId: 'latest-id' })
-        const actionPlan = actionPlanFactory.build({ id: 'not-latest-id' })
+        const actionPlan = actionPlanFactory.approved().build({ id: 'not-latest-id' })
 
         const approvedActionPlanSummaries = approvedActionPlanSummaryFactory.buildList(3)
 
-        const actionPlanPresenter = new ActionPlanPresenter(
-          referralWithNewerActionPlan,
-          actionPlan,
-          serviceCategories,
-          'probation-practitioner',
-          null,
-          approvedActionPlanSummaries
-        )
+        users.forEach(userType => {
+          const actionPlanPresenter = new ActionPlanPresenter(
+            referralWithNewerActionPlan,
+            actionPlan,
+            serviceCategories,
+            userType,
+            null,
+            approvedActionPlanSummaries
+          )
 
-        expect(actionPlanPresenter.showPreviousActionPlanNotificationBanner).toEqual(true)
+          expect(actionPlanPresenter.showPreviousActionPlanNotificationBanner).toEqual(true)
+        })
       })
     })
   })

--- a/server/routes/shared/action-plan/actionPlanProgressPresenter.ts
+++ b/server/routes/shared/action-plan/actionPlanProgressPresenter.ts
@@ -1,17 +1,22 @@
 import ActionPlan from '../../../models/actionPlan'
 import ApprovedActionPlanSummary from '../../../models/approvedActionPlanSummary'
 import ActionPlanSummaryPresenter from './actionPlanSummaryPresenter'
+import ActionPlanUtils from '../../../utils/actionPlanUtils'
 
 export default class ActionPlanProgressPresenter {
   currentActionPlanSummaryPresenter: ActionPlanSummaryPresenter
 
+  readonly sortedApprovedActionPlanSummaries: ApprovedActionPlanSummary[]
+
   constructor(
     private readonly referralId: string,
     private readonly currentActionPlan: ActionPlan | null,
-    readonly approvedActionPlanSummaries: ApprovedActionPlanSummary[],
+    approvedActionPlanSummaries: ApprovedActionPlanSummary[],
     readonly userType: 'service-provider' | 'probation-practitioner'
   ) {
     this.currentActionPlanSummaryPresenter = new ActionPlanSummaryPresenter(currentActionPlan, userType)
+    this.sortedApprovedActionPlanSummaries =
+      ActionPlanUtils.sortApprovedActionPlanSummaries(approvedActionPlanSummaries)
   }
 
   readonly tableHeaders = ['Version', 'Status', 'Submitted', 'Approved', 'Action']

--- a/server/routes/shared/action-plan/actionPlanProgressView.ts
+++ b/server/routes/shared/action-plan/actionPlanProgressView.ts
@@ -15,9 +15,9 @@ export default class ActionPlanProgressView {
     }
 
     rows.push(
-      ...this.presenter.approvedActionPlanSummaries.map((summary, i) => [
+      ...this.presenter.sortedApprovedActionPlanSummaries.map((summary, i) => [
         {
-          text: (this.presenter.approvedActionPlanSummaries.length - i).toString(),
+          text: (this.presenter.sortedApprovedActionPlanSummaries.length - i).toString(),
           classes: 'action-plan-version',
         },
         {

--- a/server/routes/shared/action-plan/actionPlanView.ts
+++ b/server/routes/shared/action-plan/actionPlanView.ts
@@ -56,7 +56,7 @@ export default class ActionPlanView {
 
   get viewingPreviousActionPlanNotificationBannerArgs(): NotificationBannerArgs {
     return {
-      html: `<p class="govuk-body-m">You're looking at an older version of the action plan.</p><a href="${this.presenter.viewProbationPractitionerLatestActionPlanURL}">View the current action plan.</a>`,
+      html: `<p class="govuk-body-m">You're looking at an older version of the action plan.</p><a href="${this.presenter.latestApprovedActionPlanUrl}">View the latest approved action plan.</a>`,
     }
   }
 

--- a/server/utils/actionPlanUtils.test.ts
+++ b/server/utils/actionPlanUtils.test.ts
@@ -2,6 +2,28 @@ import ActionPlanUtils from './actionPlanUtils'
 import Factory from '../../testutils/factories/approvedActionPlanSummary'
 
 describe(ActionPlanUtils, () => {
+  describe('sortApprovedActionPlanSummaries', () => {
+    it('returns empty list for an empty list', () => {
+      const sorted = ActionPlanUtils.sortApprovedActionPlanSummaries([])
+      expect(sorted).toEqual([])
+    })
+
+    it('returns a list sorted by approval date', () => {
+      const sorted = ActionPlanUtils.sortApprovedActionPlanSummaries([
+        Factory.build({ approvedAt: '2021-01-01T12:12:12+00:00' }),
+        Factory.build({ approvedAt: '2021-01-02T14:00:00+00:00' }), // newest
+        Factory.build({ approvedAt: '2021-01-02T12:12:12+00:00' }),
+        Factory.build({ approvedAt: '2020-01-02T12:12:12+00:00' }), // oldest
+      ])
+      expect(sorted.map(it => it.approvedAt)).toEqual([
+        '2021-01-02T14:00:00+00:00',
+        '2021-01-02T12:12:12+00:00',
+        '2021-01-01T12:12:12+00:00',
+        '2020-01-02T12:12:12+00:00',
+      ])
+    })
+  })
+
   describe('getLatestApprovedActionPlanSummary', () => {
     it('returns null for an empty list', () => {
       const latest = ActionPlanUtils.getLatestApprovedActionPlanSummary([])

--- a/server/utils/actionPlanUtils.ts
+++ b/server/utils/actionPlanUtils.ts
@@ -9,14 +9,16 @@ export enum ActionPlanStatus {
 }
 
 export default class ActionPlanUtils {
+  static sortApprovedActionPlanSummaries(
+    actionPlanSummaries: ApprovedActionPlanSummary[]
+  ): ApprovedActionPlanSummary[] {
+    return actionPlanSummaries.sort((a, b) => new Date(b.approvedAt).getTime() - new Date(a.approvedAt).getTime())
+  }
+
   static getLatestApprovedActionPlanSummary(
     actionPlanSummaries: ApprovedActionPlanSummary[]
   ): ApprovedActionPlanSummary | null {
-    return (
-      actionPlanSummaries.sort((a, b) => {
-        return new Date(a.approvedAt) >= new Date(b.approvedAt) ? -1 : 1
-      })?.[0] ?? null
-    )
+    return ActionPlanUtils.sortApprovedActionPlanSummaries(actionPlanSummaries)?.[0] ?? null
   }
 
   private static actionPlanTagClass(actionPlanStatus: ActionPlanStatus): string {


### PR DESCRIPTION
## What does this pull request do?


fix a bug where PP clicks on 'view current action plan' and get taken to an unapproved AP. also fixes a bug where the 'view current action plan' banner appears on the current action plan if the SP has created a new draft. 

ALSO

always ensure approved action plans are sorted by approval date

## What is the intent behind these changes?

less confusion when viewing older action plans