### PR TITLE
fix the typo in action plan section

### DIFF
--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -32,7 +32,7 @@
 {{ govukTable(actionPlanTableArgs(govukTag, csrfToken)) }}
 {% else %}
 <p class="govuk-body">
-  Once a caseworker has been assigned the action plan can be sumbitted.
+  Once a caseworker has been assigned the action plan can be submitted.
 </p>
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 {% endif %}


### PR DESCRIPTION
## What does this pull request do?

Fixes the typo in an action plan section

## What is the intent behind these changes?

There was a typo in the word submitted. This was fixed as part of this pull request
