### PR TITLE
Update titles on SP pages to use contract type instead of Service category

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.spec.js
+++ b/integration_tests/integration/serviceProviderReferrals.spec.js
@@ -1846,7 +1846,7 @@ describe('Service provider referrals dashboard', () => {
         `/service-provider/end-of-service-report/${draftEndOfServiceReport.id}/outcomes/1`
       )
 
-      cy.contains('Accommodation: End of service report')
+      cy.contains('Social inclusion: End of service report')
       cy.contains('About desired outcome 1')
       cy.contains(selectedDesiredOutcomes[0].description)
 
@@ -1874,7 +1874,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.contains('Save and continue').click()
 
-      cy.contains('Accommodation: End of service report')
+      cy.contains('Social inclusion: End of service report')
       cy.contains('About desired outcome 2')
       cy.contains(selectedDesiredOutcomes[1].description)
 
@@ -1905,7 +1905,7 @@ describe('Service provider referrals dashboard', () => {
 
       cy.contains('Save and continue').click()
 
-      cy.contains('Accommodation: End of service report')
+      cy.contains('Social inclusion: End of service report')
       cy.contains('Would you like to give any additional information about this intervention (optional)?')
       cy.contains(
         'Provide any further information that you believe is important for the probation practitioner to know.'

--- a/server/routes/service-provider/action-plan/confirmation/actionPlanConfirmationPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/confirmation/actionPlanConfirmationPresenter.test.ts
@@ -1,13 +1,11 @@
 import ActionPlanConfirmationPresenter from './actionPlanConfirmationPresenter'
 import sentReferralFactory from '../../../../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../../../../testutils/factories/serviceCategory'
 
 describe(ActionPlanConfirmationPresenter, () => {
   describe('progressHref', () => {
     it('returns the relative URL of the service provider referral progress page', () => {
       const sentReferral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new ActionPlanConfirmationPresenter(sentReferral, serviceCategory)
+      const presenter = new ActionPlanConfirmationPresenter(sentReferral, 'Personal wellbeing')
 
       expect(presenter.progressHref).toEqual(`/service-provider/referrals/${sentReferral.id}/progress`)
     })
@@ -19,8 +17,7 @@ describe(ActionPlanConfirmationPresenter, () => {
         referenceNumber: 'CEF345',
         referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
       })
-      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-      const presenter = new ActionPlanConfirmationPresenter(sentReferral, serviceCategory)
+      const presenter = new ActionPlanConfirmationPresenter(sentReferral, 'Social inclusion')
 
       expect(presenter.summary).toEqual([
         { key: 'Name', lines: ['Johnny Davis'] },

--- a/server/routes/service-provider/action-plan/confirmation/actionPlanConfirmationPresenter.ts
+++ b/server/routes/service-provider/action-plan/confirmation/actionPlanConfirmationPresenter.ts
@@ -1,11 +1,10 @@
 import SentReferral from '../../../../models/sentReferral'
-import ServiceCategory from '../../../../models/serviceCategory'
 import { SummaryListItem } from '../../../../utils/summaryList'
 import utils from '../../../../utils/utils'
 import PresenterUtils from '../../../../utils/presenterUtils'
 
 export default class ActionPlanConfirmationPresenter {
-  constructor(private readonly sentReferral: SentReferral, private readonly serviceCategory: ServiceCategory) {}
+  constructor(private readonly sentReferral: SentReferral, private readonly interventionTitle: string) {}
 
   progressHref = `/service-provider/referrals/${this.sentReferral.id}/progress`
 
@@ -25,7 +24,7 @@ export default class ActionPlanConfirmationPresenter {
     },
     {
       key: 'Service category',
-      lines: [utils.convertToProperCase(this.serviceCategory.name)],
+      lines: [utils.convertToProperCase(this.interventionTitle)],
     },
   ]
 }

--- a/server/routes/service-provider/action-plan/number-of-sessions/actionPlanNumberOfSessionsPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/number-of-sessions/actionPlanNumberOfSessionsPresenter.test.ts
@@ -9,13 +9,16 @@ describe(ActionPlanNumberOfSessionsPresenter, () => {
       const presenter = new ActionPlanNumberOfSessionsPresenter(
         actionPlanFactory.build({ numberOfSessions: 10 }),
         serviceUserFactory.build({ firstName: 'Alex', surname: 'River' }),
-        serviceCategoryFactory.build({ name: 'accommodation' })
+        serviceCategoryFactory.build({ name: 'accommodation' }),
+        null,
+        null,
+        'Personal wellbeing'
       )
 
       expect(presenter.text).toMatchObject({
-        serviceCategoryName: 'Accommodation',
+        serviceCategoryName: 'Personal wellbeing',
         serviceUserFirstName: 'Alex',
-        title: 'Accommodation - create action plan',
+        title: 'Personal wellbeing - create action plan',
       })
     })
 
@@ -34,7 +37,9 @@ describe(ActionPlanNumberOfSessionsPresenter, () => {
                   message: 'Enter the number of sessions',
                 },
               ],
-            }
+            },
+            null,
+            'Personal wellbeing'
           )
 
           expect(presenter.text.numberOfSessions.errorMessage).toEqual('Enter the number of sessions')
@@ -47,7 +52,9 @@ describe(ActionPlanNumberOfSessionsPresenter, () => {
             actionPlanFactory.build(),
             serviceUserFactory.build(),
             serviceCategoryFactory.build(),
-            null
+            null,
+            null,
+            'Womens services'
           )
 
           expect(presenter.text.numberOfSessions.errorMessage).toBeNull()
@@ -71,7 +78,9 @@ describe(ActionPlanNumberOfSessionsPresenter, () => {
                 message: 'Enter the number of sessions',
               },
             ],
-          }
+          },
+          null,
+          'Personal wellbeing'
         )
 
         expect(presenter.errorSummary).toEqual([
@@ -86,7 +95,9 @@ describe(ActionPlanNumberOfSessionsPresenter, () => {
           actionPlanFactory.build(),
           serviceUserFactory.build(),
           serviceCategoryFactory.build(),
-          null
+          null,
+          null,
+          'Personal wellbeing'
         )
 
         expect(presenter.errorSummary).toBeNull()
@@ -102,7 +113,8 @@ describe(ActionPlanNumberOfSessionsPresenter, () => {
           serviceUserFactory.build(),
           serviceCategoryFactory.build(),
           null,
-          { 'number-of-sessions': '4' }
+          { 'number-of-sessions': '4' },
+          'Personal wellbeing'
         )
 
         expect(presenter.fields.numberOfSessions).toEqual('4')
@@ -117,7 +129,8 @@ describe(ActionPlanNumberOfSessionsPresenter, () => {
           serviceUserFactory.build(),
           serviceCategoryFactory.build(),
           null,
-          null
+          null,
+          'Personal wellbeing'
         )
 
         expect(presenter.fields.numberOfSessions).toEqual('10')

--- a/server/routes/service-provider/action-plan/number-of-sessions/actionPlanNumberOfSessionsPresenter.ts
+++ b/server/routes/service-provider/action-plan/number-of-sessions/actionPlanNumberOfSessionsPresenter.ts
@@ -11,18 +11,19 @@ export default class ActionPlanNumberOfSessionsPresenter {
     private readonly serviceUser: DeliusServiceUser,
     private readonly serviceCategory: ServiceCategory,
     private readonly error: FormValidationError | null = null,
-    private readonly userInputData: Record<string, unknown> | null = null
+    private readonly userInputData: Record<string, unknown> | null = null,
+    private readonly interventionTitle: string
   ) {}
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error)
 
   readonly text = {
-    title: `${utils.convertToProperCase(this.serviceCategory.name)} - create action plan`,
+    title: `${utils.convertToProperCase(this.interventionTitle)} - create action plan`,
     numberOfSessions: {
       errorMessage: PresenterUtils.errorMessage(this.error, 'number-of-sessions'),
     },
     serviceUserFirstName: this.serviceUser.firstName,
-    serviceCategoryName: utils.convertToProperCase(this.serviceCategory.name),
+    serviceCategoryName: utils.convertToProperCase(this.interventionTitle),
   }
 
   private readonly utils = new PresenterUtils(this.userInputData)

--- a/server/routes/service-provider/end-of-service-report/check-answers/endOfServiceReportCheckAnswersPresenter.test.ts
+++ b/server/routes/service-provider/end-of-service-report/check-answers/endOfServiceReportCheckAnswersPresenter.test.ts
@@ -38,9 +38,12 @@ describe(EndOfServiceReportCheckAnswersPresenter, () => {
 
   describe('text', () => {
     it('returns text to be displayed', () => {
-      const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, buildEndOfServiceReport(), [
-        serviceCategory,
-      ])
+      const presenter = new EndOfServiceReportCheckAnswersPresenter(
+        referral,
+        buildEndOfServiceReport(),
+        [serviceCategory],
+        'Personal wellbeing'
+      )
 
       expect(presenter.text).toEqual({
         subTitle: 'Review the end of service report',
@@ -50,9 +53,12 @@ describe(EndOfServiceReportCheckAnswersPresenter, () => {
 
   describe('answersPresenter', () => {
     it('returns a presenter', () => {
-      const presenter = new EndOfServiceReportCheckAnswersPresenter(referral, buildEndOfServiceReport(), [
-        serviceCategory,
-      ])
+      const presenter = new EndOfServiceReportCheckAnswersPresenter(
+        referral,
+        buildEndOfServiceReport(),
+        [serviceCategory],
+        'Personal wellbeing'
+      )
 
       expect(presenter.answersPresenter).toBeDefined()
     })

--- a/server/routes/service-provider/end-of-service-report/check-answers/endOfServiceReportCheckAnswersPresenter.ts
+++ b/server/routes/service-provider/end-of-service-report/check-answers/endOfServiceReportCheckAnswersPresenter.ts
@@ -8,7 +8,8 @@ export default class EndOfServiceReportCheckAnswersPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategories: ServiceCategory[]
+    private readonly serviceCategories: ServiceCategory[],
+    private readonly interventionTitle: string
   ) {}
 
   readonly formAction = `/service-provider/end-of-service-report/${this.endOfServiceReport.id}/submit`
@@ -17,7 +18,7 @@ export default class EndOfServiceReportCheckAnswersPresenter {
     subTitle: 'Review the end of service report',
   }
 
-  readonly formPagePresenter = new EndOfServiceReportFormPresenter(this.serviceCategories[0], this.referral)
+  readonly formPagePresenter = new EndOfServiceReportFormPresenter(this.interventionTitle, this.referral)
     .checkAnswersPage
 
   readonly answersPresenter = new EndOfServiceReportAnswersPresenter(

--- a/server/routes/service-provider/end-of-service-report/confirmation/endOfServiceReportConfirmationPresenter.test.ts
+++ b/server/routes/service-provider/end-of-service-report/confirmation/endOfServiceReportConfirmationPresenter.test.ts
@@ -1,13 +1,11 @@
 import EndOfServiceReportConfirmationPresenter from './endOfServiceReportConfirmationPresenter'
 import sentReferralFactory from '../../../../../testutils/factories/sentReferral'
-import serviceCategoryFactory from '../../../../../testutils/factories/serviceCategory'
 
 describe(EndOfServiceReportConfirmationPresenter, () => {
   describe('progressHref', () => {
     it('returns the relative URL of the service provider referral progress page', () => {
       const sentReferral = sentReferralFactory.build()
-      const serviceCategory = serviceCategoryFactory.build()
-      const presenter = new EndOfServiceReportConfirmationPresenter(sentReferral, serviceCategory)
+      const presenter = new EndOfServiceReportConfirmationPresenter(sentReferral, 'Personal wellbeing')
 
       expect(presenter.progressHref).toEqual(`/service-provider/referrals/${sentReferral.id}/progress`)
     })
@@ -19,8 +17,7 @@ describe(EndOfServiceReportConfirmationPresenter, () => {
         referenceNumber: 'CEF345',
         referral: { serviceUser: { firstName: 'Johnny', lastName: 'Davis' } },
       })
-      const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-      const presenter = new EndOfServiceReportConfirmationPresenter(sentReferral, serviceCategory)
+      const presenter = new EndOfServiceReportConfirmationPresenter(sentReferral, 'Social inclusion')
 
       expect(presenter.summary).toEqual([
         { key: 'Name', lines: ['Johnny Davis'] },

--- a/server/routes/service-provider/end-of-service-report/confirmation/endOfServiceReportConfirmationPresenter.ts
+++ b/server/routes/service-provider/end-of-service-report/confirmation/endOfServiceReportConfirmationPresenter.ts
@@ -1,11 +1,10 @@
 import SentReferral from '../../../../models/sentReferral'
-import ServiceCategory from '../../../../models/serviceCategory'
 import PresenterUtils from '../../../../utils/presenterUtils'
 import { SummaryListItem } from '../../../../utils/summaryList'
 import utils from '../../../../utils/utils'
 
 export default class EndOfServiceReportConfirmationPresenter {
-  constructor(private readonly referral: SentReferral, private readonly serviceCategory: ServiceCategory) {}
+  constructor(private readonly referral: SentReferral, private readonly interventionTitle: string) {}
 
   progressHref = `/service-provider/referrals/${this.referral.id}/progress`
 
@@ -20,7 +19,7 @@ export default class EndOfServiceReportConfirmationPresenter {
     },
     {
       key: 'Service category',
-      lines: [utils.convertToProperCase(this.serviceCategory.name)],
+      lines: [utils.convertToProperCase(this.interventionTitle)],
     },
   ]
 }

--- a/server/routes/service-provider/end-of-service-report/endOfServiceReportFormPresenter.test.ts
+++ b/server/routes/service-provider/end-of-service-report/endOfServiceReportFormPresenter.test.ts
@@ -1,9 +1,7 @@
 import EndOfServiceReportFormPresenter from './endOfServiceReportFormPresenter'
-import serviceCategoryFactory from '../../../../testutils/factories/serviceCategory'
 import sentReferralFactory from '../../../../testutils/factories/sentReferral'
 
 describe(EndOfServiceReportFormPresenter, () => {
-  const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
   const referral = sentReferralFactory.build({
     referral: {
       desiredOutcomes: [
@@ -15,36 +13,40 @@ describe(EndOfServiceReportFormPresenter, () => {
 
   describe('title', () => {
     it('returns the title for all the form pages', () => {
-      const presenter = new EndOfServiceReportFormPresenter(serviceCategory, referral).checkAnswersPage
-      expect(presenter.text.title).toEqual('Social inclusion: End of service report')
+      const presenter = new EndOfServiceReportFormPresenter('Personal Wellbeing', referral).checkAnswersPage
+      expect(presenter.text.title).toEqual('Personal wellbeing: End of service report')
     })
   })
 
   describe('numberOfPages', () => {
     it('returns the number of pages in the end of service report journey', () => {
-      const presenter = new EndOfServiceReportFormPresenter(serviceCategory, referral).checkAnswersPage
+      const presenter = new EndOfServiceReportFormPresenter('Personal Wellbeing', referral).checkAnswersPage
       expect(presenter.text.numberOfPages).toEqual('7')
+      expect(presenter.text.title).toEqual('Personal wellbeing: End of service report')
     })
   })
 
   describe('.outcomePage', () => {
     it('has the correct page number', () => {
-      const presenter = new EndOfServiceReportFormPresenter(serviceCategory, referral).desiredOutcomePage(2)
+      const presenter = new EndOfServiceReportFormPresenter('Personal Wellbeing', referral).desiredOutcomePage(2)
       expect(presenter.text.pageNumber).toEqual('2')
+      expect(presenter.text.title).toEqual('Personal wellbeing: End of service report')
     })
   })
 
   describe('.furtherInformationPage', () => {
     it('has the correct page number', () => {
-      const presenter = new EndOfServiceReportFormPresenter(serviceCategory, referral).furtherInformationPage
+      const presenter = new EndOfServiceReportFormPresenter('Personal Wellbeing', referral).furtherInformationPage
       expect(presenter.text.pageNumber).toEqual('6')
+      expect(presenter.text.title).toEqual('Personal wellbeing: End of service report')
     })
   })
 
   describe('.checkAnswersPage', () => {
     it('has the correct page number', () => {
-      const presenter = new EndOfServiceReportFormPresenter(serviceCategory, referral).checkAnswersPage
+      const presenter = new EndOfServiceReportFormPresenter('Personal Wellbeing', referral).checkAnswersPage
       expect(presenter.text.pageNumber).toEqual('7')
+      expect(presenter.text.title).toEqual('Personal wellbeing: End of service report')
     })
   })
 })

--- a/server/routes/service-provider/end-of-service-report/endOfServiceReportFormPresenter.ts
+++ b/server/routes/service-provider/end-of-service-report/endOfServiceReportFormPresenter.ts
@@ -1,5 +1,4 @@
 import SentReferral from '../../../models/sentReferral'
-import ServiceCategory from '../../../models/serviceCategory'
 import utils from '../../../utils/utils'
 
 interface EndOfServiceReportFormPagePresenter {
@@ -11,14 +10,14 @@ interface EndOfServiceReportFormPagePresenter {
 }
 
 export default class EndOfServiceReportFormPresenter {
-  constructor(private readonly serviceCategory: ServiceCategory, private readonly referral: SentReferral) {}
+  constructor(private readonly interventionTitle: string, private readonly referral: SentReferral) {}
 
   private get numberOfDesiredOutcomes(): number {
     return this.referral.referral.desiredOutcomes.flatMap(desiredOutcome => desiredOutcome.desiredOutcomesIds).length
   }
 
   private get title(): string {
-    return `${utils.convertToProperCase(this.serviceCategory.name)}: End of service report`
+    return `${utils.convertToProperCase(this.interventionTitle)}: End of service report`
   }
 
   private get numberOfPages(): string {

--- a/server/routes/service-provider/end-of-service-report/further-information/endOfServiceReportFurtherInformationPresenter.test.ts
+++ b/server/routes/service-provider/end-of-service-report/further-information/endOfServiceReportFurtherInformationPresenter.test.ts
@@ -10,7 +10,13 @@ describe(EndOfServiceReportFurtherInformationPresenter, () => {
 
   describe('text', () => {
     it('returns text to be displayed', () => {
-      const presenter = new EndOfServiceReportFurtherInformationPresenter(endOfServiceReport, serviceCategory, referral)
+      const presenter = new EndOfServiceReportFurtherInformationPresenter(
+        endOfServiceReport,
+        serviceCategory,
+        referral,
+        null,
+        'Personal wellbeing'
+      )
 
       expect(presenter.text).toEqual({
         subTitle: 'Would you like to give any additional information about this intervention (optional)?',
@@ -26,7 +32,8 @@ describe(EndOfServiceReportFurtherInformationPresenter, () => {
             endOfServiceReport,
             serviceCategory,
             referral,
-            null
+            null,
+            'Personal wellbeing'
           )
 
           expect(presenter.fields).toEqual({ furtherInformation: { value: 'Some further information' } })
@@ -41,7 +48,8 @@ describe(EndOfServiceReportFurtherInformationPresenter, () => {
             referral,
             {
               'further-information': 'Some user input further information',
-            }
+            },
+            'Personal wellbeing'
           )
 
           expect(presenter.fields).toEqual({ furtherInformation: { value: 'Some user input further information' } })

--- a/server/routes/service-provider/end-of-service-report/further-information/endOfServiceReportFurtherInformationPresenter.ts
+++ b/server/routes/service-provider/end-of-service-report/further-information/endOfServiceReportFurtherInformationPresenter.ts
@@ -9,17 +9,17 @@ export default class EndOfServiceReportFurtherInformationPresenter {
     private readonly endOfServiceReport: EndOfServiceReport,
     private readonly serviceCategory: ServiceCategory,
     private readonly referral: SentReferral,
-    private readonly userInputData: Record<string, unknown> | null = null
+    private readonly userInputData: Record<string, unknown> | null = null,
+    private readonly title: string
   ) {}
 
   readonly text = {
     subTitle: 'Would you like to give any additional information about this intervention (optional)?',
   }
 
-  readonly formPagePresenter = new EndOfServiceReportFormPresenter(this.serviceCategory, this.referral)
-    .furtherInformationPage
-
   private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly formPagePresenter = new EndOfServiceReportFormPresenter(this.title, this.referral).furtherInformationPage
 
   readonly fields = {
     furtherInformation: {

--- a/server/routes/service-provider/end-of-service-report/outcomes/endOfServiceReportOutcomePresenter.test.ts
+++ b/server/routes/service-provider/end-of-service-report/outcomes/endOfServiceReportOutcomePresenter.test.ts
@@ -16,9 +16,9 @@ describe(EndOfServiceReportOutcomePresenter, () => {
       const presenter = new EndOfServiceReportOutcomePresenter(
         referral,
         endOfServiceReport,
-        serviceCategory,
         desiredOutcome,
         desiredOutcomeNumber,
+        'Personal wellbeing',
         null
       )
 
@@ -39,9 +39,9 @@ describe(EndOfServiceReportOutcomePresenter, () => {
         const presenter = new EndOfServiceReportOutcomePresenter(
           referral,
           endOfServiceReport,
-          serviceCategory,
           desiredOutcome,
           desiredOutcomeNumber,
+          'Personal wellbeing',
           null
         )
 
@@ -85,9 +85,9 @@ describe(EndOfServiceReportOutcomePresenter, () => {
           const presenter = new EndOfServiceReportOutcomePresenter(
             referral,
             endOfServiceReport,
-            serviceCategory,
             desiredOutcome,
             desiredOutcomeNumber,
+            'Personal wellbeing',
             outcome
           )
 
@@ -135,9 +135,9 @@ describe(EndOfServiceReportOutcomePresenter, () => {
           const presenter = new EndOfServiceReportOutcomePresenter(
             referral,
             endOfServiceReport,
-            serviceCategory,
             desiredOutcome,
             desiredOutcomeNumber,
+            'Personal wellbeing',
             outcome,
             userInputData
           )
@@ -181,9 +181,9 @@ describe(EndOfServiceReportOutcomePresenter, () => {
         const presenter = new EndOfServiceReportOutcomePresenter(
           referral,
           endOfServiceReport,
-          serviceCategory,
           desiredOutcome,
           desiredOutcomeNumber,
+          'Personal wellbeing',
           null,
           userInputData
         )
@@ -229,9 +229,9 @@ describe(EndOfServiceReportOutcomePresenter, () => {
         const presenter = new EndOfServiceReportOutcomePresenter(
           referral,
           endOfServiceReport,
-          serviceCategory,
           desiredOutcome,
           desiredOutcomeNumber,
+          'Personal wellbeing',
           null,
           null,
           error
@@ -261,9 +261,9 @@ describe(EndOfServiceReportOutcomePresenter, () => {
         const presenter = new EndOfServiceReportOutcomePresenter(
           referral,
           endOfServiceReport,
-          serviceCategory,
           desiredOutcome,
           desiredOutcomeNumber,
+          'Personal wellbeing',
           null,
           null,
           error
@@ -278,9 +278,9 @@ describe(EndOfServiceReportOutcomePresenter, () => {
         const presenter = new EndOfServiceReportOutcomePresenter(
           referral,
           endOfServiceReport,
-          serviceCategory,
           desiredOutcome,
           desiredOutcomeNumber,
+          'Personal wellbeing',
           null
         )
 

--- a/server/routes/service-provider/end-of-service-report/outcomes/endOfServiceReportOutcomePresenter.ts
+++ b/server/routes/service-provider/end-of-service-report/outcomes/endOfServiceReportOutcomePresenter.ts
@@ -1,7 +1,6 @@
 import DesiredOutcome from '../../../../models/desiredOutcome'
 import EndOfServiceReport, { EndOfServiceReportOutcome } from '../../../../models/endOfServiceReport'
 import SentReferral from '../../../../models/sentReferral'
-import ServiceCategory from '../../../../models/serviceCategory'
 import { FormValidationError } from '../../../../utils/formValidationError'
 import PresenterUtils from '../../../../utils/presenterUtils'
 import EndOfServiceReportFormPresenter from '../endOfServiceReportFormPresenter'
@@ -10,9 +9,9 @@ export default class EndOfServiceReportOutcomePresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategory: ServiceCategory,
     private readonly desiredOutcome: DesiredOutcome,
     private readonly desiredOutcomeNumber: number,
+    private readonly interventionTitle: string,
     private readonly outcome: EndOfServiceReportOutcome | null,
     private readonly userInputData: Record<string, unknown> | null = null,
     private readonly error: FormValidationError | null = null
@@ -30,7 +29,7 @@ export default class EndOfServiceReportOutcomePresenter {
   }
 
   readonly formPagePresenter = new EndOfServiceReportFormPresenter(
-    this.serviceCategory,
+    this.interventionTitle,
     this.referral
   ).desiredOutcomePage(this.desiredOutcomeNumber)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -839,6 +839,12 @@ describe('GET /service-provider/action-plan/:actionPlanId/number-of-sessions', (
   it('displays a page to set the number of sessions on an action plan', async () => {
     const deliusServiceUser = deliusServiceUserFactory.build()
     const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
+    const interventionForTest = interventionFactory.build({
+      contractType: {
+        code: 'ACC',
+        name: 'Accommodation',
+      },
+    })
     const referral = sentReferralFactory.assigned().build({
       referral: {
         serviceCategoryIds: [serviceCategory.id],
@@ -851,6 +857,7 @@ describe('GET /service-provider/action-plan/:actionPlanId/number-of-sessions', (
     interventionsService.getActionPlan.mockResolvedValue(draftActionPlan)
     interventionsService.getSentReferral.mockResolvedValue(referral)
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(interventionForTest)
 
     await request(app)
       .get(`/service-provider/action-plan/${draftActionPlan.id}/number-of-sessions`)
@@ -887,11 +894,18 @@ describe('POST /service-provider/action-plan/:actionPlanId/number-of-sessions', 
         },
       })
       const draftActionPlan = actionPlanFactory.justCreated(referral.id).build()
+      const interventionForTest = interventionFactory.build({
+        contractType: {
+          code: 'ACC',
+          name: 'Accommodation',
+        },
+      })
 
       communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
       interventionsService.getActionPlan.mockResolvedValue(draftActionPlan)
       interventionsService.getSentReferral.mockResolvedValue(referral)
       interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+      interventionsService.getIntervention.mockResolvedValue(interventionForTest)
 
       await request(app)
         .post(`/service-provider/action-plan/1/number-of-sessions`)
@@ -917,11 +931,18 @@ describe('POST /service-provider/action-plan/:actionPlanId/number-of-sessions', 
         },
       })
       const draftActionPlan = actionPlanFactory.justCreated(referral.id).build()
+      const interventionForTest = interventionFactory.build({
+        contractType: {
+          code: 'ACC',
+          name: 'Accommodation',
+        },
+      })
 
       communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
       interventionsService.getActionPlan.mockResolvedValue(draftActionPlan)
       interventionsService.getSentReferral.mockResolvedValue(referral)
       interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+      interventionsService.getIntervention.mockResolvedValue(interventionForTest)
 
       interventionsService.updateDraftActionPlan.mockRejectedValue(
         createError(400, 'bad request', {
@@ -962,10 +983,17 @@ describe('GET /service-provider/action-plan/:actionPlanId/review', () => {
       activities: [{ id: '1', description: 'Do a thing', createdAt: '2021-03-01T10:00:00Z' }],
       numberOfSessions: 10,
     })
+    const interventionForTest = interventionFactory.build({
+      contractType: {
+        code: 'ACC',
+        name: 'Accommodation',
+      },
+    })
 
     interventionsService.getActionPlan.mockResolvedValue(draftActionPlan)
     interventionsService.getSentReferral.mockResolvedValue(referral)
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(interventionForTest)
 
     await request(app)
       .get(`/service-provider/action-plan/${draftActionPlan.id}/review`)
@@ -1006,10 +1034,17 @@ describe('GET /service-provider/action-plan/:actionPlanId/confirmation', () => {
       },
     })
     const submittedActionPlan = actionPlanFactory.submitted().build({ referralId: referral.id })
+    const interventionForTest = interventionFactory.build({
+      contractType: {
+        code: 'ACC',
+        name: 'Accommodation',
+      },
+    })
 
     interventionsService.getActionPlan.mockResolvedValue(submittedActionPlan)
     interventionsService.getSentReferral.mockResolvedValue(referral)
     interventionsService.getServiceCategory.mockResolvedValue(serviceCategory)
+    interventionsService.getIntervention.mockResolvedValue(interventionForTest)
 
     await request(app)
       .get(`/service-provider/action-plan/${submittedActionPlan.id}/confirmation`)
@@ -1152,7 +1187,13 @@ describe('POST /service-provider/referrals/:id/end-of-service-report', () => {
 describe('GET /service-provider/end-of-service-report/:id/outcomes/:number', () => {
   it('renders a form', async () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
+    const intervention = interventionFactory.build({
+      serviceCategories: [serviceCategory],
+      contractType: {
+        code: 'ACC',
+        name: 'Accommodation',
+      },
+    })
     const desiredOutcome = serviceCategory.desiredOutcomes[0]
     const referral = sentReferralFactory.build({
       referral: {
@@ -1173,7 +1214,6 @@ describe('GET /service-provider/end-of-service-report/:id/outcomes/:number', () 
       .get(`/service-provider/end-of-service-report/${endOfServiceReport.id}/outcomes/1`)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Social inclusion: End of service report')
         expect(res.text).toContain('About desired outcome 1')
         expect(res.text).toContain(desiredOutcome.description)
       })


### PR DESCRIPTION
## What does this pull request do?

Changes the titles on SP pages, specifically creating an action plan and end of service report. The titles have been changed from using the service category to use the contract type.

## What is the intent behind these changes?

The titles before the change were not clear as showing which level the actions on the page were being performed at. In order to improve this we should be using the contractType as the title rather than the service category. Ticket can be found here: https://trello.com/c/WcgM54IU