### PR TITLE
Skip past appointment tests

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -2943,7 +2943,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     pastAppointmentTime.setUTCHours(2, 0, 0, 0) // create appointment in the morning
     const pastAppointmentTimeString = pastAppointmentTime.toISOString().replace(/(.*)(:00\.000Z)$/, '$1:00Z')
 
-    describe('with a past appointment time', () => {
+    // TODO skip past appointment tests until Pact contract update can be scheduled
+    // see https://trello.com/c/ZKPMdxVa
+    describe.skip('with a past appointment time', () => {
       it('returns a scheduled action plan appointment with feedback', async () => {
         const actionPlanAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 2,


### PR DESCRIPTION
## What does this pull request do?

Temporarily remove test until Pact contract update can be scheduled daily.

## What is the intent behind these changes?

Pact contract is not regenerated at run time - the contract (specifically dates) is fixed at the last point the ui contract was uploaded.
If the UI Pact contract updates are scheduled - https://trello.com/c/ZKPMdxVa - this can be re-enabled
