### PR TITLE
Allow pruned interventions to complete EoSRs

### DIFF
--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -399,7 +399,6 @@ describe('GET /probation-practitioner/referrals/:id/progress', () => {
 describe('GET /probation-practitioner/end-of-service-report/:id', () => {
   it('renders a page with the contents of the end of service report', async () => {
     const serviceCategory = serviceCategoryFactory.build()
-    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
     const referral = sentReferralFactory.build({
       referral: {
         serviceCategoryIds: [serviceCategory.id],
@@ -423,7 +422,7 @@ describe('GET /probation-practitioner/end-of-service-report/:id', () => {
 
     interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
     interventionsService.getSentReferral.mockResolvedValue(referral)
-    interventionsService.getIntervention.mockResolvedValue(intervention)
+    interventionsService.getServiceCategories.mockResolvedValue([serviceCategory])
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
 
     await request(app)
@@ -435,28 +434,6 @@ describe('GET /probation-practitioner/end-of-service-report/:id', () => {
         expect(res.text).toContain('Some progression comments')
         expect(res.text).toContain('Some task comments')
         expect(res.text).toContain('Some further information')
-      })
-  })
-
-  it('throws error if not all service categories were obtainable', async () => {
-    const serviceCategory = serviceCategoryFactory.build()
-    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
-    const referral = sentReferralFactory.build({
-      referral: {
-        serviceCategoryIds: [serviceCategory.id, 'someOtherId'],
-      },
-    })
-    const endOfServiceReport = endOfServiceReportFactory.build()
-    const deliusServiceUser = deliusServiceUserFactory.build()
-    interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
-    interventionsService.getSentReferral.mockResolvedValue(referral)
-    interventionsService.getIntervention.mockResolvedValue(intervention)
-    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-    await request(app)
-      .get(`/probation-practitioner/end-of-service-report/${endOfServiceReport.id}`)
-      .expect(500)
-      .expect(res => {
-        expect(res.text).toContain('Expected service categories are missing in intervention')
       })
   })
 })

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -267,13 +267,10 @@ export default class ProbationPractitionerReferralsController {
     const { accessToken } = res.locals.user.token
     const endOfServiceReport = await this.interventionsService.getEndOfServiceReport(accessToken, req.params.id)
     const referral = await this.interventionsService.getSentReferral(accessToken, endOfServiceReport.referralId)
-    const intervention = await this.interventionsService.getIntervention(accessToken, referral.referral.interventionId)
-    const serviceCategories = intervention.serviceCategories.filter(serviceCategory =>
-      referral.referral.serviceCategoryIds.some(serviceCategoryId => serviceCategoryId === serviceCategory.id)
+    const serviceCategories = await this.interventionsService.getServiceCategories(
+      accessToken,
+      referral.referral.serviceCategoryIds
     )
-    if (serviceCategories.length !== referral.referral.serviceCategoryIds.length) {
-      throw new Error('Expected service categories are missing in intervention')
-    }
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
 
     const presenter = new EndOfServiceReportPresenter(

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1682,7 +1682,6 @@ describe('GET /service-provider/action-plan/:actionPlanId/confirmation', () => {
 describe('GET /service-provider/end-of-service-report/:id', () => {
   it('renders a page with the contents of the end of service report', async () => {
     const serviceCategory = serviceCategoryFactory.build()
-    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
     const referral = sentReferralFactory.build({
       referral: {
         serviceCategoryIds: [serviceCategory.id],
@@ -1706,7 +1705,7 @@ describe('GET /service-provider/end-of-service-report/:id', () => {
 
     interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
     interventionsService.getSentReferral.mockResolvedValue(referral)
-    interventionsService.getIntervention.mockResolvedValue(intervention)
+    interventionsService.getServiceCategories.mockResolvedValue([serviceCategory])
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
 
     await request(app)
@@ -1721,31 +1720,8 @@ describe('GET /service-provider/end-of-service-report/:id', () => {
       })
   })
 
-  it('throws error if not all service categories were obtainable', async () => {
-    const serviceCategory = serviceCategoryFactory.build()
-    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
-    const referral = sentReferralFactory.build({
-      referral: {
-        serviceCategoryIds: [serviceCategory.id, 'someOtherId'],
-      },
-    })
-    const endOfServiceReport = endOfServiceReportFactory.build()
-    const deliusServiceUser = deliusServiceUserFactory.build()
-    interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
-    interventionsService.getSentReferral.mockResolvedValue(referral)
-    interventionsService.getIntervention.mockResolvedValue(intervention)
-    communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
-    await request(app)
-      .get(`/service-provider/end-of-service-report/${endOfServiceReport.id}`)
-      .expect(500)
-      .expect(res => {
-        expect(res.text).toContain('Expected service categories are missing in intervention')
-      })
-  })
-
   it('throws an error if trying to view an in-progress end of service report', async () => {
     const serviceCategory = serviceCategoryFactory.build()
-    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
     const referral = sentReferralFactory.build({
       referral: {
         serviceCategoryIds: [serviceCategory.id],
@@ -1756,7 +1732,7 @@ describe('GET /service-provider/end-of-service-report/:id', () => {
 
     interventionsService.getEndOfServiceReport.mockResolvedValue(inProgressEndOfServiceReport)
     interventionsService.getSentReferral.mockResolvedValue(referral)
-    interventionsService.getIntervention.mockResolvedValue(intervention)
+    interventionsService.getServiceCategories.mockResolvedValue([serviceCategory])
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
 
     await request(app)
@@ -1812,7 +1788,6 @@ describe('GET /service-provider/end-of-service-report/:id/outcomes/:number', () 
   it('renders a form', async () => {
     const serviceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
     const intervention = interventionFactory.build({
-      serviceCategories: [serviceCategory],
       contractType: {
         code: 'ACC',
         name: 'Accommodation',
@@ -1830,6 +1805,7 @@ describe('GET /service-provider/end-of-service-report/:id/outcomes/:number', () 
     const deliusServiceUser = deliusServiceUserFactory.build()
 
     interventionsService.getIntervention.mockResolvedValue(intervention)
+    interventionsService.getServiceCategories.mockResolvedValue([serviceCategory])
     interventionsService.getSentReferral.mockResolvedValue(referral)
     interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
@@ -1864,7 +1840,6 @@ describe('POST /service-provider/end-of-service-report/:id/outcomes/:number', ()
     describe('when the outcome number doesn’t refer to the last of the referral’s desired outcomes', () => {
       it('updates the appointment on the interventions service and redirects to the page for the next outcome', async () => {
         const serviceCategory = serviceCategoryFactory.build()
-        const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
         const desiredOutcome = serviceCategory.desiredOutcomes[0]
         const referral = sentReferralFactory.build({
           referral: {
@@ -1872,12 +1847,11 @@ describe('POST /service-provider/end-of-service-report/:id/outcomes/:number', ()
               { serviceCategoryId: serviceCategory.id, desiredOutcomesIds: [desiredOutcome.id, '2', '3'] },
             ],
             serviceCategoryIds: [serviceCategory.id],
-            interventionId: intervention.id,
           },
         })
         const endOfServiceReport = endOfServiceReportFactory.build()
 
-        interventionsService.getIntervention.mockResolvedValue(intervention)
+        interventionsService.getServiceCategories.mockResolvedValue([serviceCategory])
         interventionsService.getSentReferral.mockResolvedValue(referral)
         interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
         interventionsService.updateDraftEndOfServiceReport.mockResolvedValue(endOfServiceReport)
@@ -1911,7 +1885,6 @@ describe('POST /service-provider/end-of-service-report/:id/outcomes/:number', ()
     describe('when the outcome refers to the last of the referral’s desired outcomes', () => {
       it('updates the appointment on the interventions service and redirects to the further information form', async () => {
         const serviceCategory = serviceCategoryFactory.build()
-        const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
         const desiredOutcome = serviceCategory.desiredOutcomes[0]
         const referral = sentReferralFactory.build({
           referral: {
@@ -1919,12 +1892,11 @@ describe('POST /service-provider/end-of-service-report/:id/outcomes/:number', ()
               { serviceCategoryId: serviceCategory.id, desiredOutcomesIds: ['2', '3', desiredOutcome.id] },
             ],
             serviceCategoryIds: [serviceCategory.id],
-            interventionId: intervention.id,
           },
         })
         const endOfServiceReport = endOfServiceReportFactory.build()
 
-        interventionsService.getIntervention.mockResolvedValue(intervention)
+        interventionsService.getServiceCategories.mockResolvedValue([serviceCategory])
         interventionsService.getSentReferral.mockResolvedValue(referral)
         interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
         interventionsService.updateDraftEndOfServiceReport.mockResolvedValue(endOfServiceReport)
@@ -1997,7 +1969,6 @@ describe('POST /service-provider/end-of-service-report/:id/outcomes/:number', ()
             },
           ],
         })
-        const intervention = interventionFactory.build({ serviceCategories: [serviceCategory1, serviceCategory2] })
         const desiredOutcome = serviceCategory2.desiredOutcomes[0]
         const referral = sentReferralFactory.build({
           referral: {
@@ -2006,12 +1977,11 @@ describe('POST /service-provider/end-of-service-report/:id/outcomes/:number', ()
               { serviceCategoryId: serviceCategory2.id, desiredOutcomesIds: [desiredOutcome.id, '5'] },
             ],
             serviceCategoryIds: [serviceCategory1.id, serviceCategory2.id],
-            interventionId: intervention.id,
           },
         })
         const endOfServiceReport = endOfServiceReportFactory.build()
 
-        interventionsService.getIntervention.mockResolvedValue(intervention)
+        interventionsService.getServiceCategories.mockResolvedValue([serviceCategory1, serviceCategory2])
         interventionsService.getSentReferral.mockResolvedValue(referral)
         interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
         interventionsService.updateDraftEndOfServiceReport.mockResolvedValue(endOfServiceReport)
@@ -2046,7 +2016,7 @@ describe('POST /service-provider/end-of-service-report/:id/outcomes/:number', ()
   describe('with invalid data', () => {
     it('renders an error page and does not update the appointment on the interventions service', async () => {
       const serviceCategory = serviceCategoryFactory.build()
-      const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
+      const intervention = interventionFactory.build()
       const desiredOutcome = serviceCategory.desiredOutcomes[0]
       const referral = sentReferralFactory.build({
         referral: {
@@ -2062,6 +2032,7 @@ describe('POST /service-provider/end-of-service-report/:id/outcomes/:number', ()
       const deliusServiceUser = deliusServiceUserFactory.build()
 
       interventionsService.getIntervention.mockResolvedValue(intervention)
+      interventionsService.getServiceCategories.mockResolvedValue([serviceCategory])
       interventionsService.getSentReferral.mockResolvedValue(referral)
       interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
       interventionsService.updateDraftEndOfServiceReport.mockResolvedValue(endOfServiceReport)
@@ -2085,7 +2056,7 @@ describe('GET /service-provider/end-of-service-report/:id/further-information', 
   it('renders a form page', async () => {
     const endOfServiceReport = endOfServiceReportFactory.build()
     const serviceCategory = serviceCategoryFactory.build()
-    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
+    const intervention = interventionFactory.build()
     const referral = sentReferralFactory.build({
       referral: {
         serviceCategoryIds: [serviceCategory.id],
@@ -2097,6 +2068,7 @@ describe('GET /service-provider/end-of-service-report/:id/further-information', 
     interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
     interventionsService.getSentReferral.mockResolvedValue(referral)
     interventionsService.getIntervention.mockResolvedValue(intervention)
+    interventionsService.getServiceCategories.mockResolvedValue([serviceCategory])
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
 
     await request(app)
@@ -2132,7 +2104,7 @@ describe('POST /service-provider/end-of-service-report/:id/further-information',
 describe('GET /service-provider/end-of-service-report/:id/check-answers', () => {
   it('renders a page with the contents of the end of service report', async () => {
     const serviceCategory = serviceCategoryFactory.build()
-    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
+    const intervention = interventionFactory.build()
     const referral = sentReferralFactory.build({
       referral: {
         desiredOutcomes: [
@@ -2161,6 +2133,7 @@ describe('GET /service-provider/end-of-service-report/:id/check-answers', () => 
     interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
     interventionsService.getSentReferral.mockResolvedValue(referral)
     interventionsService.getIntervention.mockResolvedValue(intervention)
+    interventionsService.getServiceCategories.mockResolvedValue([serviceCategory])
     communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUser)
 
     await request(app)
@@ -2193,7 +2166,7 @@ describe('POST /service-provider/end-of-service-report/:id/submit', () => {
 describe('GET /service-provider/end-of-service-report/:id/confirmation', () => {
   it('displays a confirmation page for that end of service report', async () => {
     const serviceCategory = serviceCategoryFactory.build()
-    const intervention = interventionFactory.build({ serviceCategories: [serviceCategory] })
+    const intervention = interventionFactory.build()
     const endOfServiceReport = endOfServiceReportFactory.build()
     const referral = sentReferralFactory.build({
       referral: {
@@ -2204,6 +2177,7 @@ describe('GET /service-provider/end-of-service-report/:id/confirmation', () => {
     interventionsService.getEndOfServiceReport.mockResolvedValue(endOfServiceReport)
     interventionsService.getSentReferral.mockResolvedValue(referral)
     interventionsService.getIntervention.mockResolvedValue(intervention)
+    interventionsService.getServiceCategories.mockResolvedValue([serviceCategory])
 
     await request(app)
       .get(`/service-provider/end-of-service-report/${endOfServiceReport.id}/confirmation`)

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -23,11 +23,11 @@ jest.mock('../services/hmppsAuthService')
 
 /*
  It seems that perhaps after upgrading to Jest 27.x, it’s broken something in jest-pact
- (a Jest hook?) which is responsible for increasing the Jest timeout to 30s to give the 
- mock web server time to start up. I’m basing this on the error that’s displayed below 
+ (a Jest hook?) which is responsible for increasing the Jest timeout to 30s to give the
+ mock web server time to start up. I’m basing this on the error that’s displayed below
  when I run the tests.
 
- I’ve created IC-2024 to investigate this, but I think the temporary solution 
+ I’ve created IC-2024 to investigate this, but I think the temporary solution
  is to set the timeout ourselves.
 
   ● Pact between Interventions UI and Interventions Service › with 30000 ms timeout for Pact › getDraftReferral › returns a referral for the gi
@@ -1311,7 +1311,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('getServiceCategory', () => {
+  describe('getServiceCategory/getServiceCategories', () => {
     const complexityLevels = [
       {
         id: 'd0db50b0-4a50-4fc7-a006-9c97530e38b2',
@@ -1396,7 +1396,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
     })
 
-    it('returns a service category', async () => {
+    it('getServiceCategory returns a single service category by ID', async () => {
       const serviceCategory = await interventionsService.getServiceCategory(
         probationPractitionerToken,
         '428ee70f-3001-4399-95a6-ad25eaaede16'
@@ -1406,6 +1406,18 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expect(serviceCategory.name).toEqual('Accommodation')
       expect(serviceCategory.complexityLevels).toEqual(complexityLevels)
       expect(serviceCategory.desiredOutcomes).toEqual(desiredOutcomes)
+    })
+
+    it('getServiceCategories returns a list of service categories by ID', async () => {
+      const serviceCategories = await interventionsService.getServiceCategories(probationPractitionerToken, [
+        '428ee70f-3001-4399-95a6-ad25eaaede16',
+        '428ee70f-3001-4399-95a6-ad25eaaede16',
+      ])
+
+      expect(serviceCategories[0].id).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
+      expect(serviceCategories[0].name).toEqual('Accommodation')
+      expect(serviceCategories[1].id).toEqual('428ee70f-3001-4399-95a6-ad25eaaede16')
+      expect(serviceCategories[1].name).toEqual('Accommodation')
     })
   })
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -284,6 +284,12 @@ export default class InterventionsService {
     })) as ServiceCategory
   }
 
+  async getServiceCategories(token: string, serviceCategoryIds: string[]): Promise<ServiceCategory[]> {
+    // observation: will generate lots of small calls; however, service categories are practically static
+    // it might make sense to preload them at application startup, so that recycling the pods will evict the cache
+    return Promise.all(serviceCategoryIds.map(serviceCategoryId => this.getServiceCategory(token, serviceCategoryId)))
+  }
+
   async getChangelog(token: string, referralId: string): Promise<Changelog[]> {
     const restClient = this.createRestClient(token)
 


### PR DESCRIPTION

## What does this pull request do?

Context:

The "Mentoring" intervention had two service categories:

1. Lifestyle and Associates
2. Social Inclusion

The latter was removed a couple of weeks later.

"Mentoring" referrals with "Social Inclusion" selected at the time are unable to complete an end-of-service report (https://sentry.io/organizations/ministryofjustice/issues/3141468937/?project=5807822).

---

This change takes the available service categories from the referral, instead of its intervention, allowing for "pruned" categories to be completed.

## What is the intent behind these changes?

To allow referrals with "pruned" categories to be completed by end-of-service reports.

Currently, service provider users see "something did not work" pages.

### Success measured by

Decrease of "complete" referrals without a started/submitted end-of-service report. 