### PR TITLE
prevent feedback on future appointments

### DIFF
--- a/integration_tests/integration/monitor.cy.js
+++ b/integration_tests/integration/monitor.cy.js
@@ -240,7 +240,7 @@ describe('Probation Practitioner monitor journey', () => {
           {
             'Session details': 'Session 3',
             'Date and time': '10:02am on 31 May 2021',
-            Status: 'scheduled',
+            Status: 'awaiting feedback',
             Action: '',
           },
           {
@@ -352,7 +352,7 @@ describe('Probation Practitioner monitor journey', () => {
           expect(result[2]).to.deep.include({
             'Session details': 'Session 3',
             'Date and time': '10:02am on 31 Jul 2021',
-            Status: 'scheduled',
+            Status: 'awaiting feedback',
             Action: '',
           })
           expect(result[3]).to.contains(/^Session 2 history/gi)

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -1418,7 +1418,7 @@ describe('Service provider referrals dashboard', () => {
           expect(result[1]).to.deep.include({
             'Session details': 'Session 2',
             'Date and time': '10:02am on 31 Mar 2021',
-            Status: 'scheduled',
+            Status: 'awaiting feedback',
           })
           expect(result[1]).to.contains(/^Reschedule session[\n|\t]*Give feedback$/)
         })
@@ -1561,7 +1561,7 @@ describe('Service provider referrals dashboard', () => {
           expect(result[1]).to.deep.include({
             'Session details': 'Session 2',
             'Date and time': '10:02am on 31 Mar 2021',
-            Status: 'scheduled',
+            Status: 'awaiting feedback',
           })
           expect(result[1]).to.contain(/^Reschedule session[\n|\t]*Give feedback$/)
         })
@@ -1626,7 +1626,7 @@ describe('Service provider referrals dashboard', () => {
         }),
         actionPlanAppointmentFactory.build({
           sessionNumber: 3,
-          appointmentTime: '2021-07-31T09:02:02Z',
+          appointmentTime: new Date(Date.now() + 100000000).toISOString(),
           durationInMinutes: 75,
           appointmentDeliveryType: 'PHONE_CALL',
         }),
@@ -1662,20 +1662,19 @@ describe('Service provider referrals dashboard', () => {
           expect(result[0]).to.deep.include({
             'Session details': 'Session 1',
             'Date and time': '9:02am on 24 Mar 2021',
-            Status: 'scheduled',
+            Status: 'awaiting feedback',
           })
           expect(result[0]).to.contains(/^Reschedule session[\n|\n]*Give feedback$/)
           expect(result[1]).to.contains(/^Session 1 history/gi)
           expect(result[2]).to.deep.include({
             'Session details': 'Session 2',
             'Date and time': '10:02am on 31 Aug 2021',
-            Status: 'scheduled',
+            Status: 'awaiting feedback',
           })
           expect(result[2]).to.contains(/^Reschedule session[\n|\n]*Give feedback$/)
           expect(result[3]).to.contains(/^Session 2 history/gi)
           expect(result[4]).to.deep.include({
             'Session details': 'Session 3',
-            'Date and time': '10:02am on 31 Jul 2021',
             Status: 'scheduled',
           })
           expect(result[4]).to.contains(/^Reschedule session[\n|\n]*Give feedback$/)

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -57,7 +57,7 @@ describe(InterventionProgressPresenter, () => {
 
     describe('when an appointment has been scheduled', () => {
       describe('and the appointment is in the future', () => {
-        it('populates the table with formatted session information, with the "Reschedule session" and "Give feedback" links displayed and "scheduled" status', () => {
+        it('populates the table with formatted session information, with "scheduled" status', () => {
           const referral = sentReferralFactory.build()
           const intervention = interventionFactory.build()
           const supplierAssessment = supplierAssessmentFactory.build()
@@ -112,7 +112,7 @@ describe(InterventionProgressPresenter, () => {
       })
 
       describe('and the appointment is in the past', () => {
-        it('populates the table with formatted session information, with the "Reschedule session" and "Give feedback" links displayed and "scheduled" status', () => {
+        it('populates the table with formatted session information, with "Awaiting feedback" status', () => {
           const referral = sentReferralFactory.build()
           const intervention = interventionFactory.build()
           const supplierAssessment = supplierAssessmentFactory.build()
@@ -137,8 +137,8 @@ describe(InterventionProgressPresenter, () => {
               sessionNumber: 1,
               appointmentTime: '1:00pm on 7 Dec 1920',
               tagArgs: {
-                text: 'scheduled',
-                classes: 'govuk-tag--blue',
+                text: 'awaiting feedback',
+                classes: 'govuk-tag--red',
               },
               link: null,
             },

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -151,7 +151,7 @@ describe(InterventionProgressPresenter, () => {
       })
     })
 
-    describe('when an appointment has been scheduled', () => {
+    describe('when an appointment has been scheduled in the past', () => {
       it('populates the table with formatted session information, with the "Reschedule session" and "Give feedback" links displayed', () => {
         const referral = sentReferralFactory.build()
         const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
@@ -176,7 +176,7 @@ describe(InterventionProgressPresenter, () => {
             sessionNumber: 1,
             appointmentTime: 'Midday on 7 Dec 2020',
             isParent: true,
-            statusPresenter: new SessionStatusPresenter(SessionStatus.scheduled),
+            statusPresenter: new SessionStatusPresenter(SessionStatus.awaitingFeedback),
             links: [
               {
                 href: '/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/sessions/1/edit/start',
@@ -188,6 +188,41 @@ describe(InterventionProgressPresenter, () => {
               },
             ],
           },
+        ])
+      })
+    })
+
+    describe('when an appointment has been scheduled in the future', () => {
+      it('populates the table with formatted session information, with the "Reschedule session" link displayed', () => {
+        const referral = sentReferralFactory.build()
+        const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
+        const intervention = interventionFactory.build()
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          intervention,
+          actionPlan,
+          [],
+          [
+            actionPlanAppointmentFactory.build({
+              sessionNumber: 1,
+              appointmentTime: new Date(Date.now() + 1000000).toISOString(),
+              durationInMinutes: 120,
+            }),
+          ],
+          supplierAssessmentFactory.build(),
+          null
+        )
+        expect(presenter.sessionTableRows).toEqual([
+          expect.objectContaining({
+            sessionNumber: 1,
+            statusPresenter: new SessionStatusPresenter(SessionStatus.scheduled),
+            links: [
+              {
+                href: '/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/sessions/1/edit/start',
+                text: 'Reschedule session',
+              },
+            ],
+          }),
         ])
       })
     })

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -186,7 +186,6 @@ export default class InterventionProgressPresenter {
         ]
         break
       case SessionStatus.awaitingFeedback:
-      case SessionStatus.scheduled:
         links = [
           {
             text: 'Reschedule session',
@@ -195,6 +194,14 @@ export default class InterventionProgressPresenter {
           {
             text: 'Give feedback',
             href: giveFeedbackHref,
+          },
+        ]
+        break
+      case SessionStatus.scheduled:
+        links = [
+          {
+            text: 'Reschedule session',
+            href: editHref,
           },
         ]
         break

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2937,14 +2937,16 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
   })
 
   describe('updateActionPlanAppointment', () => {
-    const appointmentTime = new Date()
-    appointmentTime.setMonth(appointmentTime.getMonth() + 4)
+    const futureAppointmentTime = new Date()
+    futureAppointmentTime.setMonth(futureAppointmentTime.getMonth() + 4)
+    const pastAppointmentTime = new Date()
+    pastAppointmentTime.setHours(0, 0, 0, 0) // set to start of current day
 
     describe('with a past appointment time', () => {
       it('returns a scheduled action plan appointment with feedback', async () => {
         const actionPlanAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 2,
-          appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
+          appointmentTime: `${pastAppointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
           durationInMinutes: 60,
           sessionType: 'ONE_TO_ONE',
           appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -2982,7 +2984,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             method: 'PATCH',
             path: '/action-plan/345059d4-1697-467b-8914-fedec9957279/appointment/2',
             body: {
-              appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
+              appointmentTime: `${pastAppointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
               durationInMinutes: 60,
               sessionType: 'ONE_TO_ONE',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -3021,7 +3023,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             '345059d4-1697-467b-8914-fedec9957279',
             2,
             {
-              appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
+              appointmentTime: `${pastAppointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
               durationInMinutes: 60,
               sessionType: 'ONE_TO_ONE',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -3050,7 +3052,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       it('returns an updated action plan appointment', async () => {
         const actionPlanAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 2,
-          appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
+          appointmentTime: `${futureAppointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
           durationInMinutes: 60,
           sessionType: 'ONE_TO_ONE',
           appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -3072,7 +3074,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             method: 'PATCH',
             path: '/action-plan/345059d4-1697-467b-8914-fedec9957279/appointment/2',
             body: {
-              appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
+              appointmentTime: `${futureAppointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
               durationInMinutes: 60,
               sessionType: 'ONE_TO_ONE',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',
@@ -3103,7 +3105,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             '345059d4-1697-467b-8914-fedec9957279',
             2,
             {
-              appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
+              appointmentTime: `${futureAppointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
               durationInMinutes: 60,
               sessionType: 'ONE_TO_ONE',
               appointmentDeliveryType: 'IN_PERSON_MEETING_OTHER',

--- a/server/utils/sessionStatus.test.ts
+++ b/server/utils/sessionStatus.test.ts
@@ -50,8 +50,8 @@ describe(sessionStatus.forAppointment, () => {
         const pastAppointment = actionPlanAppointmentFactory.scheduled().build({
           appointmentTime: pastDate,
         })
-        it('returns "scheduled" status', () => {
-          expect(sessionStatus.forAppointment(pastAppointment)).toEqual(SessionStatus.scheduled)
+        it('returns "awaiting feedback" status', () => {
+          expect(sessionStatus.forAppointment(pastAppointment)).toEqual(SessionStatus.awaitingFeedback)
         })
       })
 

--- a/server/utils/sessionStatus.ts
+++ b/server/utils/sessionStatus.ts
@@ -26,10 +26,7 @@ export default {
     }
 
     if (appointment.appointmentTime) {
-      if (
-        appointmentDecorator.isInitialAssessmentAppointment &&
-        appointmentDecorator.appointmentIsInThePast(appointment)
-      ) {
+      if (appointmentDecorator.appointmentIsInThePast(appointment)) {
         return SessionStatus.awaitingFeedback
       }
       return SessionStatus.scheduled


### PR DESCRIPTION
## What does this pull request do?

https://trello.com/c/SP3ESYUs
remove feedback link for future appointments

## What is the intent behind these changes?

Users should not be able to submit feedback for an appointment that isn't due yet