### PR TITLE
Link to newly declared APIs for developer portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -18,6 +18,6 @@ spec:
   lifecycle: production
   consumesApis:
     - api:hmpps-interventions
-    # - api:hmpps-assess-risks-and-needs # not yet defined
+    - api:hmpps-risks-and-needs
+    - api:hmpps-community
     # - api:hmpps-auth # not yet defined
-    # - api:community-api # not yet defined


### PR DESCRIPTION
## What does this pull request do?

Link to newly declared APIs for developer portal

- [`api:hmpps-risks-and-needs`](https://developer-portal.apps.live.cloud-platform.service.justice.gov.uk/catalog/default/api/hmpps-risks-and-needs)
- [`api:hmpps-community`](https://developer-portal.apps.live.cloud-platform.service.justice.gov.uk/catalog/default/api/hmpps-community)

Will appear in [the UI graph in developer-portal](https://developer-portal.apps.live.cloud-platform.service.justice.gov.uk/catalog-graph?rootEntityRefs%5B%5D=component%3Adefault%2Fhmpps-interventions-ui&maxDepth=%E2%88%9E&selectedKinds%5B%5D=api&selectedKinds%5B%5D=component&selectedKinds%5B%5D=location&selectedKinds%5B%5D=resource&unidirectional=false&mergeRelations=true&direction=LR&showFilters=true)

## What is the intent behind these changes?

Extend the [developer portal](https://developer-portal.apps.live.cloud-platform.service.justice.gov.uk/) so that all (currently defined) dependencies are visible.