### PR TITLE
Re-enable WAF with strict thresholds without POSTs

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/values.yaml
+++ b/helm_deploy/hmpps-interventions-ui/values.yaml
@@ -56,4 +56,25 @@ generic-service:
       SecRuleEngine On
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
-      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50,setvar:tx.outbound_anomaly_score_threshold=50"
+      # disable these false positives for POST requests; they are always authenticated
+      SecRule REQUEST_METHOD "POST" \
+        "id:10000, \
+        phase:2, \
+        t:none, \
+        ctl:ruleRemoveByTag=platform-windows, \
+        ctl:ruleRemoveByTag=language-shell, \
+        ctl:ruleRemoveByTag=language-php, \
+        ctl:ruleRemoveById=921110, \
+        ctl:ruleRemoveById=921120, \
+        ctl:ruleRemoveById=942190, \
+        ctl:ruleRemoveById=942230, \
+        ctl:ruleRemoveById=942100, \
+        ctl:ruleRemoveById=942360, \
+        ctl:ruleRemoveById=941370, \
+        ctl:ruleRemoveById=930120, \
+        ctl:ruleRemoveById=941180, \
+        ctl:ruleRemoveById=941310, \
+        ctl:ruleRemoveById=941130, \
+        ctl:ruleRemoveById=942250, \
+        nolog, \
+        pass"


### PR DESCRIPTION
## What does this pull request do?

Re-applies #1884 with correct syntax. Follows #1893.

IPB-9: Running the WAF in data collection mode for 22 full days resulted in:

  797 x Remote Command Execution: Windows Command Injection, rule: 932110
  170 x HTTP Request Smuggling Attack, rule: 921110
  72 x HTTP Response Splitting Attack, rule: 921120
  57 x Remote Command Execution: Windows Command Injection, rule: 932115
  51 x Detects MSSQL code execution and information gathering attempts, rule: 942190
  48 x Remote Command Execution: Unix Command Injection, rule: 932100
  48 x Detects conditional SQL injection attempts, rule: 942230
  38 x detected SQLi using libinjection., rule: 942100
  38 x PHP Injection Attack: Variable Function Call Found, rule: 933210
  29 x Detects concatenated basic SQL injection and SQLLFI attempts, rule: 942360
  11 x PHP Injection Attack: High-Risk PHP Function Call Found, rule: 933160
  11 x Remote Command Execution: Unix Command Injection, rule: 932105
  5 x Remote Command Execution: Direct Unix Command Execution, rule: 932150
  3 x JavaScript global variable found, rule: 941370
  2 x OS File Access Attempt, rule: 930120
  2 x Node-Validator Blacklist Keywords, rule: 941180
  1 x Detects MATCH AGAINST, MERGE and EXECUTE IMMEDIATE injections, rule: 942250
  1 x Remote Command Execution: Windows FOR/IF Command Found, rule: 932140
  1 x US-ASCII Malformed Encoding XSS Filter - Attack Detected, rule: 941310
  1 x XSS Filter - Category 3: Attribute Vector, rule: 941130

for all `POST` requests.

Since `standardRouter` ensures all unauthenticated requests are caught, we can disable these rules by tag or ID for POST scanning; the router (currently) guarantees they are genuine requests.

I played with the idea of adding a blanket `SecRuleUpdateTargetByTag OWASP_CRS` exclusion, but let's only disable things that have triggered.

## What is the intent behind these changes?

Re-enable request blocking with the false positives configured out.
