### PR TITLE
add pagination back to the top of all dashboard that aren't open cases for service providers

### DIFF
--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -62,6 +62,7 @@
       <hr class="govuk-section-break govuk-section-break--m">
 
       {% if presenter.dashboardType !== 'All open cases'%}
+      {% include "../partials/pagination.njk" %}
         <hr class="govuk-section-break govuk-section-break--m">
         {{ govukTable(tableArgs) }}
       {% endif %}


### PR DESCRIPTION
## What does this pull request do?

Adds pagination back to the top of all dashboard that aren't open cases for service providers

## What is the intent behind these changes?

Allows easy navigation of the paginated results.
