### PR TITLE
Case search all open cases

### DIFF
--- a/integration_tests/integration/dashboards.cy.js
+++ b/integration_tests/integration/dashboards.cy.js
@@ -313,7 +313,7 @@ describe('Dashboards', () => {
 
     describe('table sort headings', () => {
       beforeEach(() => {
-        cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent([]).build())
+        cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent(sentReferrals).build())
         cy.login()
       })
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -140,9 +140,9 @@ export default {
       cancelledCases: Number(get('PP_CANCELLED_CASES_PAGE_SIZE', '500')),
     },
     serviceProvider: {
-      percentageOfPaginationUsers: Number(get('SP_PERCENTAGE_OF_DASHBOARD_PAGINATION_USERS', '0')),
+      percentageOfPaginationUsers: Number(get('SP_PERCENTAGE_OF_DASHBOARD_PAGINATION_USERS', '100')),
       myCases: Number(get('SP_MY_CASES_PAGE_SIZE', '500')),
-      openCases: Number(get('SP_OPEN_CASES_PAGE_SIZE', '500')),
+      openCases: Number(get('SP_OPEN_CASES_PAGE_SIZE', '1')),
       unassignedCases: Number(get('SP_UNASSIGNED_CASES_PAGE_SIZE', '500')),
       completedCases: Number(get('SP_COMPLETED_PAGE_SIZE', '500')),
     },

--- a/server/config.ts
+++ b/server/config.ts
@@ -142,7 +142,7 @@ export default {
     serviceProvider: {
       percentageOfPaginationUsers: Number(get('SP_PERCENTAGE_OF_DASHBOARD_PAGINATION_USERS', '100')),
       myCases: Number(get('SP_MY_CASES_PAGE_SIZE', '500')),
-      openCases: Number(get('SP_OPEN_CASES_PAGE_SIZE', '1')),
+      openCases: Number(get('SP_OPEN_CASES_PAGE_SIZE', '500')),
       unassignedCases: Number(get('SP_UNASSIGNED_CASES_PAGE_SIZE', '500')),
       completedCases: Number(get('SP_COMPLETED_PAGE_SIZE', '500')),
     },

--- a/server/routes/deprecated/dashboardWithoutPaginationPresenter.ts
+++ b/server/routes/deprecated/dashboardWithoutPaginationPresenter.ts
@@ -6,16 +6,24 @@ import utils from '../../utils/utils'
 import DateUtils from '../../utils/dateUtils'
 import LoggedInUser from '../../models/loggedInUser'
 
+import PresenterUtils from '../../utils/presenterUtils'
+
 export type DashboardType = 'My cases' | 'All open cases' | 'Unassigned cases' | 'Completed cases'
 export default class DashboardWithoutPaginationPresenter {
   constructor(
     private readonly referralsSummary: ServiceProviderSentReferralSummary[],
     readonly dashboardType: DashboardType,
-    private readonly loggedInUser: LoggedInUser
+    private readonly loggedInUser: LoggedInUser,
+    readonly searchText?: string,
+    private readonly userInputData: Record<string, string> | null = null
   ) {}
 
   private readonly showAssignedCaseworkerColumn =
     this.dashboardType === 'My cases' || this.dashboardType === 'Unassigned cases'
+
+  readonly hrefSearchText = `/service-provider/dashboard/all-open-cases`
+
+  readonly presenterUtils = new PresenterUtils(this.userInputData).selectionValue
 
   readonly dashboardTypePersistentId = this.dashboardType.replace(/\s/g, '')
 

--- a/server/routes/deprecated/dashboardWithoutPaginationView.ts
+++ b/server/routes/deprecated/dashboardWithoutPaginationView.ts
@@ -50,7 +50,6 @@ export default class DashboardWithoutPaginationView {
       autocomplete: 'off',
       id: 'open-case-search-text',
       name: 'open-case-search-text',
-      // value: this.presenter.searchText
     }
   }
 

--- a/server/routes/deprecated/dashboardWithoutPaginationView.ts
+++ b/server/routes/deprecated/dashboardWithoutPaginationView.ts
@@ -1,5 +1,5 @@
 import ViewUtils from '../../utils/viewUtils'
-import { TableArgs } from '../../utils/govukFrontendTypes'
+import { TableArgs, InputArgs } from '../../utils/govukFrontendTypes'
 import DashboardWithoutPaginationPresenter from './dashboardWithoutPaginationPresenter'
 
 export default class DashboardWithoutPaginationView {
@@ -40,6 +40,20 @@ export default class DashboardWithoutPaginationView {
     ],
   }
 
+  private get subjectInputArgs(): InputArgs {
+    return {
+      label: {
+        text: 'Search by a person on probation in open cases',
+        classes: 'govuk-label--l',
+      },
+
+      autocomplete: 'off',
+      id: 'open-case-search-text',
+      name: 'open-case-search-text',
+      // value: this.presenter.searchText
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/dashboardWithoutPagination',
@@ -48,6 +62,8 @@ export default class DashboardWithoutPaginationView {
         tableArgs: this.tableArgs,
         primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items),
         subNavArgs: this.subNavArgs,
+        subjectInputArgs: this.subjectInputArgs,
+        showSearchResult: {},
       },
     ]
   }

--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -44,6 +44,7 @@ export default class DashboardView {
         primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items),
         subNavArgs: this.subNavArgs,
         pagination: this.presenter.pagination.mojPaginationArgs,
+        showSearchResult: {},
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -8,6 +8,7 @@ import { Page } from '../../models/pagination'
 import Pagination from '../../utils/pagination/pagination'
 import ControllerUtils from '../../utils/controllerUtils'
 import SentReferralSummaries from '../../models/sentReferralSummaries'
+import PresenterUtils from '../../utils/presenterUtils'
 
 export type DashboardType = 'My cases' | 'All open cases' | 'Unassigned cases' | 'Completed cases'
 export default class DashboardPresenter {
@@ -22,9 +23,14 @@ export default class DashboardPresenter {
     readonly dashboardType: DashboardType,
     private readonly loggedInUser: LoggedInUser,
     readonly tablePersistentId: string,
-    private readonly requestedSort: string
+    private readonly requestedSort: string,
+    readonly searchText: string | null = null,
+    private readonly userInputData: Record<string, string> | null = null
   ) {
-    this.pagination = new Pagination(sentReferralSummaries)
+    this.pagination = new Pagination(
+      sentReferralSummaries,
+      this.searchText ? `open-case-search-text=${searchText}` : null
+    )
     const [sortField, sortOrder] = this.requestedSort.split(',')
     this.requestedSortField = sortField
     this.requestedSortOrder = ControllerUtils.sortOrderToAriaSort(sortOrder)
@@ -67,6 +73,14 @@ export default class DashboardPresenter {
     this.dashboardType === 'All open cases' || this.dashboardType === 'Completed cases'
 
   readonly title = this.dashboardType
+
+  readonly SearchText = this.searchText
+
+  readonly hrefSearchText = `/service-provider/dashboard/all-open-cases`
+
+  readonly presenterUtils = new PresenterUtils(this.userInputData).selectionValue
+
+  readonly borderStyle = 'govuk-width-container--grey'
 
   get tableHeadings(): SortableTableHeaders {
     return DashboardPresenter.headingsAndSortFields

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -1,6 +1,6 @@
 import DashboardPresenter from './dashboardPresenter'
 import ViewUtils from '../../utils/viewUtils'
-import { TableArgs } from '../../utils/govukFrontendTypes'
+import { TableArgs, InputArgs } from '../../utils/govukFrontendTypes'
 
 export default class DashboardView {
   constructor(private readonly presenter: DashboardPresenter) {}
@@ -35,6 +35,24 @@ export default class DashboardView {
     ],
   }
 
+  private get subjectInputArgs(): InputArgs {
+    return {
+      classes: 'moj-search__input govuk-!-width-two-thirds govuk-!-margin-left-9',
+      label: {
+        classes: 'govuk-label--m govuk-!-margin-left-9 govuk-!-margin-top-8',
+        text: 'Search by a person on probation in open cases',
+      },
+      autocomplete: 'off',
+      hint: {
+        classes: 'moj-search__hint govuk-!-margin-left-9 govuk-details__summary-text',
+        text: 'You need to enter their first and last name, for example Matt Jones.',
+      },
+      id: 'open-case-search-text',
+      name: 'open-case-search-text',
+      value: this.presenter.searchText ?? undefined,
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/dashboard',
@@ -43,7 +61,9 @@ export default class DashboardView {
         tableArgs: this.tableArgs,
         primaryNavArgs: ViewUtils.primaryNav(this.presenter.navItemsPresenter.items),
         subNavArgs: this.subNavArgs,
+        subjectInputArgs: this.subjectInputArgs,
         pagination: this.presenter.pagination.mojPaginationArgs,
+        clearHref: this.presenter.hrefSearchText,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -322,7 +322,7 @@ describe('GET /service-provider/dashboard/all-open-cases', () => {
     })
 
     await request(app)
-      .get('/service-provider/dashboard/all-open-cases?open-case-search-text=Alex River')
+      .get('/service-provider/dashboard/all-open-cases?open-case-search-text=Alex%20River')
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('All open cases')

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -259,6 +259,98 @@ describe('GET /service-provider/dashboard/all-open-cases', () => {
       })
   })
 
+  it('all open cases and no cases when there are no open cases to be viewed', async () => {
+    const referrals: SentReferralSummaries[] = []
+    const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockResolvedValue(page)
+    await request(app)
+      .get('/service-provider/dashboard/all-open-cases')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('All open cases')
+        expect(res.text).not.toContain('Alex River')
+        expect(res.text).not.toContain('Accommodation Services - West Midlands')
+        expect(res.text).not.toContain('George River')
+        expect(res.text).toContain(`There are no results for`)
+      })
+  })
+
+  it('displays a list of all open cases when no search is present', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'Alex',
+          lastName: 'River',
+        },
+      }),
+      sentReferralSummariesFactory.build({
+        serviceUser: {
+          firstName: 'George',
+          lastName: 'River',
+        },
+      }),
+    ]
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockImplementation(() => {
+      return Promise.resolve(pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>)
+    })
+
+    await request(app)
+      .get('/service-provider/dashboard/all-open-cases')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('All open cases')
+        expect(res.text).toContain('Alex River')
+        expect(res.text).toContain('Accommodation Services - West Midlands')
+        expect(res.text).toContain('George River')
+      })
+  })
+
+  it('displays a list of all open cases with search text is not empty', async () => {
+    const referrals = [
+      sentReferralSummariesFactory.assigned().build({
+        serviceUser: {
+          firstName: 'Alex',
+          lastName: 'River',
+        },
+      }),
+    ]
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockImplementation(() => {
+      return Promise.resolve(pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>)
+    })
+
+    await request(app)
+      .get('/service-provider/dashboard/all-open-cases?open-case-search-text=Alex River')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('All open cases')
+        expect(res.text).toContain('Alex River')
+        expect(res.text).toContain('Accommodation Services - West Midlands')
+        expect(res.text).not.toContain('George River')
+      })
+  })
+
+  it('displays no records found when the search yields no results', async () => {
+    const searchText = 'nonsense'
+
+    interventionsService.getSentReferralsForUserTokenPaged.mockImplementation(() => {
+      return Promise.resolve(pageFactory.pageContent([]).build() as Page<SentReferralSummaries>)
+    })
+
+    await request(app)
+      .get(`/service-provider/dashboard/all-open-cases?open-case-search-text=${searchText}`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('All open cases')
+        expect(res.text).not.toContain('Alex River')
+        expect(res.text).not.toContain('Accommodation Services - West Midlands')
+        expect(res.text).not.toContain('George River')
+        expect(res.text).toContain(`There are no results for "${searchText}"`)
+      })
+  })
+
   it('displays a dashboard page with invalid page number', async () => {
     apiConfig.dashboards.serviceProvider.openCases = 1
     const referrals = [

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -110,11 +110,20 @@ export default class ServiceProviderReferralsController {
   }
 
   async showAllOpenCasesDashboard(req: Request, res: Response): Promise<void> {
+    const searchText = (req.query['open-case-search-text'] as string) ?? null
+
     if (
       FeatureFlagService.enableForUser(res.locals.user, config.dashboards.serviceProvider.percentageOfPaginationUsers)
     ) {
       const pageSize = config.dashboards.serviceProvider.openCases
-      await this.renderDashboard(req, res, { concluded: false }, 'All open cases', 'spAllOpenCases', pageSize)
+      await this.renderDashboard(
+        req,
+        res,
+        { concluded: false, search: searchText?.trim() },
+        'All open cases',
+        'spAllOpenCases',
+        pageSize
+      )
       return
     }
 
@@ -197,7 +206,14 @@ export default class ServiceProviderReferralsController {
 
     req.session.dashboardOriginPage = req.originalUrl
 
-    const presenter = new DashboardPresenter(cases, dashboardType, res.locals.user, tablePersistentId, sort[0])
+    const presenter = new DashboardPresenter(
+      cases,
+      dashboardType,
+      res.locals.user,
+      tablePersistentId,
+      sort[0],
+      getSentReferralsFilterParams.search
+    )
     const view = new DashboardView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, null)
@@ -208,11 +224,16 @@ export default class ServiceProviderReferralsController {
     req: Request,
     res: Response,
     referralsSummary: ServiceProviderSentReferralSummary[],
-    dashboardType: DashboardType
+    dashboardType: DashboardType,
+    searchText?: string
   ): void {
     req.session.dashboardOriginPage = req.originalUrl
-
-    const presenter = new DashboardWithoutPaginationPresenter(referralsSummary, dashboardType, res.locals.user)
+    const presenter = new DashboardWithoutPaginationPresenter(
+      referralsSummary,
+      dashboardType,
+      res.locals.user,
+      searchText
+    )
     const view = new DashboardWithoutPaginationView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, null)

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -30,6 +30,7 @@ export default function serviceProviderRoutes(router: Router, services: Services
   get(router, '/dashboard/all-open-cases', (req, res) =>
     serviceProviderReferralsController.showAllOpenCasesDashboard(req, res)
   )
+
   get(router, '/dashboard/unassigned-cases', (req, res) =>
     serviceProviderReferralsController.showUnassignedCasesDashboard(req, res)
   )

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -84,6 +84,7 @@ export interface GetSentReferralsFilterParams {
   cancelled?: boolean
   unassigned?: boolean
   assignedTo?: string
+  search?: string
 }
 
 export enum SPDashboardType {
@@ -290,6 +291,20 @@ export default class InterventionsService {
     return (await restClient.get({
       path: `/sent-referrals/summary/service-provider`,
       query,
+      headers: { Accept: 'application/json' },
+    })) as ServiceProviderSentReferralSummary[]
+  }
+
+  async getServiceProviderSentReferralsSummaryForUserTokenWithSearchText(
+    token: string,
+    searchText: string,
+    dashboardType?: SPDashboardType
+  ): Promise<ServiceProviderSentReferralSummary[]> {
+    const restClient = this.createRestClient(token)
+    const query = dashboardType ? { dashboardType } : undefined
+    return (await restClient.get({
+      path: `/sent-referrals/summaries`,
+      query: { ...query, searchText },
       headers: { Accept: 'application/json' },
     })) as ServiceProviderSentReferralSummary[]
   }

--- a/server/utils/pagination/pagination.ts
+++ b/server/utils/pagination/pagination.ts
@@ -29,7 +29,7 @@ interface MojPaginationArgs {
 }
 
 export default class Pagination {
-  constructor(private readonly page: Page<unknown>) {}
+  constructor(private readonly page: Page<unknown>, private readonly params: string | null = null) {}
 
   private constructPageItems(pageNumberRange: number[], chosenPageNumber: number): MojPaginationArgs['items'] {
     return pageNumberRange.map(pageNumber => {
@@ -37,7 +37,7 @@ export default class Pagination {
         type: 'pageNumber',
         selected: chosenPageNumber === pageNumber,
         text: pageNumber,
-        href: `?page=${pageNumber}`,
+        href: this.params ? `?${this.params}&page=${pageNumber}` : `?page=${pageNumber}`,
       }
     })
   }
@@ -86,8 +86,20 @@ export default class Pagination {
     }
     return {
       items,
-      previous: chosenPageNumber === 1 ? undefined : { text: 'Previous', href: `?page=${chosenPageNumber - 1}` },
-      next: chosenPageNumber === totalPages ? undefined : { text: 'Next', href: `?page=${chosenPageNumber + 1}` },
+      previous:
+        chosenPageNumber === 1
+          ? undefined
+          : {
+              text: 'Previous',
+              href: this.params ? `?${this.params}&page=${chosenPageNumber - 1}` : `?page=${chosenPageNumber - 1}`,
+            },
+      next:
+        chosenPageNumber === totalPages
+          ? undefined
+          : {
+              text: 'Next',
+              href: this.params ? `?${this.params}&page=${chosenPageNumber + 1}` : `?page=${chosenPageNumber + 1}`,
+            },
       results: { from, to, count },
     }
   }

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -1,6 +1,9 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -13,14 +16,62 @@
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
 
-        {{ mojSubNavigation(subNavArgs) }}
-        {% include "../partials/pagination.njk" %}
+      {{ mojSubNavigation(subNavArgs) }}
+
+      {% if presenter.dashboardType === 'All open cases' %}
+        <div class="govuk-grid-row govuk-template">
+          <form action="{{presenter.hrefSearchText}}" method="get">
+            <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+            {{ govukInput(subjectInputArgs) }}
+
+            <div class="govuk-button-group govuk-!-margin-left-9">
+              {{ govukButton({ text: "Search", name: "searchButtonAllOpenCases", preventDoubleClick: true}) }}
+              <a class="govuk-link" data-ga-action="click" data-ga-value="1" href={{ clearHref }}>Clear</a>
+            </div>
+          </form>
+        </div>
+
+        <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-7">
+          {% include "../partials/pagination.njk" %}
+        </div>
+        
+        {% if presenter.SearchText == '' %}
+          <div class="govuk-width-container govuk-!-margin-left-7">
+            <h2 class="govuk-heading-m govuk-!-margin-top-7">You have not entered any search terms</h2>
+            <div class="govuk-list--bullet govuk-!-margin-bottom-5">
+              <li class="govuk-body govuk-!-margin-bottom-0">Enter the full name of the person on probation</li>
+            </div>
+          </div>
+        {% elif tableArgs.rows.length <1 and presenter.SearchText !== '' %}
+          <div class="govuk-width-container govuk-!-margin-left-7">
+              <h2 class="govuk-heading-m govuk-!-margin-top-7"> There are no results for "{{presenter.SearchText | escape }}"</h2>
+                <div class="govuk-list--bullet govuk-!-margin-bottom-5">
+                  <li class="govuk-body govuk-!-margin-bottom-0">Check the Spelling</li>
+                  <li class="govuk-body govuk-!-margin-bottom-0">Make sure that you have entered their full name or how it appears in open cases</li>
+                </div>
+              <p>If the referral has finished or was cancelled, look in <a href="/service-provider/dashboard/completed-cases"> Completed Cases </a>. </p>
+              <p>If you think referral is missing from cases, <a href="/report-a-problem"> raise a support ticket </a>. </p>
+          </div>
+        {% else %}
+          {{ govukTable(tableArgs) }}
+        {% endif %}
+
+      {% endif %}
+
+      <hr class="govuk-section-break govuk-section-break--m">
+
+      {% if presenter.dashboardType !== 'All open cases'%}
         <hr class="govuk-section-break govuk-section-break--m">
         {{ govukTable(tableArgs) }}
+      {% endif %}
 
-      <script src="/assets/mojServerSideSortableTable.js">
-      </script>
+      <script src="/assets/mojSortableTable.js"></script>
     </div>
   </div>
   {% include "../partials/pagination.njk" %}
 {% endblock %}
+
+
+
+

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -71,7 +71,3 @@
   </div>
   {% include "../partials/pagination.njk" %}
 {% endblock %}
-
-
-
-

--- a/server/views/serviceProviderReferrals/dashboardWithoutPagination.njk
+++ b/server/views/serviceProviderReferrals/dashboardWithoutPagination.njk
@@ -1,6 +1,9 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
 
 {% extends "../partials/layout.njk" %}
 
@@ -12,11 +15,22 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
-
+     
         {{ mojSubNavigation(subNavArgs) }}
+
+        {% if presenter.dashboardType === 'All open cases' %}
+        <form action="{{presenter.hrefSearchText}}" method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+        {{ govukInput(subjectInputArgs) }}
+        {{ govukButton({ text: "Search" , preventDoubleClick: true}) }}
+        </form>
+        <a class="govuk-link" data-ga-action="click" data-ga-value="1" href="">Clear</a>
+        
+      {% endif %}
+
         <hr class="govuk-section-break govuk-section-break--m">
         {{ govukTable(tableArgs) }}
-
+      
       <script src="/assets/mojSortableTable.js">
       </script>
     </div>


### PR DESCRIPTION
## What does this pull request do?

This PR adds search functionality to paginated all open cases dashboard.
- when search yields no results, content is displayed to user to explain how to correct
- when nothing is in the search bar when user clicks search, content is displayed to user to explain how to correct

## What is the intent behind these changes?

The user should be able to search for open cases in order to find the case they need.
