### PR TITLE
never pass 'undefined' to http-error createError function.

### DIFF
--- a/server/services/assessRisksAndNeedsService.ts
+++ b/server/services/assessRisksAndNeedsService.ts
@@ -36,7 +36,7 @@ export default class AssessRisksAndNeedsService {
         return null
       }
 
-      throw createError(restClientError.status, restClientError, {
+      throw createError(restClientError.status || 500, restClientError, {
         userMessage: "Could not get service user's risk scores from OASys.",
       })
     }

--- a/server/services/communityApiService.ts
+++ b/server/services/communityApiService.ts
@@ -37,7 +37,7 @@ export default class CommunityApiService {
       })) as ExpandedDeliusServiceUser
     } catch (err) {
       const restClientError = err as RestClientError
-      throw createError(restClientError.status, restClientError, {
+      throw createError(restClientError.status || 500, restClientError, {
         userMessage: 'Could not retrieve service user details from nDelius.',
       })
     }
@@ -80,7 +80,7 @@ export default class CommunityApiService {
       return deliusOffenderManagers.find(offenderManager => offenderManager.isResponsibleOfficer) || null
     } catch (err) {
       const restClientError = err as RestClientError
-      throw createError(restClientError.status, restClientError, {
+      throw createError(restClientError.status || 500, restClientError, {
         userMessage: 'Could retrieve Responsible Officer from nDelius.',
       })
     }


### PR DESCRIPTION
## What does this pull request do?

never pass 'undefined' to http-error createError function.

## What is the intent behind these changes?
some errors thrown by 'RestClient' do not have a http status code,
for example timeouts or connection errors. in these cases,
pass a status of 500 instead. this doesn't really have any effect
on the application's behaviour, because 'external' errors always
end up with a 500 response anyway. this is a sensible default either
way because a 500 is the appropriate response code for an unhandled
internal error.

this also stops us getting alerts in sentry that look like
'argument #1 unsupported type undefined'.