### PR TITLE
add quiet deps option to build:sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build:views": "cp -R server/views dist/server/",
-    "build:sass": "sass --no-source-map --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend ./assets/sass/application.sass:./assets/stylesheets/application.css ./assets/sass/application-ie8.sass:./assets/stylesheets/application-ie8.css --style compressed",
+    "build:sass": "sass --no-source-map --quiet-deps --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend ./assets/sass/application.sass:./assets/stylesheets/application.css ./assets/sass/application-ie8.sass:./assets/stylesheets/application-ie8.css --style compressed",
     "build:typecheck": "tsc",
     "build:typecheck:prod": "tsc --build tsconfig.prod.json",
     "build:typecheck:browser": "cd browser && tsc",


### PR DESCRIPTION
Sass build is outputting various `Deprecation Warning` messages in build
These are all for the `govuk-frontend` module, not code in interventions-ui
This rule only stops deprecation warnings, not any errors
https://sass-lang.com/documentation/cli/dart-sass#quiet-deps

## What does this pull request do?

adds `--quiet-deps` option to build:sass

## What is the intent behind these changes?

Stop deprecation warnings for `govuk-frontend` module
