### PR TITLE
Back button to end of service report view

### DIFF
--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -252,7 +252,12 @@ export default class ProbationPractitionerReferralsController {
     }
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new EndOfServiceReportPresenter(referral, endOfServiceReport, serviceCategories)
+    const presenter = new EndOfServiceReportPresenter(
+      referral,
+      endOfServiceReport,
+      serviceCategories,
+      'probation-practitioner'
+    )
     const view = new EndOfServiceReportView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -887,7 +887,12 @@ export default class ServiceProviderReferralsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
-    const presenter = new EndOfServiceReportPresenter(referral, endOfServiceReport, serviceCategories)
+    const presenter = new EndOfServiceReportPresenter(
+      referral,
+      endOfServiceReport,
+      serviceCategories,
+      'service-provider'
+    )
     const view = new EndOfServiceReportView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/shared/endOfServiceReport/endOfServiceReportPresenter.test.ts
+++ b/server/routes/shared/endOfServiceReport/endOfServiceReportPresenter.test.ts
@@ -54,4 +54,36 @@ describe(EndOfServiceReportPresenter, () => {
       expect(presenter.answersPresenter).toBeDefined()
     })
   })
+
+  describe('back link probation practitioner user', () => {
+    it('returns correct link with Id', () => {
+      const referralId = '81d754aa-d868-4347-9c0f-50690773014e'
+      const probationPractitioner = 'probation-practitioner'
+      const backLinkUrl = `/${probationPractitioner}/referrals/${referralId}/progress`
+      const presenter = new EndOfServiceReportPresenter(
+        referral,
+        buildEndOfServiceReport(),
+        [serviceCategory],
+        probationPractitioner
+      )
+
+      expect(presenter.hrefBackLink).toBeDefined()
+      expect(presenter.hrefBackLink).toBe(backLinkUrl)
+    })
+  })
+  describe('back link service provider user', () => {
+    it('returns correct link with Id', () => {
+      const referralId = '81d754aa-d868-4347-9c0f-50690773014e'
+      const serviceProvider = 'service-provider'
+      const backLinkUrl = `/${serviceProvider}/referrals/${referralId}/progress`
+      const presenter = new EndOfServiceReportPresenter(
+        referral,
+        buildEndOfServiceReport(),
+        [serviceCategory],
+        serviceProvider
+      )
+      expect(presenter.hrefBackLink).toBeDefined()
+      expect(presenter.hrefBackLink).toBe(backLinkUrl)
+    })
+  })
 })

--- a/server/routes/shared/endOfServiceReport/endOfServiceReportPresenter.ts
+++ b/server/routes/shared/endOfServiceReport/endOfServiceReportPresenter.ts
@@ -8,8 +8,11 @@ export default class EndOfServiceReportPresenter {
   constructor(
     private readonly referral: SentReferral,
     private readonly endOfServiceReport: EndOfServiceReport,
-    private readonly serviceCategories: ServiceCategory[]
+    private readonly serviceCategories: ServiceCategory[],
+    private readonly userType?: 'probation-practitioner' | 'service-provider'
   ) {}
+
+  readonly hrefBackLink = `/${this.userType}/referrals/${this.endOfServiceReport.referralId}/progress`
 
   readonly text = {
     introduction: `The service provider has created an end of service report for ${PresenterUtils.fullName(

--- a/server/routes/shared/endOfServiceReport/endOfServiceReportView.ts
+++ b/server/routes/shared/endOfServiceReport/endOfServiceReportView.ts
@@ -2,13 +2,22 @@ import EndOfServiceReportAnswersView from '../endOfServiceReportAnswersView'
 import EndOfServiceReportPresenter from './endOfServiceReportPresenter'
 
 export default class EndOfServiceReportView {
-  constructor(private readonly presenter: EndOfServiceReportPresenter) {}
+  constructor(
+    private readonly presenter: EndOfServiceReportPresenter,
+    private readonly serviceProviderReferralProgress?: string
+  ) {}
 
   private readonly answersView = new EndOfServiceReportAnswersView(this.presenter.answersPresenter)
+
+  private readonly backLinkArgs = {
+    text: 'Back',
+    href: this.presenter.hrefBackLink,
+  }
 
   readonly renderArgs: [string, Record<string, unknown>] = [
     'shared/endOfServiceReport',
     {
+      backLinkArgs: this.backLinkArgs,
       presenter: this.presenter,
       ...this.answersView.locals,
     },

--- a/server/views/shared/endOfServiceReport.njk
+++ b/server/views/shared/endOfServiceReport.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% extends "../partials/layout.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = "End of service report" %}
 {% set pageSubTitle = "View" %}
@@ -8,6 +9,7 @@
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+     {{ govukBackLink(backLinkArgs) }}
       <h1 class="govuk-heading-l">End of service report</h1>
 
       <p class="govuk-body">{{ presenter.text.introduction }}</p>


### PR DESCRIPTION
## What does this pull request do?

Adds back button to service-provider/end-of-service-report to successfully navigate to the previous page

## What is the intent behind these changes?
to solve bug (https://trello.com/c/0k21mW9b/305-%F0%9F%90%9Bpages-missing-back-button)
