### PR TITLE
fixing reason examples in amending employment responsibilities

### DIFF
--- a/server/routes/amendAReferral/employment-responsibilities/amendEmploymentResponsibilitiesPresenter.test.ts
+++ b/server/routes/amendAReferral/employment-responsibilities/amendEmploymentResponsibilitiesPresenter.test.ts
@@ -54,7 +54,7 @@ describe('AmendEmploymentResponsibilitiesPresenter', () => {
         },
         reasonForChange: {
           title: `What's the reason for changing Alex's caring or employment responsibilities?`,
-          hint: `For example, they would prefer to speak in their native language`,
+          hint: `For example, they're now caring for a family member`,
         },
       })
     })

--- a/server/routes/amendAReferral/employment-responsibilities/amendEmploymentResponsibilitiesPresenter.ts
+++ b/server/routes/amendAReferral/employment-responsibilities/amendEmploymentResponsibilitiesPresenter.ts
@@ -41,7 +41,7 @@ export default class AmendEmploymentResponsibilitiesPresenter {
     },
     reasonForChange: {
       title: `What's the reason for changing ${this.serviceUser.firstName}'s caring or employment responsibilities?`,
-      hint: `For example, they would prefer to speak in their native language`,
+      hint: `For example, they're now caring for a family member`,
     },
   }
 


### PR DESCRIPTION
## What does this pull request do?

- changes the wordings for the reason examples in the amend employment responsibilities page

## What is the intent behind these changes?

- the reason example in the amend employment responsibilities page was not the right one and needs changing
