### PR TITLE
Update base image openssl to latest version for CVE-2022-0778

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN addgroup --gid 2000 --system appgroup && \
     adduser --uid 2000 --system appuser && \
     adduser appuser appgroup
 
-RUN apk upgrade --no-cache
+RUN apk upgrade --no-cache && \
+    apk add openssl>1.1.1n-r0
 
 WORKDIR /app
 


### PR DESCRIPTION
## What does this pull request do?

Update base image openssl to latest version for CVE-2022-0778

## What is the intent behind these changes?

fix known vulnerability

https://nvd.nist.gov/vuln/detail/CVE-2022-0778