### PR TITLE
typescript / jwt-decode version updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "indefinite": "^2.4.1",
         "joi": "^17.6.0",
         "jquery": "^3.6.1",
-        "jwt-decode": "^2.2.0",
+        "jwt-decode": "^3.1.2",
         "md5": "^2.3.0",
         "nocache": "^3.0.4",
         "nunjucks": "^3.2.3",
@@ -104,7 +104,7 @@
         "supertest": "^6.2.4",
         "ts-jest": "^27.1.4",
         "ts-node": "^10.9.1",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       },
       "engines": {
         "node": ">=14",
@@ -13144,9 +13144,9 @@
       }
     },
     "node_modules/jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/keygrip": {
       "version": "1.1.0",
@@ -18087,9 +18087,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -28918,9 +28918,9 @@
       }
     },
     "jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "keygrip": {
       "version": "1.1.0",
@@ -32636,9 +32636,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true
     },
     "uid-safe": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "indefinite": "^2.4.1",
     "joi": "^17.6.0",
     "jquery": "^3.6.1",
-    "jwt-decode": "^2.2.0",
+    "jwt-decode": "^3.1.2",
     "md5": "^2.3.0",
     "nocache": "^3.0.4",
     "nunjucks": "^3.2.3",
@@ -189,6 +189,6 @@
     "supertest": "^6.2.4",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.8.2"
   }
 }


### PR DESCRIPTION
## What does this pull request do?

bump typescript to the latest version
update `passport.ts` to use extended interface for jwtDecode
remove `ts-ignore` command- @types/passport has been updated so longer needed

## What is the intent behind these changes?

update dependencies to the latest versions