### PR TITLE
Switch to passive WAF monitoring

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/values.yaml
+++ b/helm_deploy/hmpps-interventions-ui/values.yaml
@@ -54,17 +54,6 @@ generic-service:
     v0_47_enabled: false
     modsecurity_snippet: |
       SecRuleEngine On
-      SecAuditEngine RelevantOnly
-      SecAuditLog /var/log/nginx/error.log
-      SecAuditLogType Serial
-      SecRequestBodyAccess On
-      SecAuditLogParts ACHKZ
-      SecAuditLogFormat JSON
-      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6,setvar:tx.outbound_anomaly_score_threshold=4"
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
-      SecRuleRemoveById 921110
-      SecRuleUpdateTargetById 942100 "!ARGS"  # disable libinjection testing on request args. to disable all SQLi testing, modify rules in the range 942100-942999
-      SecRuleRemoveByTag language-php
-      SecRuleRemoveByTag language-shell
-      SecRuleRemoveByTag platform-windows
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50,setvar:tx.outbound_anomaly_score_threshold=50"


### PR DESCRIPTION

## What does this pull request do?

Switch to passive WAF monitoring

## What is the intent behind these changes?

We are getting many complaints about genuine requests blocked by the web application firewall (WAF).

I cannot see the triggering rules in the logs for the UI, but I can see them in the API.

For now, use the same config as the API to monitor triggered rules and create a reasonable allow list.
