### PR TITLE
Adding contract type name in to draft referral

### DIFF
--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -33,4 +33,5 @@ export default interface DraftReferral extends WithNullableValues<ReferralFields
   interventionId: string
   // risk information is a special field which is only set on the draft referral
   additionalRiskInformation: string | null
+  contractTypeName: string
 }

--- a/server/routes/probationPractitionerReferrals/findStartPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/findStartPresenter.test.ts
@@ -53,18 +53,21 @@ describe('FindStartPresenter', () => {
           createdAt: '3 Jan 2021',
           providerName: 'service provider name 2',
           serviceUserFullName: 'Hardip Fraiser',
+          contractTypeName: 'Accommodation',
           url: '/referrals/2/form',
         },
         {
           createdAt: '2 Jan 2021',
           providerName: 'service provider name 1',
           serviceUserFullName: 'Rob Shah-Brookes',
+          contractTypeName: 'Accommodation',
           url: '/referrals/1/form',
         },
         {
           createdAt: '1 Jan 2021',
           providerName: 'service provider name 3',
           serviceUserFullName: 'Jenny Catherine',
+          contractTypeName: 'Accommodation',
           url: '/referrals/3/form',
         },
       ])

--- a/server/routes/probationPractitionerReferrals/findStartPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/findStartPresenter.ts
@@ -20,6 +20,7 @@ export default class FindStartPresenter {
       .map(referral => ({
         serviceUserFullName: PresenterUtils.fullName(referral.serviceUser),
         providerName: referral.serviceProvider?.name ?? '',
+        contractTypeName: referral.contractTypeName,
         createdAt: DateUtils.formattedDate(referral.createdAt, { month: 'short' }),
         url: `/referrals/${referral.id}/form`,
       }))
@@ -52,6 +53,7 @@ export default class FindStartPresenter {
 interface DraftReferralSummaryPresenter {
   serviceUserFullName: string
   providerName: string
+  contractTypeName: string
   createdAt: string
   url: string
 }

--- a/server/routes/probationPractitionerReferrals/findStartView.ts
+++ b/server/routes/probationPractitionerReferrals/findStartView.ts
@@ -8,11 +8,12 @@ export default class FindStartView {
   private get tableArgs(): TableArgs {
     return {
       firstCellIsHeader: true,
-      head: [{ text: 'Service user' }, { text: 'Provider' }, { text: 'Started on' }],
+      head: [{ text: 'Name' }, { text: 'Provider' }, { text: 'Intervention type' }, { text: 'Started on' }],
       rows: this.presenter.orderedReferrals.map(referral => {
         return [
           { html: `<a href="${ViewUtils.escape(referral.url)}">${ViewUtils.escape(referral.serviceUserFullName)}</a>` },
           { text: referral.providerName },
+          { text: referral.contractTypeName },
           { text: referral.createdAt },
         ]
       }),

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -104,6 +104,7 @@ describe('GET /probation-practitioner/find', () => {
         expect(res.text).toContain('Refer and monitor an intervention')
         expect(res.text).toContain('Find interventions')
         expect(res.text).toContain('Alex River')
+        expect(res.text).toContain('Accommodation')
       })
   })
 })

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -171,4 +171,5 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   whenUnavailable: null,
   additionalRiskInformation: null,
   maximumEnforceableDays: null,
+  contractTypeName: interventionFactory.build().contractType.name,
 }))


### PR DESCRIPTION
## What does this pull request do?

This pull request adds the Contract Type Name to the draft referral model, and adds a column to display this in the find interventions draft referral table.
Also updates column heading in the same table to change 'Service user' to 'Name'

## What is the intent behind these changes?

The intent is to provide additional information to the user so that they can better identify draft referrals.
