### PR TITLE
all open cases pagination fix for sp dashboard

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -40,6 +40,7 @@ const RedisStore = connectRedis(session)
 declare module 'express-session' {
   export interface SessionData {
     dashboardOriginPage: string
+    searchText: string
   }
 }
 

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -55,10 +55,7 @@ export default class DashboardPresenter {
     readonly searchText: string | null = null,
     private readonly userInputData: Record<string, string> | null = null
   ) {
-    this.pagination = new Pagination(
-      sentReferralSummaries,
-      this.searchText ? `open-case-search-text=${searchText}` : null
-    )
+    this.pagination = new Pagination(sentReferralSummaries, this.searchText ? `paginated=true` : null)
     const [sortField, sortOrder] = this.requestedSort.split(',')
     this.requestedSortField = sortField
     this.requestedSortOrder = ControllerUtils.sortOrderToAriaSort(sortOrder)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -151,6 +151,7 @@ export default class ServiceProviderReferralsController {
   }
 
   async showUnassignedCasesDashboard(req: Request, res: Response): Promise<void> {
+    this.handlePaginatedSearchText(req)
     const searchText = (req.body['case-search-text'] as string) ?? null
     if (
       FeatureFlagService.enableForUser(res.locals.user, config.dashboards.serviceProvider.percentageOfPaginationUsers)
@@ -175,6 +176,7 @@ export default class ServiceProviderReferralsController {
   }
 
   async showCompletedCasesDashboard(req: Request, res: Response): Promise<void> {
+    this.handlePaginatedSearchText(req)
     const searchText = (req.body['case-search-text'] as string) ?? null
     if (
       FeatureFlagService.enableForUser(res.locals.user, config.dashboards.serviceProvider.percentageOfPaginationUsers)

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -110,7 +110,22 @@ export default class ServiceProviderReferralsController {
     this.renderDashboardWithoutPagination(req, res, referralsSummary, 'My cases')
   }
 
+  private handlePaginatedSearchText(req: Request) {
+    if (req.query.paginated === 'true') {
+      req.body['case-search-text'] = req.session.searchText
+    }
+
+    if (req.method === 'GET' && req.query.paginated === undefined) {
+      req.session.searchText = undefined
+    }
+
+    if (req.method === 'POST') {
+      req.session.searchText = req.body['case-search-text'] as string
+    }
+  }
+
   async showAllOpenCasesDashboard(req: Request, res: Response): Promise<void> {
+    this.handlePaginatedSearchText(req)
     const searchText = (req.body['case-search-text'] as string) ?? null
 
     if (

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -26,7 +26,6 @@ export default function serviceProviderRoutes(router: Router, services: Services
     services.draftsService,
     services.referenceDataService
   )
-
   get(router, '/dashboard', (req, res) => serviceProviderReferralsController.showMyCasesDashboard(req, res))
   get(router, '/dashboard/my-cases', (req, res) => serviceProviderReferralsController.showMyCasesDashboard(req, res))
   get(router, '/dashboard/all-open-cases', (req, res) =>


### PR DESCRIPTION
## What does this pull request do?

Fix to the service provider all open cases dashboard pagination when there is a search term. 
We will now pull and store the search in session data. Upon accessing the page without the new query param, previous stored data will be cleared so that the page isn't loaded with any previous search terms.


## What is the intent behind these changes?

Allows a user to search and also use the pagination. This was broken when we moved to using POST for the search.