### PR TITLE
Add banner for database migration downtime

### DIFF
--- a/server/broadcast-message-config.json
+++ b/server/broadcast-message-config.json
@@ -1,5 +1,5 @@
 {
-  "start": "2022-02-09T00:00:00+00:00",
-  "end": "2022-02-09T21:00:00+00:00",
-  "message": "You will not be able to make referrals or record activity details on this service between 7:30pm and 9pm on Wednesday 9 February. This is because of nDelius essential maintenance work."
+  "start": "2022-10-25T00:00:00+01:00",
+  "end": "2022-10-25T20:30:00+01:00",
+  "message": "You will not be able to use this service between 8pm and 8:30pm today, 25 October. This is to update the database."
 }


### PR DESCRIPTION
## What does this pull request do?

Add a banner for database migration downtime

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/1526295/197731887-4fc82cc7-2f42-4c85-b56a-1d3fdf7cc630.png">

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/1526295/197732146-e733b234-6c22-49fb-86bb-6f5dd7ba659a.png">


## What is the intent behind these changes?

To allow us to bring the service down while we migrate the database to PostgreSQL 14.
