### PR TITLE
Updated Interventions details page to remove unused tab section

### DIFF
--- a/integration_tests/integration/findInterventions.spec.js
+++ b/integration_tests/integration/findInterventions.spec.js
@@ -70,7 +70,5 @@ context('Find an intervention', () => {
 
     cy.get('h1').contains('Better solutions (anger management)')
     cy.contains('Thinking and behaviour')
-
-    cy.get('#service-provider-tab').contains('Harmony Living')
   })
 })

--- a/server/routes/findInterventions/interventionDetailsPresenter.test.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.test.ts
@@ -1,7 +1,6 @@
 import { DeepPartial } from 'fishery'
 import interventionFactory from '../../../testutils/factories/intervention'
 import eligibilityFactory from '../../../testutils/factories/eligibility'
-import serviceProviderFactory from '../../../testutils/factories/serviceProvider'
 import serviceCategoryFactory from '../../../testutils/factories/serviceCategory'
 import Intervention from '../../models/intervention'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
@@ -104,30 +103,6 @@ three lines.`,
         loggedInUser
       )
       expect(presenter.truncatedDescription).toEqual(`${new Array(501).join('x')}...`)
-    })
-  })
-
-  describe('tabs', () => {
-    const presenter = new InterventionDetailsPresenter(
-      interventionFactory.build({
-        serviceProvider: serviceProviderFactory.build({ name: 'Harmony Living' }),
-      }),
-      loggedInUser
-    )
-
-    it('returns an array of summary lists, each with an id and title', () => {
-      expect(presenter.tabs).toEqual([
-        {
-          id: 'service-provider-tab',
-          title: 'Service Provider',
-          items: [
-            {
-              key: 'Name',
-              lines: ['Harmony Living'],
-            },
-          ],
-        },
-      ])
     })
   })
 

--- a/server/routes/findInterventions/interventionDetailsPresenter.ts
+++ b/server/routes/findInterventions/interventionDetailsPresenter.ts
@@ -31,16 +31,6 @@ export default class InterventionDetailsPresenter {
     return `${firstLine.substring(0, 500)}${firstLine.length > 500 ? '...' : ''}`
   }
 
-  get tabs(): { id: string; title: string; items: SummaryListItem[] }[] {
-    return [
-      {
-        id: 'service-provider-tab',
-        title: 'Service Provider',
-        items: this.serviceProviderSummary,
-      },
-    ]
-  }
-
   get summary(): SummaryListItem[] {
     const summary = [
       {

--- a/server/routes/findInterventions/interventionDetailsView.ts
+++ b/server/routes/findInterventions/interventionDetailsView.ts
@@ -1,6 +1,6 @@
 import ViewUtils from '../../utils/viewUtils'
 import { SummaryListItem } from '../../utils/summaryList'
-import { SummaryListArgs, TabsArgs } from '../../utils/govukFrontendTypes'
+import { SummaryListArgs } from '../../utils/govukFrontendTypes'
 import InterventionDetailsPresenter from './interventionDetailsPresenter'
 
 export default class InterventionDetailsView {
@@ -13,27 +13,12 @@ export default class InterventionDetailsView {
     }
   }
 
-  private tabsArgs(summaryListMacro: (args: SummaryListArgs) => string): TabsArgs {
-    return {
-      items: this.presenter.tabs.map(tab => {
-        return {
-          label: tab.title,
-          id: tab.id,
-          panel: {
-            html: summaryListMacro(InterventionDetailsView.summaryListArgs(tab.items)),
-          },
-        }
-      }),
-    }
-  }
-
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'findInterventions/interventionDetails',
       {
         presenter: this.presenter,
         summaryListArgs: InterventionDetailsView.summaryListArgs,
-        tabsArgs: this.tabsArgs.bind(this),
         primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items),
       },
     ]

--- a/server/views/findInterventions/interventionDetails.njk
+++ b/server/views/findInterventions/interventionDetails.njk
@@ -25,7 +25,6 @@
         {{ govukButton({ text: "Make a referral" }) }}
       </form>
 
-      {{ govukTabs(tabsArgs(govukSummaryList)) }}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Removes tab from the bottom of the Interventions details page as it is not used.

## What is the intent behind these changes?

The tab at the bottom of the interventions details page was going to be used to include other information than the service provider however this has never been done so we can safely remove the tab. The information is already easily visible right above where the tab was.

Image post change:

<img width="842" alt="Screenshot 2022-04-22 at 13 37 17" src="https://user-images.githubusercontent.com/103187669/164715641-63134215-0dcc-491e-93fa-1b8896782d89.png">


