### PR TITLE
Upgrade hmpps orb to keep builds running after 11 Oct 2022

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@3.11
+  hmpps: ministryofjustice/hmpps@6
   node: circleci/node@4.1.0
 
 executors:
   integration:
     docker:
-      - image: cimg/node:16.14.2-browsers
+      - image: cimg/node:16.17-browsers
       - image: rodolpheche/wiremock:2.27.2-alpine
         command: ["--port", "9091"]
       - image: bitnami/redis:6.0
@@ -22,7 +22,7 @@ jobs:
       PACT_BROKER_USERNAME: "interventions"
     executor:
       name: hmpps/node
-      tag: 16.14.2-browsers
+      tag: 16.17-browsers
     steps:
       - checkout
       - node/install-npm:
@@ -46,7 +46,9 @@ jobs:
     environment:
       PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
       PACT_BROKER_USERNAME: "interventions"
-    executor: hmpps/node
+    executor:
+      name: hmpps/node
+      tag: 16.17-browsers
     parameters:
       tag:
         type: string


### PR DESCRIPTION


## What does this pull request do?

Upgrade hmpps orb for new setup_remote_docker syntax.

CircleCI said "In order to avoid possible job failures, please update your config by Tuesday, Oct. 11"



## What is the intent behind these changes?

From CircleCI:

> To keep users as current as possible, CircleCI is in the process of
> updating the underlying architecture for the setup_remote_docker
> feature, as well as other benefits. Old versions of Docker when combined
> with a newer Docker image in rare cases may have incompatibility issues
> with a custom script in a run command.
>
> In order to avoid possible job failures, please update your config by
> Tuesday, Oct. 11 to use the default version of Docker in
> `setup_remote_docker jobs`. This can be achieved by eliminating the
> version flag specified in each job that uses setup_remote_docker.
>
> The default Docker version in jobs that use setup_remote_docker was
> updated to version 20.10.17. The default is now being updated regularly.

This commit brings it those changes from the `ministryofjustice/hmpps@6` orb.

CircleCI config diff omitted as it contains huge Slack payload changes. I manually verified that the `setup_remote_docker` changes were in.
