### PR TITLE
Fix/back link to dashboard

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -35,6 +35,12 @@ import UserDataService from './services/userDataService'
 
 const RedisStore = connectRedis(session)
 
+declare module 'express-session' {
+  export interface SessionData {
+    dashboardOriginPage: string
+  }
+}
+
 export default function createApp(
   communityApiService: CommunityApiService,
   interventionsService: InterventionsService,

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -72,7 +72,8 @@ export default class CaseNotesController {
       caseNotesPage,
       userDetails,
       serviceUser,
-      loggedInUserType
+      loggedInUserType,
+      req.session.dashboardOriginPage
     )
     const view = new CaseNotesView(presenter)
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/caseNotes/viewAll/caseNotesPresenter.test.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesPresenter.test.ts
@@ -165,4 +165,35 @@ describe('CaseNotesPresenter', () => {
       expect(presenter.serviceUserName).toEqual('Firstname Surname')
     })
   })
+
+  describe('back link', () => {
+    it('should default the hrefBackLink if dashboardOriginPage not passed in', () => {
+      const caseNote = caseNoteFactory.build()
+      const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+      const presenter = new CaseNotesPresenter(
+        referralId,
+        interventionFactory.build(),
+        page,
+        new Map(),
+        deliusServiceUserFactory.build({ firstName: 'FIRSTNAME', surname: 'SURNAME' }),
+        'service-provider'
+      )
+      expect(presenter.hrefBackLink).toEqual('/service-provider/dashboard')
+    })
+
+    it('should populate the hrefBackLink from dashboardOriginPage when passed in', () => {
+      const caseNote = caseNoteFactory.build()
+      const page = pageFactory.pageContent([caseNote]).build() as Page<CaseNote>
+      const presenter = new CaseNotesPresenter(
+        referralId,
+        interventionFactory.build(),
+        page,
+        new Map(),
+        deliusServiceUserFactory.build({ firstName: 'FIRSTNAME', surname: 'SURNAME' }),
+        'service-provider',
+        '/service-provider/dashboard/backlink'
+      )
+      expect(presenter.hrefBackLink).toEqual('/service-provider/dashboard/backlink')
+    })
+  })
 })

--- a/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
+++ b/server/routes/caseNotes/viewAll/caseNotesPresenter.ts
@@ -29,7 +29,8 @@ export default class CaseNotesPresenter {
     private caseNotes: Page<CaseNote>,
     private officerUserNameMapping: Map<string, undefined | string>,
     private serviceUser: DeliusServiceUser,
-    public loggedInUserType: 'service-provider' | 'probation-practitioner'
+    public loggedInUserType: 'service-provider' | 'probation-practitioner',
+    private readonly dashboardOriginPage?: string
   ) {
     this.pagination = new Pagination(caseNotes)
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
@@ -45,7 +46,7 @@ export default class CaseNotesPresenter {
 
   readonly backlinkPageNumber = this.caseNotes.number + 1
 
-  readonly hrefBackLink = `/${this.loggedInUserType}/dashboard`
+  readonly hrefBackLink = this.dashboardOriginPage || `/${this.loggedInUserType}/dashboard`
 
   readonly hrefCaseNoteStart = `/${this.loggedInUserType}/referrals/${this.referralId}/add-case-note/start`
 

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -921,4 +921,42 @@ describe(InterventionProgressPresenter, () => {
       })
     })
   })
+
+  describe('back link', () => {
+    it('should default the hrefBackLink if dashboardOriginPage not passed in', () => {
+      const referral = sentReferralFactory.build()
+      const intervention = interventionFactory.build()
+      const supplierAssessment = supplierAssessmentFactory.justCreated.build()
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null,
+        undefined
+      )
+
+      expect(presenter.hrefBackLink).toEqual('/probation-practioner/dashboard')
+    })
+
+    it('should populate the hrefBackLink from dashboardOriginPage when passed in', () => {
+      const referral = sentReferralFactory.build()
+      const intervention = interventionFactory.build()
+      const supplierAssessment = supplierAssessmentFactory.justCreated.build()
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null,
+        '/probation-practioner/dashboard/backlink'
+      )
+
+      expect(presenter.hrefBackLink).toEqual('/probation-practioner/dashboard/backlink')
+    })
+  })
 })

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -45,7 +45,8 @@ export default class InterventionProgressPresenter {
     private readonly actionPlan: ActionPlan | null,
     private readonly approvedActionPlanSummaries: ApprovedActionPlanSummary[],
     private readonly supplierAssessment: SupplierAssessment,
-    private readonly assignee: AuthUserDetails | null
+    private readonly assignee: AuthUserDetails | null,
+    private readonly dashboardOriginPage?: string
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Progress,
@@ -118,6 +119,8 @@ export default class InterventionProgressPresenter {
       }
     })
   }
+
+  readonly hrefBackLink = this.dashboardOriginPage || '/probation-practioner/dashboard'
 
   private sessionTableParams(appointment: ActionPlanAppointment): {
     text: string

--- a/server/routes/probationPractitionerReferrals/interventionProgressView.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressView.ts
@@ -72,7 +72,7 @@ export default class InterventionProgressView {
 
   private readonly backLinkArgs = {
     text: 'Back',
-    href: '/probation-practitioner/dashboard',
+    href: this.presenter.hrefBackLink,
   }
 
   get renderArgs(): [string, Record<string, unknown>] {

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -111,6 +111,8 @@ export default class ProbationPractitionerReferralsController {
       paginationQuery
     )
 
+    req.session.dashboardOriginPage = req.originalUrl
+
     const presenter = new DashboardPresenter(cases, res.locals.user, dashboardType, tablePersistentId, sort[0])
     const view = new DashboardView(presenter)
     ControllerUtils.renderWithLayout(res, view, null)
@@ -186,7 +188,8 @@ export default class ProbationPractitionerReferralsController {
       actionPlan,
       approvedActionPlanSummaries,
       supplierAssessment,
-      assignee
+      assignee,
+      req.session.dashboardOriginPage
     )
     const view = new InterventionProgressView(presenter)
 
@@ -230,7 +233,8 @@ export default class ProbationPractitionerReferralsController {
       expandedServiceUser,
       riskSummary,
       responsibleOfficer,
-      req.query.detailsUpdated === 'true'
+      req.query.detailsUpdated === 'true',
+      req.session.dashboardOriginPage
     )
     const view = new ShowReferralView(presenter)
     ControllerUtils.renderWithLayout(res, view, expandedServiceUser)

--- a/server/routes/referral/cancellation/confirmation/referralCancellationConfirmationPresenter.test.ts
+++ b/server/routes/referral/cancellation/confirmation/referralCancellationConfirmationPresenter.test.ts
@@ -40,4 +40,24 @@ describe(ReferralCancellationConfirmationPresenter, () => {
       ])
     })
   })
+
+  describe('back link', () => {
+    it('should default the hrefBackLink if dashboardOriginPage not passed in', () => {
+      const sentReferral = sentReferralFactory.build()
+      const intervention = interventionFactory.build()
+      const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, intervention)
+      expect(presenter.myCasesHref).toEqual('/probation-practitioner/dashboard')
+    })
+
+    it('should populate the hrefBackLink from dashboardOriginPage when passed in', () => {
+      const sentReferral = sentReferralFactory.build()
+      const intervention = interventionFactory.build()
+      const presenter = new ReferralCancellationConfirmationPresenter(
+        sentReferral,
+        intervention,
+        '/probation-practitioner/dashboard/backlink'
+      )
+      expect(presenter.myCasesHref).toEqual('/probation-practitioner/dashboard/backlink')
+    })
+  })
 })

--- a/server/routes/referral/cancellation/confirmation/referralCancellationConfirmationPresenter.ts
+++ b/server/routes/referral/cancellation/confirmation/referralCancellationConfirmationPresenter.ts
@@ -5,7 +5,11 @@ import utils from '../../../../utils/utils'
 import Intervention from '../../../../models/intervention'
 
 export default class ReferralCancellationConfirmationPresenter {
-  constructor(private readonly referral: SentReferral, private readonly intervention: Intervention) {}
+  constructor(
+    private readonly referral: SentReferral,
+    private readonly intervention: Intervention,
+    private readonly dashboardOriginPage?: string
+  ) {}
 
   readonly text = {
     confirmationText: 'This referral has been cancelled',
@@ -13,7 +17,7 @@ export default class ReferralCancellationConfirmationPresenter {
     whatHappensNextText: `You need to contact the service provider outside the service to let them know about the change.`,
   }
 
-  readonly myCasesHref = '/probation-practitioner/dashboard'
+  readonly myCasesHref = this.dashboardOriginPage || '/probation-practitioner/dashboard'
 
   readonly serviceUserSummary: SummaryListItem[] = [
     {

--- a/server/routes/referral/cancellation/referralCancellationController.ts
+++ b/server/routes/referral/cancellation/referralCancellationController.ts
@@ -144,7 +144,11 @@ export default class ReferralCancellationController {
     )
     const serviceUser = await this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
 
-    const presenter = new ReferralCancellationConfirmationPresenter(sentReferral, intervention)
+    const presenter = new ReferralCancellationConfirmationPresenter(
+      sentReferral,
+      intervention,
+      req.session.dashboardOriginPage
+    )
     const view = new ReferralCancellationConfirmationView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.test.ts
@@ -140,4 +140,27 @@ describe(AssignmentConfirmationPresenter, () => {
       })
     })
   })
+
+  describe('back link', () => {
+    it('should default the hrefBackLink if dashboardOriginPage not passed in', () => {
+      const sentReferral = sentReferralFactory.build()
+      const intervention = interventionFactory.build()
+      const assignee = hmppsAuthUserFactory.build()
+      const presenter = new AssignmentConfirmationPresenter(sentReferral, intervention, assignee)
+      expect(presenter.dashboardHref).toEqual('/service-provider/dashboard')
+    })
+
+    it('should populate the hrefBackLink from dashboardOriginPage when passed in', () => {
+      const sentReferral = sentReferralFactory.build()
+      const intervention = interventionFactory.build()
+      const assignee = hmppsAuthUserFactory.build()
+      const presenter = new AssignmentConfirmationPresenter(
+        sentReferral,
+        intervention,
+        assignee,
+        '/service-provider/dashboard/backlink'
+      )
+      expect(presenter.dashboardHref).toEqual('/service-provider/dashboard/backlink')
+    })
+  })
 })

--- a/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/assignmentConfirmationPresenter.ts
@@ -9,10 +9,11 @@ export default class AssignmentConfirmationPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly intervention: Intervention,
-    private readonly assignee: AuthUserDetails
+    private readonly assignee: AuthUserDetails,
+    private readonly dashboardOriginPage?: string
   ) {}
 
-  readonly dashboardHref = '/service-provider/dashboard'
+  readonly dashboardHref = this.dashboardOriginPage || '/service-provider/dashboard'
 
   readonly summary: SummaryListItem[] = [
     {

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -1037,4 +1037,40 @@ describe(InterventionProgressPresenter, () => {
       })
     })
   })
+
+  describe('back link', () => {
+    it('should default the hrefBackLink if dashboardOriginPage not passed in', () => {
+      const referral = sentReferralFactory.build()
+      const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        null,
+        [],
+        [],
+        supplierAssessmentFactory.build(),
+        null,
+        undefined
+      )
+
+      expect(presenter.hrefBackLink).toEqual('/service-provider/dashboard')
+    })
+
+    it('should populate the hrefBackLink from dashboardOriginPage when passed in', () => {
+      const referral = sentReferralFactory.build()
+      const intervention = interventionFactory.build({ contractType: { name: 'accommodation' } })
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        null,
+        [],
+        [],
+        supplierAssessmentFactory.build(),
+        null,
+        '/service-provider/dashboard/backlink'
+      )
+
+      expect(presenter.hrefBackLink).toEqual('/service-provider/dashboard/backlink')
+    })
+  })
 })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -79,9 +79,7 @@ export default class InterventionProgressPresenter {
     return this.referralAssigned ? `${this.assignee!.email}` : null
   }
 
-  get hrefBackLink(): string {
-    return this.dashboardOriginPage ? `${this.dashboardOriginPage}` : '/service-provider/dashboard'
-  }
+  readonly hrefBackLink = this.dashboardOriginPage || '/service-provider/dashboard'
 
   readonly text = {
     title: utils.convertToTitleCase(this.intervention.contractType.name),

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -50,7 +50,8 @@ export default class InterventionProgressPresenter {
     private readonly approvedActionPlanSummaries: ApprovedActionPlanSummary[],
     private readonly actionPlanAppointments: ActionPlanAppointment[],
     private readonly supplierAssessment: SupplierAssessment,
-    private readonly assignee: AuthUserDetails | null
+    private readonly assignee: AuthUserDetails | null,
+    private readonly dashboardOriginPage?: string
   ) {
     const subNavUrlPrefix = 'service-provider'
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
@@ -76,6 +77,10 @@ export default class InterventionProgressPresenter {
 
   get assignedCaseworkerEmail(): string | null {
     return this.referralAssigned ? `${this.assignee!.email}` : null
+  }
+
+  get hrefBackLink(): string {
+    return this.dashboardOriginPage ? `${this.dashboardOriginPage}` : '/service-provider/dashboard'
   }
 
   readonly text = {

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -89,7 +89,7 @@ export default class InterventionProgressView {
 
   private readonly backLinkArgs = {
     text: 'Back',
-    href: '/service-provider/dashboard',
+    href: this.presenter.hrefBackLink,
   }
 
   private endOfServiceReportSummaryListArgs(tagMacro: (args: TagArgs) => string, csrfToken: string): SummaryListArgs {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest'
 import { Express } from 'express'
 import createError from 'http-errors'
 import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
+import getCookieValue from '../testutils/responseUtils'
 import InterventionsService from '../../services/interventionsService'
 import apiConfig from '../../config'
 import sentReferralFactory from '../../../testutils/factories/sentReferral'
@@ -110,6 +111,52 @@ describe('GET /service-provider/dashboard', () => {
         expect(res.text).toContain('Accommodation Services - West Midlands')
       })
   })
+
+  it('stores dashboard link in cookies', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'Michael',
+        },
+      }),
+    ]
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+
+    await request(app)
+      .get('/service-provider/dashboard')
+      .expect(res => {
+        const cookieVal = getCookieValue(res.header['set-cookie'])
+        expect(cookieVal).toMatchObject({
+          dashboardOriginPage: '/service-provider/dashboard',
+        })
+      })
+  })
+
+  it('stores dashboard link in cookies with correct page number', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'Michael',
+        },
+      }),
+    ]
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+
+    await request(app)
+      .get('/service-provider/dashboard?page=2')
+      .expect(res => {
+        const cookieVal = getCookieValue(res.header['set-cookie'])
+        expect(cookieVal).toMatchObject({
+          dashboardOriginPage: '/service-provider/dashboard?page=2',
+        })
+      })
+  })
 })
 
 describe('GET /service-provider/dashboard/my-cases', () => {
@@ -132,6 +179,52 @@ describe('GET /service-provider/dashboard/my-cases', () => {
         expect(res.text).toContain('My cases')
         expect(res.text).toContain('George Michael')
         expect(res.text).toContain('Accommodation Services - West Midlands')
+      })
+  })
+
+  it('stores dashboard link in cookies', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'Michael',
+        },
+      }),
+    ]
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+
+    await request(app)
+      .get('/service-provider/dashboard/my-cases')
+      .expect(res => {
+        const cookieVal = getCookieValue(res.header['set-cookie'])
+        expect(cookieVal).toMatchObject({
+          dashboardOriginPage: '/service-provider/dashboard/my-cases',
+        })
+      })
+  })
+
+  it('stores dashboard link in cookies with correct page number', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'Michael',
+        },
+      }),
+    ]
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+
+    await request(app)
+      .get('/service-provider/dashboard/my-cases?page=2')
+      .expect(res => {
+        const cookieVal = getCookieValue(res.header['set-cookie'])
+        expect(cookieVal).toMatchObject({
+          dashboardOriginPage: '/service-provider/dashboard/my-cases?page=2',
+        })
       })
   })
 })
@@ -198,6 +291,52 @@ describe('GET /service-provider/dashboard/all-open-cases', () => {
         expect(res.text).toContain('Showing <b>1</b> to <b>2</b> of <b>2</b>')
       })
   })
+
+  it('stores dashboard link in cookies', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'Michael',
+        },
+      }),
+    ]
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+
+    await request(app)
+      .get('/service-provider/dashboard/all-open-cases')
+      .expect(res => {
+        const cookieVal = getCookieValue(res.header['set-cookie'])
+        expect(cookieVal).toMatchObject({
+          dashboardOriginPage: '/service-provider/dashboard/all-open-cases',
+        })
+      })
+  })
+
+  it('stores dashboard link in cookies with correct page number', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'Michael',
+        },
+      }),
+    ]
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+
+    await request(app)
+      .get('/service-provider/dashboard/all-open-cases?page=2')
+      .expect(res => {
+        const cookieVal = getCookieValue(res.header['set-cookie'])
+        expect(cookieVal).toMatchObject({
+          dashboardOriginPage: '/service-provider/dashboard/all-open-cases?page=2',
+        })
+      })
+  })
 })
 
 describe('GET /service-provider/dashboard/unassigned-cases', () => {
@@ -222,6 +361,52 @@ describe('GET /service-provider/dashboard/unassigned-cases', () => {
         expect(res.text).toContain('Accommodation Services - West Midlands')
       })
   })
+
+  it('stores dashboard link in cookies', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'Michael',
+        },
+      }),
+    ]
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+
+    await request(app)
+      .get('/service-provider/dashboard/unassigned-cases')
+      .expect(res => {
+        const cookieVal = getCookieValue(res.header['set-cookie'])
+        expect(cookieVal).toMatchObject({
+          dashboardOriginPage: '/service-provider/dashboard/unassigned-cases',
+        })
+      })
+  })
+
+  it('stores dashboard link in cookies with correct page number', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'Michael',
+        },
+      }),
+    ]
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+
+    await request(app)
+      .get('/service-provider/dashboard/unassigned-cases?page=2')
+      .expect(res => {
+        const cookieVal = getCookieValue(res.header['set-cookie'])
+        expect(cookieVal).toMatchObject({
+          dashboardOriginPage: '/service-provider/dashboard/unassigned-cases?page=2',
+        })
+      })
+  })
 })
 
 describe('GET /service-provider/dashboard/completed-cases', () => {
@@ -244,6 +429,52 @@ describe('GET /service-provider/dashboard/completed-cases', () => {
         expect(res.text).toContain('My cases')
         expect(res.text).toContain('George Michael')
         expect(res.text).toContain('Accommodation Services - West Midlands')
+      })
+  })
+
+  it('stores dashboard link in cookies', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'Michael',
+        },
+      }),
+    ]
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+
+    await request(app)
+      .get('/service-provider/dashboard/completed-cases')
+      .expect(res => {
+        const cookieVal = getCookieValue(res.header['set-cookie'])
+        expect(cookieVal).toMatchObject({
+          dashboardOriginPage: '/service-provider/dashboard/completed-cases',
+        })
+      })
+  })
+
+  it('stores dashboard link in cookies with correct page number', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'Michael',
+        },
+      }),
+    ]
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+
+    await request(app)
+      .get('/service-provider/dashboard/completed-cases?page=2')
+      .expect(res => {
+        const cookieVal = getCookieValue(res.header['set-cookie'])
+        expect(cookieVal).toMatchObject({
+          dashboardOriginPage: '/service-provider/dashboard/completed-cases?page=2',
+        })
       })
   })
 })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -106,7 +106,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       SPDashboardType.MyCases
     )
-    this.renderDashboardWithoutPagination(res, referralsSummary, 'My cases')
+    this.renderDashboardWithoutPagination(req, res, referralsSummary, 'My cases')
   }
 
   async showAllOpenCasesDashboard(req: Request, res: Response): Promise<void> {
@@ -122,7 +122,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       SPDashboardType.OpenCases
     )
-    this.renderDashboardWithoutPagination(res, referralsSummary, 'All open cases')
+    this.renderDashboardWithoutPagination(req, res, referralsSummary, 'All open cases')
   }
 
   async showUnassignedCasesDashboard(req: Request, res: Response): Promise<void> {
@@ -145,7 +145,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       SPDashboardType.UnassignedCases
     )
-    this.renderDashboardWithoutPagination(res, referralsSummary, 'Unassigned cases')
+    this.renderDashboardWithoutPagination(req, res, referralsSummary, 'Unassigned cases')
   }
 
   async showCompletedCasesDashboard(req: Request, res: Response): Promise<void> {
@@ -161,7 +161,7 @@ export default class ServiceProviderReferralsController {
       res.locals.user.token.accessToken,
       SPDashboardType.CompletedCases
     )
-    this.renderDashboardWithoutPagination(res, referralsSummary, 'Completed cases')
+    this.renderDashboardWithoutPagination(req, res, referralsSummary, 'Completed cases')
   }
 
   private async renderDashboard(
@@ -195,6 +195,8 @@ export default class ServiceProviderReferralsController {
       paginationQuery
     )
 
+    req.session.dashboardOriginPage = req.originalUrl
+
     const presenter = new DashboardPresenter(cases, dashboardType, res.locals.user, tablePersistentId, sort[0])
     const view = new DashboardView(presenter)
 
@@ -203,10 +205,13 @@ export default class ServiceProviderReferralsController {
 
   // To be removed once we are happy with the pagination work.
   private renderDashboardWithoutPagination(
+    req: Request,
     res: Response,
     referralsSummary: ServiceProviderSentReferralSummary[],
     dashboardType: DashboardType
   ): void {
+    req.session.dashboardOriginPage = req.originalUrl
+
     const presenter = new DashboardWithoutPaginationPresenter(referralsSummary, dashboardType, res.locals.user)
     const view = new DashboardWithoutPaginationView(presenter)
 
@@ -261,7 +266,9 @@ export default class ServiceProviderReferralsController {
       true,
       expandedServiceUser,
       riskSummary,
-      responsibleOfficer
+      responsibleOfficer,
+      false,
+      req.session.dashboardOriginPage
     )
     const view = new ShowReferralView(presenter)
 
@@ -315,7 +322,8 @@ export default class ServiceProviderReferralsController {
       approvedActionPlanSummaries,
       actionPlanAppointments,
       supplierAssessment,
-      assignee
+      assignee,
+      req.session.dashboardOriginPage
     )
     const view = new InterventionProgressView(presenter)
 
@@ -432,7 +440,12 @@ export default class ServiceProviderReferralsController {
       this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn),
     ])
 
-    const presenter = new AssignmentConfirmationPresenter(referral, intervention, assignee)
+    const presenter = new AssignmentConfirmationPresenter(
+      referral,
+      intervention,
+      assignee,
+      req.session.dashboardOriginPage
+    )
     const view = new AssignmentConfirmationView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/shared/referralOverviewPagePresenter.test.ts
+++ b/server/routes/shared/referralOverviewPagePresenter.test.ts
@@ -42,12 +42,34 @@ describe(ReferralOverviewPagePresenter, () => {
   })
 
   describe('dashboardURL', () => {
-    const values: ('service-provider' | 'probation-practitioner')[] = ['service-provider', 'probation-practitioner']
-    it.each(values)('returns a relative URL for the %s dashboard', prefix => {
-      const sentReferral = sentReferralFactory.build()
-      const presenter = new ReferralOverviewPagePresenter(ReferralOverviewPageSection.Details, sentReferral.id, prefix)
+    describe('dashboard origin page not passed in', () => {
+      const values: ('service-provider' | 'probation-practitioner')[] = ['service-provider', 'probation-practitioner']
+      it.each(values)('returns a relative URL for the %s dashboard', prefix => {
+        const sentReferral = sentReferralFactory.build()
+        const presenter = new ReferralOverviewPagePresenter(
+          ReferralOverviewPageSection.Details,
+          sentReferral.id,
+          prefix,
+          undefined
+        )
 
-      expect(presenter.dashboardURL).toEqual(`/${prefix}/dashboard`)
+        expect(presenter.dashboardURL).toEqual(`/${prefix}/dashboard`)
+      })
+    })
+
+    describe('dashboard origin page passed in', () => {
+      const values: ('service-provider' | 'probation-practitioner')[] = ['service-provider', 'probation-practitioner']
+      it.each(values)('returns a relative URL for the %s dashboard', prefix => {
+        const sentReferral = sentReferralFactory.build()
+        const presenter = new ReferralOverviewPagePresenter(
+          ReferralOverviewPageSection.Details,
+          sentReferral.id,
+          prefix,
+          '/service-provider/dashboard/backlink'
+        )
+
+        expect(presenter.dashboardURL).toEqual('/service-provider/dashboard/backlink')
+      })
     })
   })
 })

--- a/server/routes/shared/referralOverviewPagePresenter.ts
+++ b/server/routes/shared/referralOverviewPagePresenter.ts
@@ -8,7 +8,8 @@ export default class ReferralOverviewPagePresenter {
   constructor(
     private readonly section: ReferralOverviewPageSection,
     private readonly referralId: string,
-    private readonly subNavUrlPrefix: 'service-provider' | 'probation-practitioner'
+    private readonly subNavUrlPrefix: 'service-provider' | 'probation-practitioner',
+    private readonly dashboardOriginPage?: string
   ) {}
 
   readonly subNavArgs = {
@@ -31,5 +32,7 @@ export default class ReferralOverviewPagePresenter {
     ],
   }
 
-  readonly dashboardURL = `/${this.subNavUrlPrefix}/dashboard`
+  readonly dashboardURL = this.dashboardOriginPage
+    ? `${this.dashboardOriginPage}`
+    : `/${this.subNavUrlPrefix}/dashboard`
 }

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -41,12 +41,14 @@ export default class ShowReferralPresenter {
     private readonly deliusServiceUser: ExpandedDeliusServiceUser,
     readonly riskSummary: RiskSummary | null,
     private readonly responsibleOfficer: DeliusOffenderManager | null,
-    readonly showSuccess: boolean = false
+    readonly showSuccess: boolean = false,
+    private readonly dashboardOriginPage?: string
   ) {
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
       ReferralOverviewPageSection.Details,
       sentReferral.id,
-      userType
+      userType,
+      dashboardOriginPage
     )
 
     this.roshPanelPresenter = new RoshPanelPresenter(riskSummary)

--- a/server/routes/testutils/responseUtils.ts
+++ b/server/routes/testutils/responseUtils.ts
@@ -1,0 +1,10 @@
+export default function getCookieValue(cookieHeader = []) {
+  const regExp = /.*express:sess=(\w*);.*/
+  const cookieValBase64 = cookieHeader.reduce((found: string, curr: string) => {
+    if (found) return found
+    const [, sessToken] = regExp.exec(curr) || []
+    return sessToken
+  }, '')
+  const decodeCookie = Buffer.from(cookieValBase64, 'base64').toString() || ''
+  return JSON.parse(decodeCookie)
+}


### PR DESCRIPTION
## What does this pull request do?

Clicking back will take users back to their most recent view, so will return to the same dashboard tab (and page within that tab) 

## What is the intent behind these changes?

When processing multiple cases on clicking back users are no longer returned to the home page, from which they then have to navigate back to the list they were viewing, instead it returns them to the same view they opened the case from.

https://trello.com/c/zRBi9aBN