### PR TITLE
Re-enable WAF with strict thresholds without POSTs

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/values.yaml
+++ b/helm_deploy/hmpps-interventions-ui/values.yaml
@@ -56,4 +56,20 @@ generic-service:
       SecRuleEngine On
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
-      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50,setvar:tx.outbound_anomaly_score_threshold=50"
+      # disable false positive tags for POST requests
+      SecRuleUpdateTargetByTag platform-windows "!REQUEST_METHOD:POST"
+      SecRuleUpdateTargetByTag language-shell "!REQUEST_METHOD:POST"
+      SecRuleUpdateTargetByTag language-php "!REQUEST_METHOD:POST"
+      # disable these false positives for POST requests; they are always authenticated
+      SecRuleUpdateTargetById 921110 "!REQUEST_METHOD:POST"  # HTTP Request Smuggling Attack, occurred 170 times
+      SecRuleUpdateTargetById 921120 "!REQUEST_METHOD:POST"  # HTTP Response Splitting Attack, occurred 72 times
+      SecRuleUpdateTargetById 942190 "!REQUEST_METHOD:POST"  # Detects MSSQL code execution and information gathering attempts, occurred 51 times
+      SecRuleUpdateTargetById 942230 "!REQUEST_METHOD:POST"  # Detects conditional SQL injection attempts, occurred 48 times
+      SecRuleUpdateTargetById 942100 "!REQUEST_METHOD:POST"  # detected SQLi using libinjection., occurred 38 times
+      SecRuleUpdateTargetById 942360 "!REQUEST_METHOD:POST"  # Detects concatenated basic SQL injection and SQLLFI attempts, occurred 29 times
+      SecRuleUpdateTargetById 941370 "!REQUEST_METHOD:POST"  # JavaScript global variable found, occurred 3 times
+      SecRuleUpdateTargetById 930120 "!REQUEST_METHOD:POST"  # OS File Access Attempt, occurred 2 times
+      SecRuleUpdateTargetById 941180 "!REQUEST_METHOD:POST"  # Node-Validator Blacklist Keywords, occurred 2 times
+      SecRuleUpdateTargetById 941310 "!REQUEST_METHOD:POST"  # US-ASCII Malformed Encoding XSS Filter - Attack Detected, occurred 1 time
+      SecRuleUpdateTargetById 941130 "!REQUEST_METHOD:POST"  # XSS Filter - Category 3: Attribute Vector, occurred 1 time
+      SecRuleUpdateTargetById 942250 "!REQUEST_METHOD:POST"  # Detects MATCH AGAINST, MERGE and EXECUTE IMMEDIATE injections, occurred 1 time


### PR DESCRIPTION
## What does this pull request do?

IPB-9: Running the WAF in data collection mode for 22 full days resulted in:

  797 x Remote Command Execution: Windows Command Injection, rule: 932110
  170 x HTTP Request Smuggling Attack, rule: 921110
  72 x HTTP Response Splitting Attack, rule: 921120
  57 x Remote Command Execution: Windows Command Injection, rule: 932115
  51 x Detects MSSQL code execution and information gathering attempts, rule: 942190
  48 x Remote Command Execution: Unix Command Injection, rule: 932100
  48 x Detects conditional SQL injection attempts, rule: 942230
  38 x detected SQLi using libinjection., rule: 942100
  38 x PHP Injection Attack: Variable Function Call Found, rule: 933210
  29 x Detects concatenated basic SQL injection and SQLLFI attempts, rule: 942360
  11 x PHP Injection Attack: High-Risk PHP Function Call Found, rule: 933160
  11 x Remote Command Execution: Unix Command Injection, rule: 932105
  5 x Remote Command Execution: Direct Unix Command Execution, rule: 932150
  3 x JavaScript global variable found, rule: 941370
  2 x OS File Access Attempt, rule: 930120
  2 x Node-Validator Blacklist Keywords, rule: 941180
  1 x Detects MATCH AGAINST, MERGE and EXECUTE IMMEDIATE injections, rule: 942250
  1 x Remote Command Execution: Windows FOR/IF Command Found, rule: 932140
  1 x US-ASCII Malformed Encoding XSS Filter - Attack Detected, rule: 941310
  1 x XSS Filter - Category 3: Attribute Vector, rule: 941130

for all `POST` requests.

Since `standardRouter` ensures all unauthenticated requests are caught, we can disable these rules by tag or ID for POST scanning; the router (currently) guarantees they are genuine requests.

I played with the idea of adding a blanket `SecRuleUpdateTargetByTag OWASP_CRS` exclusion, but let's only disable things that have triggered.

## What is the intent behind these changes?

Re-enable request blocking with the false positives configured out.
