### PR TITLE
Skip dev dependencies in security audit

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,6 @@
 {
   "moderate": true,
   "package-manager": "auto",
-  "registry": "https://registry.npmjs.org"
+  "registry": "https://registry.npmjs.org",
+  "skip-dev": true
 }


### PR DESCRIPTION
## What does this pull request do?

Skips dev dependencies when running audit

## What is the intent behind these changes?

devDependencies are not installed in production, so dev vulnerabilities should not stop nightly checks from running
(raised as a result of vulnerability in a `nodemon` dependency)