### PR TITLE
remove deprecated `mocked` util function from test

### DIFF
--- a/server/services/draftsService.test.ts
+++ b/server/services/draftsService.test.ts
@@ -1,10 +1,12 @@
 import { Callback, RedisClient } from 'redis'
-import { mocked } from 'ts-jest/utils'
-import { v4 } from 'uuid'
 import DraftsService from './draftsService'
 
-jest.mock('uuid')
-const mockedUuid = mocked(v4)
+let mockedUuid: string
+jest.mock('uuid', () => {
+  return {
+    v4: () => mockedUuid,
+  }
+})
 
 interface ChosenRedisOverloads {
   get: (key: string, cb?: Callback<string | null>) => boolean
@@ -27,7 +29,7 @@ describe(DraftsService, () => {
 
   describe('.createDraft', () => {
     it('generates a random UUID and stores the data in Redis under a key derived from that UUID, with the given expiry time', async () => {
-      mockedUuid.mockReturnValue('2dc7ef56-58dd-4339-9924-c33318738068')
+      mockedUuid = '2dc7ef56-58dd-4339-9924-c33318738068'
 
       redis.set.mockImplementation((_key, _value, _mode, _duration, cb) => {
         cb!(null, 'OK')


### PR DESCRIPTION
replace `mocked` with jest.mock

## What does this pull request do?

Replace the deprecated `mocked` function with jest.mock call

## What is the intent behind these changes?

Stop deprecated warning from appearing in tests:
`'mocked' util function is now deprecated and has been moved to Jest repository, see https://github.com/facebook/jest/pull/12089. In 'ts-jest' v28.0.0, 'mocked' function will be completely removed. Users are encouraged to use to Jest v27.4.0 or above to have 'mocked' function available from 'jest-mock'. `
