### PR TITLE
Update passport to 0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "md5": "^2.3.0",
         "nocache": "^3.0.4",
         "nunjucks": "^3.2.3",
-        "passport": "^0.5.2",
+        "passport": "^0.5.3",
         "passport-oauth2": "^1.6.1",
         "redis": "^3.1.1",
         "superagent": "^7.1.2",
@@ -15445,9 +15445,9 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.2.tgz",
-      "integrity": "sha512-w9n/Ot5I7orGD4y+7V3EFJCQEznE5RxHamUxcqLT2QoJY0f2JdN8GyHonYFvN0Vz+L6lUJfVhrk2aZz2LbuREw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"
@@ -31037,9 +31037,9 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "passport": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.2.tgz",
-      "integrity": "sha512-w9n/Ot5I7orGD4y+7V3EFJCQEznE5RxHamUxcqLT2QoJY0f2JdN8GyHonYFvN0Vz+L6lUJfVhrk2aZz2LbuREw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "md5": "^2.3.0",
     "nocache": "^3.0.4",
     "nunjucks": "^3.2.3",
-    "passport": "^0.5.2",
+    "passport": "^0.5.3",
     "passport-oauth2": "^1.6.1",
     "redis": "^3.1.1",
     "superagent": "^7.1.2",


### PR DESCRIPTION
## What does this pull request do?

Updates passport to version 0.5.3
Version 0.6 has breaking changes and [types/passport](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/passport) has not been updated to reflect this
- req.logout() now requires a callback

## What is the intent behind these changes?

Keep dependencies up to date
