### PR TITLE
Remove old, unused ingress

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/values.yaml
+++ b/helm_deploy/hmpps-interventions-ui/values.yaml
@@ -51,7 +51,7 @@ generic-service:
   ingress:
     enabled: true
     v1_2_enabled: true
-    v0_47_enabled: true
+    v0_47_enabled: false
     modsecurity_snippet: |
       SecRuleEngine On
       SecAuditEngine RelevantOnly


### PR DESCRIPTION
## What does this pull request do?

Remove old, unused ingress

See also:

- https://github.com/ministryofjustice/hmpps-interventions-service/pull/1309

## What is the intent behind these changes?

Remove unused ingresses so we don't block migrations.

> [We are intending to proceed with Kubernetes 1.22 upgrade next week](https://mojdt.slack.com/archives/CH6D099DF/p1667207580078859).
> This is a final reminder for teams that still need to move to new Ingress Controllers and remove deprecated API versions.
> Here is the list of ingresses and namespaces that still need to be updated before Tuesday 15th November.



## Diff

```diff
diff --git a/before.yaml b/after.yaml
index a373df9d..016872c1 100644
--- a/before.yaml
+++ b/after.yaml
@@ -181,57 +181,6 @@ spec:
             - name: TOKEN_VERIFICATION_ENABLED
               value: "true"
 ---
-# Source: hmpps-interventions-ui/charts/generic-service/templates/ingress.yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: hmpps-interventions-ui
-  labels:
-    helm.sh/chart: generic-service-1.5.0
-    app: hmpps-interventions-ui
-    release: hmpps-interventions-ui
-    app.kubernetes.io/version: "testing"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    nginx.ingress.kubernetes.io/custom-http-errors: "418"
-    external-dns.alpha.kubernetes.io/set-identifier: hmpps-interventions-ui-hmpps-interventions-prod-green
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
-    kubernetes.io/ingress.class: "modsec01"
-    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/modsecurity-snippet: 
-      |
-        SecRuleEngine On
-        SecAuditEngine RelevantOnly
-        SecAuditLog /var/log/nginx/error.log
-        SecAuditLogType Serial
-        SecRequestBodyAccess On
-        SecAuditLogParts ACHKZ
-        SecAuditLogFormat JSON
-        SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6,setvar:tx.outbound_anomaly_score_threshold=4"
-        SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
-        SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
-        SecRuleRemoveById 921110
-        SecRuleUpdateTargetById 942100 "!ARGS"  # disable libinjection testing on request args. to disable all SQLi testing, modify rules in the range 942100-942999
-        SecRuleRemoveByTag language-php
-        SecRuleRemoveByTag language-shell
-        SecRuleRemoveByTag platform-windows
-spec:
-  tls:
-  - hosts:
-    - refer-monitor-intervention.service.justice.gov.uk
-    secretName: tls-certificate
-  rules:
-    - host: refer-monitor-intervention.service.justice.gov.uk
-      http:
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: hmpps-interventions-ui
-                port:
-                  number: 80
----
 # Source: hmpps-interventions-ui/charts/generic-service/templates/ingress_v1_2.yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
```