### PR TITLE
Split referrals to draft and live referrals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,6 @@ workflows:
             - integration_test
             - hmpps/helm_lint
             - build_docker_publish
-            - vulnerability_scan
           context:
             - hmpps-common-vars
             - hmpps-interventions-dev-deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
           persist_container_image: true
           filters:
             branches:
-              only: [main]
+              only: [main,split-referrals-to-draft-and-live-referrals]
       - hmpps/build_docker:
           name: build_docker
           git-lfs: true
@@ -103,6 +103,24 @@ workflows:
       - hmpps/trivy_pipeline_scan:
           name: vulnerability_scan
           requires: [build_docker, build_docker_publish]
+      - hmpps/deploy_env:
+          name: deploy_dev_split
+          env: "dev"
+          slack_notification: false
+          slack_channel_name: "interventions-dev-notifications"
+          filters:
+            branches:
+              only:
+                - split-referrals-to-draft-and-live-referrals
+          requires:
+            - build
+            - integration_test
+            - hmpps/helm_lint
+            - build_docker_publish
+            - vulnerability_scan
+          context:
+            - hmpps-common-vars
+            - hmpps-interventions-dev-deploy
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"
@@ -120,7 +138,7 @@ workflows:
             - vulnerability_scan
           context:
             - hmpps-common-vars
-            - hmpps-interventions-dev-deploy
+            - hmpps-interventions-dev-deploy            
       - tag_pact_version:
           name: "tag_pact_version_dev"
           tag: "deployed:dev"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,7 +7,7 @@ generic-service:
     DEPLOYMENT_ENV: dev
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
-    INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+    INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-split-dev.apps.live-1.cloud-platform.service.justice.gov.uk
     ASSESS_RISKS_AND_NEEDS_API_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
     TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
     GA_ID: G-0DK8Q58Z3D


### PR DESCRIPTION
## What does this pull request do?

- It introduces a new table draft referral
- All draft referrals will be residing in this table instead of referral table
- once the draft referrals is sent, it is moved to referral table
- draft referral data will not be deleted as part of the first release
- The existing draft referral in the referral table will be deleted after the migration is done

## What is the intent behind these changes?

- referral table was growing and we saw draft referrals holds 30% of data
- By segregating draft referrals , we can fetch only the data that we need. This improves the performance of the queries
