### PR TITLE
fix amend remove optional from title

### DIFF
--- a/server/routes/amendAReferral/accessibility-needs/amendAccessibilityNeedsPresenter.ts
+++ b/server/routes/amendAReferral/accessibility-needs/amendAccessibilityNeedsPresenter.ts
@@ -34,7 +34,7 @@ export default class AccessibilityNeedsPresenter {
 
   readonly text = {
     accessibilityNeeds: {
-      label: `Change details about ${this.serviceUser?.firstName}'s mobility, disability or accessibility needs (optional)`,
+      label: `Change details about ${this.serviceUser?.firstName}'s mobility, disability or accessibility needs`,
       hint: 'For example, if they use a wheelchair, use a hearing aid or have a learning difficulty.',
       errorMessage: this.errorMessageForField('accessibility-needs'),
     },

--- a/server/routes/amendAReferral/additionalInformation/amendAdditionalInformationPresenter.ts
+++ b/server/routes/amendAReferral/additionalInformation/amendAdditionalInformationPresenter.ts
@@ -28,7 +28,7 @@ export default class AmendAdditionalInformationPresenter {
 
   readonly backLinkUrl: string
 
-  readonly title = `Change additional information about ${this.sentReferral.referral.serviceUser.firstName}'s needs (optional)`
+  readonly title = `Change additional information about ${this.sentReferral.referral.serviceUser.firstName}'s needs`
 
   readonly reasonForChangeTitle = `What's the reason for changing the additional information?`
 


### PR DESCRIPTION
## What does this pull request do?

- remove the optional word from the headings of some of the amend pages

## What is the intent behind these changes?

- It was understood that the optional word was not required there