### PR TITLE
fixing security audit failure in @sideway/formula

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "http-errors": "^2.0.0",
         "http-status-codes": "^2.2.0",
         "indefinite": "^2.4.2",
-        "joi": "^17.7.0",
+        "joi": "^17.8.3",
         "jquery": "^3.6.3",
         "jwt-decode": "^3.1.2",
         "md5": "^2.3.0",
@@ -3459,9 +3459,9 @@
       }
     },
     "node_modules/@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
@@ -12980,14 +12980,14 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
-      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "version": "17.8.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.8.3.tgz",
+      "integrity": "sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
         "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
+        "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
     },
@@ -21521,9 +21521,9 @@
       }
     },
     "@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "@sideway/pinpoint": {
       "version": "2.0.0",
@@ -28824,14 +28824,14 @@
       "dev": true
     },
     "joi": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
-      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "version": "17.8.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.8.3.tgz",
+      "integrity": "sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
         "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
+        "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "http-errors": "^2.0.0",
     "http-status-codes": "^2.2.0",
     "indefinite": "^2.4.2",
-    "joi": "^17.7.0",
+    "joi": "^17.8.3",
     "jquery": "^3.6.3",
     "jwt-decode": "^3.1.2",
     "md5": "^2.3.0",


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-ui/7377/workflows/6e63f404-0cd3-47fa-b67c-8aeef35efda8/jobs/40175

## What does this pull request do?

- Upgrades the `Joi` framework to latest version `17.8.3` [https://www.npmjs.com/package/joi/v/17.8.3]
- Upgrading in turn upgrades `@sideway/formula` to the latest version where the security vulnerability is mitigated

## What is the intent behind these changes?

- `@sideway/formula` failed the security audit check(Link above). So we need to upgrade the `joi` framework to upgrade to the latest version which has the vulnerability issue fixed
