### PR TITLE
Document auth API usage for the developer portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -20,4 +20,4 @@ spec:
     - api:hmpps-interventions
     - api:hmpps-risks-and-needs
     - api:hmpps-community
-    # - api:hmpps-auth # not yet defined
+    - api:hmpps-auth


### PR DESCRIPTION
## What does this pull request do?

Document auth API usage for the developer portal

## What is the intent behind these changes?

Provide a realistic [map of dependencies](https://developer-portal.apps.live.cloud-platform.service.justice.gov.uk/catalog-graph?rootEntityRefs%5B%5D=component%3Adefault%2Fhmpps-interventions-ui&maxDepth=%E2%88%9E&selectedRelations%5B%5D=consumesApi&selectedRelations%5B%5D=dependsOn&selectedRelations%5B%5D=apiProvidedBy&unidirectional=false&mergeRelations=true&direction=TB&showFilters=true) (it's only token-verification-api that's missing now)

This change would map hmpps-auth into the above graph