### PR TITLE
Updated config to remove approval for preprod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,10 +126,6 @@ workflows:
           tag: "deployed:dev"
           requires: [deploy_dev]
           context: [hmpps-common-vars]
-      - approve_postdev:
-          type: approval
-          requires:
-            - deploy_dev
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"
@@ -137,7 +133,7 @@ workflows:
           slack_notification: true
           slack_channel_name: "interventions-dev-notifications"
           requires:
-            - approve_postdev
+            - deploy_dev
           context:
             - hmpps-common-vars
             - hmpps-interventions-preprod-deploy


### PR DESCRIPTION
## What does this pull request do?

Removes the requirement for us to manually approve pre-prod deployment.

## What is the intent behind these changes?

Save time for developers having to approve pre-prod each time.
