### PR TITLE
Remove risk information for PP user test

### DIFF
--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -67,26 +67,6 @@ describe(ShowReferralPresenter, () => {
       expect(presenter.canShowFullSupplementaryRiskInformation).toBeFalsy()
     })
 
-    it("don't show full risk information if probabation practitioner", () => {
-      const referral = sentReferralFactory.build(referralParams)
-
-      const presenter = new ShowReferralPresenter(
-        referral,
-        intervention,
-        deliusConviction,
-        supplementaryRiskInformationFactory.build(),
-        deliusUser,
-        null,
-        null,
-        'probation-practitioner',
-        true,
-        deliusServiceUser,
-        riskSummary,
-        responsibleOfficer
-      )
-      expect(presenter.canShowFullSupplementaryRiskInformation).toBeFalsy()
-    })
-
     it('show full risk information if redacted risk is available and service provider', () => {
       const referral = sentReferralFactory.build(referralParams)
       config.apis.assessRisksAndNeedsApi.riskSummaryEnabled = true


### PR DESCRIPTION
## What does this pull request do?

Removes invalid test in showReferralPresenter.test.ts

## What is the intent behind these changes?

canShowFullSupplementaryRiskInformation doesn't check user type, so this isn't a valid test
If the `ASSESS_RISKS_AND_NEEDS_API_RISK_SUMMARY_ENABLED` env variable is set to true this test fails
