### PR TITLE
Show system-made case notes with "System" sender

### DIFF
--- a/server/services/hmppsAuthService.test.ts
+++ b/server/services/hmppsAuthService.test.ts
@@ -73,6 +73,20 @@ describe('hmppsAuthService', () => {
       const output = await hmppsAuthService.getUserDetailsByUsername(token.access_token, username)
       expect(output).toEqual(response)
     })
+
+    it('should return system user for "hmpps-interventions-service" username', async () => {
+      const username = 'hmpps-interventions-service'
+
+      const output = await hmppsAuthService.getUserDetailsByUsername(token.access_token, username)
+      expect(output).toEqual({
+        username: 'hmpps-interventions-service',
+        active: true,
+        name: 'System',
+        authSource: 'urn:hmpps:interventions',
+        userId: '00000000-0000-0000-0000-000000000000',
+        uuid: '00000000-0000-0000-0000-000000000000',
+      })
+    })
   })
 
   describe('getSPUserByEmailAddress', () => {

--- a/server/services/hmppsAuthService.ts
+++ b/server/services/hmppsAuthService.ts
@@ -1,6 +1,5 @@
 import superagent, { Response } from 'superagent'
 import querystring from 'querystring'
-// import { createClient } from 'redis'
 import * as redis from 'redis'
 import logger from '../../log'
 import config from '../config'
@@ -24,6 +23,7 @@ const redisClient = redis.createClient({
 })
 
 const REDIS_PREFIX = 'systemToken:' // prefix has been removed from redis config, so manually add it to key
+const FAKE_SYSTEM_USER = 'hmpps-interventions-service' // see also https://github.com/ministryofjustice/hmpps-interventions-service/pull/1353
 
 redisClient
   .connect()
@@ -46,6 +46,17 @@ export default class HmppsAuthService {
   }
 
   async getUserDetailsByUsername(userToken: string, username: string): Promise<UserDetails> {
+    if (username === FAKE_SYSTEM_USER) {
+      return {
+        username,
+        active: true,
+        name: 'System',
+        authSource: 'urn:hmpps:interventions',
+        userId: '00000000-0000-0000-0000-000000000000',
+        uuid: '00000000-0000-0000-0000-000000000000',
+      } as UserDetails
+    }
+
     logger.info(`Getting user details: calling HMPPS Auth`)
     return (await this.restClient(userToken).get({ path: `/api/user/${username}` })) as UserDetails
   }


### PR DESCRIPTION

## What does this pull request do?

Show system-made case notes with "System" sender

https://github.com/ministryofjustice/hmpps-interventions-service/pull/1353

## What is the intent behind these changes?

We have a requirement to display case notes from the "system". We created a "fake" user for this purpose, which does not exist in hmpps-auth.

To capture this, we short-circuit the lookup logic for this particular user and use a canned response.
