### PR TITLE
make page title dynamically change based on activity number

### DIFF
--- a/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesView.ts
+++ b/server/routes/service-provider/action-plan/add-activities/addActionPlanActivitiesView.ts
@@ -20,6 +20,7 @@ export default class AddActionPlanActivitiesView {
         addActivityTextareaArgs: this.addActivityTextareaArgs,
         errorSummaryArgs: this.errorSummaryArgs,
         backLinkArgs: this.backLinkArgs,
+        subtitle: `Add activity ${this.presenter.activityNumber}`,
       },
     ]
   }

--- a/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/addActivities.njk
@@ -4,8 +4,7 @@
 {% extends "./actionPlanFormTemplate.njk" %}
 
 {% set pageTitle = "Action plan" %}
-{% set pageSubTitle = "Add activity" %}
-
+{% set pageSubTitle = subtitle %}
 {% block formSection %}
   <p class="govuk-body-m">This will be shared with the probation practitioner for approval. The first version of the action plan must be submitted within 5 working days from the initial assessment.</p>
 


### PR DESCRIPTION
## What does this pull request do?

Changes the page sub title to include the activity number.

## What is the intent behind these changes?

The page subtitle currently does not change based on activity number which is an accessibility issue.
