### PR TITLE
Capitalise SPDashboardType constants

### DIFF
--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -95,10 +95,10 @@ export interface GetSentReferralsFilterParams {
 }
 
 export enum SPDashboardType {
-  MyCases = 'myCases',
-  OpenCases = 'openCases',
-  UnassignedCases = 'unassignedCases',
-  CompletedCases = 'completedCases',
+  MyCases = 'MyCases',
+  OpenCases = 'OpenCases',
+  UnassignedCases = 'UnassignedCases',
+  CompletedCases = 'CompletedCases',
 }
 
 export type InterventionsServiceError = RestClientError


### PR DESCRIPTION
## What does this pull request do?

Capitalises the SPDashboardType enum constants.

## What is the intent behind these changes?

To match the corresponding DashboardTypes constants in hmpps-interventions-service which needed to be capitalised to pass Ktlint checks.
