### PR TITLE
Populate pact secrets from shared context, not local

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ workflows:
   version: 2
   build_test_and_deploy:
     jobs:
-      - build
+      - build:
+          context: [hmpps-common-vars]
       - integration_test
       - hmpps/helm_lint
       - hmpps/build_docker:


### PR DESCRIPTION
## What does this pull request do?

We had a local copy of the pact broker password. Now that it had to be rotated, it's extra work for us because it isn't done through automation.

Instead, let's use the shared "hmpps-common-vars" context to pass down these shared secrets.

## What is the intent behind these changes?

Reduce the overhead of rotating secrets, making it simpler.

Related: https://github.com/ministryofjustice/hmpps-interventions-service/pull/1381