### PR TITLE
Invalidate client token cache on client rotation

### DIFF
--- a/server/services/hmppsAuthService.test.ts
+++ b/server/services/hmppsAuthService.test.ts
@@ -298,7 +298,7 @@ describe('hmppsAuthService', () => {
       const output = await hmppsAuthService.getApiClientToken()
 
       expect(output).toEqual(token.access_token)
-      expect(mockRedis.v4.set).toBeCalledWith('systemToken:%ANONYMOUS%', token.access_token, { EX: 240 })
+      expect(mockRedis.v4.set).toBeCalledWith('systemToken:interventions:%ANONYMOUS%', token.access_token, { EX: 240 })
     })
   })
 

--- a/server/services/hmppsAuthService.ts
+++ b/server/services/hmppsAuthService.ts
@@ -114,7 +114,7 @@ export default class HmppsAuthService {
   }
 
   async getApiClientToken(): Promise<string> {
-    const redisKey = `${REDIS_PREFIX}%ANONYMOUS%`
+    const redisKey = `${REDIS_PREFIX}${config.apis.hmppsAuth.apiClientId}:%ANONYMOUS%`
 
     const tokenFromRedis = await redisClient.v4.get(redisKey)
     if (tokenFromRedis) {


### PR DESCRIPTION
## What does this pull request do?

Invalidate client token cache on client rotation

## What is the intent behind these changes?

We have an issue with [401 Unauthorized responses](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22:%22bc7f3a8b-0f52-468e-a9d8-7e14de8af239%22,%22timestamp%22:%222023-02-08T10:02:36.318Z%22%7D/ComponentId/%7B%22Name%22:%22nomisapi-prod%22,%22ResourceGroup%22:%22nomisapi-prod-rg%22,%22SubscriptionId%22:%22a5ddf257-3b21-4ba9-a28c-ab30f751b383%22%7D) when UI makes hmpps-auth calls.

We think this token was cached in Redis after a token rotation happened this morning.

To mitigate, we should cache by the client ID in the cache key so that any further rotation will discard the previous cache value.