### PR TITLE
Specify timezone in Cypress test appointmentTimes

### DIFF
--- a/integration_tests/integration/referral.cy.js
+++ b/integration_tests/integration/referral.cy.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import moment from 'moment-timezone'
 import draftReferralFactory from '../../testutils/factories/draftReferral'
 import sentReferralFactory from '../../testutils/factories/sentReferral'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import moment from 'moment-timezone'
 import sentReferralFactory from '../../testutils/factories/sentReferral'
 import sentReferralForSummaries from '../../testutils/factories/sentReferralSummaries'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
@@ -912,7 +912,7 @@ describe('Service provider referrals dashboard', () => {
     describe('with valid inputs and an appointment in the future', () => {
       describe('when booking for an In-Person Meeting - Other Location', () => {
         it('should present no errors and display scheduled appointment', () => {
-          const tomorrow = moment('09:02:00', 'HH:mm:ss').add(1, 'days')
+          const tomorrow = moment.tz('09:02:00', 'HH:mm:ss', 'Europe/London').add(1, 'days')
           cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type(tomorrow.format('D'))
           cy.get('#date-month').type(tomorrow.format('M'))
@@ -984,7 +984,7 @@ describe('Service provider referrals dashboard', () => {
 
         describe('and their chosen date causes a clash of appointments', () => {
           it('the user is able to amend their chosen date and re-submit', () => {
-            const tomorrow = moment('09:02:00', 'HH:mm:ss').add(1, 'days')
+            const tomorrow = moment.tz('09:02:00', 'HH:mm:ss', 'Europe/London').add(1, 'days')
             const rescheduledDate = moment('09:02:00', 'HH:mm:ss').add(2, 'days')
             cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
             cy.get('#date-day').type(tomorrow.format('D'))
@@ -1070,7 +1070,7 @@ describe('Service provider referrals dashboard', () => {
 
       describe('when booking for an In-Person Meeting - NPS Location', () => {
         it('should present no errors and display scheduled appointment', () => {
-          const tomorrow = moment('09:02:00', 'HH:mm:ss').add(1, 'days')
+          const tomorrow = moment.tz('09:02:00', 'HH:mm:ss', 'Europe/London').add(1, 'days')
           cy.visit(`/service-provider/action-plan/${actionPlan.id}/sessions/1/edit/start`)
           cy.get('#date-day').type(tomorrow.format('D'))
           cy.get('#date-month').type(tomorrow.format('M'))
@@ -2201,7 +2201,7 @@ describe('Service provider referrals dashboard', () => {
 
       describe('with appointments in the future', () => {
         it('presents a confirmation page and the booking is successful', () => {
-          const tomorrow = moment('09:02:02', 'HH:mm:ss').add(1, 'days')
+          const tomorrow = moment.tz('09:02:00', 'HH:mm:ss', 'Europe/London').add(1, 'days')
           cy.visit(`/service-provider/referrals/${referral.id}/progress`)
           cy.get('#supplier-assessment-status').contains('not scheduled')
           cy.contains('Schedule initial assessment').click()
@@ -2290,7 +2290,7 @@ describe('Service provider referrals dashboard', () => {
         })
 
         it('User schedules a supplier assessment appointment, changing their chosen time after it turns out to cause a clash of appointments', () => {
-          const tomorrow = moment('09:02:02', 'HH:mm:ss').add(1, 'days')
+          const tomorrow = moment.tz('09:02:00', 'HH:mm:ss', 'Europe/London').add(1, 'days')
           const rescheduledDate = moment('16:15:00', 'HH:mm:ss').add(2, 'days')
           cy.visit(`/service-provider/referrals/${referral.id}/supplier-assessment/schedule/start`)
 
@@ -2361,7 +2361,7 @@ describe('Service provider referrals dashboard', () => {
         })
 
         it('User reschedules a supplier assessment appointment', () => {
-          const tomorrow = moment('09:02:02', 'HH:mm:ss').add(1, 'days')
+          const tomorrow = moment.tz('09:02:00', 'HH:mm:ss', 'Europe/London').add(1, 'days')
           const rescheduledDate = moment('16:15:00', 'HH:mm:ss').add(1, 'days')
           const scheduledAppointment = initialAssessmentAppointmentFactory.build({
             appointmentTime: tomorrow.format(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "mocha": "^10.2.0",
         "mocha-junit-reporter": "^2.2.0",
         "mockdate": "^3.0.5",
-        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.42",
         "nock": "^13.2.9",
         "nodemon": "^2.0.20",
         "prettier": "^2.8.2",
@@ -14809,11 +14809,12 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.39",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
-      "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
+      "version": "0.5.42",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.42.tgz",
+      "integrity": "sha512-tjI9goqwzkflKSTxJo+jC/W8riTFwEjjunssmFvAWlvNVApjbkJM7UHggyKO0q1Fd/kZVKY77H7C9A0XKhhAFw==",
+      "dev": true,
       "dependencies": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -17753,6 +17754,17 @@
       },
       "engines": {
         "node": ">=14.8"
+      }
+    },
+    "node_modules/timezone-support/node_modules/moment-timezone": {
+      "version": "0.5.39",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
+      "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tiny-glob": {
@@ -30208,11 +30220,12 @@
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
-      "version": "0.5.39",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
-      "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
+      "version": "0.5.42",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.42.tgz",
+      "integrity": "sha512-tjI9goqwzkflKSTxJo+jC/W8riTFwEjjunssmFvAWlvNVApjbkJM7UHggyKO0q1Fd/kZVKY77H7C9A0XKhhAFw==",
+      "dev": true,
       "requires": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       }
     },
     "mri": {
@@ -32464,6 +32477,16 @@
       "integrity": "sha512-N04dOzxt7Bw3PZ5ts8ofkQx6RsqWDo8cUQ/a8fdtywB58NIctmdbUUDWZSrgtI7c2jzA6MZ1Z6jY6OtBvc+CUQ==",
       "requires": {
         "moment-timezone": "0.5.39"
+      },
+      "dependencies": {
+        "moment-timezone": {
+          "version": "0.5.39",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
+          "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
+          "requires": {
+            "moment": ">= 2.9.0"
+          }
+        }
       }
     },
     "tiny-glob": {

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "mocha": "^10.2.0",
     "mocha-junit-reporter": "^2.2.0",
     "mockdate": "^3.0.5",
-    "moment": "^2.29.4",
+    "moment-timezone": "^0.5.42",
     "nock": "^13.2.9",
     "nodemon": "^2.0.20",
     "prettier": "^2.8.2",

--- a/server/routes/makeAReferral/expected-release-date/expectedReleaseDateForm.test.ts
+++ b/server/routes/makeAReferral/expected-release-date/expectedReleaseDateForm.test.ts
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import moment from 'moment-timezone'
 import ExpectedReleaseDateForm from './expectedReleaseDateForm'
 import TestUtils from '../../../../testutils/testUtils'
 

--- a/server/routes/makeAReferral/makeAReferralController.test.ts
+++ b/server/routes/makeAReferral/makeAReferralController.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest'
 import { Express } from 'express'
 import createError from 'http-errors'
-import moment from 'moment'
+import moment from 'moment-timezone'
 import InterventionsService from '../../services/interventionsService'
 import ServiceUser from '../../models/serviceUser'
 import CommunityApiService from '../../services/communityApiService'

--- a/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.test.ts
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import moment from 'moment-timezone'
 import { ListStyle } from '../../../utils/summaryList'
 import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
 import expandedDeliusServiceUserFactory from '../../../../testutils/factories/expandedDeliusServiceUser'

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1,6 +1,6 @@
 import { pactWith } from 'jest-pact'
 import { Matchers } from '@pact-foundation/pact'
-import moment from 'moment'
+import moment from 'moment-timezone'
 import InterventionsService, { UpdateDraftEndOfServiceReportParams } from './interventionsService'
 import SentReferral from '../models/sentReferral'
 import SentReferralSummaries from '../models/sentReferralSummaries'

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -1,5 +1,5 @@
 import { Factory } from 'fishery'
-import moment from 'moment'
+import moment from 'moment-timezone'
 import DraftReferral, { CurrentLocationType } from '../../server/models/draftReferral'
 import serviceCategoryFactory from './serviceCategory'
 import interventionFactory from './intervention'

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -1,5 +1,5 @@
 import { Factory } from 'fishery'
-import moment from 'moment'
+import moment from 'moment-timezone'
 import SentReferral from '../../server/models/sentReferral'
 import { CurrentLocationType, ReferralFields } from '../../server/models/draftReferral'
 import serviceCategoryFactory from './serviceCategory'


### PR DESCRIPTION
## What does this pull request do?

Replaces moment with moment-timezone library and specifies 'Europe/London' timezone for the appointmentTime stubs in the ServiceProviderReferrals cypress test.

## What is the intent behind these changes?

To fix and prevent failing integration tests related to the time switching to and from BST.
