### PR TITLE
addressing the feedback from UAT

### DIFF
--- a/server/routes/makeAReferral/expected-release-date/expectedReleaseDatePresenter.ts
+++ b/server/routes/makeAReferral/expected-release-date/expectedReleaseDatePresenter.ts
@@ -11,7 +11,7 @@ export default class ExpectedReleaseDatePresenter {
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {
-    this.backLinkUrl = `/referrals/${referral.id}/form`
+    this.backLinkUrl = `/referrals/${referral.id}/submit-current-location`
   }
 
   private errorMessageForField(field: string): string | null {
@@ -42,7 +42,7 @@ export default class ExpectedReleaseDatePresenter {
     'When you know the date, you will need to make direct contact with the service provider.'
 
   readonly fields = {
-    hasExpectedReleaseDate: this.utils.booleanValue(this.referral.hasExpectedReleaseDate, 'expected-release-date'),
+    hasExpectedReleaseDate: this.knowsExpectedReleaseDate(),
     releaseDate: this.utils.dateValue(
       this.referral.expectedReleaseDate === null
         ? null
@@ -54,5 +54,18 @@ export default class ExpectedReleaseDatePresenter {
       this.referral.expectedReleaseDateMissingReason,
       'unknown-release-date-reason'
     ),
+  }
+
+  knowsExpectedReleaseDate(): boolean | null {
+    if (this.referral.hasExpectedReleaseDate != null) {
+      this.utils.booleanValue(this.referral.hasExpectedReleaseDate, 'expected-release-date')
+    }
+    if (this.referral.expectedReleaseDate != null) {
+      return true
+    }
+    if (this.referral.expectedReleaseDateMissingReason != null) {
+      return false
+    }
+    return null
   }
 }

--- a/server/views/makeAReferral/expectedReleaseDate.njk
+++ b/server/views/makeAReferral/expectedReleaseDate.njk
@@ -25,7 +25,7 @@
       {% endif %}
 
 
-      <h1 class="govuk-heading-l">{{ presenter.text.title }}</h1>
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
       <p class="govuk-body">{{ presenter.text.description }} </p>
 
       <form method="post">
@@ -43,6 +43,8 @@
         }}
         {% endset -%}
         {{ govukRadios(expectedReleaseDateRadioArgs(expectedReleaseDateHtml,releaseDateUnknownReasonHtml)) }}
+        <br>
+        <br>
         <br>
         {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
       </form>

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -87,7 +87,7 @@
 {% endif %}
 {% if presenter.canCancelReferral %}
 <h2 class="govuk-heading-m">Cancel this referral</h2>
-<p>You can cancel this referral if it’s no longer needed. Next, you’ll be asked for a reason and then an email will be sent to the service provider. You’ll still be able to view the referral in the cancelled referrals case list.</p>
+<p>You can cancel this referral if it’s no longer needed. Next, you’ll be asked for a reason. You’ll still be able to view the referral in the cancelled referrals case list.</p>
 <p>You can also <a href='{{ presenter.amendReferralHref }}'>change some parts of the referral</a>, rather than cancelling it.</p>
 <a href='{{ presenter.referralCancellationHref }}'>Cancel this referral</a>
 {% elseif presenter.referralEndRequested %}


### PR DESCRIPTION
## What does this pull request do?

- set the back link in expected release date to submitting current location
- showing the correct option when expected release date page is already selected and the user comes again to that page.

## What is the intent behind these changes?

- Fixing the issues raised during the UAT
