### PR TITLE
Recover from errors on session/draft storage

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -118,12 +118,16 @@ export default function createApp(
     },
     password: config.redis.password,
   })
+
   redisClient
     .connect()
     .then(() => logger.info('App Redis connected'))
     .catch((error: Error) => {
       logger.error({ err: error }, 'App Redis connect error')
     })
+  redisClient.on('error', error => {
+    logger.error({ err: error }, 'App Redis connect error')
+  })
 
   app.use(
     session({


### PR DESCRIPTION

## What does this pull request do?

Partially cover IPB-204: Recover from errors on session/draft storage.

The `redisClient` in `hmppsAuthService.ts` recovers from all intermittent outages, but this main one does not, and the only difference is the `on('error', ...)` handler.

Tested locally, and without this handler, the connection remains dead. With it, it recovers.

(This does not replace a proper liveness check, though -- that one should ping all Redis connections -- rest of IPB-204 is to expose healthchecks)

## What is the intent behind these changes?

So that intermittent Redis connection errors will not get the application in a "stuck" state.

Based on the current evidence, I think this will mitigate this pattern:

![image](https://user-images.githubusercontent.com/1526295/214448989-2f3d4e2b-b099-47c4-a626-039e54e947c9.png)
![image](https://user-images.githubusercontent.com/1526295/214449149-6688ec2a-65d2-421c-8775-26b2c283fe62.png)
