### PR TITLE
updated the pact test cases to the new sent-referrals

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start:dev": "npm run build && NODE_ENV=development npm run watch",
     "start:test": "export $(cat test.env) && npm run start",
     "test": "jest --runInBand",
+    "test-debug": "npm test --watch -t",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open",
     "int-test-video": "CYPRESS_NO_COMMAND_LOG=1 cypress run --config video=true,slowTestThreshold=15000 --env CYPRESS_COMMAND_DELAY=1200",


### PR DESCRIPTION
## What does this pull request do?

updates the pact test for the new API `/sent-referrals/summaries` and remove the pact test for the deprecated API `/sent-referrals`

## What is the intent behind these changes?

We have published a new API `/sent-referrals/summaries`, so it requires the pact test to be updated to test the new API. Also, we have deprecated the old API `/sent-referrals`, so it requires the pact test to be removed for that API.
