### PR TITLE
removing sub title from enforceable days and completion date

### DIFF
--- a/server/routes/amendAReferral/changelogDetail/changelogDetailView.ts
+++ b/server/routes/amendAReferral/changelogDetail/changelogDetailView.ts
@@ -38,14 +38,12 @@ export default class ChangelogDetailView {
         }
       case 'MAXIMUM_ENFORCEABLE_DAYS':
         return {
-          changesubtitle: 'you changed enforceable days:',
           from: `<p>${oldValue[0].trim()} days</p>`,
           to: `<p>${newValue[0].trim()} days</p>`,
           reason: this.presenter.changelogDetail.reasonForChange,
         }
       case 'COMPLETION_DATETIME':
         return {
-          changesubtitle: 'you changed the completion deadline:',
           from: `<p>${oldValue[0].trim()}</p>`,
           to: `<p>${newValue[0].trim()}</p>`,
           reason: this.presenter.changelogDetail.reasonForChange,


### PR DESCRIPTION
## What does this pull request do?

removed unwanted sub title from change log detail page of enforceable days and completion days

## What is the intent behind these changes?

we decided the subtitle is not required and have to be removed
