### PR TITLE
Change referral details tab text to alternative wording

### DIFF
--- a/server/routes/shared/referralOverviewPagePresenter.ts
+++ b/server/routes/shared/referralOverviewPagePresenter.ts
@@ -21,7 +21,7 @@ export default class ReferralOverviewPagePresenter {
         active: this.section === ReferralOverviewPageSection.Progress,
       },
       {
-        text: 'Referral details',
+        text: this.subNavUrlPrefix === 'service-provider' ? 'Referral details' : 'View or change referral',
         href: `/${this.subNavUrlPrefix}/referrals/${this.referralId}/details`,
         active: this.section === ReferralOverviewPageSection.Details,
       },


### PR DESCRIPTION
Change referral details tab text to alternative wording for probation-practitioners.   Retain existing wording for service providers.

## What does this pull request do?

Change wording for tab, conditional on being a probation practitioner, remains as it was for service users

## What is the intent behind these changes?

Makes it clearer that the details can be edit / amended by practitioners
