### PR TITLE
add changelink into pp referral details page for updating enforceable days

### DIFF
--- a/server/routes/amendAReferral/amendAReferralController.test.ts
+++ b/server/routes/amendAReferral/amendAReferralController.test.ts
@@ -55,7 +55,7 @@ describe('POST /probation-practitioner/referrals/:id/update-maximum-enforceable-
       .post(`/probation-practitioner/referrals/${referral.id}/update-maximum-enforceable-days`)
       .send({ 'reason-for-change': 'new value', 'maximum-enforceable-days': 10 })
       .expect(302)
-      .expect('Location', `/probation-practitioner/referrals/${referral.id}/details`)
+      .expect('Location', `/probation-practitioner/referrals/${referral.id}/details?detailsUpdated=true`)
   })
 
   describe('with form validation errors', () => {

--- a/server/routes/amendAReferral/amendAReferralController.ts
+++ b/server/routes/amendAReferral/amendAReferralController.ts
@@ -23,7 +23,7 @@ export default class AmendAReferralController {
 
       if (!formData.error) {
         await this.interventionsService.updateSentReferralDetails(accessToken, referralId, formData.paramsForUpdate)
-        return res.redirect(`/probation-practitioner/referrals/${req.params.id}/details`)
+        return res.redirect(`/probation-practitioner/referrals/${req.params.id}/details?detailsUpdated=true`)
       }
 
       error = formData.error

--- a/server/routes/makeAReferral/makeAReferralController.test.ts
+++ b/server/routes/makeAReferral/makeAReferralController.test.ts
@@ -723,7 +723,7 @@ describe('POST /referrals/:id/completion-deadline', () => {
           'reason-for-change': 'reason',
         })
         .expect(302)
-        .expect('Location', '/probation-practitioner/referrals/1/details?success=true')
+        .expect('Location', '/probation-practitioner/referrals/1/details?detailsUpdated=true')
 
       expect(interventionsService.updateSentReferralDetails.mock.calls[0]).toEqual([
         'token',

--- a/server/routes/makeAReferral/makeAReferralController.ts
+++ b/server/routes/makeAReferral/makeAReferralController.ts
@@ -367,7 +367,7 @@ export default class MakeAReferralController {
     }
 
     if (isSentReferral && error === null) {
-      res.redirect(`/probation-practitioner/referrals/${req.params.id}/details?success=true`)
+      res.redirect(`/probation-practitioner/referrals/${req.params.id}/details?detailsUpdated=true`)
       return
     }
 

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -208,7 +208,6 @@ export default class ProbationPractitionerReferralsController {
   async showReferral(req: Request, res: Response): Promise<void> {
     const { accessToken } = res.locals.user.token
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, req.params.id)
-    const showSuccess = !!req.query.success
 
     const { crn } = sentReferral.referral.serviceUser
     const [intervention, sentBy, expandedServiceUser, conviction, riskInformation, riskSummary, responsibleOfficer] =
@@ -243,7 +242,7 @@ export default class ProbationPractitionerReferralsController {
       expandedServiceUser,
       riskSummary,
       responsibleOfficer,
-      showSuccess
+      req.query.detailsUpdated === 'true'
     )
     const view = new ShowReferralView(presenter)
     ControllerUtils.renderWithLayout(res, view, expandedServiceUser)

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -236,6 +236,10 @@ export default class ShowReferralPresenter {
       {
         key: 'Maximum number of enforceable days',
         lines: [String(this.sentReferral.referral.maximumEnforceableDays)],
+        changeLink:
+          this.userType === 'probation-practitioner'
+            ? `/probation-practitioner/referrals/${this.sentReferral.id}/update-maximum-enforceable-days`
+            : undefined,
       },
       {
         key: 'Further information for the provider',

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -64,8 +64,9 @@ export default class ShowReferralView {
   private readonly insetTextArgs =
     this.presenter.userType === 'probation-practitioner'
       ? {
-          html: `${ViewUtils.escape(`You can amend the completion date on this referral.`)}<br>
-          ${ViewUtils.escape(`This will send a notification to the service provider`)}`,
+          html:
+            'You can amend the number of enforceable days or the completion date on this referral.<br/>' +
+            'This will send a notification to the service provider',
         }
       : null
 


### PR DESCRIPTION

## What does this pull request do?

changed the query param used to gate displaying the success banner on referral details page from `success` to `detailsUpdated`

add changelink into pp referral details page for updating enforceable days

## What is the intent behind these changes?

reduce rates of re-referrals
