### PR TITLE
re-enable deprecated login/logout urls to reduce 404 rates due to bookmarked urls

### DIFF
--- a/server/authentication/passport.ts
+++ b/server/authentication/passport.ts
@@ -123,4 +123,11 @@ export default function passportSetup(app: Application, hmppsAuthService: HmppsA
     res.render('logoutSuccess')
   }
   app.get('/sign-out/success', signOutSuccess)
+
+  // deprecated endpoints that we need to keep around due to bookmarks etc.
+  app.get('/login', signIn)
+  app.get('/login/callback', signInCallback('/sign-in'))
+  app.get('/logout', (req, res) => {
+    signOut('sign-out', req, res)
+  })
 }


### PR DESCRIPTION

## What does this pull request do?

re-enable deprecated login/logout urls to reduce 404 rates due to bookmarked urls

## What is the intent behind these changes?

reduce 404s  -- lots of people still hit these old endpoints

[link to AppInsights query](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA2XOsQrCQBAE0N6vWK5KQEEwbSrBUsEfkEuyeAd3u7q3qyj5eC8WNjbTzBsYwbth0bKa4RlQEMbENl3OnPDoM0Lfg4ukKA8kjUxlY9H9sGCxpHuevrDbduBpgoaW5cikPlIBl%252FgayQEL%252FBds6trVXCxnL%252FGNcGCTU1iyQF%252BtkTYtDC8YIjUacz3r820Nu1BngjShVJUs0xi86AeI5aV40AAAAA%253D%253D/timespan/P7D)

<img width="2199" alt="image" src="https://user-images.githubusercontent.com/1526295/162951851-ecf28756-e5a5-43ec-a46f-3585027b7ff4.png">

