### PR TITLE
Add simple helper function for parsing ints from query params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@ministryofjustice/frontend": "1.0.1",
         "@sentry/node": "^6.17.9",
         "@types/connect-flash": "0.0.37",
+        "@types/express-serve-static-core": "^4.17.28",
+        "@types/qs": "^6.9.7",
         "@types/uuid": "^8.3.4",
         "agentkeepalive": "^4.2.0",
         "applicationinsights": "^2.2.1",
@@ -3596,9 +3598,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.21.tgz",
-      "integrity": "sha512-gwCiEZqW6f7EoR8TTEfalyEhb1zA5jQJnRngr97+3pzMaO1RKoI1w2bw07TK72renMUVWcWS5mLI6rk1NqN0nA==",
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3867,9 +3869,9 @@
       "dev": true
     },
     "node_modules/@types/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA=="
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.3",
@@ -22252,9 +22254,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.21.tgz",
-      "integrity": "sha512-gwCiEZqW6f7EoR8TTEfalyEhb1zA5jQJnRngr97+3pzMaO1RKoI1w2bw07TK72renMUVWcWS5mLI6rk1NqN0nA==",
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -22522,9 +22524,9 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA=="
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/range-parser": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
     "@ministryofjustice/frontend": "1.0.1",
     "@sentry/node": "^6.17.9",
     "@types/connect-flash": "0.0.37",
+    "@types/express-serve-static-core": "^4.17.28",
+    "@types/qs": "^6.9.7",
     "@types/uuid": "^8.3.4",
     "agentkeepalive": "^4.2.0",
     "applicationinsights": "^2.2.1",

--- a/server/config.ts
+++ b/server/config.ts
@@ -115,10 +115,10 @@ export default {
       agent: new AgentConfig(),
       dashboardPageSize: {
         pp: {
-          openCases: get('PP_OPEN_CASES_PAGE_SIZE', '500'),
-          unassignedCases: get('PP_UNASSIGNED_CASES_PAGE_SIZE', '500'),
-          completedCases: get('PP_MY_CASES_PAGE_SIZE', '500'),
-          cancelledCases: get('PP_CANCELLED_CASES_PAGE_SIZE', '500'),
+          openCases: Number(get('PP_OPEN_CASES_PAGE_SIZE', '500')),
+          unassignedCases: Number(get('PP_UNASSIGNED_CASES_PAGE_SIZE', '500')),
+          completedCases: Number(get('PP_MY_CASES_PAGE_SIZE', '500')),
+          cancelledCases: Number(get('PP_CANCELLED_CASES_PAGE_SIZE', '500')),
         },
       },
     },

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -135,9 +135,7 @@ export default class CaseNotesController {
     const { accessToken } = res.locals.user.token
     const { caseNoteId } = req.params
 
-    const parsedBacklinkPageNumber = Number(req.query.backlinkPageNumber)
-    const backlinkPageNumber =
-      Number.isNaN(parsedBacklinkPageNumber) || parsedBacklinkPageNumber < 1 ? null : parsedBacklinkPageNumber
+    const backlinkPageNumber = ControllerUtils.parseQueryParamAsPositiveInteger(req, 'backlinkPageNumber')
 
     const caseNote = await this.interventionsService.getCaseNote(accessToken, caseNoteId)
     const sentByUserDetails = await this.hmppsAuthService.getUserDetailsByUsername(

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -150,7 +150,7 @@ describe('GET /probation-practitioner/dashboard', () => {
     })
   })
   it('displays a dashboard page with invalid page number', async () => {
-    apiConfig.apis.interventionsService.dashboardPageSize.pp.openCases = '1'
+    apiConfig.apis.interventionsService.dashboardPageSize.pp.openCases = 1
     const intervention = interventionFactory.build({ id: '1', title: 'Accommodation Services - West Midlands' })
     const referrals = [
       sentReferralFactory.assigned().build({

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -69,11 +69,11 @@ export default class ProbationPractitionerReferralsController {
     res: Response,
     getSentReferralsFilterParams: GetSentReferralsFilterParams,
     dashboardType: PPDashboardType,
-    pageSize: string
+    pageSize: number
   ) {
     const paginationQuery = {
       page: ControllerUtils.parseQueryParamAsPositiveInteger(req, 'page') ?? undefined,
-      size: Number(pageSize),
+      size: pageSize,
       sort: ['sentAt,DESC'],
     }
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -71,9 +71,8 @@ export default class ProbationPractitionerReferralsController {
     dashboardType: PPDashboardType,
     pageSize: string
   ) {
-    const pageNumber = req.query.page
     const paginationQuery = {
-      page: pageNumber ? Number(pageNumber) : undefined,
+      page: ControllerUtils.parseQueryParamAsPositiveInteger(req, 'page') ?? undefined,
       size: Number(pageSize),
       sort: ['sentAt,DESC'],
     }

--- a/server/utils/controllerUtils.test.ts
+++ b/server/utils/controllerUtils.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { ParsedQs } from 'qs'
 import ControllerUtils from './controllerUtils'
 import deliusServiceUserFactory from '../../testutils/factories/deliusServiceUser'
 import config from '../config'
@@ -6,6 +7,31 @@ import DraftsService from '../services/draftsService'
 import { createDraftFactory } from '../../testutils/factories/draft'
 
 describe(ControllerUtils, () => {
+  describe('parseQueryParamAsPositiveInteger', () => {
+    it('returns null for missing query param', () => {
+      expect(
+        ControllerUtils.parseQueryParamAsPositiveInteger({ query: {} as ParsedQs } as Request, 'missing')
+      ).toBeNull()
+    })
+
+    it('returns null for invalid int values', () => {
+      const req = {
+        query: { value1: '[]', value2: '-1', value3: 'NaN', value4: '0', value5: [] } as ParsedQs,
+      } as Request
+      expect(ControllerUtils.parseQueryParamAsPositiveInteger(req, 'value1')).toBeNull()
+      expect(ControllerUtils.parseQueryParamAsPositiveInteger(req, 'value2')).toBeNull()
+      expect(ControllerUtils.parseQueryParamAsPositiveInteger(req, 'value3')).toBeNull()
+      expect(ControllerUtils.parseQueryParamAsPositiveInteger(req, 'value4')).toBeNull()
+      expect(ControllerUtils.parseQueryParamAsPositiveInteger(req, 'value5')).toBeNull()
+    })
+
+    it('returns a number for valid int values', () => {
+      const req = { query: { value1: '12', value2: '345' } as ParsedQs } as Request
+      expect(ControllerUtils.parseQueryParamAsPositiveInteger(req, 'value1')).toEqual(12)
+      expect(ControllerUtils.parseQueryParamAsPositiveInteger(req, 'value2')).toEqual(345)
+    })
+  })
+
   describe('.renderWithLayout', () => {
     describe('with null serviceUser', () => {
       it('calls render on the response, passing the content view’s renderArgs augmented with a headerPresenter object in the locals', () => {

--- a/server/utils/controllerUtils.ts
+++ b/server/utils/controllerUtils.ts
@@ -55,4 +55,9 @@ export default class ControllerUtils {
 
     return { rendered: false, draft }
   }
+
+  static parseQueryParamAsPositiveInteger(req: Request, name: string): number | null {
+    const param = Number(req.query[name])
+    return Number.isNaN(param) || param < 1 ? null : param
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

Add simple helper function for parsing ints from query params

## What is the intent behind these changes?

allow this functionality to be: reused; unit tested; easily identified.
