### PR TITLE
remove downtime banner from template

### DIFF
--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -12,13 +12,7 @@
   {{ mojPrimaryNavigation(primaryNavArgs) }}
 {% endblock %}
 
-
-
 {% block pageContent %}
-
-{% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-{% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,11 +12,6 @@
 {% endblock %}
 
 {% block pageContent %}
-
-{% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-{% endif %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>


### PR DESCRIPTION
## What does this pull request do?

Removes the downtime banner from both the sp & pp dashboards.

## What is the intent behind these changes?

The service should no longer be unavailable after the auth downtime, so we need to remove the banner.
Leaving the rest of the setup code in so it can be re-used later on a generic downtime banner.
