### PR TITLE
add planned downtime banner to sp & pp dashboards

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -41,6 +41,7 @@ declare module 'express-session' {
   export interface SessionData {
     dashboardOriginPage: string
     searchText: string
+    disableDowntimeBanner: boolean
   }
 }
 

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.test.ts
@@ -43,7 +43,7 @@ describe('DashboardPresenter', () => {
   describe('tableRows', () => {
     it('returns a list of table rows with appropriate sort values', () => {
       const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
-      const presenter = new DashboardPresenter(page, loggedInUser, 'Open cases', 'ppOpenCases', 'sentAt,ASC')
+      const presenter = new DashboardPresenter(page, loggedInUser, 'Open cases', 'ppOpenCases', 'sentAt,ASC', false)
 
       expect(presenter.tableRows).toEqual([
         [

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.test.ts
@@ -43,7 +43,15 @@ describe('DashboardPresenter', () => {
   describe('tableRows', () => {
     it('returns a list of table rows with appropriate sort values', () => {
       const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
-      const presenter = new DashboardPresenter(page, loggedInUser, 'Open cases', 'ppOpenCases', 'sentAt,ASC', false)
+      const presenter = new DashboardPresenter(
+        page,
+        loggedInUser,
+        'Open cases',
+        'ppOpenCases',
+        'sentAt,ASC',
+        true,
+        'abc'
+      )
 
       expect(presenter.tableRows).toEqual([
         [

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
@@ -22,13 +22,19 @@ export default class DashboardPresenter {
     private readonly loggedInUser: LoggedInUser,
     readonly dashboardType: PPDashboardType,
     readonly tablePersistentId: string,
-    private readonly requestedSort: string
+    private readonly requestedSort: string,
+    readonly disableDowntimeBanner: boolean,
+    readonly dashboardOrigin: string,
   ) {
     this.pagination = new Pagination(sentReferrals)
 
     const [sortField, sortOrder] = this.requestedSort.split(',')
     this.requestedSortField = sortField
     this.requestedSortOrder = ControllerUtils.sortOrderToAriaSort(sortOrder)
+  }
+
+  get closeHref(): string {
+    return `${this.dashboardOrigin}?dismissDowntimeBanner=true`
   }
 
   // this maps the column headings in the table to the database field used

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
@@ -24,7 +24,7 @@ export default class DashboardPresenter {
     readonly tablePersistentId: string,
     private readonly requestedSort: string,
     readonly disableDowntimeBanner: boolean,
-    readonly dashboardOrigin: string,
+    readonly dashboardOrigin: string
   ) {
     this.pagination = new Pagination(sentReferrals)
 

--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -1,4 +1,4 @@
-import { TableArgs } from '../../utils/govukFrontendTypes'
+import { NotificationBannerArgs, TableArgs } from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
 import DashboardPresenter from './dashboardPresenter'
 
@@ -35,6 +35,18 @@ export default class DashboardView {
     ],
   }
 
+  get serviceOutageBannerArgs(): NotificationBannerArgs {
+    const text =
+      'Refer and monitor an intervention will not be available on Saturday 29 April 2023 between 5pm and 8pm.'
+
+    const html = `<p>${text}</p>`
+    return {
+      titleText: 'Planned downtime',
+      html,
+      classes: 'govuk-notification-banner--info',
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'probationPractitionerReferrals/dashboard',
@@ -45,6 +57,7 @@ export default class DashboardView {
         subNavArgs: this.subNavArgs,
         pagination: this.presenter.pagination.mojPaginationArgs,
         showSearchResult: {},
+        serviceOutageBannerArgs: this.serviceOutageBannerArgs,
       },
     ]
   }

--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -41,7 +41,7 @@ export default class DashboardView {
 
     const html = `<p>${text}</p>
                   <p><a href= ${this.presenter.closeHref}>Close</a></p>`
-    return{
+    return {
       titleText: 'Planned downtime',
       html,
       classes: 'govuk-notification-banner--info',

--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -35,12 +35,13 @@ export default class DashboardView {
     ],
   }
 
-  get serviceOutageBannerArgs(): NotificationBannerArgs {
+  get serviceOutageBannerArgs(): NotificationBannerArgs | null {
     const text =
       'Refer and monitor an intervention will not be available on Saturday 29 April 2023 between 5pm and 8pm.'
 
-    const html = `<p>${text}</p>`
-    return {
+    const html = `<p>${text}</p>
+                  <p><a href= ${this.presenter.closeHref}>Close</a></p>`
+    return{
       titleText: 'Planned downtime',
       html,
       classes: 'govuk-notification-banner--info',

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -90,6 +90,9 @@ export default class ProbationPractitionerReferralsController {
     tablePersistentId: string,
     pageSize: number
   ) {
+    if(req.query['dismissDowntimeBanner']){
+      req.session.disableDowntimeBanner = true
+    }
     const sort = await ControllerUtils.getSortOrderFromMojServerSideSortableTable(
       req,
       res,
@@ -114,8 +117,9 @@ export default class ProbationPractitionerReferralsController {
     )
 
     req.session.dashboardOriginPage = req.originalUrl
+    const disablePlannedDowntimeNotification = req.session.disableDowntimeBanner ? req.session.disableDowntimeBanner : false
 
-    const presenter = new DashboardPresenter(cases, res.locals.user, dashboardType, tablePersistentId, sort[0])
+    const presenter = new DashboardPresenter(cases, res.locals.user, dashboardType, tablePersistentId, sort[0], disablePlannedDowntimeNotification, req.session.dashboardOriginPage)
     const view = new DashboardView(presenter)
     ControllerUtils.renderWithLayout(res, view, null)
   }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -90,7 +90,7 @@ export default class ProbationPractitionerReferralsController {
     tablePersistentId: string,
     pageSize: number
   ) {
-    if(req.query['dismissDowntimeBanner']){
+    if (req.query.dismissDowntimeBanner) {
       req.session.disableDowntimeBanner = true
     }
     const sort = await ControllerUtils.getSortOrderFromMojServerSideSortableTable(
@@ -117,9 +117,20 @@ export default class ProbationPractitionerReferralsController {
     )
 
     req.session.dashboardOriginPage = req.originalUrl
-    const disablePlannedDowntimeNotification = req.session.disableDowntimeBanner ? req.session.disableDowntimeBanner : false
+    const disablePlannedDowntimeNotification = req.session.disableDowntimeBanner
+      ? req.session.disableDowntimeBanner
+      : false
 
-    const presenter = new DashboardPresenter(cases, res.locals.user, dashboardType, tablePersistentId, sort[0], disablePlannedDowntimeNotification, req.session.dashboardOriginPage)
+    const presenter = new DashboardPresenter(
+      cases,
+      res.locals.user,
+      dashboardType,
+      tablePersistentId,
+      sort[0],
+      disablePlannedDowntimeNotification,
+      req.session.dashboardOriginPage
+    )
+
     const view = new DashboardView(presenter)
     ControllerUtils.renderWithLayout(res, view, null)
   }

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -42,7 +42,7 @@ describe(DashboardPresenter, () => {
   describe('tableHeadings', () => {
     it('persistentId is the database sort field', () => {
       const page = pageFactory.pageContent([]).build() as Page<SentReferralSummaries>
-      const presenter = new DashboardPresenter(page, 'My cases', loggedInUser, 'tableId', 'sentAt,DESC')
+      const presenter = new DashboardPresenter(page, 'My cases', loggedInUser, 'tableId', 'sentAt,DESC', true, 'abc')
       expect(presenter.tableHeadings.map(headers => headers.persistentId)).toEqual([
         'sentAt',
         'referenceNumber',
@@ -59,7 +59,15 @@ describe(DashboardPresenter, () => {
       it('returns the table’s rows', () => {
         const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
 
-        const presenter = new DashboardPresenter(page, dashboardType, loggedInUser, 'tableId', 'sentAt,DESC')
+        const presenter = new DashboardPresenter(
+          page,
+          dashboardType,
+          loggedInUser,
+          'tableId',
+          'sentAt,DESC',
+          true,
+          'abc'
+        )
 
         expect(presenter.tableRows).toEqual([
           [
@@ -108,7 +116,15 @@ describe(DashboardPresenter, () => {
       describe('when a referral has been assigned to a caseworker', () => {
         it('includes the caseworker’s username', () => {
           const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
-          const presenter = new DashboardPresenter(page, dashboardType, loggedInUser, 'tableId', 'sentAt,DESC')
+          const presenter = new DashboardPresenter(
+            page,
+            dashboardType,
+            loggedInUser,
+            'tableId',
+            'sentAt,DESC',
+            true,
+            'abc'
+          )
 
           expect(presenter.tableRows[0][4]).toMatchObject({ text: 'UserABC' })
         })
@@ -119,7 +135,15 @@ describe(DashboardPresenter, () => {
     describe.each(dontDisplayCaseworkerDashboardTypes)('with %s dashboard type', dashboardType => {
       it('does not display the case worker column', () => {
         const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
-        const presenter = new DashboardPresenter(page, dashboardType, loggedInUser, 'tableId', 'sentAt,DESC')
+        const presenter = new DashboardPresenter(
+          page,
+          dashboardType,
+          loggedInUser,
+          'tableId',
+          'sentAt,DESC',
+          true,
+          'abc'
+        )
 
         expect(presenter.tableRows).toEqual([
           [
@@ -152,7 +176,15 @@ describe(DashboardPresenter, () => {
     describe('when a referral has been assigned to a caseworker', () => {
       it('links to the intervention progress page', () => {
         const page = pageFactory.pageContent(referrals).build() as Page<SentReferralSummaries>
-        const presenter = new DashboardPresenter(page, 'All open cases', loggedInUser, 'tableId', 'sentAt,DESC')
+        const presenter = new DashboardPresenter(
+          page,
+          'All open cases',
+          loggedInUser,
+          'tableId',
+          'sentAt,DESC',
+          true,
+          'abc'
+        )
 
         expect(presenter.tableRows[0][5]).toMatchObject({
           href: `/service-provider/referrals/1/progress`,

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -52,10 +52,10 @@ export default class DashboardPresenter {
     private readonly loggedInUser: LoggedInUser,
     readonly tablePersistentId: string,
     private readonly requestedSort: string,
-    readonly searchText: string | null = null,
     readonly disableDowntimeBanner: boolean,
     readonly dashboardOrigin: string,
-    private readonly userInputData: Record<string, string> | null = null,
+    readonly searchText: string | null = null,
+    private readonly userInputData: Record<string, string> | null = null
   ) {
     this.pagination = new Pagination(sentReferralSummaries, this.searchText ? `paginatedSearch=true` : null)
     const [sortField, sortOrder] = this.requestedSort.split(',')

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -53,12 +53,18 @@ export default class DashboardPresenter {
     readonly tablePersistentId: string,
     private readonly requestedSort: string,
     readonly searchText: string | null = null,
-    private readonly userInputData: Record<string, string> | null = null
+    readonly disableDowntimeBanner: boolean,
+    readonly dashboardOrigin: string,
+    private readonly userInputData: Record<string, string> | null = null,
   ) {
     this.pagination = new Pagination(sentReferralSummaries, this.searchText ? `paginatedSearch=true` : null)
     const [sortField, sortOrder] = this.requestedSort.split(',')
     this.requestedSortField = sortField
     this.requestedSortOrder = ControllerUtils.sortOrderToAriaSort(sortOrder)
+  }
+
+  get closeHref(): string {
+    return `${this.dashboardOrigin}?dismissDowntimeBanner=true`
   }
 
   // this maps the column headings in the table to the database field used

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -58,7 +58,8 @@ export default class DashboardView {
     const text =
       'Refer and monitor an intervention will not be available on Saturday 29 April 2023 between 5pm and 8pm.'
 
-    const html = `<p>${text}</p>`
+    const html = `<p>${text}</p>
+                  <p><a href= ${this.presenter.closeHref}>Close</a></p>`
     return {
       titleText: 'Planned downtime',
       html,

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -1,6 +1,6 @@
 import DashboardPresenter from './dashboardPresenter'
 import ViewUtils from '../../utils/viewUtils'
-import { TableArgs, InputArgs } from '../../utils/govukFrontendTypes'
+import { TableArgs, InputArgs, NotificationBannerArgs } from '../../utils/govukFrontendTypes'
 
 export default class DashboardView {
   constructor(private readonly presenter: DashboardPresenter) {}
@@ -54,6 +54,18 @@ export default class DashboardView {
     }
   }
 
+  get serviceOutageBannerArgs(): NotificationBannerArgs {
+    const text =
+      'Refer and monitor an intervention will not be available on Saturday 29 April 2023 between 5pm and 8pm.'
+
+    const html = `<p>${text}</p>`
+    return {
+      titleText: 'Planned downtime',
+      html,
+      classes: 'govuk-notification-banner--info',
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'serviceProviderReferrals/dashboard',
@@ -65,6 +77,7 @@ export default class DashboardView {
         subjectInputArgs: this.subjectInputArgs,
         pagination: this.presenter.pagination.mojPaginationArgs,
         clearHref: this.presenter.hrefLinkForClear,
+        serviceOutageBannerArgs: this.serviceOutageBannerArgs,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -208,7 +208,7 @@ export default class ServiceProviderReferralsController {
     tablePersistentId: string,
     pageSize: number
   ) {
-    if(req.query['dismissDowntimeBanner']){
+    if (req.query.dismissDowntimeBanner) {
       req.session.disableDowntimeBanner = true
     }
     const sort = await ControllerUtils.getSortOrderFromMojServerSideSortableTable(
@@ -235,7 +235,9 @@ export default class ServiceProviderReferralsController {
     )
 
     req.session.dashboardOriginPage = req.originalUrl
-    const disablePlannedDowntimeNotification = req.session.disableDowntimeBanner ? req.session.disableDowntimeBanner : false
+    const disablePlannedDowntimeNotification = req.session.disableDowntimeBanner
+      ? req.session.disableDowntimeBanner
+      : false
 
     const presenter = new DashboardPresenter(
       cases,
@@ -243,9 +245,9 @@ export default class ServiceProviderReferralsController {
       res.locals.user,
       tablePersistentId,
       sort[0],
-      getSentReferralsFilterParams.search,
       disablePlannedDowntimeNotification,
-      req.session.dashboardOriginPage
+      req.session.dashboardOriginPage,
+      getSentReferralsFilterParams.search
     )
     const view = new DashboardView(presenter)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -208,6 +208,9 @@ export default class ServiceProviderReferralsController {
     tablePersistentId: string,
     pageSize: number
   ) {
+    if(req.query['dismissDowntimeBanner']){
+      req.session.disableDowntimeBanner = true
+    }
     const sort = await ControllerUtils.getSortOrderFromMojServerSideSortableTable(
       req,
       res,
@@ -232,6 +235,7 @@ export default class ServiceProviderReferralsController {
     )
 
     req.session.dashboardOriginPage = req.originalUrl
+    const disablePlannedDowntimeNotification = req.session.disableDowntimeBanner ? req.session.disableDowntimeBanner : false
 
     const presenter = new DashboardPresenter(
       cases,
@@ -239,7 +243,9 @@ export default class ServiceProviderReferralsController {
       res.locals.user,
       tablePersistentId,
       sort[0],
-      getSentReferralsFilterParams.search
+      getSentReferralsFilterParams.search,
+      disablePlannedDowntimeNotification,
+      req.session.dashboardOriginPage
     )
     const view = new DashboardView(presenter)
 

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -15,7 +15,10 @@
 
 
 {% block pageContent %}
-{{ govukNotificationBanner(serviceOutageBannerArgs) }}
+
+{% if presenter.disableDowntimeBanner != true %}
+    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
+{% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -11,7 +12,10 @@
   {{ mojPrimaryNavigation(primaryNavArgs) }}
 {% endblock %}
 
+
+
 {% block pageContent %}
+{{ govukNotificationBanner(serviceOutageBannerArgs) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,6 +12,7 @@
 {% endblock %}
 
 {% block pageContent %}
+{{ govukNotificationBanner(serviceOutageBannerArgs) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,7 +12,11 @@
 {% endblock %}
 
 {% block pageContent %}
-{{ govukNotificationBanner(serviceOutageBannerArgs) }}
+
+{% if presenter.disableDowntimeBanner != true %}
+    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
+{% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>


### PR DESCRIPTION
## What does this pull request do?

Adds a banner to the sp & pp dashboards to show planned downtime information.

## What is the intent behind these changes?

To notify users that the service will be unavailable at a certain time.
