### PR TITLE
Fix for search by PoP UI issues

### DIFF
--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -44,7 +44,7 @@ export default class DashboardView {
       },
       autocomplete: 'off',
       hint: {
-        classes: 'moj-search__hint govuk-!-margin-left-9 govuk-details__summary-text',
+        classes: 'moj-search__hint govuk-!-margin-left-9',
         text: 'You need to enter their first and last name, for example Matt Jones.',
       },
       id: 'open-case-search-text',

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -19,7 +19,7 @@
       {{ mojSubNavigation(subNavArgs) }}
 
       {% if presenter.dashboardType === 'All open cases' %}
-        <div class="govuk-grid-row govuk-template">
+        <div class="govuk-template">
           <form action="{{presenter.hrefSearchText}}" method="get">
             <input type="hidden" name="_csrf" value="{{csrfToken}}">
 


### PR DESCRIPTION
## What does this pull request do?

Applies a fix to a couple of the UI issues raised during UAT for search by PoP including the underline of hint text and the search box negative padding.

## What is the intent behind these changes?

Creates a better user experience by maintaining consistency across the service
