### PR TITLE
Ipb 367/case search pagination loss

### DIFF
--- a/browser/mojServerSideSortableTable.ts
+++ b/browser/mojServerSideSortableTable.ts
@@ -83,8 +83,10 @@ class PersistentServerSideSortOrder {
       const redirectLocation = window.location.href.split('?')[0]
 
       // eslint-disable-next-line no-unused-expressions
-      window.location.href.includes('paginated=true')
-        ? window.location.replace(`${redirectLocation}?paginated=true&sort=${columnPersistentId},${newAriaSortOrder}`)
+      window.location.href.includes('paginatedSearch=true')
+        ? window.location.replace(
+            `${redirectLocation}?paginatedSearch=true&sort=${columnPersistentId},${newAriaSortOrder}`
+          )
         : window.location.replace(`${redirectLocation}?sort=${columnPersistentId},${newAriaSortOrder}`)
     }
   }

--- a/browser/mojServerSideSortableTable.ts
+++ b/browser/mojServerSideSortableTable.ts
@@ -81,7 +81,11 @@ class PersistentServerSideSortOrder {
     // IE11 doesn't support `.includes`, so we're using `indexOf` here.
     if (['descending', 'ascending'].indexOf(newAriaSortOrder) > -1) {
       const redirectLocation = window.location.href.split('?')[0]
-      window.location.replace(`${redirectLocation}?sort=${columnPersistentId},${newAriaSortOrder}`)
+
+      // eslint-disable-next-line no-unused-expressions
+      window.location.href.includes('paginated=true')
+        ? window.location.replace(`${redirectLocation}?paginated=true&sort=${columnPersistentId},${newAriaSortOrder}`)
+        : window.location.replace(`${redirectLocation}?sort=${columnPersistentId},${newAriaSortOrder}`)
     }
   }
 }

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -121,6 +121,10 @@ export default class DashboardPresenter {
   }
 
   get hrefLinkForSearch(): string {
+    return `${dashboardDetails[this.dashboardType].tabHref}?paginated=true`
+  }
+
+  get hrefLinkForClear(): string {
     return dashboardDetails[this.dashboardType].tabHref
   }
 

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -55,7 +55,7 @@ export default class DashboardPresenter {
     readonly searchText: string | null = null,
     private readonly userInputData: Record<string, string> | null = null
   ) {
-    this.pagination = new Pagination(sentReferralSummaries, this.searchText ? `paginated=true` : null)
+    this.pagination = new Pagination(sentReferralSummaries, this.searchText ? `paginatedSearch=true` : null)
     const [sortField, sortOrder] = this.requestedSort.split(',')
     this.requestedSortField = sortField
     this.requestedSortOrder = ControllerUtils.sortOrderToAriaSort(sortOrder)
@@ -121,7 +121,7 @@ export default class DashboardPresenter {
   }
 
   get hrefLinkForSearch(): string {
-    return `${dashboardDetails[this.dashboardType].tabHref}?paginated=true`
+    return `${dashboardDetails[this.dashboardType].tabHref}?paginatedSearch=true`
   }
 
   get hrefLinkForClear(): string {

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -64,7 +64,7 @@ export default class DashboardView {
         subNavArgs: this.subNavArgs,
         subjectInputArgs: this.subjectInputArgs,
         pagination: this.presenter.pagination.mojPaginationArgs,
-        clearHref: this.presenter.hrefLinkForSearch,
+        clearHref: this.presenter.hrefLinkForClear,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -111,7 +111,7 @@ export default class ServiceProviderReferralsController {
   }
 
   private handlePaginatedSearchText(req: Request) {
-    if (req.query.paginated === 'true') {
+    if (req.method === 'GET' && req.query.paginated === 'true') {
       req.body['case-search-text'] = req.session.searchText
     }
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -111,11 +111,11 @@ export default class ServiceProviderReferralsController {
   }
 
   private handlePaginatedSearchText(req: Request) {
-    if (req.method === 'GET' && req.query.paginated === 'true') {
+    if (req.method === 'GET' && req.query.paginatedSearch === 'true') {
       req.body['case-search-text'] = req.session.searchText
     }
 
-    if (req.method === 'GET' && req.query.paginated === undefined) {
+    if (req.method === 'GET' && req.query.paginatedSearch === undefined) {
       req.session.searchText = undefined
     }
 


### PR DESCRIPTION
## What does this pull request do?

fixes the loss of search when the dashboard table is re-ordered.

## What is the intent behind these changes?

Currently the dashboard will resort back to an unfiltered table when a new sort order is provided. This change is to prevent that and retain the search
