### PR TITLE
Display notification banner if no changes made

### DIFF
--- a/integration_tests/integration/amend-referral.cy.js
+++ b/integration_tests/integration/amend-referral.cy.js
@@ -292,6 +292,10 @@ context('Amend a referral', () => {
         )
         cy.contains('What are the desired outcomes for Accommodation?')
 
+        cy.get('[data-cy=desired-outcomes]').within(() => {
+          cy.get(':checkbox').last().check()
+        })
+
         cy.contains('Save changes').click()
 
         cy.get('.govuk-error-summary').within(() => {
@@ -329,9 +333,9 @@ context('Amend a referral', () => {
 
         cy.contains('Save changes').click()
 
-        cy.get('.govuk-error-summary').within(() => {
-          cy.contains('There is a problem')
-          cy.contains('You have not changed any desired outcomes.')
+        cy.get('.govuk-notification-banner').within(() => {
+          cy.contains('Important')
+          cy.contains('You have not made any changes to desired outcomes.')
         })
       })
     })

--- a/server/models/referralDesiredOutcomes.ts
+++ b/server/models/referralDesiredOutcomes.ts
@@ -4,4 +4,5 @@ export default interface ReferralDesiredOutcomes {
 }
 export interface ReferralDesiredOutcomesUpdate extends ReferralDesiredOutcomes {
   reasonForChange: string
+  changesMade: boolean
 }

--- a/server/routes/amendAReferral/amendAReferralController.test.ts
+++ b/server/routes/amendAReferral/amendAReferralController.test.ts
@@ -117,10 +117,27 @@ describe('POST /probation-practitioner/referrals/:referralId/:serviceCategoryId/
   })
 
   describe('with form validation errors', () => {
+    it('redirects to amend referral with changesMade query param set if no changes made', () => {
+      const desiredOutcomes = referral.referral.desiredOutcomes[0]
+      return request(app)
+        .post(
+          `/probation-practitioner/referrals/${referral.id}/${desiredOutcomes.serviceCategoryId}/update-desired-outcomes`
+        )
+        .send({
+          'reason-for-change': 'no changes to outcomes',
+          'desired-outcomes-ids': desiredOutcomes.desiredOutcomesIds,
+        })
+        .expect(302)
+        .expect(
+          'Location',
+          `/probation-practitioner/referrals/${referral.id}/${desiredOutcomes.serviceCategoryId}/update-desired-outcomes?noChanges=true`
+        )
+    })
+
     it('renders an error message', () => {
       return request(app)
         .post(`/probation-practitioner/referrals/${referral.id}/${serviceCategory.id}/update-desired-outcomes`)
-        .send({ 'reason-for-change': ' ' })
+        .send({ 'reason-for-change': ' ', 'desired-outcomes-ids': ['3415a6f2-38ef-4613-bb95-33355deff17e'] })
         .expect(400)
         .expect(res => {
           expect(res.text).toContain('A reason for changing the referral must be supplied')

--- a/server/routes/amendAReferral/desired-outcomes/amendDesiredOutcomesForm.test.ts
+++ b/server/routes/amendAReferral/desired-outcomes/amendDesiredOutcomesForm.test.ts
@@ -83,12 +83,8 @@ describe(AmendDesiredOutcomesForm, () => {
       }
       const data = await new AmendDesiredOutcomesForm(request).data()
 
-      expect(data.paramsForUpdate).toBeNull()
-      expect(data.error?.errors).toContainEqual({
-        errorSummaryLinkedField: AmendDesiredOutcomesForm.desiredOutcomesId,
-        formFields: [AmendDesiredOutcomesForm.desiredOutcomesId],
-        message: errorMessages.desiredOutcomes.noChanges,
-      })
+      expect(data.paramsForUpdate).toMatchObject({ changesMade: false })
+      expect(data.error).toBeNull()
     })
   })
 })

--- a/server/routes/amendAReferral/desired-outcomes/amendDesiredOutcomesForm.ts
+++ b/server/routes/amendAReferral/desired-outcomes/amendDesiredOutcomesForm.ts
@@ -19,6 +19,16 @@ export default class AmendDesiredOutcomesForm {
       validations: AmendDesiredOutcomesForm.validations,
     })
 
+    const noChangesMade = this.checkForNoChangesError(validationResult)
+
+    if (noChangesMade) {
+      return {
+        paramsForUpdate: {
+          changesMade: false,
+        },
+        error: null,
+      }
+    }
     const error = this.error(validationResult)
 
     if (error) {
@@ -32,6 +42,7 @@ export default class AmendDesiredOutcomesForm {
       paramsForUpdate: {
         desiredOutcomesIds: this.request.body[AmendDesiredOutcomesForm.desiredOutcomesId],
         reasonForChange: this.request.body[AmendDesiredOutcomesForm.reasonForChangeId],
+        changesMade: true,
       },
       error: null,
     }
@@ -65,5 +76,15 @@ export default class AmendDesiredOutcomesForm {
         message: validationError.msg,
       })),
     }
+  }
+
+  private checkForNoChangesError(validationResult: Result<ValidationError>): boolean | null {
+    if (validationResult.isEmpty()) {
+      return null
+    }
+
+    return validationResult.array().some(validationError => {
+      return validationError.msg === errorMessages.desiredOutcomes.noChanges
+    })
   }
 }

--- a/server/routes/amendAReferral/desired-outcomes/amendDesiredOutcomesPresenter.ts
+++ b/server/routes/amendAReferral/desired-outcomes/amendDesiredOutcomesPresenter.ts
@@ -10,7 +10,8 @@ export default class AmendDesiredOutcomesPresenter {
     private readonly referral: SentReferral,
     private readonly serviceCategory: ServiceCategory,
     private readonly error: FormValidationError | null = null,
-    private readonly userInputData: Record<string, string[]> | null = null
+    private readonly userInputData: Record<string, string[]> | null = null,
+    readonly showNoChangesBanner: boolean = false
   ) {
     this.backLinkUrl = `/probation-practitioner/referrals/${referral.id}/details`
     this.fields = {

--- a/server/routes/amendAReferral/desired-outcomes/amendDesiredOutcomesView.ts
+++ b/server/routes/amendAReferral/desired-outcomes/amendDesiredOutcomesView.ts
@@ -1,4 +1,4 @@
-import { CheckboxesArgs, TextareaArgs } from '../../../utils/govukFrontendTypes'
+import { CheckboxesArgs, TextareaArgs, NotificationBannerArgs } from '../../../utils/govukFrontendTypes'
 import ViewUtils from '../../../utils/viewUtils'
 import AmendDesiredOutcomesForm from './amendDesiredOutcomesForm'
 import AmendDesiredOutcomesPresenter from './amendDesiredOutcomesPresenter'
@@ -31,6 +31,7 @@ export default class AmendDesiredOutcomesView {
         errorSummaryArgs: this.errorSummaryArgs,
         reasonForChangeInputArgs: this.textAreaArgs,
         backLinkArgs: { href: this.presenter.backLinkUrl },
+        notificationBannerArgs: this.notificationBannerArgs,
       },
     ]
   }
@@ -61,5 +62,18 @@ export default class AmendDesiredOutcomesView {
         'data-cy': 'desired-outcomes',
       },
     }
+  }
+
+  get notificationBannerArgs(): NotificationBannerArgs | null {
+    const html = `<hr class="govuk-section-break govuk-section-break--s">
+          <p>
+          You have not made any changes to desired outcomes. If you want to leave the desired outcomes as they are, <a href= ${this.presenter.backLinkUrl}>cancel and go back</a>.
+          </p>`
+    return this.presenter.showNoChangesBanner
+      ? {
+          titleText: 'Important',
+          html,
+        }
+      : null
   }
 }

--- a/server/views/amendAReferral/desiredOutcomes.njk
+++ b/server/views/amendAReferral/desiredOutcomes.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -14,6 +15,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ govukBackLink(backLinkArgs) }}
+
+      {% if notificationBannerArgs %}
+         {{ govukNotificationBanner(notificationBannerArgs) }}
+      {% endif %}
 
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">


### PR DESCRIPTION
## What does this pull request do?

Shows info banner when no changes are made when amending outcomes

## What is the intent behind these changes?

If nothing has changed on desired outcomes and the user goes to save changes an error shouldn’t throw on reason for changing
design: https://www.figma.com/file/UPHNDGeHMPKM6hZcAvZjk2/Working---Master-Design?node-id=7340%3A75906

