### PR TITLE
auth mockapi - handle unexpected requests

### DIFF
--- a/mockApis/auth.ts
+++ b/mockApis/auth.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import jwt from 'jsonwebtoken'
 import Wiremock from './wiremock'
 import TokenVerifiationMocks from './tokenVerification'
@@ -24,8 +25,12 @@ export default class AuthServiceMocks {
   getLoginUrl = async (): Promise<string> => {
     return this.wiremock.getRequests().then(data => {
       const { requests } = data.body
-      const stateParam = requests[0].request.queryParams.state
-      const stateValue = stateParam ? stateParam.values[0] : requests[1].request.queryParams.state.values[0]
+      const stateParam = requests?.[0]?.request?.queryParams?.state
+      const stateValue = stateParam ? stateParam?.values?.[0] : requests?.[1]?.request?.queryParams?.state?.values[0]
+      if (!stateValue) {
+        console.error(`Unable to retrieve query params from login request - ${requests[0]?.request?.url}`)
+        throw new Error(`getLoginUrl - unable to retrieve query params`)
+      }
       return `/sign-in/callback?code=codexxxx&state=${stateValue}`
     })
   }


### PR DESCRIPTION
## What does this pull request do?

Ongoing improvement to Integration tests - handle unexpected request

## What is the intent behind these changes?

Occasionally the auth mock tries to handle a request that is not a login request, and does not find any query params
This is probably due to a race condition, resulting in the wrong request being returned which causes an unhandled exception error