### PR TITLE
Enroll the repository to the MoJ developer portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    circleci.com/project-slug: github/ministryofjustice/hmpps-interventions-ui
+    sentry.io/project-slug: interventions-ui-prod
+  name: hmpps-interventions-ui
+  title: Intervention UI
+  description: Responsible for curating and delivering published interventions and services
+  tags:
+    - node
+    - express
+spec:
+  type: website
+  owner: group:hmpps-interventions-dev
+  system: system:hmpps-interventions # system is defined in hmpps-interventions-service
+  lifecycle: production
+  consumesApis:
+    - api:hmpps-interventions
+    # - api:hmpps-assess-risks-and-needs # not yet defined
+    # - api:hmpps-auth # not yet defined
+    # - api:community-api # not yet defined


### PR DESCRIPTION


## What does this pull request do?

This pull request adds a Backstage entity metadata file to this
repository so that the component can be added to the developer portal
(https://developer-portal.apps.live.cloud-platform.service.justice.gov.uk/catalog)

Similar:

- https://github.com/ministryofjustice/hmpps-interventions-service/pull/925
- https://github.com/ministryofjustice/hmpps-assess-risks-and-needs/pull/146

## What is the intent behind these changes?

The intent is for repositories to self-describe dependencies so that

- discovering integrations
- discovering existing solutions

becomes much simpler.
