### PR TITLE
Also pin the CI node images to 16.x

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,7 +9,7 @@
       "groupSlug": "all-npm-minor-patch"
     },
     {
-      "matchPackageNames": ["node"],
+      "matchPackageNames": ["node", "cimg/node"],
       "allowedVersions": "<=16"
     },
     {


### PR DESCRIPTION
## What does this pull request do?

Pin the CI node images to 16.x.

Missed from f2ab725a7ec73d0b2e2bd3da92e06e3f809020d2 (#1939)

Renovate is trying to upgrade CircleCI's image to v19:

```yaml
executors:
  integration:
    docker:
      - image: cimg/node:16.19-browsers
```


## What is the intent behind these changes?

Reduce the noise of Renovate PRs upgrading resources that require planned and wider work to upgrade.