### PR TITLE
Avoid using "unavailable" wording in unhandled error

### DIFF
--- a/server/views/errors/unhandledError.njk
+++ b/server/views/errors/unhandledError.njk
@@ -4,7 +4,7 @@
     {% block content %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
+                <h1 class="govuk-heading-l">Sorry, there is a problem</h1>
 
                 {% if userMessage %}
                     <p class="govuk-body">{{ userMessage }}</p>


### PR DESCRIPTION

## What does this pull request do?

Avoid using "unavailable" wording in unhandled error

Ticket: https://trello.com/c/hSKCmGf5/567-design-and-dev-card-redesign-error-message

## What is the intent behind these changes?

This error shows when our dependencies are unreachable (cannot log in, cannot read risk or team information), which makes "unavailable" misleading.