### PR TITLE
Remove pinned validator dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,8 +49,7 @@
         "redis": "^4.1.0",
         "superagent": "^7.1.6",
         "timezone-support": "^2.0.2",
-        "uuid": "^8.3.2",
-        "validator": "^13.7.0"
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@pact-foundation/pact": "^9.17.3",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
       "prettier --write"
     ]
   },
-  "//": "TODO validator is pinned for CVE-2021-3765; remove when fixed upstream",
   "dependencies": {
     "@ministryofjustice/frontend": "1.4.2",
     "@sentry/node": "^7.1.1",
@@ -135,8 +134,7 @@
     "redis": "^4.1.0",
     "superagent": "^7.1.6",
     "timezone-support": "^2.0.2",
-    "uuid": "^8.3.2",
-    "validator": "^13.7.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@pact-foundation/pact": "^9.17.3",


### PR DESCRIPTION
## What does this pull request do?

Remove pinned validator package

## What is the intent behind these changes?

Validator was pinned in change `6e50969` to fix `CVE-2021-3765` vulnerability
The package is pulled in by express-validator
The latest version of express-validator has `"validator": "^13.7.0"`
So no longer need this to be pinned
