### PR TITLE
Updated referral cancelled text to tell PP's they need to inform SP's

### DIFF
--- a/server/routes/referral/cancellation/confirmation/referralCancellationConfirmationPresenter.test.ts
+++ b/server/routes/referral/cancellation/confirmation/referralCancellationConfirmationPresenter.test.ts
@@ -11,8 +11,9 @@ describe(ReferralCancellationConfirmationPresenter, () => {
 
       expect(presenter.text).toMatchObject({
         confirmationText: 'This referral has been cancelled',
+        headingText: 'What you need to do next',
         whatHappensNextText:
-          "Service provider will be notified about the cancellation. You don't have to do anything else.",
+          'You need to contact the service provider outside the service to let them know about the change.',
       })
     })
   })

--- a/server/routes/referral/cancellation/confirmation/referralCancellationConfirmationPresenter.ts
+++ b/server/routes/referral/cancellation/confirmation/referralCancellationConfirmationPresenter.ts
@@ -9,8 +9,8 @@ export default class ReferralCancellationConfirmationPresenter {
 
   readonly text = {
     confirmationText: 'This referral has been cancelled',
-    whatHappensNextText:
-      "Service provider will be notified about the cancellation. You don't have to do anything else.",
+    headingText: 'What you need to do next',
+    whatHappensNextText: `You need to contact the service provider outside the service to let them know about the change.`,
   }
 
   readonly myCasesHref = '/probation-practitioner/dashboard'

--- a/server/views/probationPractitionerReferrals/referralCancellationConfirmation.njk
+++ b/server/views/probationPractitionerReferrals/referralCancellationConfirmation.njk
@@ -13,6 +13,8 @@
 
       {{ govukSummaryList(summaryListArgs) }}
 
+      <h2 class="govuk-heading-m">{{presenter.text.headingText}}</p>
+
       <p class="govuk-body">{{presenter.text.whatHappensNextText}}</p>
 
       <a href="{{ presenter.myCasesHref }}" class="govuk-button">Go back to My Cases</a>


### PR DESCRIPTION
## What does this pull request do?

Updates the text on the referral cancelled page.

## What is the intent behind these changes?

Currently, emails are not being sent out when a referral is cancelled - the text needs to be changed as a temporary solution to let the PP's know it is their responsibility to inform SP's
