### PR TITLE
Add a retry to failing tests

### DIFF
--- a/integration_tests/integration/dashboards.spec.js
+++ b/integration_tests/integration/dashboards.spec.js
@@ -169,29 +169,40 @@ describe('Dashboards', () => {
     })
 
     describe('table sort headings', () => {
-      it('should show which column the table is currently sorted by', () => {
+      beforeEach(() => {
         cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent([]).build())
         cy.login()
-
-        const headings = ['Date sent', 'Referral', 'Person', 'Intervention type', 'Provider']
-        headings.forEach(heading => {
-          cy.get('table').within(() => cy.contains('button', heading).click())
-
-          // check the clicked heading is sorted and all others are not
-          cy.get('thead')
-            .find('th')
-            .each($el => {
-              const sort = $el.text() === heading ? 'ascending' : 'none'
-              cy.wrap($el).should('have.attr', { 'aria-sort': sort })
-            })
-
-          // clicking again sorts in the other direction
-          cy.get('table').within(() => cy.contains('button', heading).click())
-          cy.get('table').within(() =>
-            cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' })
-          )
-        })
       })
+
+      it(
+        'should show which column the table is currently sorted by',
+        {
+          retries: {
+            runMode: 2,
+            openMode: 1,
+          },
+        },
+        () => {
+          const headings = ['Date sent', 'Referral', 'Person', 'Intervention type', 'Provider']
+          headings.forEach(heading => {
+            cy.get('table').within(() => cy.contains('button', heading).click())
+
+            // check the clicked heading is sorted and all others are not
+            cy.get('thead')
+              .find('th')
+              .each($el => {
+                const sort = $el.text() === heading ? 'ascending' : 'none'
+                cy.wrap($el).should('have.attr', { 'aria-sort': sort })
+              })
+
+            // clicking again sorts in the other direction
+            cy.get('table').within(() => cy.contains('button', heading).click())
+            cy.get('table').within(() =>
+              cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' })
+            )
+          })
+        }
+      )
     })
   })
 
@@ -301,29 +312,40 @@ describe('Dashboards', () => {
     })
 
     describe('table sort headings', () => {
-      it('should show which column the table is currently sorted by', () => {
+      beforeEach(() => {
         cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent([]).build())
         cy.login()
-
-        const headings = ['Date received', 'Referral', 'Person', 'Intervention type']
-        headings.forEach(heading => {
-          cy.get('table').within(() => cy.contains('button', heading).click())
-
-          // check the clicked heading is sorted and all others are not
-          cy.get('thead')
-            .find('th')
-            .each($el => {
-              const sort = $el.text() === heading ? 'ascending' : 'none'
-              cy.wrap($el).should('have.attr', { 'aria-sort': sort })
-            })
-
-          // clicking again sorts in the other direction
-          cy.get('table').within(() => cy.contains('button', heading).click())
-          cy.get('table').within(() =>
-            cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' })
-          )
-        })
       })
+
+      it(
+        'should show which column the table is currently sorted by',
+        {
+          retries: {
+            runMode: 2,
+            openMode: 1,
+          },
+        },
+        () => {
+          const headings = ['Date received', 'Referral', 'Person', 'Intervention type']
+          headings.forEach(heading => {
+            cy.get('table').within(() => cy.contains('button', heading).click())
+
+            // check the clicked heading is sorted and all others are not
+            cy.get('thead')
+              .find('th')
+              .each($el => {
+                const sort = $el.text() === heading ? 'ascending' : 'none'
+                cy.wrap($el).should('have.attr', { 'aria-sort': sort })
+              })
+
+            // clicking again sorts in the other direction
+            cy.get('table').within(() => cy.contains('button', heading).click())
+            cy.get('table').within(() =>
+              cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' })
+            )
+          })
+        }
+      )
 
       const dashBoardTables = [
         {
@@ -346,9 +368,6 @@ describe('Dashboards', () => {
 
       dashBoardTables.forEach(table => {
         it(`persists the sort order when coming back to the page for dashboard "${table.dashboardType}"`, () => {
-          cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent([]).build())
-          cy.login()
-
           cy.contains(table.dashboardType).click()
 
           cy.get('table').within(() => cy.contains('button', table.sortField).click())


### PR DESCRIPTION
Intermittent `element is detached from the DOM.` errors are causing the
cypress tests to fail, this will retry the failing tests

## What does this pull request do?

Adds retry parameter to failing tests 
(`runMode` for `cypress run` commands and `openMode` for `cypress open` commands)

Also moves cy.stub setup to beforeEach, to try and reduce likelihood of tests running while setup is completing

## What is the intent behind these changes?

To try and stop intermittent failures of integration_test pipeline
