### PR TITLE
🚸 Retry reads and writes on transient errors

### DIFF
--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -29,6 +29,9 @@ interface PostRequest {
 
 export type RestClientError = HttpError
 
+const readRetryCount = 1
+const writeRetryCount = 1
+
 export default class RestClient {
   agent: Agent
 
@@ -83,7 +86,7 @@ export default class RestClient {
       const unauthenticatedRequest = superagent
         .get(`${this.apiUrl()}${path}`)
         .agent(this.agent)
-        .retry(0)
+        .retry(readRetryCount)
         .query(query)
         .set(headers)
         .responseType(responseType)
@@ -114,7 +117,7 @@ export default class RestClient {
         .post(`${this.apiUrl()}${path}`)
         .send(data)
         .agent(this.agent)
-        .retry(0)
+        .retry(writeRetryCount)
         .set(headers)
         .responseType(responseType)
         .timeout(this.timeoutConfig())
@@ -145,7 +148,7 @@ export default class RestClient {
         .patch(`${this.apiUrl()}${path}`)
         .send(data)
         .agent(this.agent)
-        .retry(0)
+        .retry(writeRetryCount)
         .set(headers)
         .responseType(responseType)
         .timeout(this.timeoutConfig())
@@ -176,7 +179,7 @@ export default class RestClient {
         .put(`${this.apiUrl()}${path}`)
         .send(data)
         .agent(this.agent)
-        .retry(0)
+        .retry(writeRetryCount)
         .set(headers)
         .responseType(responseType)
         .timeout(this.timeoutConfig())


### PR DESCRIPTION


## What does this pull request do?

Retry reads and writes to external services on transient errors to improve user experience.

## What is the intent behind these changes?

Currently, users experience random network blips as fatal errors (for example, 502 Bad Gateway responses) and we should retry those transient failures.

This change will retry only those. Quoting https://visionmedia.github.io/superagent/#retrying-requests:

> By default the following status codes are retried:
>
>     408
>     413
>     429
>     500
>     502
>     503
>     504
>     521
>     522
>     524
>
> By default the following error codes are retried:
>
>     'ETIMEDOUT'
>     'ECONNRESET'
>     'EADDRINUSE'
>     'ECONNREFUSED'
>     'EPIPE'
>     'ENOTFOUND'
>     'ENETUNREACH'
>     'EAI_AGAIN'

which are good enough defaults for us.

This was previously turned off in b24a3d2ca21fcf5d0e679d13d75cc686e14d9737 to mitigate load-related snowballing.

Further improvements could focus on introducing [circuit breakers](https://microservicesdev.com/circuit-breaker-pattern).