### PR TITLE
Updating initial assessment to read supplier assessment

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -2254,7 +2254,7 @@ describe('Service provider referrals dashboard', () => {
           // chunk of work on our mocks that I don’t want to do now.
           cy.stubGetSupplierAssessment(referral.id, supplierAssessmentWithScheduledAppointment)
 
-          cy.get('h1').contains('Initial assessment appointment added')
+          cy.get('h1').contains('Supplier assessment appointment added')
           cy.contains('Return to progress').click()
 
           cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)
@@ -2345,7 +2345,7 @@ describe('Service provider referrals dashboard', () => {
           cy.get('h1').contains('Confirm appointment details')
           cy.get('button').contains('Confirm').click()
 
-          cy.get('h1').contains('Initial assessment appointment added')
+          cy.get('h1').contains('Supplier assessment appointment added')
         })
 
         it('User reschedules a supplier assessment appointment', () => {
@@ -2411,7 +2411,7 @@ describe('Service provider referrals dashboard', () => {
           // See comment in previous test about why we do this after the update
           cy.stubGetSupplierAssessment(referral.id, supplierAssessmentWithScheduledAppointment)
 
-          cy.get('h1').contains('Initial assessment appointment updated')
+          cy.get('h1').contains('Supplier assessment appointment updated')
           cy.contains('Return to progress').click()
 
           cy.location('pathname').should('equal', `/service-provider/referrals/${referral.id}/progress`)

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -440,7 +440,7 @@ describe('Scheduling a supplier assessment appointment', () => {
         .get(`/service-provider/referrals/1/supplier-assessment/scheduled-confirmation`)
         .expect(200)
         .expect(res => {
-          expect(res.text).toContain('Initial assessment appointment added')
+          expect(res.text).toContain('Supplier assessment appointment added')
         })
     })
   })
@@ -453,7 +453,7 @@ describe('Scheduling a supplier assessment appointment', () => {
         .get(`/service-provider/referrals/1/supplier-assessment/scheduled-confirmation`)
         .expect(200)
         .expect(res => {
-          expect(res.text).toContain('Initial assessment appointment added')
+          expect(res.text).toContain('Supplier assessment appointment added')
         })
     })
   })

--- a/server/routes/serviceProviderReferrals/supplierAssessmentAppointmentConfirmationPresenter.ts
+++ b/server/routes/serviceProviderReferrals/supplierAssessmentAppointmentConfirmationPresenter.ts
@@ -3,7 +3,7 @@ import SentReferral from '../../models/sentReferral'
 export default class SupplierAssessmentAppointmentConfirmationPresenter {
   constructor(private readonly referral: SentReferral, private readonly isReschedule: boolean) {}
 
-  readonly title = `Initial assessment appointment ${this.isReschedule ? 'updated' : 'added'}`
+  readonly title = `Supplier assessment appointment ${this.isReschedule ? 'updated' : 'added'}`
 
   readonly progressHref = `/service-provider/referrals/${this.referral.id}/progress`
 }


### PR DESCRIPTION
## What does this pull request do?

This PR corrects the wording from initial assessment to supplier assessment

## What is the intent behind these changes?

It should be called Supplier assessment appointment as that is accurate and consistent.
