### PR TITLE
Fix for all open cases showing as search error when no cases exist

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -269,10 +269,7 @@ describe('GET /service-provider/dashboard/all-open-cases', () => {
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('All open cases')
-        expect(res.text).not.toContain('Alex River')
-        expect(res.text).not.toContain('Accommodation Services - West Midlands')
-        expect(res.text).not.toContain('George River')
-        expect(res.text).toContain(`There are no results for`)
+        expect(res.text).toContain('Date received') // Proves tables existence
       })
   })
 

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -43,7 +43,7 @@
               <li class="govuk-body govuk-!-margin-bottom-0">Enter the full name of the person on probation</li>
             </div>
           </div>
-        {% elif tableArgs.rows.length <1 and presenter.SearchText !== '' %}
+        {% elif tableArgs.rows.length <1 and presenter.SearchText !== null %}
           <div class="govuk-width-container govuk-!-margin-left-7">
               <h2 class="govuk-heading-m govuk-!-margin-top-7"> There are no results for "{{presenter.SearchText | escape }}"</h2>
                 <div class="govuk-list--bullet govuk-!-margin-bottom-5">


### PR DESCRIPTION
## What does this pull request do?

Implements a fix for removing the search error when no cases exist for the open cases tab

## What is the intent behind these changes?

Users should be able to see an empty table rather than a search error to make it clearer that they have no open cases
