### PR TITLE
Wiremock stub for prisoner-offender-search get prisoner endpoint

### DIFF
--- a/mockApis/prisonerOffenderSearch.ts
+++ b/mockApis/prisonerOffenderSearch.ts
@@ -1,0 +1,21 @@
+import Wiremock from './wiremock'
+
+export default class PrisonerOffenderSearchMocks {
+  constructor(private readonly wiremock: Wiremock, private readonly mockPrefix: string) {}
+
+  stubGetPrisonerById = async (responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/prisoner/([a-zA-Z0-9/-]*)`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
+}

--- a/mocks.ts
+++ b/mocks.ts
@@ -14,15 +14,18 @@ import deliusConvictionFactory from './testutils/factories/deliusConviction'
 import AssessRisksAndNeedsServiceMocks from './mockApis/assessRisksAndNeedsService'
 import riskSummaryFactory from './testutils/factories/riskSummary'
 import prisonFactory from './testutils/factories/prison'
+import prisonerFactory from './testutils/factories/prisoner'
 import supplementaryRiskInformationFactory from './testutils/factories/supplementaryRiskInformation'
 import deliusServiceUser from './testutils/factories/deliusServiceUser'
 import PrisonRegisterServiceMocks from './mockApis/prisonRegisterService'
+import PrisonerOffenderSearchMocks from './mockApis/prisonerOffenderSearch'
 
 const wiremock = new Wiremock('http://localhost:9092/__admin')
 const interventionsMocks = new InterventionsServiceMocks(wiremock, '')
 const communityApiMocks = new CommunityApiMocks(wiremock, '')
 const assessRisksAndNeedsApiMocks = new AssessRisksAndNeedsServiceMocks(wiremock, '')
 const prisonRegisterServiceMocks = new PrisonRegisterServiceMocks(wiremock, '')
+const prisonerOffenderSearchMocks = new PrisonerOffenderSearchMocks(wiremock, '')
 
 export default async function setUpMocks(): Promise<void> {
   await wiremock.resetStubs()
@@ -185,5 +188,6 @@ export default async function setUpMocks(): Promise<void> {
       })
     }),
     prisonRegisterServiceMocks.stubGetPrisons(prisonFactory.prisonList()),
+    prisonerOffenderSearchMocks.stubGetPrisonerById(prisonerFactory.build()),
   ])
 }

--- a/server/models/prisonerOffenderSearch/prisoner.ts
+++ b/server/models/prisonerOffenderSearch/prisoner.ts
@@ -1,0 +1,11 @@
+export default interface Prisoner {
+  prisonId: string
+  releaseDate: string
+  confirmedReleaseDate: string
+  nonDtoReleaseDate: string
+  automaticReleaseDate: string
+  postRecallReleaseDate: string
+  conditionalReleaseDate: string
+  actualParoleDate: string
+  dischargeDate: string
+}

--- a/testutils/factories/prisoner.ts
+++ b/testutils/factories/prisoner.ts
@@ -1,0 +1,14 @@
+import { Factory } from 'fishery'
+import Prisoner from '../../server/models/prisonerOffenderSearch/prisoner'
+
+export default Factory.define<Prisoner>(() => ({
+  prisonId: 'MDI',
+  releaseDate: '2023-05-02',
+  confirmedReleaseDate: '2023-05-01',
+  nonDtoReleaseDate: '2023-05-01',
+  automaticReleaseDate: '2023-05-01',
+  postRecallReleaseDate: '2023-05-01',
+  conditionalReleaseDate: '2023-05-01',
+  actualParoleDate: '2023-05-01',
+  dischargeDate: '2020-05-01',
+}))

--- a/wiremock_mappings/prisonerOffenderSearchProxy.json
+++ b/wiremock_mappings/prisonerOffenderSearchProxy.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "ANY",
+    "urlPattern": "/prisoner/.*"
+  },
+  "response": {
+    "proxyBaseUrl": "http://prisoner-offender-search:8080"
+  },
+  "priority": 7
+}


### PR DESCRIPTION
## What does this pull request do?

Adds wiremock stub for prisoner-offender-search GET /prisoner/{id} endpoint.

## What is the intent behind these changes?

To mock prisoner-offender-search API with stub data for local development.
