### PR TITLE
Fix integration tests for non-chromium browsers

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
-    "chromeWebSecurity": false,
     "baseUrl": "http://localhost:3007",
     "ignoreTestFiles": "**/!(*.spec).js",
     "fixturesFolder": "integration_tests/fixtures",

--- a/integration_tests/integration/login.spec.js
+++ b/integration_tests/integration/login.spec.js
@@ -51,8 +51,9 @@ context('Login', () => {
     })
 
     it('the user can sign out', () => {
+      cy.location('pathname').should('eq', '/probation-practitioner/dashboard')
       cy.get('[data-qa=sign-out]').click()
-      AuthLoginPage.verifyOnPage()
+      cy.location('pathname').should('eq', '/sign-out/success')
     })
 
     it('the user cannot access service provider pages', () => {
@@ -96,8 +97,9 @@ context('Login', () => {
     })
 
     it('the user can sign out', () => {
+      cy.location('pathname').should('eq', '/service-provider/dashboard')
       cy.get('[data-qa=sign-out]').click()
-      AuthLoginPage.verifyOnPage()
+      cy.location('pathname').should('eq', '/sign-out/success')
     })
 
     it('the user cannot access probation practitioner pages', () => {

--- a/mockApis/auth.ts
+++ b/mockApis/auth.ts
@@ -78,11 +78,11 @@ export default class AuthServiceMocks {
         urlPattern: '/auth/sign-out.*',
       },
       response: {
-        status: 200,
+        status: 302,
         headers: {
           'Content-Type': 'text/html',
+          Location: 'http://localhost:3007/sign-out/success',
         },
-        body: '<html><body>Sign-in page<h1>Sign in</h1></body></html>',
       },
     })
   }


### PR DESCRIPTION
## What does this pull request do?

Fixes integration tests for Firefox

## What is the intent behind these changes?

Running int tests using Firefox fails in login.spec.js with:
`CypressError: Cypress detected a cross origin error happened on page load:`
The `chromeWebSecurity` flag is used to get past this in Chrome
This change removes the need for that flag + allows tests to be run in Firefox
when calling `/sign-out` `passport.js` redirects to the auth service endpoint '/auth/sign-out'
this in turn redirects back to `/sign-out/success`
this change bypasses auth service and does the same redirect
removing the need for any cross-origin handling
`chromeWebSecurity` flag removed so Chrome runs the same as Firefox
