### PR TITLE
Updated docker-compose to the most recent version of postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - ASSESSRISKSANDNEEDS_BASEURL=http://assess-risks-and-needs:8080
 
   postgres:
-    image: postgres:10-alpine
+    image: postgres:14.2-alpine
     container_name: postgres
     networks:
       - hmpps


### PR DESCRIPTION
## What does this pull request do?

Uses the most recent version of postgres which is the version used by the service to fix the deprecated image version

## What is the intent behind these changes?

Prevents us from having an unsupported postgres image in the future.
