### PR TITLE
new cancel referral design

### DIFF
--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -272,6 +272,22 @@ describe(InterventionProgressPresenter, () => {
         `/probation-practitioner/referrals/${referral.id}/cancellation/start`
       )
     })
+    it('returns the url for the view or change referral page', () => {
+      const referral = sentReferralFactory.build()
+      const intervention = interventionFactory.build()
+      const supplierAssessment = supplierAssessmentFactory.build()
+      const presenter = new InterventionProgressPresenter(
+        referral,
+        intervention,
+        [],
+        null,
+        [],
+        supplierAssessment,
+        null
+      )
+
+      expect(presenter.amendReferralHref).toEqual(`/probation-practitioner/referrals/${referral.id}/details`)
+    })
   })
 
   describe('referralAssigned', () => {

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -97,6 +97,8 @@ export default class InterventionProgressPresenter {
 
   readonly referralCancellationHref = `/probation-practitioner/referrals/${this.referral.id}/cancellation/start`
 
+  readonly amendReferralHref = `/probation-practitioner/referrals/${this.referral.id}/details`
+
   readonly hasSessions = this.actionPlanAppointments.length !== 0
 
   readonly sessionTableHeaders = ['Session details', 'Date and time', 'Status', 'Action']

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -86,6 +86,9 @@
 <p>Below you will be able to find the end of service report created by the service provider. Once submitted, you will be able to read and download it.</p>
 {% endif %}
 {% if presenter.canCancelReferral %}
+<h2 class="govuk-heading-m">Cancel this Referral</h2>
+<p>You can cancel this referral if it’s no longer needed. Next, you’ll be asked for a reason and then an email will be sent to the service provider. You’ll still be able to view the referral in the cancelled referrals case list.</p>
+<p>You can also <a href='{{ presenter.amendReferralHref }}'>change some parts of the referral</a>, rather than cancelling it.</p>
 <a href='{{ presenter.referralCancellationHref }}'>Cancel this referral</a>
 {% elseif presenter.referralEndRequested %}
 <p class="govuk-body">{{ presenter.referralEndRequestedText }}</p>


### PR DESCRIPTION
## What does this pull request do?

Introducing a new way of displaying cancel a referral link. Its now displayed with title and a description to make it more explicit

## What is the intent behind these changes?

The cancel referral link was not placed well in the referral details page. That is the intent behind bringing this change
