### PR TITLE
update wiremock container

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -11,7 +11,7 @@ services:
       - '6380:6379'
 
   test-wiremock:
-    image: rodolpheche/wiremock
+    image: wiremock/wiremock
     networks:
     - hmpps_int
     container_name: wiremock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - ./testutils/docker/postgres:/docker-entrypoint-initdb.d:ro
 
   wiremock:
-    image: rodolpheche/wiremock
+    image: wiremock/wiremock
     networks:
       - hmpps
     restart: always


### PR DESCRIPTION
The old `rodolpheche/wiremock` image is deprecated.  New image also compatible with m1 chips.

## What does this pull request do?

Updates image used by wiremock

## What is the intent behind these changes?

The old image is deprecated (https://hub.docker.com/r/rodolpheche/wiremock/#!) this is the recommended official image.
The updated image is also compatible with m1 chips, so container does not run in emulation mode
