### PR TITLE
Fix sorting by 'intervention type' on dashboards.

### DIFF
--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
@@ -54,7 +54,7 @@ export default class DashboardPresenter {
     },
     {
       columnName: 'Intervention type',
-      sortField: 'intervention.dynamicFrameworkContract.contractType',
+      sortField: 'intervention.title',
     },
     {
       columnName: 'Provider',

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -60,7 +60,7 @@ describe(DashboardPresenter, () => {
         'sentAt',
         'referenceNumber',
         'serviceUserData.lastName',
-        'intervention.dynamicFrameworkContract.contractType',
+        'intervention.title',
         null,
       ])
     })

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -53,7 +53,7 @@ export default class DashboardPresenter {
     },
     {
       columnName: 'Intervention type',
-      sortField: 'intervention.dynamicFrameworkContract.contractType',
+      sortField: 'intervention.title',
     },
     {
       columnName: 'Caseworker',


### PR DESCRIPTION


## What does this pull request do?
Fix sorting by 'intervention type' on dashboards.

The existing implementation was actually sorting by contract type,
which is not the data that is used to populate that column in the
table.

## What is the intent behind these changes?

make the sort reflective of what's actually in the tabvle.
