### PR TITLE
stop exposing peronsal details on the dashboard url

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -323,7 +323,8 @@ describe('GET /service-provider/dashboard/all-open-cases', () => {
     })
 
     await request(app)
-      .get('/service-provider/dashboard/all-open-cases?open-case-search-text=Alex%20River')
+      .post(`/service-provider/dashboard/all-open-cases`)
+      .send({ 'open-case-search-text': `Alex%20River` })
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('All open cases')
@@ -341,7 +342,8 @@ describe('GET /service-provider/dashboard/all-open-cases', () => {
     })
 
     await request(app)
-      .get(`/service-provider/dashboard/all-open-cases?open-case-search-text=${searchText}`)
+      .post(`/service-provider/dashboard/all-open-cases`)
+      .send({ 'open-case-search-text': `${searchText}` })
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('All open cases')
@@ -366,7 +368,8 @@ describe('GET /service-provider/dashboard/all-open-cases', () => {
     })
 
     await request(app)
-      .get(`/service-provider/dashboard/all-open-cases?open-case-search-text=${searchText}`)
+      .post(`/service-provider/dashboard/all-open-cases`)
+      .send({ 'open-case-search-text': `${searchText}` })
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('You have not entered any search terms')

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -110,7 +110,7 @@ export default class ServiceProviderReferralsController {
   }
 
   async showAllOpenCasesDashboard(req: Request, res: Response): Promise<void> {
-    const searchText = (req.query['open-case-search-text'] as string) ?? null
+    const searchText = (req.body['open-case-search-text'] as string) ?? null
 
     if (
       FeatureFlagService.enableForUser(res.locals.user, config.dashboards.serviceProvider.percentageOfPaginationUsers)

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -31,6 +31,9 @@ export default function serviceProviderRoutes(router: Router, services: Services
   get(router, '/dashboard/all-open-cases', (req, res) =>
     serviceProviderReferralsController.showAllOpenCasesDashboard(req, res)
   )
+  post(router, '/dashboard/all-open-cases', (req, res) =>
+    serviceProviderReferralsController.showAllOpenCasesDashboard(req, res)
+  )
 
   get(router, '/dashboard/unassigned-cases', (req, res) =>
     serviceProviderReferralsController.showUnassignedCasesDashboard(req, res)

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -20,7 +20,7 @@
 
       {% if presenter.dashboardType === 'All open cases' %}
         <div class="govuk-template">
-          <form action="{{presenter.hrefSearchText}}" method="get">
+          <form action="{{presenter.hrefSearchText}}" method="post">
             <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
             {{ govukInput(subjectInputArgs) }}


### PR DESCRIPTION
## What does this pull request do?

- converts the rendering of dashboard page to a post request

## What is the intent behind these changes?

- When a user searches for either by name or reference number, it is shown in the url as it is a GET request. This is exposing the user name in the url which is a security vulnerability. So, we have to change the GET to a POST Request.