### PR TITLE
Ipb 10/expected release date

### DIFF
--- a/integration_tests/integration/referral.cy.js
+++ b/integration_tests/integration/referral.cy.js
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import draftReferralFactory from '../../testutils/factories/draftReferral'
 import sentReferralFactory from '../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
@@ -114,6 +115,17 @@ describe('Referral form', () => {
         })
 
       const completedServiceUserDetailsDraftReferral = draftReferralFactory
+        .filledFormUpToExpectedReleaseDate([accommodationServiceCategory], false, CurrentLocationType.custody)
+        .build({
+          id: draftReferral.id,
+          serviceCategoryIds: [accommodationServiceCategory.id],
+          interventionId: draftReferral.interventionId,
+          serviceProvider: {
+            name: 'Harmony Living',
+          },
+        })
+
+      const completedExpectedReleaseDatesDraftReferral = draftReferralFactory
         .filledFormUpToCurrentLocation([accommodationServiceCategory], false, CurrentLocationType.community)
         .build({
           id: draftReferral.id,
@@ -267,8 +279,21 @@ describe('Referral form', () => {
       cy.get('h1').contains('Submit Alex River’s current location')
 
       cy.withinFieldsetThatContains('Where is Alex today?', () => {
-        cy.contains('Community').click()
+        cy.contains('Custody (select even if Alex is due to be released today)').click()
       })
+      cy.get('#prison-select').type('Aylesbury (HMYOI)')
+      cy.stubGetDraftReferral(draftReferral.id, completedExpectedReleaseDatesDraftReferral)
+      cy.contains('Save and continue').click()
+
+      // Submit expected release date
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/expected-release-date`)
+      cy.get('h1').contains('Do you know the expected release date')
+      cy.contains('Yes').click()
+      const tomorrow = moment().add(1, 'days')
+      cy.contains('Day').type(tomorrow.format('DD'))
+      cy.contains('Month').type(tomorrow.format('MM'))
+      cy.contains('Year').type(tomorrow.format('YYYY'))
+
       cy.stubGetDraftReferral(draftReferral.id, completedServiceUserDetailsDraftReferral)
       cy.contains('Save and continue').click()
 

--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -25,6 +25,9 @@ export interface ReferralFields {
   maximumEnforceableDays: number
   personCurrentLocationType: CurrentLocationType | null
   personCustodyPrisonId: string | null
+  hasExpectedReleaseDate: boolean | null
+  expectedReleaseDate: string | null
+  expectedReleaseDateMissingReason: string | null
 }
 
 export enum CurrentLocationType {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -142,6 +142,12 @@ function probationPractitionerRoutesWithoutPrefix(router: Router, services: Serv
   post(router, '/referrals/:id/submit-current-location', (req, res) =>
     makeAReferralController.submitCurrentLocation(req, res)
   )
+  get(router, '/referrals/:id/expected-release-date', (req, res) =>
+    makeAReferralController.viewExpectedReleaseDate(req, res)
+  )
+  post(router, '/referrals/:id/expected-release-date', (req, res) =>
+    makeAReferralController.updateExpectedReleaseDate(req, res)
+  )
   get(router, '/referrals/:id/risk-information', (req, res) => makeAReferralController.viewRiskInformation(req, res))
   post(router, '/referrals/:id/risk-information', (req, res) => makeAReferralController.updateRiskInformation(req, res))
 

--- a/server/routes/makeAReferral/check-answers/checkAnswersPresenter.ts
+++ b/server/routes/makeAReferral/check-answers/checkAnswersPresenter.ts
@@ -30,7 +30,9 @@ export default class CheckAnswersPresenter {
         this.referral.serviceUser,
         this.deliusServiceUser,
         this.referral?.personCurrentLocationType,
-        this.referral?.personCustodyPrisonId
+        this.referral?.personCustodyPrisonId,
+        this.referral?.expectedReleaseDate,
+        this.referral?.expectedReleaseDateMissingReason
       ).summary,
     }
   }

--- a/server/routes/makeAReferral/expected-release-date/expectedReleaseDateForm.test.ts
+++ b/server/routes/makeAReferral/expected-release-date/expectedReleaseDateForm.test.ts
@@ -1,0 +1,203 @@
+import moment from 'moment'
+import ExpectedReleaseDateForm from './expectedReleaseDateForm'
+import TestUtils from '../../../../testutils/testUtils'
+
+describe(ExpectedReleaseDateForm, () => {
+  describe('data', () => {
+    describe('when a expected release date is known', () => {
+      it('returns a paramsForUpdate with the expected release date', async () => {
+        const tomorrow = moment().add(1, 'days')
+        const request = TestUtils.createRequest({
+          'expected-release-date': 'yes',
+          'release-date-year': tomorrow.format('YYYY'),
+          'release-date-month': tomorrow.format('M'),
+          'release-date-day': tomorrow.format('D'),
+          'release-date-unknown-reason': '',
+        })
+        const data = await new ExpectedReleaseDateForm(request).data()
+
+        expect(data.paramsForUpdate?.hasExpectedReleaseDate).toEqual(true)
+        expect(data.paramsForUpdate?.expectedReleaseDate).toEqual(tomorrow.format('YYYY-MM-DD'))
+        expect(data.paramsForUpdate?.expectedReleaseDateMissingReason).toEqual(null)
+      })
+    })
+
+    describe('when a expected release date is not known', () => {
+      it('returns a paramsForUpdate with the reason for why the release date is not known', async () => {
+        const request = TestUtils.createRequest({
+          'expected-release-date': 'no',
+          'release-date-year': null,
+          'release-date-month': null,
+          'release-date-day': null,
+          'release-date-unknown-reason': 'data not received from nDelius',
+        })
+        const data = await new ExpectedReleaseDateForm(request).data()
+
+        expect(data.paramsForUpdate?.hasExpectedReleaseDate).toEqual(false)
+        expect(data.paramsForUpdate?.expectedReleaseDate).toEqual(null)
+        expect(data.paramsForUpdate?.expectedReleaseDateMissingReason).toEqual('data not received from nDelius')
+      })
+    })
+  })
+  describe('invalid-data', () => {
+    describe('when day of the expected release date is not passed', () => {
+      it('returns a validation error with the appropriate error message', async () => {
+        const request = TestUtils.createRequest({
+          'expected-release-date': 'yes',
+          'release-date-year': '2021',
+          'release-date-month': '09',
+          'release-date-day': '',
+          'release-date-unknown-reason': '',
+        })
+        const data = await new ExpectedReleaseDateForm(request).data()
+
+        expect(data.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'release-date-day',
+              formFields: ['release-date-day'],
+              message: 'The expected release date must include a day',
+            },
+          ],
+        })
+      })
+    })
+    describe('when month of the expected release date is not passed', () => {
+      it('returns a validation error with the appropriate error message', async () => {
+        const request = TestUtils.createRequest({
+          'expected-release-date': 'yes',
+          'release-date-year': '2021',
+          'release-date-month': '',
+          'release-date-day': '12',
+          'release-date-unknown-reason': '',
+        })
+        const data = await new ExpectedReleaseDateForm(request).data()
+
+        expect(data.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'release-date-month',
+              formFields: ['release-date-month'],
+              message: 'The expected release date must include a month',
+            },
+          ],
+        })
+      })
+    })
+    describe('when year of the expected release date is not passed', () => {
+      it('returns a validation error with the appropriate error message', async () => {
+        const request = TestUtils.createRequest({
+          'expected-release-date': 'yes',
+          'release-date-year': '',
+          'release-date-month': '7',
+          'release-date-day': '12',
+          'release-date-unknown-reason': '',
+        })
+        const data = await new ExpectedReleaseDateForm(request).data()
+
+        expect(data.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'release-date-year',
+              formFields: ['release-date-year'],
+              message: 'The expected release date must include a year',
+            },
+          ],
+        })
+      })
+    })
+    describe('when an invalid expected release date is passed', () => {
+      it('returns a validation error with the appropriate error message', async () => {
+        const request = TestUtils.createRequest({
+          'expected-release-date': 'yes',
+          'release-date-year': '2023',
+          'release-date-month': '7.5',
+          'release-date-day': '12',
+          'release-date-unknown-reason': '',
+        })
+        const data = await new ExpectedReleaseDateForm(request).data()
+
+        expect(data.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'release-date-month',
+              formFields: ['release-date-month'],
+              message: 'The expected release date must be a real date',
+            },
+          ],
+        })
+      })
+    })
+    describe('when a past expected release date is passed', () => {
+      it('returns a validation error with the appropriate error message', async () => {
+        const request = TestUtils.createRequest({
+          'expected-release-date': 'yes',
+          'release-date-year': '2022',
+          'release-date-month': '12',
+          'release-date-day': '12',
+          'release-date-unknown-reason': '',
+        })
+        const data = await new ExpectedReleaseDateForm(request).data()
+
+        expect(data.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'release-date-day',
+              formFields: ['release-date-day'],
+              message: 'The expected release date must be in the future',
+            },
+          ],
+        })
+      })
+    })
+    describe('when an reason for not knowing the expected date is not filled', () => {
+      it('returns a validation error with the appropriate error message', async () => {
+        const request = TestUtils.createRequest({
+          'expected-release-date': 'no',
+          'release-date-unknown-reason': '',
+        })
+        const data = await new ExpectedReleaseDateForm(request).data()
+
+        expect(data.error).toEqual({
+          errors: [
+            {
+              errorSummaryLinkedField: 'release-date-unknown-reason',
+              formFields: ['release-date-unknown-reason'],
+              message: 'You must enter why the expected release date is not known',
+            },
+          ],
+        })
+      })
+    })
+  })
+  describe('conditional-validation', () => {
+    describe('release date validation does not kicks off when expected date is not known', () => {
+      it('returns a paramsForUpdate with the expected release date', async () => {
+        const request = TestUtils.createRequest({
+          'expected-release-date': 'no',
+          'release-date-year': '2021',
+          'release-date-month': '',
+          'release-date-day': '12',
+          'release-date-unknown-reason': 'will be available in nDelius soon',
+        })
+        const data = await new ExpectedReleaseDateForm(request).data()
+        expect(data.error).toEqual(null)
+      })
+    })
+
+    describe('release unknow reason text validation does not kicks off when expected date is known', () => {
+      it('returns a paramsForUpdate with the expected release date', async () => {
+        const request = TestUtils.createRequest({
+          'expected-release-date': 'yes',
+          'release-date-year': '2023',
+          'release-date-month': '7',
+          'release-date-day': '12',
+          'release-date-unknown-reason': '',
+        })
+        const data = await new ExpectedReleaseDateForm(request).data()
+
+        expect(data.error).toEqual(null)
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/expected-release-date/expectedReleaseDateForm.ts
+++ b/server/routes/makeAReferral/expected-release-date/expectedReleaseDateForm.ts
@@ -1,0 +1,111 @@
+import { Request } from 'express'
+import { body, Result, ValidationChain, ValidationError } from 'express-validator'
+import DraftReferral from '../../../models/draftReferral'
+import CalendarDayInput from '../../../utils/forms/inputs/calendarDayInput'
+import errorMessages from '../../../utils/errorMessages'
+import { FormData } from '../../../utils/forms/formData'
+import FormUtils from '../../../utils/formUtils'
+import { FormValidationError } from '../../../utils/formValidationError'
+import { FormValidationResult } from '../../../utils/forms/formValidationResult'
+
+export default class ExpectedReleaseDateForm {
+  constructor(private readonly request: Request) {}
+
+  static readonly releaseDateUnknownReason = 'release-date-unknown-reason'
+
+  readonly checkFutureDateErrorMessage = 'The expected release date must be in the future'
+
+  async data(): Promise<FormData<Partial<DraftReferral>>> {
+    const dateInput = new CalendarDayInput(
+      this.request,
+      'release-date',
+      errorMessages.releaseDate,
+      null,
+      true,
+      this.checkFutureDateErrorMessage
+    )
+    const releaseDateResult = await dateInput.validate()
+
+    const validationResult = await ExpectedReleaseDateForm.validate(this.request)
+
+    if (this.expectedReleaseDate) {
+      return releaseDateResult.error
+        ? {
+            paramsForUpdate: null,
+            error: {
+              errors: [...(releaseDateResult.error?.errors ?? [])],
+            },
+          }
+        : {
+            paramsForUpdate: {
+              hasExpectedReleaseDate: this.expectedReleaseDate,
+              expectedReleaseDate: this.expectedReleaseDate ? releaseDateResult.value.iso8601 : null,
+              expectedReleaseDateMissingReason: !this.expectedReleaseDate
+                ? this.request.body['release-date-unknown-reason']
+                : null,
+            },
+            error: null,
+          }
+    }
+    return validationResult!.error
+      ? {
+          paramsForUpdate: null,
+          error: {
+            errors: [...(validationResult!.error?.errors ?? [])],
+          },
+        }
+      : {
+          paramsForUpdate: {
+            hasExpectedReleaseDate: this.expectedReleaseDate,
+            expectedReleaseDate: this.expectedReleaseDate ? this.request.body['release-date'] : null,
+            expectedReleaseDateMissingReason: !this.expectedReleaseDate
+              ? this.request.body['release-date-unknown-reason']
+              : null,
+          },
+          error: null,
+        }
+  }
+
+  static get validations(): ValidationChain[] {
+    return [
+      body('release-date-unknown-reason')
+        .if(body('expected-release-date').equals('no'))
+        .notEmpty()
+        .withMessage(errorMessages.releaseDateUnknownReason.empty),
+    ]
+  }
+
+  static async validate(request: Request): Promise<FormValidationResult<DraftReferral>> {
+    const validationResult = await FormUtils.runValidations({
+      request,
+      validations: ExpectedReleaseDateForm.validations,
+    })
+
+    const error = ExpectedReleaseDateForm.error(validationResult)
+    if (error) {
+      return { value: null, error }
+    }
+    return {
+      value: request.body[ExpectedReleaseDateForm.releaseDateUnknownReason],
+      error: null,
+    }
+  }
+
+  public static error(validationResult: Result<ValidationError>): FormValidationError | null {
+    if (validationResult.isEmpty()) {
+      return null
+    }
+
+    return {
+      errors: validationResult.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
+  }
+
+  private get expectedReleaseDate(): boolean {
+    return this.request.body['expected-release-date'] === 'yes'
+  }
+}

--- a/server/routes/makeAReferral/expected-release-date/expectedReleaseDatePresenter.test.ts
+++ b/server/routes/makeAReferral/expected-release-date/expectedReleaseDatePresenter.test.ts
@@ -1,0 +1,119 @@
+import ExpectedReleaseDatePresenter from './expectedReleaseDatePresenter'
+import draftReferralFactory from '../../../../testutils/factories/draftReferral'
+
+describe('ExpectedReleaseDatePresenter', () => {
+  describe('errorSummary', () => {
+    describe('when error is null', () => {
+      it('returns null', () => {
+        const referral = draftReferralFactory.build()
+        const presenter = new ExpectedReleaseDatePresenter(referral)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when error is not null', () => {
+      it('returns a summary of the errors sorted into the order their fields appear on the page', () => {
+        const referral = draftReferralFactory.build()
+        const presenter = new ExpectedReleaseDatePresenter(referral, {
+          errors: [
+            {
+              formFields: ['release-date-unknown-reason'],
+              errorSummaryLinkedField: 'release-date-unknown-reason',
+              message: 'release-date-unknown-reason msg',
+            },
+          ],
+        })
+
+        expect(presenter.errorSummary).toEqual([
+          { field: 'release-date-unknown-reason', message: 'release-date-unknown-reason msg' },
+        ])
+      })
+    })
+  })
+
+  describe('text', () => {
+    it('returns content to be displayed on the page', () => {
+      const referral = draftReferralFactory
+        .serviceCategorySelected()
+        .serviceUserSelected()
+        .build({ serviceUser: { firstName: 'Geoffrey' } })
+      const presenter = new ExpectedReleaseDatePresenter(referral)
+
+      expect(presenter.text).toEqual({
+        releaseDate: {
+          label: 'Add the expected release date',
+        },
+        releaseDateUnknownReason: {
+          label: 'Enter why the expected release date is not known',
+          errorMessage: null,
+        },
+      })
+    })
+
+    describe('when there are errors', () => {
+      it('populates the error messages for the fields with errors', () => {
+        const referral = draftReferralFactory
+          .serviceCategorySelected()
+          .serviceUserSelected()
+          .build({ serviceUser: { firstName: 'Geoffrey' } })
+        const presenter = new ExpectedReleaseDatePresenter(referral, {
+          errors: [
+            {
+              formFields: ['release-date-unknown-reason'],
+              errorSummaryLinkedField: 'release-date-unknown-reason',
+              message: 'release-date-unknown-reason msg',
+            },
+            {
+              formFields: ['release-date-day'],
+              errorSummaryLinkedField: 'release-date-day',
+              message: 'The expected release date must include a day',
+            },
+          ],
+        })
+
+        expect(presenter.text).toMatchObject({
+          releaseDate: {
+            label: 'Add the expected release date',
+          },
+          releaseDateUnknownReason: {
+            label: 'Enter why the expected release date is not known',
+            errorMessage: 'release-date-unknown-reason msg',
+          },
+        })
+      })
+    })
+  })
+
+  describe('fields', () => {
+    describe('when there is no data on the referral', () => {
+      it('replays empty answers', () => {
+        const referral = draftReferralFactory.build()
+        const presenter = new ExpectedReleaseDatePresenter(referral)
+
+        expect(presenter.fields.hasExpectedReleaseDate).toBe(null)
+        expect(presenter.fields.releaseDateUnknownReason).toBe('')
+        expect(presenter.fields.releaseDate.day.value).toBe('')
+        expect(presenter.fields.releaseDate.month.value).toBe('')
+        expect(presenter.fields.releaseDate.year.value).toBe('')
+      })
+    })
+
+    describe('when there is data on the referral', () => {
+      it('replays the data from the referral', () => {
+        const referral = draftReferralFactory.build({
+          hasExpectedReleaseDate: true,
+          expectedReleaseDate: '2023-07-22',
+          expectedReleaseDateMissingReason: '',
+        })
+        const presenter = new ExpectedReleaseDatePresenter(referral)
+
+        expect(presenter.fields.hasExpectedReleaseDate).toBe(true)
+        expect(presenter.fields.releaseDateUnknownReason).toBe('')
+        expect(presenter.fields.releaseDate.day.value).toBe('22')
+        expect(presenter.fields.releaseDate.month.value).toBe('7')
+        expect(presenter.fields.releaseDate.year.value).toBe('2023')
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/expected-release-date/expectedReleaseDatePresenter.ts
+++ b/server/routes/makeAReferral/expected-release-date/expectedReleaseDatePresenter.ts
@@ -1,0 +1,54 @@
+import DraftReferral from '../../../models/draftReferral'
+import { FormValidationError } from '../../../utils/formValidationError'
+import PresenterUtils from '../../../utils/presenterUtils'
+import CalendarDay from '../../../utils/calendarDay'
+
+export default class ExpectedReleaseDatePresenter {
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {}
+
+  private errorMessageForField(field: string): string | null {
+    return PresenterUtils.errorMessage(this.error, field)
+  }
+
+  readonly expectedReleaseDateHint = 'For example, 31 3 1980'
+
+  readonly text = {
+    releaseDate: {
+      label: 'Add the expected release date',
+    },
+    releaseDateUnknownReason: {
+      label: 'Enter why the expected release date is not known',
+      errorMessage: this.errorMessageForField('release-date-unknown-reason'),
+    },
+  }
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error, {
+    fieldOrder: ['expected-release-date', 'release-date'],
+  })
+
+  private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly title = 'Do you know the expected release date?'
+
+  readonly expectedReleaseWarningMessage =
+    'When you know the date, you will need to make direct contact with the service provider.'
+
+  readonly fields = {
+    hasExpectedReleaseDate: this.utils.booleanValue(this.referral.hasExpectedReleaseDate, 'expected-release-date'),
+    releaseDate: this.utils.dateValue(
+      this.referral.expectedReleaseDate === null
+        ? null
+        : CalendarDay.parseIso8601Date(this.referral.expectedReleaseDate),
+      'release-date',
+      this.error
+    ),
+    releaseDateUnknownReason: this.utils.stringValue(
+      this.referral.expectedReleaseDateMissingReason,
+      'unknown-release-date-reason'
+    ),
+  }
+}

--- a/server/routes/makeAReferral/expected-release-date/expectedReleaseDateView.ts
+++ b/server/routes/makeAReferral/expected-release-date/expectedReleaseDateView.ts
@@ -1,0 +1,106 @@
+import ExpectedReleaseDatePresenter from './expectedReleaseDatePresenter'
+import ViewUtils from '../../../utils/viewUtils'
+import { DateInputArgs, RadiosArgs, TextareaArgs } from '../../../utils/govukFrontendTypes'
+
+export default class ExpectedReleaseDateView {
+  constructor(private readonly presenter: ExpectedReleaseDatePresenter) {}
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+
+  private expectedReleaseDateRadioArgs(yesHtml: string, noHtml: string): RadiosArgs {
+    return {
+      idPrefix: 'expected-release-date',
+      name: 'expected-release-date',
+      fieldset: {
+        legend: {
+          text: this.presenter.title,
+          isPageHeading: true,
+          classes: 'govuk-fieldset__legend--l',
+        },
+      },
+      hint: {
+        text: 'You can find this in nDelius and NOMIS',
+      },
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes',
+          checked: this.presenter.fields.hasExpectedReleaseDate === true,
+          conditional: {
+            html: yesHtml,
+          },
+        },
+        {
+          value: 'no',
+          text: 'No',
+          checked: this.presenter.fields.hasExpectedReleaseDate === false,
+          conditional: {
+            html: noHtml,
+          },
+        },
+      ],
+    }
+  }
+
+  private get dateInputArgs(): DateInputArgs {
+    return {
+      id: 'release-date',
+      namePrefix: 'release-date',
+      fieldset: {
+        legend: {
+          text: this.presenter.text.releaseDate.label,
+        },
+      },
+      hint: {
+        text: this.presenter.expectedReleaseDateHint,
+      },
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.releaseDate.errorMessage),
+      items: [
+        {
+          classes: `govuk-input--width-2${this.presenter.fields.releaseDate.day.hasError ? ' govuk-input--error' : ''}`,
+          name: 'day',
+          value: this.presenter.fields.releaseDate.day.value,
+        },
+        {
+          classes: `govuk-input--width-2${
+            this.presenter.fields.releaseDate.month.hasError ? ' govuk-input--error' : ''
+          }`,
+          name: 'month',
+          value: this.presenter.fields.releaseDate.month.value,
+        },
+        {
+          classes: `govuk-input--width-4${
+            this.presenter.fields.releaseDate.year.hasError ? ' govuk-input--error' : ''
+          }`,
+          name: 'year',
+          value: this.presenter.fields.releaseDate.year.value,
+        },
+      ],
+    }
+  }
+
+  private get releaseDateUnknownReasonArgs(): TextareaArgs {
+    return {
+      id: 'release-date-unknown-reason',
+      name: 'release-date-unknown-reason',
+      label: {
+        text: this.presenter.text.releaseDateUnknownReason.label,
+      },
+      value: this.presenter.fields.releaseDateUnknownReason,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.releaseDateUnknownReason.errorMessage),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'makeAReferral/expectedReleaseDate',
+      {
+        presenter: this.presenter,
+        errorSummaryArgs: this.errorSummaryArgs,
+        expectedReleaseDateRadioArgs: this.expectedReleaseDateRadioArgs.bind(this),
+        releaseDateUnknownReasonArgs: this.releaseDateUnknownReasonArgs,
+        dateInputArgs: this.dateInputArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.test.ts
@@ -1,7 +1,9 @@
+import moment from 'moment'
 import { ListStyle } from '../../../utils/summaryList'
 import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
 import expandedDeliusServiceUserFactory from '../../../../testutils/factories/expandedDeliusServiceUser'
 import { CurrentLocationType } from '../../../models/draftReferral'
+import DateUtils from '../../../utils/dateUtils'
 
 describe(ServiceUserDetailsPresenter, () => {
   const serviceUser = {
@@ -68,11 +70,13 @@ describe(ServiceUserDetailsPresenter, () => {
 
   describe('summary', () => {
     it('returns an array of summary list items for each field on the Service user', () => {
+      const tomorrow = moment().add(1, 'days')
       const presenter = new ServiceUserDetailsPresenter(
         serviceUser,
         deliusServiceUser,
         CurrentLocationType.custody,
-        'aaa'
+        'aaa',
+        tomorrow.format('YYYY-MM-DD')
       )
 
       expect(presenter.summary).toEqual([
@@ -83,6 +87,7 @@ describe(ServiceUserDetailsPresenter, () => {
         { key: 'Date of birth', lines: ['1 January 1980'] },
         { key: 'Location at time of referral', lines: ['CUSTODY'] },
         { key: 'Current Establishment', lines: ['aaa'] },
+        { key: 'Expected release date', lines: [DateUtils.formattedDate(tomorrow.format('YYYY-MM-DD'))] },
         {
           key: 'Address',
           lines: ['Flat 10 Test Walk', 'London', 'City of London', 'Greater London', 'SW16 1AQ'],

--- a/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.ts
+++ b/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.ts
@@ -11,7 +11,9 @@ export default class ServiceUserDetailsPresenter {
     private readonly serviceUser: ServiceUser,
     private readonly deliusServiceUserDetails: ExpandedDeliusServiceUser,
     private readonly personCurrentLocationType: CurrentLocationType | null = null,
-    private readonly personCustodyPrisonId: string | null = null
+    private readonly personCustodyPrisonId: string | null = null,
+    private readonly popReleaseDate: string | null = null,
+    private readonly popReleaseDateUnknownReason: string | null = null
   ) {}
 
   readonly title = `${this.serviceUser.firstName || 'The person on probation'}'s information`
@@ -53,11 +55,11 @@ export default class ServiceUserDetailsPresenter {
           {
             key: 'Current Establishment',
             lines: [this.personCustodyPrisonId ? this.personCustodyPrisonId : ''],
+          },
+          {
+            key: 'Expected release date',
+            lines: [this.expectedReleaseDate !== '' ? this.expectedReleaseDate : this.expectedReleaseDateUnKnownReason],
           }
-          // {
-          //   key: 'Expected release date',
-          //   lines: [this.referral?.personCurrentLocationType ? this.referral?.personCurrentLocationType : ''],
-          // }
         )
       }
     }
@@ -92,5 +94,19 @@ export default class ServiceUserDetailsPresenter {
       return ''
     }
     return DateUtils.formattedDate(this.serviceUser.dateOfBirth)
+  }
+
+  private get expectedReleaseDate() {
+    if (this.popReleaseDate === null) {
+      return ''
+    }
+    return DateUtils.formattedDate(this.popReleaseDate)
+  }
+
+  private get expectedReleaseDateUnKnownReason() {
+    if (this.popReleaseDateUnknownReason === null) {
+      return ''
+    }
+    return this.popReleaseDateUnknownReason
   }
 }

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -284,7 +284,9 @@ export default class ShowReferralPresenter {
       this.sentReferral.referral.serviceUser,
       this.deliusServiceUser,
       this.sentReferral.referral.personCurrentLocationType,
-      this.sentReferral.referral.personCustodyPrisonId
+      this.sentReferral.referral.personCustodyPrisonId,
+      this.sentReferral.referral.expectedReleaseDate,
+      this.sentReferral.referral.expectedReleaseDateMissingReason
     ).summary
   }
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1,5 +1,6 @@
 import { pactWith } from 'jest-pact'
 import { Matchers } from '@pact-foundation/pact'
+import moment from 'moment'
 import InterventionsService, { UpdateDraftEndOfServiceReportParams } from './interventionsService'
 import SentReferral from '../models/sentReferral'
 import SentReferralSummaries from '../models/sentReferralSummaries'
@@ -1552,6 +1553,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       maximumEnforceableDays: 10,
       personCurrentLocationType: CurrentLocationType.custody,
       personCustodyPrisonId: 'aaa',
+      expectedReleaseDate: moment().add(1, 'days').format('YYYY-MM-DD'),
+      expectedReleaseDateMissingReason: null,
+      hasExpectedReleaseDate: null,
     },
   }
 

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -67,6 +67,13 @@ export default {
     invalidDate: 'The date by which the service needs to be completed must be a real date',
     mustBeInFuture: 'The date by which the service needs to be completed must be in the future',
   },
+  releaseDate: {
+    dayEmpty: 'The expected release date must include a day',
+    monthEmpty: 'The expected release date must include a month',
+    yearEmpty: 'The expected release date must include a year',
+    invalidDate: 'The expected release date must be a real date',
+    mustBeInFuture: 'The expected release date must be in the future',
+  },
   reasonForChange: {
     cannotBeEmpty: 'Reason for change cannot be empty',
   },
@@ -128,6 +135,9 @@ export default {
   needsInterpreterWithoutName: {
     empty: `Select yes if there is a need for an interpreter`,
     noChanges: 'You have no changes to whether an interpreter is needed.',
+  },
+  releaseDateUnknownReason: {
+    empty: `You must enter why the expected release date is not known`,
   },
   hasAdditionalResponsibilities: {
     empty: (name: string) => `Select yes if ${name} has caring or employment responsibilities`,

--- a/server/views/makeAReferral/expectedReleaseDate.njk
+++ b/server/views/makeAReferral/expectedReleaseDate.njk
@@ -1,0 +1,42 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Expected release date" %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {% set expectedReleaseDateHtml %}
+        {{ govukDateInput(dateInputArgs) }}
+        {% endset -%}
+        {% set releaseDateUnknownReasonHtml %}
+        {{ govukTextarea(releaseDateUnknownReasonArgs) }}
+        {{ govukWarningText({
+          html: presenter.expectedReleaseWarningMessage,
+          iconFallbackText: "Warning"
+          })
+        }}
+        {% endset -%}
+        {{ govukRadios(expectedReleaseDateRadioArgs(expectedReleaseDateHtml,releaseDateUnknownReasonHtml)) }}
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -1,4 +1,5 @@
 import { Factory } from 'fishery'
+import moment from 'moment'
 import DraftReferral, { CurrentLocationType } from '../../server/models/draftReferral'
 import serviceCategoryFactory from './serviceCategory'
 import interventionFactory from './intervention'
@@ -96,6 +97,16 @@ class DraftReferralFactory extends Factory<DraftReferral> {
     })
   }
 
+  filledFormUpToExpectedReleaseDate(
+    serviceCategories: ServiceCategory[] = [serviceCategoryFactory.build()],
+    skipAdditionalRiskInformation = false
+  ) {
+    const tomorrow = moment().add(1, 'days')
+    return this.filledFormUpToCurrentLocation(serviceCategories, skipAdditionalRiskInformation).params({
+      expectedReleaseDate: tomorrow.format('YYYY-MM-DD'),
+    })
+  }
+
   filledFormUpToRelevantSentence(serviceCategories: ServiceCategory[] = [serviceCategoryFactory.build()]) {
     return this.filledFormUpToCurrentLocation(serviceCategories).params({
       relevantSentenceId: 123456789,
@@ -182,6 +193,9 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   whenUnavailable: null,
   additionalRiskInformation: null,
   maximumEnforceableDays: null,
+  hasExpectedReleaseDate: null,
+  expectedReleaseDate: null,
+  expectedReleaseDateMissingReason: null,
   contractTypeName: interventionFactory.build().contractType.name,
   personCurrentLocationType: null,
   personCustodyPrisonId: null,

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -1,4 +1,5 @@
 import { Factory } from 'fishery'
+import moment from 'moment'
 import SentReferral from '../../server/models/sentReferral'
 import { CurrentLocationType, ReferralFields } from '../../server/models/draftReferral'
 import serviceCategoryFactory from './serviceCategory'
@@ -51,6 +52,9 @@ const exampleReferralFields = () => {
     maximumEnforceableDays: 10,
     personCurrentLocationType: CurrentLocationType.custody,
     personCustodyPrisonId: 'aaa',
+    expectedReleaseDate: moment().add(1, 'days').format('YYYY-MM-DD'),
+    expectedReleaseDateMissingReason: null,
+    hasExpectedReleaseDate: null,
   }
 }
 


### PR DESCRIPTION
## What does this pull request do?

Creates a new page to capture the expected release date for a custodial referral

## What is the intent behind these changes?

We are introducing a new feature to show the users whether the referral is community or custodial. So, If a referral is custodial, its a requirement to capture the expected release date
