### PR TITLE
fix sorting of ROSH panel by converting input groups to lowercase before comparison with fixed order list

### DIFF
--- a/server/routes/shared/roshPanelPresenter.test.ts
+++ b/server/routes/shared/roshPanelPresenter.test.ts
@@ -56,10 +56,10 @@ describe(RoshPanelPresenter, () => {
     it('returns rows for each risk group in the correct order', () => {
       const presenter = new RoshPanelPresenter(riskSummary.build())
       expect(presenter.roshAnalysisRows).toEqual([
-        { riskTo: 'children', riskScore: 'HIGH' },
-        { riskTo: 'public', riskScore: 'LOW' },
-        { riskTo: 'known adult', riskScore: 'HIGH' },
-        { riskTo: 'staff', riskScore: 'VERY_HIGH' },
+        { riskTo: 'Children', riskScore: 'HIGH' },
+        { riskTo: 'Public', riskScore: 'LOW' },
+        { riskTo: 'Known adult', riskScore: 'HIGH' },
+        { riskTo: 'Staff', riskScore: 'VERY_HIGH' },
       ])
     })
   })

--- a/server/routes/shared/roshPanelPresenter.ts
+++ b/server/routes/shared/roshPanelPresenter.ts
@@ -104,7 +104,7 @@ export default class RoshPanelPresenter {
     roshGroupsDisplayOrder.forEach(group => {
       // We get the index here and then push/splice using that index value to save having to `find` on the array twice
       const matchingRoshGroupIndex = unsortedRiskGroups.findIndex(obj => {
-        return obj.riskTo === group
+        return obj.riskTo.toLowerCase() === group
       })
       if (matchingRoshGroupIndex !== -1) {
         sortedRiskGroups.push(unsortedRiskGroups[matchingRoshGroupIndex])

--- a/testutils/factories/riskSummary.ts
+++ b/testutils/factories/riskSummary.ts
@@ -21,9 +21,9 @@ export default Factory.define<RiskSummary>(() => ({
   },
   summary: {
     riskInCommunity: {
-      LOW: ['public'],
-      HIGH: ['children', 'known adult'],
-      VERY_HIGH: ['staff'],
+      LOW: ['Public'],
+      HIGH: ['Known adult', 'Children'],
+      VERY_HIGH: ['Staff'],
     },
     natureOfRisk: 'physically aggressive',
     riskImminence: 'can happen at the drop of a hat',


### PR DESCRIPTION


## What does this pull request do?

fix sorting of ROSH panel by converting input groups to lowercase before comparison with fixed order list

## What is the intent behind these changes?

fix ordering of rosh panel box in prod environments where the groups are capitalized.
