### PR TITLE
Use Page Not Available instead of throwing error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "govuk-frontend": "^4.1.0",
         "helmet": "^5.1.0",
         "http-errors": "^2.0.0",
+        "http-status-codes": "^2.2.0",
         "indefinite": "^2.4.1",
         "joi": "^17.6.0",
         "jquery": "^3.5.1",
@@ -9276,6 +9277,11 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -26301,6 +26307,11 @@
         "jsprim": "^2.0.2",
         "sshpk": "^1.14.1"
       }
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "https-proxy-agent": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "govuk-frontend": "^4.1.0",
     "helmet": "^5.1.0",
     "http-errors": "^2.0.0",
+    "http-status-codes": "^2.2.0",
     "indefinite": "^2.4.1",
     "joi": "^17.6.0",
     "jquery": "^3.5.1",

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -164,11 +164,9 @@ describe('Scheduling a supplier assessment appointment', () => {
 
         await request(app)
           .get(`/service-provider/referrals/1/supplier-assessment/schedule/abc/details`)
-          .expect(500)
+          .expect(410)
           .expect(res => {
-            expect(res.text).toContain(
-              'Too much time has passed since you started booking this appointment. Your answers have not been saved, and you will need to start again.'
-            )
+            expect(res.text).toContain('This page is no longer available')
           })
       })
     })

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -185,11 +185,9 @@ describe.each([
         draftsService.fetchDraft.mockResolvedValue(null)
         await request(app)
           .get(`/${user.userType}/referrals/${sentReferral.id}/add-case-note/non-existent-draft/details`)
-          .expect(500)
+          .expect(410)
           .expect(res => {
-            expect(res.text).toContain(
-              'Too much time has passed since you started creating this case note. Your answers have not been saved, and you will need to start again.'
-            )
+            expect(res.text).toContain('This page is no longer available')
           })
       })
     })

--- a/server/routes/referral/cancellation/referralCancellationController.test.ts
+++ b/server/routes/referral/cancellation/referralCancellationController.test.ts
@@ -114,11 +114,9 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/:draftCancellat
 
       await request(app)
         .get(`/probation-practitioner/referrals/abc/cancellation/def/reason`)
-        .expect(500)
+        .expect(410)
         .expect(res => {
-          expect(res.text).toContain(
-            'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.'
-          )
+          expect(res.text).toContain('This page is no longer available')
         })
     })
   })
@@ -161,11 +159,9 @@ describe('POST /probation-practitioner/referrals/:id/cancellation/:draftCancella
         .post(`/probation-practitioner/referrals/abc/cancellation/def/reason`)
         .type('form')
         .send({ 'cancellation-reason': 'MOV', 'cancellation-comments': 'Alex has moved out of the area' })
-        .expect(500)
+        .expect(410)
         .expect(res => {
-          expect(res.text).toContain(
-            'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.'
-          )
+          expect(res.text).toContain('This page is no longer available')
         })
     })
   })
@@ -231,11 +227,9 @@ describe('GET /probation-practitioner/referrals/:id/cancellation/:draftCancellat
 
       await request(app)
         .get(`/probation-practitioner/referrals/abc/cancellation/def/check-your-answers`)
-        .expect(500)
+        .expect(410)
         .expect(res => {
-          expect(res.text).toContain(
-            'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.'
-          )
+          expect(res.text).toContain('This page is no longer available')
         })
     })
   })
@@ -299,11 +293,9 @@ describe('POST /probation-practitioner/referrals/:id/cancellation/:draftCancella
 
       await request(app)
         .post(`/probation-practitioner/referrals/abc/cancellation/def/submit`)
-        .expect(500)
+        .expect(410)
         .expect(res => {
-          expect(res.text).toContain(
-            'Too much time has passed since you started cancelling this referral. Your answers have not been saved, and you will need to start again.'
-          )
+          expect(res.text).toContain('This page is no longer available')
         })
     })
   })

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -689,11 +689,9 @@ describe('GET /service-provider/referrals/:id/assignment/:draftAssignmentId/chec
 
       await request(app)
         .get(`/service-provider/referrals/abc/assignment/def/check`)
-        .expect(500)
+        .expect(410)
         .expect(res => {
-          expect(res.text).toContain(
-            'Too much time has passed since you started assigning this intervention to a caseworker. The referral has not been assigned, and you will need to start again.'
-          )
+          expect(res.text).toContain('This page is no longer available')
         })
     })
   })
@@ -758,11 +756,9 @@ describe('POST /service-provider/referrals/:id/:draftAssignmentId/submit', () =>
 
       await request(app)
         .post(`/service-provider/referrals/abc/assignment/def/submit`)
-        .expect(500)
+        .expect(410)
         .expect(res => {
-          expect(res.text).toContain(
-            'Too much time has passed since you started assigning this intervention to a caseworker. The referral has not been assigned, and you will need to start again.'
-          )
+          expect(res.text).toContain('This page is no longer available')
         })
     })
   })

--- a/server/routes/shared/draftNotFoundView.ts
+++ b/server/routes/shared/draftNotFoundView.ts
@@ -1,0 +1,5 @@
+export default class DraftNotFoundView {
+  get renderArgs(): [string, Record<string, unknown>] {
+    return ['shared/draftNotFound', {}]
+  }
+}

--- a/server/utils/controllerUtils.test.ts
+++ b/server/utils/controllerUtils.test.ts
@@ -133,32 +133,26 @@ describe(ControllerUtils, () => {
     })
 
     describe('when a draft is not found by the drafts service', () => {
-      it('throws an error', async () => {
+      it('renders an explanatory page', async () => {
         draftsService.fetchDraft.mockResolvedValue(null)
 
-        let thrownError: unknown = null
+        const res = { status: jest.fn(), locals: { user: { userId: 'jane.bloggs' } }, render: jest.fn() }
 
-        try {
-          await ControllerUtils.fetchDraftOrRenderMessage(
-            { params: { draftBookingId: 'abc123' } } as unknown as Request,
-            { locals: { user: { userId: 'jane.bloggs' } } } as unknown as Response,
-            draftsService,
-            {
-              idParamName: 'draftBookingId',
-              typeName: 'booking',
-              notFoundUserMessage: 'Timed out, start again',
-            }
-          )
-        } catch (e) {
-          thrownError = e
-        }
+        const result = await ControllerUtils.fetchDraftOrRenderMessage(
+          { params: { draftBookingId: 'abc123' } } as unknown as Request,
+          res as unknown as Response,
+          draftsService,
+          {
+            idParamName: 'draftBookingId',
+            typeName: 'booking',
+            notFoundUserMessage: 'Timed out, start again',
+          }
+        )
 
-        expect(thrownError).toBeInstanceOf(Error)
-        expect(thrownError).toMatchObject({
-          status: 500,
-          message: `UI-only draft booking with ID abc123 not found`,
-          userMessage: 'Timed out, start again',
-        })
+        expect(result).toEqual({ rendered: true })
+
+        expect(res.status).toHaveBeenCalledWith(410)
+        expect(res.render).toHaveBeenCalledWith('shared/draftNotFound', expect.anything())
       })
     })
   })

--- a/server/views/shared/draftNotFound.njk
+++ b/server/views/shared/draftNotFound.njk
@@ -1,0 +1,14 @@
+{% extends "../partials/layout.njk" %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">This page is no longer available</h2>
+
+      <p class="govuk-body">
+      You can’t view this page any more. If you want to perform this action again, 
+      you will need to <a href="/" class="govuk-link">return to the dashboard</a> and start again.
+      </p>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What does this pull request do?

https://trello.com/c/rFs1K8KR
Use soft deleted page instead of outputting error

## What is the intent behind these changes?

Stops error message, which includes error stack, from being shown to users
(note error message text will be updated in separate PR)
