### PR TITLE
Dates restriction input validation

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -2510,9 +2510,13 @@ describe('Service provider referrals dashboard', () => {
             new RegExp(`/service-provider/referrals/${sentReferral.id}/supplier-assessment/schedule/[a-z0-9-]+/details`)
           )
 
+          const today = new Date()
+
           cy.get('#date-day').clear().type('10')
-          cy.get('#date-month').clear().type('3')
-          cy.get('#date-year').clear().type('2022')
+          cy.get('#date-month')
+            .clear()
+            .type((today.getMonth() + 1).toString())
+          cy.get('#date-year').clear().type(today.getFullYear())
           cy.get('#time-hour').clear().type('4')
           cy.get('#time-minute').clear().type('15')
           cy.get('#time-part-of-day').select('PM')
@@ -2523,7 +2527,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           const rescheduledAppointment = initialAssessmentAppointmentFactory.build({
-            appointmentTime: '2022-03-10T016:15:00Z',
+            appointmentTime: `${today.toISOString().split('T')[0]}T16:15:00Z`,
             durationInMinutes: 45,
           })
 
@@ -2542,6 +2546,12 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('4:15pm to 5:00pm')
 
           cy.get('button').contains('Confirm').click()
+
+          cy.get('h1').contains('Initial assessment appointment added')
+
+          cy.stubGetSupplierAssessment(sentReferral.id, supplierAssessmentWithRescheduledAppointment)
+
+          cy.contains('Return to progress').click()
         })
       })
 

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -913,8 +913,8 @@ describe('Service provider referrals dashboard', () => {
         it('should present no errors and display scheduled appointment', () => {
           cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type('24')
-          cy.get('#date-month').type('3')
-          cy.get('#date-year').type('3000')
+          cy.get('#date-month').type('11')
+          cy.get('#date-year').type('2022')
           cy.get('#time-hour').type('9')
           cy.get('#time-minute').type('02')
           cy.get('#time-part-of-day').select('AM')
@@ -930,7 +930,7 @@ describe('Service provider referrals dashboard', () => {
 
           const scheduledAppointment = actionPlanAppointmentFactory.build({
             ...appointment,
-            appointmentTime: '3000-03-24T09:02:02Z',
+            appointmentTime: '2022-11-24T09:02:02Z',
             durationInMinutes: 75,
             sessionType: 'GROUP',
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -948,7 +948,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           cy.get('h1').contains('Confirm session 1 details')
-          cy.contains('24 March 3000')
+          cy.contains('24 November 2022')
           cy.contains('9:02am to 10:17am')
           cy.contains('In-person meeting')
           cy.contains('Harmony Living Office, Room 4')
@@ -964,8 +964,8 @@ describe('Service provider referrals dashboard', () => {
           cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
 
           cy.get('#date-day').should('have.value', '24')
-          cy.get('#date-month').should('have.value', '3')
-          cy.get('#date-year').should('have.value', '3000')
+          cy.get('#date-month').should('have.value', '11')
+          cy.get('#date-year').should('have.value', '2022')
           cy.get('#time-hour').should('have.value', '9')
           cy.get('#time-minute').should('have.value', '02')
           // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
@@ -984,8 +984,8 @@ describe('Service provider referrals dashboard', () => {
           it('the user is able to amend their chosen date and re-submit', () => {
             cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
             cy.get('#date-day').type('24')
-            cy.get('#date-month').type('3')
-            cy.get('#date-year').type('3000')
+            cy.get('#date-month').type('11')
+            cy.get('#date-year').type('2022')
             cy.get('#time-hour').type('9')
             cy.get('#time-minute').type('02')
             cy.get('#time-part-of-day').select('AM')
@@ -1002,7 +1002,7 @@ describe('Service provider referrals dashboard', () => {
             cy.contains('Save and continue').click()
 
             cy.get('h1').contains('Confirm session 1 details')
-            cy.contains('24 March 3000')
+            cy.contains('24 November 2022')
             cy.contains('9:02am to 10:17am')
             cy.contains('In-person meeting')
             cy.contains('Harmony Living Office, Room 4')
@@ -1019,8 +1019,8 @@ describe('Service provider referrals dashboard', () => {
 
             cy.get('h1').contains('Add session 1 details')
             cy.get('#date-day').should('have.value', '24')
-            cy.get('#date-month').should('have.value', '3')
-            cy.get('#date-year').should('have.value', '3000')
+            cy.get('#date-month').should('have.value', '11')
+            cy.get('#date-year').should('have.value', '2022')
             cy.get('#time-hour').should('have.value', '9')
             cy.get('#time-minute').should('have.value', '02')
             cy.get('#time-part-of-day').get('[selected]').should('have.text', 'AM')
@@ -1039,7 +1039,7 @@ describe('Service provider referrals dashboard', () => {
 
             const scheduledAppointment = actionPlanAppointmentFactory.build({
               ...appointment,
-              appointmentTime: '3000-03-25T09:02:02Z',
+              appointmentTime: '2022-11-25T09:02:02Z',
               durationInMinutes: 75,
               sessionType: 'GROUP',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -1066,8 +1066,8 @@ describe('Service provider referrals dashboard', () => {
         it('should present no errors and display scheduled appointment', () => {
           cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type('24')
-          cy.get('#date-month').type('3')
-          cy.get('#date-year').type('3000')
+          cy.get('#date-month').type('11')
+          cy.get('#date-year').type('2022')
           cy.get('#time-hour').type('9')
           cy.get('#time-minute').type('02')
           cy.get('#time-part-of-day').select('AM')
@@ -1079,7 +1079,7 @@ describe('Service provider referrals dashboard', () => {
 
           const scheduledAppointment = actionPlanAppointmentFactory.build({
             ...appointment,
-            appointmentTime: '3000-03-24T09:02:02Z',
+            appointmentTime: '2022-11-24T09:02:02Z',
             durationInMinutes: 75,
             sessionType: 'GROUP',
             appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
@@ -1092,7 +1092,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           cy.get('h1').contains('Confirm session 1 details')
-          cy.contains('24 March 3000')
+          cy.contains('24 November 2022')
           cy.contains('9:02am to 10:17am')
           cy.contains('In-person meeting (probation office)')
 
@@ -1104,8 +1104,8 @@ describe('Service provider referrals dashboard', () => {
           cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
 
           cy.get('#date-day').should('have.value', '24')
-          cy.get('#date-month').should('have.value', '3')
-          cy.get('#date-year').should('have.value', '3000')
+          cy.get('#date-month').should('have.value', '11')
+          cy.get('#date-year').should('have.value', '2022')
           cy.get('#time-hour').should('have.value', '9')
           cy.get('#time-minute').should('have.value', '02')
           // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
@@ -1184,72 +1184,6 @@ describe('Service provider referrals dashboard', () => {
                 behaviour: {
                   behaviourDescription: 'Alex was well behaved',
                   notifyProbationPractitioner: false,
-                },
-                submitted: true,
-                submittedBy: {
-                  firstName: 'Case',
-                  lastName: 'Worker',
-                  username: 'case.worker',
-                },
-              },
-            })
-            cy.stubGetActionPlanAppointment(actionPlan.id, 1, scheduledAppointment)
-            cy.stubGetActionPlanAppointment(actionPlan.id, 2, scheduledAppointment)
-            cy.stubUpdateActionPlanAppointment(actionPlan.id, 1, scheduledAppointment)
-            cy.get('form').contains('Confirm').click()
-
-            cy.contains('Session feedback added and submitted to the probation practitioner')
-            cy.contains('You can now deliver the next session scheduled for 24 March 2021.')
-          })
-        })
-
-        describe('on a day before today', () => {
-          it('takes the user through the feedback form upon appointment confirmation', () => {
-            cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
-
-            // schedule page
-            cy.get('#date-day').type('24')
-            cy.get('#date-month').type('3')
-            cy.get('#date-year').type('2021')
-            cy.get('#time-hour').type('9')
-            cy.get('#time-minute').type('02')
-            cy.get('#time-part-of-day').select('AM')
-            cy.get('#duration-hours').type('1')
-            cy.get('#duration-minutes').type('15')
-            cy.contains('1:1').click()
-            cy.contains('Phone call').click()
-
-            cy.contains('Save and continue').click()
-
-            // schedule check your answers page
-            cy.get('h1').contains('Confirm session 1 details')
-            cy.contains("You've chosen a date and time in the past")
-            cy.contains('9:02am to 10:17am')
-            cy.contains('Phone call')
-
-            cy.get('button').contains('Confirm').click()
-
-            // Attendance page
-            cy.contains('No').click()
-            cy.contains("Add additional information about Alex's attendance").type('Alex did not attend the session')
-            cy.contains('Save and continue').click()
-
-            cy.contains('Confirm feedback')
-            cy.contains('Alex did not attend the session')
-            cy.contains('No')
-
-            const scheduledAppointment = actionPlanAppointmentFactory.build({
-              ...appointment,
-              appointmentTime: '2021-03-24T09:02:02Z',
-              durationInMinutes: 75,
-              sessionType: 'ONE_TO_ONE',
-              appointmentDeliveryType: 'PHONE_CALL',
-              appointmentDeliveryAddress: null,
-              npsOfficeCode: null,
-              sessionFeedback: {
-                attendance: {
-                  attended: 'no',
-                  additionalAttendanceInformation: 'Alex did not attend the session',
                 },
                 submitted: true,
                 submittedBy: {
@@ -2123,7 +2057,7 @@ describe('Service provider referrals dashboard', () => {
           })
         })
         describe('that happened before today', () => {
-          it('schedules the appointment', () => {
+          it('schedules the appointment - cannot schedule before date of referral', () => {
             cy.visit(`/service-provider/referrals/${referral.id}/progress`)
             cy.get('#supplier-assessment-status').contains('not scheduled')
             cy.contains('Schedule initial assessment').click()
@@ -2139,60 +2073,7 @@ describe('Service provider referrals dashboard', () => {
             cy.get('#duration-minutes').type('15')
             cy.contains('Video call').click()
             cy.contains('Save and continue').click()
-
-            // schedule check your answers page
-            cy.get('h1').contains('Confirm appointment details')
-            cy.contains("You've chosen a date and time in the past")
-            cy.contains('9:02am to 10:17am')
-            cy.contains('Video call')
-
-            cy.get('button').contains('Confirm').click()
-
-            // Attendance page
-            cy.contains('No').click()
-            cy.contains("Add additional information about Alex's attendance").type('Alex did not attend the session')
-            cy.contains('Save and continue').click()
-
-            cy.contains('Confirm feedback')
-            cy.contains('Alex did not attend the session')
-            cy.contains('No')
-
-            const time = new Date()
-            time.setHours(0)
-            time.setMinutes(15)
-
-            const scheduledAppointment = initialAssessmentAppointmentFactory.build({
-              appointmentTime: time.toString(),
-              durationInMinutes: 75,
-              appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
-              appointmentDeliveryAddress: {
-                firstAddressLine: 'Harmony Living Office, Room 4',
-                secondAddressLine: '44 Bouverie Road',
-                townOrCity: 'Blackpool',
-                county: 'Lancashire',
-                postCode: 'SY4 0RE',
-              },
-              sessionFeedback: {
-                attendance: {
-                  attended: 'yes',
-                  additionalAttendanceInformation: 'Alex attended the session',
-                },
-                behaviour: {
-                  behaviourDescription: 'Alex was well behaved',
-                  notifyProbationPractitioner: false,
-                },
-                submitted: true,
-                submittedBy: {
-                  firstName: 'Case',
-                  lastName: 'Worker',
-                  username: 'case.worker',
-                },
-              },
-            })
-
-            cy.stubScheduleSupplierAssessmentAppointment(supplierAssessment.id, scheduledAppointment)
-            cy.get('form').contains('Confirm').click()
-            cy.contains('Initial assessment feedback added')
+            cy.contains('There is a problem').next().contains('Date must be no earlier than')
           })
         })
       })
@@ -2206,8 +2087,8 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Add appointment details')
 
           cy.get('#date-day').type('24')
-          cy.get('#date-month').type('3')
-          cy.get('#date-year').type('2025')
+          cy.get('#date-month').type('11')
+          cy.get('#date-year').type('2022')
           cy.get('#time-hour').type('9')
           cy.get('#time-minute').type('02')
           cy.get('#time-part-of-day').select('AM')
@@ -2223,7 +2104,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           const scheduledAppointment = initialAssessmentAppointmentFactory.build({
-            appointmentTime: '2025-03-24T09:02:02Z',
+            appointmentTime: '2022-11-24T09:02:02Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
             appointmentDeliveryAddress: {
@@ -2242,7 +2123,7 @@ describe('Service provider referrals dashboard', () => {
           cy.stubScheduleSupplierAssessmentAppointment(supplierAssessment.id, scheduledAppointment)
 
           cy.get('h1').contains('Confirm appointment details')
-          cy.contains('24 March 2025')
+          cy.contains('24 November 2022')
           cy.contains('9:02am to 10:17am')
           cy.contains('In-person meeting')
           cy.contains('Harmony Living Office, Room 4')
@@ -2267,7 +2148,7 @@ describe('Service provider referrals dashboard', () => {
             .getTable()
             .should('deep.equal', [
               {
-                'Date and time': '9:02am on 24 Mar 2025',
+                'Date and time': '9:02am on 24 Nov 2022',
                 Status: 'scheduled',
                 Action: 'View details or reschedule',
               },
@@ -2276,7 +2157,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('View details or reschedule').click()
           cy.get('h1').contains('View appointment details')
 
-          cy.contains('24 March 2025')
+          cy.contains('24 November 2022')
           cy.contains('9:02am to 10:17am')
           cy.contains('In-person meeting')
           cy.contains('Harmony Living Office, Room 4')
@@ -2290,8 +2171,8 @@ describe('Service provider referrals dashboard', () => {
           cy.visit(`/service-provider/referrals/${referral.id}/supplier-assessment/schedule/start`)
 
           cy.get('#date-day').type('24')
-          cy.get('#date-month').type('3')
-          cy.get('#date-year').type('2025')
+          cy.get('#date-month').type('11')
+          cy.get('#date-year').type('2022')
           cy.get('#time-hour').type('9')
           cy.get('#time-minute').type('02')
           cy.get('#time-part-of-day').select('AM')
@@ -2315,8 +2196,8 @@ describe('Service provider referrals dashboard', () => {
 
           cy.get('h1').contains('Add appointment details')
           cy.get('#date-day').should('have.value', '24')
-          cy.get('#date-month').should('have.value', '3')
-          cy.get('#date-year').should('have.value', '2025')
+          cy.get('#date-month').should('have.value', '11')
+          cy.get('#date-year').should('have.value', '2022')
           cy.get('#time-hour').should('have.value', '9')
           cy.get('#time-minute').should('have.value', '02')
           cy.get('#time-part-of-day').get('[selected]').should('have.text', 'AM')
@@ -2334,7 +2215,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           const scheduledAppointment = initialAssessmentAppointmentFactory.build({
-            appointmentTime: '2025-03-25T09:02:02Z',
+            appointmentTime: '2022-11-25T09:02:02Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
             appointmentDeliveryAddress: {
@@ -2355,7 +2236,7 @@ describe('Service provider referrals dashboard', () => {
 
         it('User reschedules a supplier assessment appointment', () => {
           const scheduledAppointment = initialAssessmentAppointmentFactory.build({
-            appointmentTime: '2025-03-24T09:02:00Z',
+            appointmentTime: '2022-11-24T09:02:00Z',
             durationInMinutes: 75,
           })
           const supplierAssessmentWithScheduledAppointment = supplierAssessmentFactory.justCreated.build({
@@ -2374,8 +2255,8 @@ describe('Service provider referrals dashboard', () => {
           cy.get('h1').contains('Change appointment details')
 
           cy.get('#date-day').should('have.value', '24')
-          cy.get('#date-month').should('have.value', '3')
-          cy.get('#date-year').should('have.value', '2025')
+          cy.get('#date-month').should('have.value', '11')
+          cy.get('#date-year').should('have.value', '2022')
           cy.get('#time-hour').should('have.value', '9')
           cy.get('#time-minute').should('have.value', '02')
           // https://stackoverflow.com/questions/51222840/cypress-io-how-do-i-get-text-of-selected-option-in-select
@@ -2384,8 +2265,8 @@ describe('Service provider referrals dashboard', () => {
           cy.get('#duration-minutes').should('have.value', '15')
 
           cy.get('#date-day').clear().type('10')
-          cy.get('#date-month').clear().type('4')
-          cy.get('#date-year').clear().type('2025')
+          cy.get('#date-month').clear().type('11')
+          cy.get('#date-year').clear().type('2022')
           cy.get('#time-hour').clear().type('4')
           cy.get('#time-minute').clear().type('15')
           cy.get('#time-part-of-day').select('PM')
@@ -2395,7 +2276,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           const rescheduledAppointment = initialAssessmentAppointmentFactory.build({
-            appointmentTime: '2025-04-10T16:15:00Z',
+            appointmentTime: '2022-11-10T16:15:00Z',
             durationInMinutes: 45,
           })
           const supplierAssessmentWithRescheduledAppointment = supplierAssessmentFactory.build({
@@ -2409,7 +2290,7 @@ describe('Service provider referrals dashboard', () => {
           )
 
           cy.get('h1').contains('Confirm appointment details')
-          cy.contains('10 April 2025')
+          cy.contains('10 November 2022')
           cy.contains('4:15pm to 5:00pm')
 
           cy.get('button').contains('Confirm').click()
@@ -2575,7 +2456,7 @@ describe('Service provider referrals dashboard', () => {
           cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
 
           const unattendedAppointment = initialAssessmentAppointmentFactory.build({
-            appointmentTime: '2025-03-24T09:02:02Z',
+            appointmentTime: '2022-03-24T09:02:02Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             sessionFeedback: {
@@ -2606,7 +2487,7 @@ describe('Service provider referrals dashboard', () => {
             .getTable()
             .should('deep.equal', [
               {
-                'Date and time': '9:02am on 24 Mar 2025',
+                'Date and time': '9:02am on 24 Mar 2022',
                 Status: 'did not attend',
                 Action: 'RescheduleView feedback',
               },
@@ -2614,7 +2495,7 @@ describe('Service provider referrals dashboard', () => {
 
           cy.get('[data-cy=supplier-assessment-table]').contains('View feedback').click()
 
-          cy.contains('24 March 2025')
+          cy.contains('24 March 2022')
           cy.contains('9:02am to 10:17am')
           cy.contains('Did Alex attend the initial assessment appointment?')
           cy.contains('No')
@@ -2629,9 +2510,13 @@ describe('Service provider referrals dashboard', () => {
             new RegExp(`/service-provider/referrals/${sentReferral.id}/supplier-assessment/schedule/[a-z0-9-]+/details`)
           )
 
+          const today = new Date()
+
           cy.get('#date-day').clear().type('10')
-          cy.get('#date-month').clear().type('2')
-          cy.get('#date-year').clear().type('2025')
+          cy.get('#date-month')
+            .clear()
+            .type((today.getMonth() + 1).toString())
+          cy.get('#date-year').clear().type(today.getFullYear())
           cy.get('#time-hour').clear().type('4')
           cy.get('#time-minute').clear().type('15')
           cy.get('#time-part-of-day').select('PM')
@@ -2642,7 +2527,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           const rescheduledAppointment = initialAssessmentAppointmentFactory.build({
-            appointmentTime: '2025-02-10T16:15:00Z',
+            appointmentTime: `${today.toISOString().split('T')[0]}T16:15:00Z`,
             durationInMinutes: 45,
           })
 
@@ -2658,7 +2543,6 @@ describe('Service provider referrals dashboard', () => {
           )
 
           cy.get('h1').contains('Confirm appointment details')
-          cy.contains('10 February 2025')
           cy.contains('4:15pm to 5:00pm')
 
           cy.get('button').contains('Confirm').click()
@@ -2668,21 +2552,6 @@ describe('Service provider referrals dashboard', () => {
           cy.stubGetSupplierAssessment(sentReferral.id, supplierAssessmentWithRescheduledAppointment)
 
           cy.contains('Return to progress').click()
-
-          cy.get('[data-cy=supplier-assessment-table]')
-            .getTable()
-            .should('deep.equal', [
-              {
-                'Date and time': '9:02am on 24 Mar 2025',
-                Status: 'did not attend',
-                Action: 'View feedback',
-              },
-              {
-                'Date and time': '4:15pm on 10 Feb 2025',
-                Status: 'scheduled',
-                Action: 'View details or reschedule',
-              },
-            ])
         })
       })
 

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -2510,13 +2510,9 @@ describe('Service provider referrals dashboard', () => {
             new RegExp(`/service-provider/referrals/${sentReferral.id}/supplier-assessment/schedule/[a-z0-9-]+/details`)
           )
 
-          const today = new Date()
-
           cy.get('#date-day').clear().type('10')
-          cy.get('#date-month')
-            .clear()
-            .type((today.getMonth() + 1).toString())
-          cy.get('#date-year').clear().type(today.getFullYear())
+          cy.get('#date-month').clear().type('3')
+          cy.get('#date-year').clear().type('2022')
           cy.get('#time-hour').clear().type('4')
           cy.get('#time-minute').clear().type('15')
           cy.get('#time-part-of-day').select('PM')
@@ -2527,7 +2523,7 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('Save and continue').click()
 
           const rescheduledAppointment = initialAssessmentAppointmentFactory.build({
-            appointmentTime: `${today.toISOString().split('T')[0]}T16:15:00Z`,
+            appointmentTime: '2022-03-10T016:15:00Z',
             durationInMinutes: 45,
           })
 
@@ -2546,12 +2542,6 @@ describe('Service provider referrals dashboard', () => {
           cy.contains('4:15pm to 5:00pm')
 
           cy.get('button').contains('Confirm').click()
-
-          cy.get('h1').contains('Initial assessment appointment added')
-
-          cy.stubGetSupplierAssessment(sentReferral.id, supplierAssessmentWithRescheduledAppointment)
-
-          cy.contains('Return to progress').click()
         })
       })
 

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -233,7 +233,7 @@ describe('Scheduling a supplier assessment appointment', () => {
         expect(draftsService.updateDraft).toHaveBeenCalledWith(
           draftBooking.id,
           {
-            appointmentTime: `${dateOfAppointment.toISOString().split('T')[0]}T08:02:00.000Z`,
+            appointmentTime: '2022-03-01T09:02:00.000Z',
             durationInMinutes: 75,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
@@ -614,15 +614,13 @@ describe('Scheduling a delivery session', () => {
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
-        const today = new Date()
-
         await request(app)
           .post(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/${draftBooking.id}/details`)
           .type('form')
           .send({
-            'date-year': today.getFullYear(),
-            'date-month': today.getUTCMonth() + 1,
-            'date-day': today.getUTCDate(),
+            'date-year': '2022',
+            'date-month': '3',
+            'date-day': '24',
             'time-hour': '9',
             'time-minute': '02',
             'time-part-of-day': 'am',
@@ -641,7 +639,7 @@ describe('Scheduling a delivery session', () => {
           draftBooking.id,
           {
             appointmentDeliveryAddress: null,
-            appointmentTime: `${today.toISOString().split('T')[0]}T08:02:00.000Z`,
+            appointmentTime: '2022-03-24T09:02:00.000Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             npsOfficeCode: null,
@@ -665,14 +663,12 @@ describe('Scheduling a delivery session', () => {
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
-        const today = new Date()
-
         await request(app)
           .post(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/${draftBooking.id}/details`)
           .type('form')
           .send({
-            'date-year': today.getFullYear(),
-            'date-month': today.getUTCMonth() + 1,
+            'date-year': '2022',
+            'date-month': '2',
             'date-day': '32',
             'time-hour': '9',
             'time-minute': '02',

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -164,9 +164,11 @@ describe('Scheduling a supplier assessment appointment', () => {
 
         await request(app)
           .get(`/service-provider/referrals/1/supplier-assessment/schedule/abc/details`)
-          .expect(410)
+          .expect(500)
           .expect(res => {
-            expect(res.text).toContain('This page is no longer available')
+            expect(res.text).toContain(
+              'Too much time has passed since you started booking this appointment. Your answers have not been saved, and you will need to start again.'
+            )
           })
       })
     })
@@ -233,7 +235,7 @@ describe('Scheduling a supplier assessment appointment', () => {
         expect(draftsService.updateDraft).toHaveBeenCalledWith(
           draftBooking.id,
           {
-            appointmentTime: '2022-03-01T09:02:00.000Z',
+            appointmentTime: `${dateOfAppointment.toISOString().split('T')[0]}T08:02:00.000Z`,
             durationInMinutes: 75,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
@@ -614,13 +616,15 @@ describe('Scheduling a delivery session', () => {
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
+        const today = new Date()
+
         await request(app)
           .post(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/${draftBooking.id}/details`)
           .type('form')
           .send({
-            'date-year': '2022',
-            'date-month': '3',
-            'date-day': '24',
+            'date-year': today.getFullYear(),
+            'date-month': today.getUTCMonth() + 1,
+            'date-day': today.getUTCDate(),
             'time-hour': '9',
             'time-minute': '02',
             'time-part-of-day': 'am',
@@ -639,7 +643,7 @@ describe('Scheduling a delivery session', () => {
           draftBooking.id,
           {
             appointmentDeliveryAddress: null,
-            appointmentTime: '2022-03-24T09:02:00.000Z',
+            appointmentTime: `${today.toISOString().split('T')[0]}T08:02:00.000Z`,
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             npsOfficeCode: null,
@@ -663,12 +667,14 @@ describe('Scheduling a delivery session', () => {
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
+        const today = new Date()
+
         await request(app)
           .post(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/${draftBooking.id}/details`)
           .type('form')
           .send({
-            'date-year': '2022',
-            'date-month': '2',
+            'date-year': today.getFullYear(),
+            'date-month': today.getUTCMonth() + 1,
             'date-day': '32',
             'time-hour': '9',
             'time-minute': '02',

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -164,11 +164,9 @@ describe('Scheduling a supplier assessment appointment', () => {
 
         await request(app)
           .get(`/service-provider/referrals/1/supplier-assessment/schedule/abc/details`)
-          .expect(500)
+          .expect(410)
           .expect(res => {
-            expect(res.text).toContain(
-              'Too much time has passed since you started booking this appointment. Your answers have not been saved, and you will need to start again.'
-            )
+            expect(res.text).toContain('This page is no longer available')
           })
       })
     })

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -235,7 +235,7 @@ describe('Scheduling a supplier assessment appointment', () => {
         expect(draftsService.updateDraft).toHaveBeenCalledWith(
           draftBooking.id,
           {
-            appointmentTime: `${dateOfAppointment.toISOString().split('T')[0]}T08:02:00.000Z`,
+            appointmentTime: '2022-03-01T09:02:00.000Z',
             durationInMinutes: 75,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
@@ -616,15 +616,13 @@ describe('Scheduling a delivery session', () => {
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
-        const today = new Date()
-
         await request(app)
           .post(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/${draftBooking.id}/details`)
           .type('form')
           .send({
-            'date-year': today.getFullYear(),
-            'date-month': today.getUTCMonth() + 1,
-            'date-day': today.getUTCDate(),
+            'date-year': '2022',
+            'date-month': '3',
+            'date-day': '24',
             'time-hour': '9',
             'time-minute': '02',
             'time-part-of-day': 'am',
@@ -643,7 +641,7 @@ describe('Scheduling a delivery session', () => {
           draftBooking.id,
           {
             appointmentDeliveryAddress: null,
-            appointmentTime: `${today.toISOString().split('T')[0]}T08:02:00.000Z`,
+            appointmentTime: '2022-03-24T09:02:00.000Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             npsOfficeCode: null,
@@ -667,14 +665,12 @@ describe('Scheduling a delivery session', () => {
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
-        const today = new Date()
-
         await request(app)
           .post(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/${draftBooking.id}/details`)
           .type('form')
           .send({
-            'date-year': today.getFullYear(),
-            'date-month': today.getUTCMonth() + 1,
+            'date-year': '2022',
+            'date-month': '2',
             'date-day': '32',
             'time-hour': '9',
             'time-minute': '02',

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -201,6 +201,10 @@ describe('Scheduling a supplier assessment appointment', () => {
         const referral = sentReferralFactory.build()
         const supplierAssessment = supplierAssessmentFactory.justCreated.build()
 
+        const dateOfSentReferral = new Date(referral.sentAt)
+        const dateOfAppointment = new Date(dateOfSentReferral.toDateString())
+        dateOfAppointment.setMonth(dateOfAppointment.getMonth() + 2)
+
         interventionsService.getSentReferral.mockResolvedValue(referral)
         interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessment)
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
@@ -209,9 +213,9 @@ describe('Scheduling a supplier assessment appointment', () => {
           .post(`/service-provider/referrals/${referral.id}/supplier-assessment/schedule/${draftBooking.id}/details`)
           .type('form')
           .send({
-            'date-day': '24',
-            'date-month': '3',
-            'date-year': '2025',
+            'date-day': dateOfAppointment.getUTCDate(),
+            'date-month': dateOfAppointment.getUTCMonth() + 1,
+            'date-year': dateOfAppointment.getFullYear(),
             'time-hour': '9',
             'time-minute': '02',
             'time-part-of-day': 'am',
@@ -229,7 +233,7 @@ describe('Scheduling a supplier assessment appointment', () => {
         expect(draftsService.updateDraft).toHaveBeenCalledWith(
           draftBooking.id,
           {
-            appointmentTime: '2025-03-24T09:02:00.000Z',
+            appointmentTime: `${dateOfAppointment.toISOString().split('T')[0]}T08:02:00.000Z`,
             durationInMinutes: 75,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
@@ -255,7 +259,7 @@ describe('Scheduling a supplier assessment appointment', () => {
             .send({
               'date-day': '32',
               'date-month': '3',
-              'date-year': '2021',
+              'date-year': 'test',
               'time-hour': '9',
               'time-minute': '02',
               'time-part-of-day': 'am',
@@ -610,13 +614,15 @@ describe('Scheduling a delivery session', () => {
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
+        const today = new Date()
+
         await request(app)
           .post(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/${draftBooking.id}/details`)
           .type('form')
           .send({
-            'date-day': '24',
-            'date-month': '3',
-            'date-year': '2025',
+            'date-year': today.getFullYear(),
+            'date-month': today.getUTCMonth() + 1,
+            'date-day': today.getUTCDate(),
             'time-hour': '9',
             'time-minute': '02',
             'time-part-of-day': 'am',
@@ -635,7 +641,7 @@ describe('Scheduling a delivery session', () => {
           draftBooking.id,
           {
             appointmentDeliveryAddress: null,
-            appointmentTime: '2025-03-24T09:02:00.000Z',
+            appointmentTime: `${today.toISOString().split('T')[0]}T08:02:00.000Z`,
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
             npsOfficeCode: null,
@@ -659,13 +665,15 @@ describe('Scheduling a delivery session', () => {
         interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
 
+        const today = new Date()
+
         await request(app)
           .post(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/${draftBooking.id}/details`)
           .type('form')
           .send({
+            'date-year': today.getFullYear(),
+            'date-month': today.getUTCMonth() + 1,
             'date-day': '32',
-            'date-month': '3',
-            'date-year': '2021',
             'time-hour': '9',
             'time-minute': '02',
             'time-part-of-day': 'am',

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -100,7 +100,7 @@ export default class AppointmentsController {
     let serverError: FormValidationError | null = null
 
     if (req.method === 'POST') {
-      const data = await new ScheduleAppointmentForm(req, deliusOfficeLocations).data()
+      const data = await new ScheduleAppointmentForm(req, deliusOfficeLocations, false, referral.sentAt).data()
       if (data.error) {
         res.status(400)
         formError = data.error
@@ -296,7 +296,7 @@ export default class AppointmentsController {
     let serverError: FormValidationError | null = null
 
     if (req.method === 'POST') {
-      const data = await new ScheduleAppointmentForm(req, deliusOfficeLocations, true).data()
+      const data = await new ScheduleAppointmentForm(req, deliusOfficeLocations, true, referral.sentAt).data()
 
       if (data.error) {
         res.status(400)

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
@@ -17,10 +17,11 @@ describe(ScheduleAppointmentForm, () => {
     describe('with valid data', () => {
       describe('with a phone call appointment', () => {
         it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
+          const today = new Date()
           const request = TestUtils.createRequest({
-            'date-year': '2025',
-            'date-month': '09',
-            'date-day': '12',
+            'date-year': today.getFullYear(),
+            'date-month': today.getUTCMonth() + 1,
+            'date-day': today.getUTCDate(),
             'time-hour': '1',
             'time-minute': '05',
             'time-part-of-day': 'pm',
@@ -33,7 +34,7 @@ describe(ScheduleAppointmentForm, () => {
           const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
 
           expect(data.paramsForUpdate).toEqual({
-            appointmentTime: '2025-09-12T12:05:00.000Z',
+            appointmentTime: `${today.toISOString().split('T')[0]}T12:05:00.000Z`,
             durationInMinutes: 90,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
@@ -45,10 +46,11 @@ describe(ScheduleAppointmentForm, () => {
 
       describe('with an other locations appointment', () => {
         it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
+          const today = new Date()
           const request = TestUtils.createRequest({
-            'date-year': '2025',
-            'date-month': '09',
-            'date-day': '12',
+            'date-year': today.getFullYear(),
+            'date-month': today.getUTCMonth() + 1,
+            'date-day': today.getUTCDate(),
             'time-hour': '1',
             'time-minute': '05',
             'time-part-of-day': 'pm',
@@ -66,7 +68,7 @@ describe(ScheduleAppointmentForm, () => {
           const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
 
           expect(data.paramsForUpdate).toEqual({
-            appointmentTime: '2025-09-12T12:05:00.000Z',
+            appointmentTime: `${today.toISOString().split('T')[0]}T12:05:00.000Z`,
             durationInMinutes: 90,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -83,10 +85,11 @@ describe(ScheduleAppointmentForm, () => {
 
         describe('with a missing second address line', () => {
           it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
+            const today = new Date()
             const request = TestUtils.createRequest({
-              'date-year': '2025',
-              'date-month': '09',
-              'date-day': '12',
+              'date-year': today.getFullYear(),
+              'date-month': today.getUTCMonth() + 1,
+              'date-day': today.getUTCDate(),
               'time-hour': '1',
               'time-minute': '05',
               'time-part-of-day': 'pm',
@@ -102,7 +105,7 @@ describe(ScheduleAppointmentForm, () => {
 
             const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
             expect(data.paramsForUpdate).toEqual({
-              appointmentTime: '2025-09-12T12:05:00.000Z',
+              appointmentTime: `${today.toISOString().split('T')[0]}T12:05:00.000Z`,
               durationInMinutes: 90,
               sessionType: 'ONE_TO_ONE',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -120,10 +123,11 @@ describe(ScheduleAppointmentForm, () => {
       })
       describe('with a delius office location appointment', () => {
         it('returns a valid appointment with an office location code', async () => {
+          const today = new Date()
           const request = TestUtils.createRequest({
-            'date-year': '2025',
-            'date-month': '09',
-            'date-day': '12',
+            'date-year': today.getFullYear(),
+            'date-month': today.getUTCMonth() + 1,
+            'date-day': today.getUTCDate(),
             'time-hour': '1',
             'time-minute': '05',
             'time-part-of-day': 'pm',
@@ -137,7 +141,7 @@ describe(ScheduleAppointmentForm, () => {
           const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
 
           expect(data.paramsForUpdate).toEqual({
-            appointmentTime: '2025-09-12T12:05:00.000Z',
+            appointmentTime: `${today.toISOString().split('T')[0]}T12:05:00.000Z`,
             durationInMinutes: 90,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
@@ -196,10 +200,11 @@ describe(ScheduleAppointmentForm, () => {
       describe('with a delius office location appointment', () => {
         describe('having an empty office location selection', () => {
           it('returns an error message for missing office location', async () => {
+            const today = new Date()
             const request = TestUtils.createRequest({
-              'date-year': '2025',
-              'date-month': '09',
-              'date-day': '12',
+              'date-year': today.getFullYear(),
+              'date-month': today.getUTCMonth(),
+              'date-day': today.getUTCDate(),
               'time-hour': '1',
               'time-minute': '05',
               'time-part-of-day': 'pm',
@@ -225,10 +230,11 @@ describe(ScheduleAppointmentForm, () => {
         })
         describe('having an invalid office location selection', () => {
           it('returns an error message for invalid office location', async () => {
+            const today = new Date()
             const request = TestUtils.createRequest({
-              'date-year': '2025',
-              'date-month': '09',
-              'date-day': '12',
+              'date-year': today.getFullYear(),
+              'date-month': today.getUTCMonth(),
+              'date-day': today.getUTCDate(),
               'time-hour': '1',
               'time-minute': '05',
               'time-part-of-day': 'pm',
@@ -247,6 +253,127 @@ describe(ScheduleAppointmentForm, () => {
                   errorSummaryLinkedField: 'delius-office-location-code',
                   formFields: ['delius-office-location-code'],
                   message: 'Select an office from the list',
+                },
+              ],
+            })
+          })
+        })
+        describe('having an early date selection', () => {
+          it('returns an error message for early appointment date', async () => {
+            const request = TestUtils.createRequest({
+              'date-year': '1999',
+              'date-month': '04',
+              'date-day': '11',
+              'time-hour': '1',
+              'time-minute': '05',
+              'time-part-of-day': 'pm',
+              'duration-hours': '1',
+              'duration-minutes': '30',
+              'session-type': 'ONE_TO_ONE',
+              'meeting-method': 'IN_PERSON_MEETING_PROBATION_OFFICE',
+              'delius-office-location-code': 'CRS0001',
+            })
+
+            const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
+
+            expect(data.error).toEqual({
+              errors: [
+                {
+                  errorSummaryLinkedField: 'date-year',
+                  formFields: ['date-year'],
+                  message: 'The session date must be a real date',
+                },
+              ],
+            })
+          })
+        })
+        describe('having a late date selection', () => {
+          it('returns an error message for late appointment date', async () => {
+            const maximumDate = new Date()
+            maximumDate.setMonth(maximumDate.getMonth() + 6)
+
+            const today = new Date()
+            const request = TestUtils.createRequest({
+              'date-year': today.getFullYear() + 10,
+              'date-month': today.getUTCMonth(),
+              'date-day': today.getUTCDate(),
+              'time-hour': '1',
+              'time-minute': '05',
+              'time-part-of-day': 'pm',
+              'duration-hours': '1',
+              'duration-minutes': '30',
+              'session-type': 'ONE_TO_ONE',
+              'meeting-method': 'IN_PERSON_MEETING_PROBATION_OFFICE',
+              'delius-office-location-code': 'CRS0001',
+            })
+
+            const data = await new ScheduleAppointmentForm(
+              request,
+              deliusOfficeLocations,
+              false,
+              '2022-01-10T09:38:07.827Z'
+            ).data()
+
+            const formattedDateMaxDate = maximumDate
+              .toLocaleDateString('en-GB', {
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+              })
+              .replace(/ /g, ' ')
+
+            expect(data.error).toEqual({
+              errors: [
+                {
+                  errorSummaryLinkedField: 'date-day',
+                  formFields: ['date-day'],
+                  message: `Date must be no later than ${formattedDateMaxDate}`,
+                },
+              ],
+            })
+          })
+        })
+        describe('having an early date selection', () => {
+          it('returns an error message for early appointment date', async () => {
+            const maximumDate = new Date()
+            maximumDate.setMonth(maximumDate.getMonth() + 6)
+
+            const today = new Date()
+            const request = TestUtils.createRequest({
+              'date-year': today.getFullYear(),
+              'date-month': today.getUTCMonth(),
+              'date-day': today.getUTCDate(),
+              'time-hour': '1',
+              'time-minute': '05',
+              'time-part-of-day': 'pm',
+              'duration-hours': '1',
+              'duration-minutes': '30',
+              'session-type': 'ONE_TO_ONE',
+              'meeting-method': 'IN_PERSON_MEETING_PROBATION_OFFICE',
+              'delius-office-location-code': 'CRS0001',
+            })
+
+            const data = await new ScheduleAppointmentForm(
+              request,
+              deliusOfficeLocations,
+              false,
+              '2022-01-10T09:38:07.827Z'
+            ).data()
+
+            const formattedToday = today
+              .toLocaleDateString('en-GB', {
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+              })
+              .replace(/ /g, ' ')
+
+            expect(data.error).toEqual({
+              errors: [
+                {
+                  errorSummaryLinkedField: 'date-day',
+                  formFields: ['date-day'],
+                  message: `Date must be no earlier than ${formattedToday}`,
                 },
               ],
             })

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.test.ts
@@ -17,11 +17,10 @@ describe(ScheduleAppointmentForm, () => {
     describe('with valid data', () => {
       describe('with a phone call appointment', () => {
         it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
-          const today = new Date()
           const request = TestUtils.createRequest({
-            'date-year': today.getFullYear(),
-            'date-month': today.getUTCMonth() + 1,
-            'date-day': today.getUTCDate(),
+            'date-year': '2022',
+            'date-month': '4',
+            'date-day': '11',
             'time-hour': '1',
             'time-minute': '05',
             'time-part-of-day': 'pm',
@@ -34,7 +33,7 @@ describe(ScheduleAppointmentForm, () => {
           const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
 
           expect(data.paramsForUpdate).toEqual({
-            appointmentTime: `${today.toISOString().split('T')[0]}T12:05:00.000Z`,
+            appointmentTime: '2022-04-11T12:05:00.000Z',
             durationInMinutes: 90,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'PHONE_CALL',
@@ -46,11 +45,10 @@ describe(ScheduleAppointmentForm, () => {
 
       describe('with an other locations appointment', () => {
         it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
-          const today = new Date()
           const request = TestUtils.createRequest({
-            'date-year': today.getFullYear(),
-            'date-month': today.getUTCMonth() + 1,
-            'date-day': today.getUTCDate(),
+            'date-year': '2022',
+            'date-month': '5',
+            'date-day': '17',
             'time-hour': '1',
             'time-minute': '05',
             'time-part-of-day': 'pm',
@@ -68,7 +66,7 @@ describe(ScheduleAppointmentForm, () => {
           const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
 
           expect(data.paramsForUpdate).toEqual({
-            appointmentTime: `${today.toISOString().split('T')[0]}T12:05:00.000Z`,
+            appointmentTime: '2022-05-17T12:05:00.000Z',
             durationInMinutes: 90,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -85,11 +83,10 @@ describe(ScheduleAppointmentForm, () => {
 
         describe('with a missing second address line', () => {
           it('returns a paramsForUpdate with the completionDeadline key, an ISO-formatted date and phone call', async () => {
-            const today = new Date()
             const request = TestUtils.createRequest({
-              'date-year': today.getFullYear(),
-              'date-month': today.getUTCMonth() + 1,
-              'date-day': today.getUTCDate(),
+              'date-year': '2022',
+              'date-month': '5',
+              'date-day': '17',
               'time-hour': '1',
               'time-minute': '05',
               'time-part-of-day': 'pm',
@@ -105,7 +102,7 @@ describe(ScheduleAppointmentForm, () => {
 
             const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
             expect(data.paramsForUpdate).toEqual({
-              appointmentTime: `${today.toISOString().split('T')[0]}T12:05:00.000Z`,
+              appointmentTime: '2022-05-17T12:05:00.000Z',
               durationInMinutes: 90,
               sessionType: 'ONE_TO_ONE',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -123,11 +120,10 @@ describe(ScheduleAppointmentForm, () => {
       })
       describe('with a delius office location appointment', () => {
         it('returns a valid appointment with an office location code', async () => {
-          const today = new Date()
           const request = TestUtils.createRequest({
-            'date-year': today.getFullYear(),
-            'date-month': today.getUTCMonth() + 1,
-            'date-day': today.getUTCDate(),
+            'date-year': '2022',
+            'date-month': '5',
+            'date-day': '24',
             'time-hour': '1',
             'time-minute': '05',
             'time-part-of-day': 'pm',
@@ -141,7 +137,7 @@ describe(ScheduleAppointmentForm, () => {
           const data = await new ScheduleAppointmentForm(request, deliusOfficeLocations).data()
 
           expect(data.paramsForUpdate).toEqual({
-            appointmentTime: `${today.toISOString().split('T')[0]}T12:05:00.000Z`,
+            appointmentTime: '2022-05-24T12:05:00.000Z',
             durationInMinutes: 90,
             sessionType: 'ONE_TO_ONE',
             appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentForm.ts
@@ -17,7 +17,8 @@ export default class ScheduleAppointmentForm {
   constructor(
     private readonly request: Request,
     private readonly deliusOfficeLocations: DeliusOfficeLocation[],
-    private readonly allowPastAppointments = false
+    private readonly allowPastAppointments = false,
+    private readonly referralDate: string | null = null
   ) {}
 
   async data(): Promise<FormData<AppointmentSchedulingDetails>> {
@@ -26,7 +27,9 @@ export default class ScheduleAppointmentForm {
         this.request,
         'date',
         'time',
-        errorMessages.scheduleAppointment.time
+        errorMessages.scheduleAppointment.time,
+        null,
+        this.referralDate
       ).validate(),
       new DurationInput(this.request, 'duration', errorMessages.scheduleAppointment.duration).validate(),
       FormUtils.runValidations({ request: this.request, validations: this.validateSessionType() }),

--- a/server/utils/forms/inputs/calendarDayInput.test.ts
+++ b/server/utils/forms/inputs/calendarDayInput.test.ts
@@ -168,6 +168,9 @@ describe(CalendarDayInput, () => {
 
       const result = await new CalendarDayInput(request, 'deadline', messages).validate()
 
+      const maximumDate = new Date()
+      maximumDate.setMonth(maximumDate.getMonth() + 6)
+
       expect(result.error).toEqual({
         errors: [
           {
@@ -182,12 +185,16 @@ describe(CalendarDayInput, () => {
 
   describe('.createErrors', () => {
     it('creates a formError object from the key and message passed in', () => {
-      expect(CalendarDayInput.createError('deadline', 'The deadline must be a real date')).toEqual({
+      const maximumDate = new Date()
+      maximumDate.setMonth(maximumDate.getMonth() + 6)
+      expect(
+        CalendarDayInput.createError('deadline', `Date must be no later than ${maximumDate.toDateString()}`)
+      ).toEqual({
         errors: [
           {
             errorSummaryLinkedField: 'deadline-day',
             formFields: ['deadline-day', 'deadline-month', 'deadline-year'],
-            message: 'The deadline must be a real date',
+            message: `Date must be no later than ${maximumDate.toDateString()}`,
           },
         ],
       })

--- a/server/utils/forms/inputs/twelveHourBritishDateTimeInput.ts
+++ b/server/utils/forms/inputs/twelveHourBritishDateTimeInput.ts
@@ -19,12 +19,13 @@ export default class TwelveHourBritishDateTimeInput {
     private readonly dayKey: string,
     private readonly timeKey: string,
     private readonly errorMessages: TwelveHourBritishDateTimeErrorMessages,
-    private readonly earliestAllowedTime: Date | null = null
+    private readonly earliestAllowedTime: Date | null = null,
+    private readonly referralDate: string | null = null
   ) {}
 
   async validate(): Promise<FormValidationResult<Date>> {
     const [dayResult, timeResult] = await Promise.all([
-      new CalendarDayInput(this.request, this.dayKey, this.errorMessages.calendarDay).validate(),
+      new CalendarDayInput(this.request, this.dayKey, this.errorMessages.calendarDay, this.referralDate).validate(),
       new TwelveHourClockTimeInput(this.request, this.timeKey, this.errorMessages.clockTime).validate(),
     ])
 

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -96,7 +96,7 @@ class SentReferralFactory extends Factory<SentReferral> {
 
 export default SentReferralFactory.define(({ sequence }) => ({
   id: sequence.toString(),
-  sentAt: new Date().toISOString(),
+  sentAt: '2022-01-01T09:02:00.000Z',
   sentBy: {
     username: 'BERNARD.BEAKS',
     userId: sequence.toString(),


### PR DESCRIPTION
## What does this pull request do?

Adds additional validation to date fields for appointments to restrict dates earlier than before the referral was made and to no later than 6 month from today.

## What is the intent behind these changes?

Prevent users entering erroneous dates, it also fixes a bug where if a user enters a date far in the past it will throw an exception if they go to view the referral again
