### PR TITLE
Render the system user as a caseworker

### DIFF
--- a/server/services/hmppsAuthService.test.ts
+++ b/server/services/hmppsAuthService.test.ts
@@ -215,6 +215,23 @@ describe('hmppsAuthService', () => {
       const output = await hmppsAuthService.getSPUserByUsername(token.access_token, 'AUTH_ADM')
       expect(output).toEqual(response)
     })
+
+    it('should return system user for "hmpps-interventions-service" username', async () => {
+      const username = 'hmpps-interventions-service'
+
+      const output = await hmppsAuthService.getSPUserByUsername(token.access_token, username)
+      expect(output).toEqual({
+        userId: '00000000-0000-0000-0000-000000000000',
+        username: 'hmpps-interventions-service',
+        email: 'system',
+        firstName: 'Refer and monitor',
+        lastName: 'System',
+        locked: false,
+        enabled: true,
+        verified: true,
+        lastLoggedIn: 'irrelevant',
+      })
+    })
   })
 
   describe('getUserRoles', () => {

--- a/server/services/hmppsAuthService.ts
+++ b/server/services/hmppsAuthService.ts
@@ -94,6 +94,20 @@ export default class HmppsAuthService {
   }
 
   async getSPUserByUsername(token: string, username: string): Promise<AuthUserDetails> {
+    if (username === FAKE_SYSTEM_USER) {
+      return {
+        userId: '00000000-0000-0000-0000-000000000000',
+        username,
+        email: 'system',
+        firstName: 'Refer and monitor',
+        lastName: 'System',
+        locked: false,
+        enabled: true,
+        verified: true,
+        lastLoggedIn: 'irrelevant',
+      } as AuthUserDetails
+    }
+
     logger.info(`Getting user detail by username: calling HMPPS Auth`)
     return (await this.restClient(token).get({
       path: `/api/authuser/${username}`,


### PR DESCRIPTION

## What does this pull request do?

Render the system user as a caseworker.

## How does it look?

<img width="300" alt="image" src="https://user-images.githubusercontent.com/1526295/208695957-3e53289c-d440-4680-9e2d-245840846ea5.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/1526295/208695285-b2ee09ce-16ea-4c3e-bf7a-ac39b4402da0.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/1526295/208695510-ae49589f-b976-444d-8167-b32fea85e806.png">


## What is the intent behind these changes?

Follow-up on d46036c256a986623854aec7904afeeada94576e.

We will be assigning the "system" user as a caseworker for transferred referrals, so we need it to be recognised as an SP user as well.
