### PR TITLE
use wiremock reset  endpoint

### DIFF
--- a/mockApis/wiremock.ts
+++ b/mockApis/wiremock.ts
@@ -12,14 +12,6 @@ export default class Wiremock {
   }
 
   async resetStubs(): Promise<unknown> {
-    const mappingsResponse = await superagent.get(`${this.adminUrl}/mappings`)
-    const body = mappingsResponse.body as { mappings: { id: string; response?: { proxyBaseUrl?: string } }[] }
-
-    const nonProxyMappings = body.mappings.filter(mapping => !mapping?.response?.proxyBaseUrl)
-
-    return Promise.all([
-      Promise.all(nonProxyMappings.map(mapping => superagent.delete(`${this.adminUrl}/mappings/${mapping.id}`))),
-      superagent.delete(`${this.adminUrl}/requests`),
-    ])
+    return superagent.post(`${this.adminUrl}/reset`)
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Use wiremock reset endpoint to initialise mappings/requests

## What is the intent behind these changes?

the int tests don't use the /wiremock_mappings, so no need to check for proxy mappings
Calling the reset endoint removes all mappings/requests
This removes the need to get all the current mappings and map through them to remove each one
