### PR TITLE
⚗️  Use service address to monitor connection aborts

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,7 +7,7 @@ generic-service:
     DEPLOYMENT_ENV: dev
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
-    INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+    INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service.hmpps-interventions-dev.svc.cluster.local
     ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
     TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
     GA_ID: G-0DK8Q58Z3D

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -8,7 +8,7 @@ generic-service:
     DEPLOYMENT_ENV: preprod
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     COMMUNITY_API_URL: https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io
-    INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
+    INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service.hmpps-interventions-preprod.svc.cluster.local
     ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk
     TOKEN_VERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
     GA_ID: G-08D8T0RZZR

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,7 +9,7 @@ generic-service:
     DEPLOYMENT_ENV: prod
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     COMMUNITY_API_URL: https://community-api-secure.probation.service.justice.gov.uk
-    INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk
+    INTERVENTIONS_SERVICE_URL: http://hmpps-interventions-service.hmpps-interventions-prod.svc.cluster.local
     ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs.hmpps.service.justice.gov.uk
     TOKEN_VERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
     GA_ID: G-THWB3S7TLX


### PR DESCRIPTION
## What does this pull request do?

⚗️  Use service address to monitor connection aborts

**Hypothesis**: ECONNABORTED/timeout spikes will reduce significantly if
we connect to the service endpoint directly

**Trade-off**: Reporting requests will land in the 'generic' pods as
currently the load is distributed via endpoints, not which pods run the
batch processors.

## What is the intent behind these changes?

We see recurring ECONNABORTED spikes when connecting to the
interventions service

We did something similar in c6a556c3492f847ec00fda54d709fa134f5c929b,
and rolled it back as we needed path splitting at the ingress level and
because there were issues with unresolved IPs during deployments

However, during a deployment the first thing that _should_ happen is
that old pod IPs are moved out of the service, so in theory that issue
was something else and this change is safe

## References

🧵 [Slack thread](https://mojdt.slack.com/archives/C57UPMZLY/p1650375856498479)
📈 [Logs of timeouts for 19 April](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:'2022-04-19T08:00:00.000Z',to:'2022-04-19T12:40:00.000Z'))&_a=(columns:!(_source),index:'45bb7370-00eb-11ec-b879-8f5b8a74f645',interval:auto,query:(language:kuery,query:'kubernetes.namespace_name:%20%22hmpps-interventions-prod%22%20and%20log:%20%22timeout%22%20and%20log:%20%22Interventions%20Service%20API%20Client%22'),sort:!(!('@timestamp',desc))))

📈 Timeouts to interventions-service over 21 days:
![image](https://user-images.githubusercontent.com/1526295/164180724-f703074e-9598-4eb6-9394-ab4bdf8908c9.png)