### PR TITLE
Allow referral to load even with deleted assignee user

### DIFF
--- a/server/models/hmppsAuth/authUserDetails.test.ts
+++ b/server/models/hmppsAuth/authUserDetails.test.ts
@@ -1,0 +1,17 @@
+import AuthUserDetails, { authUserFullName } from './authUserDetails'
+
+describe('authUserFullName', () => {
+  describe('when the user exists', () => {
+    it('returns the full name of the person', () => {
+      const user = { firstName: 'Firstname', lastName: 'Lastname', userId: 'something' } as AuthUserDetails
+      expect(authUserFullName(user)).toEqual('Firstname Lastname')
+    })
+  })
+
+  describe('when the user is missing', () => {
+    it('returns "a deleted person"', () => {
+      const user = { username: 'deleted_person_username' } as AuthUserDetails
+      expect(authUserFullName(user)).toEqual('a deleted user')
+    })
+  })
+})

--- a/server/models/hmppsAuth/authUserDetails.ts
+++ b/server/models/hmppsAuth/authUserDetails.ts
@@ -9,3 +9,7 @@ export default interface AuthUserDetails {
   verified: boolean
   lastLoggedIn: string
 }
+
+export function authUserFullName(user: AuthUserDetails): string {
+  return user.userId ? `${user.firstName} ${user.lastName}` : 'a deleted user'
+}

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -8,7 +8,7 @@ import SessionStatusPresenter from '../shared/sessionStatusPresenter'
 import Intervention from '../../models/intervention'
 import SupplierAssessment from '../../models/supplierAssessment'
 import SupplierAssessmentDecorator from '../../decorators/supplierAssessmentDecorator'
-import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
+import AuthUserDetails, { authUserFullName } from '../../models/hmppsAuth/authUserDetails'
 import { ActionPlanAppointment } from '../../models/appointment'
 import ActionPlanProgressPresenter from '../shared/action-plan/actionPlanProgressPresenter'
 import ApprovedActionPlanSummary from '../../models/approvedActionPlanSummary'
@@ -88,7 +88,7 @@ export default class InterventionProgressPresenter {
   }
 
   get assignedCaseworkerFullName(): string | null {
-    return this.referralAssigned ? `${this.assignee!.firstName} ${this.assignee!.lastName}` : null
+    return this.referralAssigned ? authUserFullName(this.assignee!) : null
   }
 
   get assignedCaseworkerEmail(): string | null {

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -156,7 +156,7 @@ export default class ProbationPractitionerReferralsController {
         : this.interventionsService.getActionPlan(accessToken, sentReferral.actionPlanId)
     const supplierAssessmentPromise = this.interventionsService.getSupplierAssessment(accessToken, sentReferral.id)
     const assigneePromise = sentReferral.assignedTo
-      ? this.hmppsAuthService.getSPUserByUsername(accessToken, sentReferral.assignedTo.username)
+      ? this.hmppsAuthService.getSPUserByUsername(accessToken, sentReferral.assignedTo.username, false)
       : Promise.resolve(null)
 
     const [intervention, actionPlan, approvedActionPlanSummaries, serviceUser, supplierAssessment, assignee] =
@@ -239,7 +239,8 @@ export default class ProbationPractitionerReferralsController {
         ? null
         : await this.hmppsAuthService.getSPUserByUsername(
             res.locals.user.token.accessToken,
-            sentReferral.assignedTo.username
+            sentReferral.assignedTo.username,
+            false
           )
 
     const presenter = new ShowReferralPresenter(

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -9,7 +9,7 @@ import Intervention from '../../models/intervention'
 import SupplierAssessment from '../../models/supplierAssessment'
 import SupplierAssessmentDecorator from '../../decorators/supplierAssessmentDecorator'
 import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../models/appointment'
-import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
+import AuthUserDetails, { authUserFullName } from '../../models/hmppsAuth/authUserDetails'
 import ActionPlanProgressPresenter from '../shared/action-plan/actionPlanProgressPresenter'
 import ApprovedActionPlanSummary from '../../models/approvedActionPlanSummary'
 
@@ -73,7 +73,7 @@ export default class InterventionProgressPresenter {
   }
 
   get assignedCaseworkerFullName(): string | null {
-    return this.referralAssigned ? `${this.assignee!.firstName} ${this.assignee!.lastName}` : null
+    return this.referralAssigned ? authUserFullName(this.assignee!) : null
   }
 
   get assignedCaseworkerEmail(): string | null {

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -267,7 +267,7 @@ export default class ServiceProviderReferralsController {
     const assignee =
       sentReferral.assignedTo === null
         ? null
-        : await this.hmppsAuthService.getSPUserByUsername(accessToken, sentReferral.assignedTo.username)
+        : await this.hmppsAuthService.getSPUserByUsername(accessToken, sentReferral.assignedTo.username, false)
 
     let formError: FormValidationError | null = null
     const error = req.query.error as string
@@ -356,7 +356,7 @@ export default class ServiceProviderReferralsController {
     const assignee =
       sentReferral.assignedTo === null
         ? null
-        : await this.hmppsAuthService.getSPUserByUsername(accessToken, sentReferral.assignedTo.username)
+        : await this.hmppsAuthService.getSPUserByUsername(accessToken, sentReferral.assignedTo.username, false)
 
     const presenter = new InterventionProgressPresenter(
       sentReferral,

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -6,7 +6,7 @@ import PresenterUtils from '../../utils/presenterUtils'
 import ServiceUserDetailsPresenter from '../makeAReferral/service-user-details/serviceUserDetailsPresenter'
 import { FormValidationError } from '../../utils/formValidationError'
 import ReferralOverviewPagePresenter, { ReferralOverviewPageSection } from './referralOverviewPagePresenter'
-import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
+import AuthUserDetails, { authUserFullName } from '../../models/hmppsAuth/authUserDetails'
 import Intervention from '../../models/intervention'
 import ServiceCategory from '../../models/serviceCategory'
 import ComplexityLevel from '../../models/complexityLevel'
@@ -72,7 +72,7 @@ export default class ShowReferralPresenter {
   }
 
   get assignedCaseworkerFullName(): string | null {
-    return this.referralAssigned ? `${this.assignee!.firstName} ${this.assignee!.lastName}` : null
+    return this.referralAssigned ? authUserFullName(this.assignee!) : null
   }
 
   get assignedCaseworkerEmail(): string | null {

--- a/server/services/hmppsAuthService.test.ts
+++ b/server/services/hmppsAuthService.test.ts
@@ -215,6 +215,50 @@ describe('hmppsAuthService', () => {
       const output = await hmppsAuthService.getSPUserByUsername(token.access_token, 'AUTH_ADM')
       expect(output).toEqual(response)
     })
+
+    it('should return stub user if not required and response is 404', async () => {
+      const response = {
+        userId: undefined,
+        username: 'MISSING',
+        email: 'MISSING',
+        firstName: undefined,
+        lastName: undefined,
+        locked: undefined,
+        enabled: undefined,
+        verified: undefined,
+        lastLoggedIn: undefined,
+      }
+
+      fakeHmppsAuthApi
+        .get('/api/authuser/MISSING')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(404, {})
+
+      const output = await hmppsAuthService.getSPUserByUsername(token.access_token, 'MISSING', false)
+      expect(output).toEqual(response)
+    })
+
+    it('raises an error if required and the response is 404', async () => {
+      fakeHmppsAuthApi
+        .get('/api/authuser/MISSING')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(404, {})
+
+      await expect(hmppsAuthService.getSPUserByUsername(token.access_token, 'MISSING', true)).rejects.toThrow(
+        'Not Found'
+      )
+    })
+
+    it('raises an error if not required but response is non-404 4xx', async () => {
+      fakeHmppsAuthApi
+        .get('/api/authuser/MISSING')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(400, {})
+
+      await expect(hmppsAuthService.getSPUserByUsername(token.access_token, 'MISSING', false)).rejects.toThrow(
+        'Bad Request'
+      )
+    })
   })
 
   describe('getUserRoles', () => {

--- a/server/services/hmppsAuthService.ts
+++ b/server/services/hmppsAuthService.ts
@@ -93,11 +93,14 @@ export default class HmppsAuthService {
     return Promise.resolve(authUsers[0])
   }
 
-  async getSPUserByUsername(token: string, username: string): Promise<AuthUserDetails> {
-    logger.info(`Getting user detail by username: calling HMPPS Auth`)
-    return (await this.restClient(token).get({
-      path: `/api/authuser/${username}`,
-    })) as AuthUserDetails
+  async getSPUserByUsername(token: string, username: string, mustExist = true): Promise<AuthUserDetails> {
+    return (await this.restClient(token)
+      .get({ path: `/api/authuser/${username}` })
+      .catch(error => {
+        if (error.status !== 404) throw error
+        if (mustExist) throw error
+        else return { username, email: username }
+      })) as AuthUserDetails
   }
 
   async getUserRoles(token: string): Promise<string[]> {


### PR DESCRIPTION
## What does this pull request do?

IPB-207: Let the referral pages load even if the caseworker (assignee) user no longer exists in hmpps-auth (the identity provider).

| Before | After |
| --- | --- |
| <img width="1481" alt="image" src="https://user-images.githubusercontent.com/1526295/214436232-740ad6e9-4e96-4791-9e20-a515becb4b31.png"> | <img width="897" alt="image" src="https://user-images.githubusercontent.com/1526295/214435844-78e49df9-1383-40ec-8ec9-a5f0298a99c3.png"> |

What is worse, the current response from auth won't be visible to end-users, so they have no hint towards what is wrong.

## What is the intent behind these changes?

Graceful degradation: an external 404 Not Found response should block other users from viewing or progressing with the referral.