### PR TITLE
view referral and check answers page for community with com

### DIFF
--- a/integration_tests/integration/amend-referral.cy.js
+++ b/integration_tests/integration/amend-referral.cy.js
@@ -387,7 +387,7 @@ context('Amend a referral', () => {
           .last()
           .should('contain', 'Desired outcomes')
           .contains('Change')
-          .click()
+        cy.get('#change-link-1').click()
 
         cy.location('pathname').should(
           'equal',
@@ -402,13 +402,11 @@ context('Amend a referral', () => {
 
         cy.contains('Accommodation service')
           .next()
-          .children()
-          .first()
           .should('contain', 'Complexity level')
-          .next()
           .should('contain', 'Desired outcomes')
           .contains('Change')
-          .click()
+
+        cy.get('#change-link-1').click()
 
         cy.location('pathname').should(
           'equal',

--- a/integration_tests/integration/probationPractitionerReferrals.cy.js
+++ b/integration_tests/integration/probationPractitionerReferrals.cy.js
@@ -467,33 +467,24 @@ describe('Probation practitioner referrals dashboard', () => {
 
     cy.contains('Accommodation service')
       .next()
-      .children()
-      .first()
       .should('contain', 'Complexity level')
       .should('contain', 'LOW COMPLEXITY')
       .should('contain', 'Service user has some capacity and means to secure')
-      .next()
       .should('contain', 'Desired outcomes')
       .should('contain', 'All barriers, as identified in the Service user action plan')
       .should('contain', 'Service user makes progress in obtaining accommodation')
 
     cy.contains('Social inclusion service')
       .next()
-      .children()
-      .first()
       .should('contain', 'Complexity level')
       .should('contain', 'MEDIUM COMPLEXITY')
       .should('contain', 'Service user is at risk of homelessness/is homeless')
-      .next()
       .should('contain', 'Desired outcomes')
       .should('contain', 'Service user is helped to secure social or supported housing')
       .should('contain', 'Service user is helped to secure a tenancy in the private rented sector (PRS)')
 
     cy.contains("The person on probation's details")
     cy.contains('English')
-    cy.contains('Agnostic')
-    cy.contains('Autism spectrum condition')
-    cy.contains('sciatica')
     cy.contains("The person on probation's details")
       .next()
       .contains('Email address')
@@ -813,13 +804,11 @@ describe('Probation practitioner referrals dashboard', () => {
 
       cy.contains('Accommodation service')
         .next()
-        .children()
-        .first()
         .should('contain', 'Complexity level')
-        .next()
         .should('contain', 'Desired outcomes')
         .contains('Change')
-        .click()
+
+      cy.get('#change-link-1').click()
 
       cy.location('pathname').should(
         'equal',

--- a/integration_tests/integration/referral.cy.js
+++ b/integration_tests/integration/referral.cy.js
@@ -230,9 +230,8 @@ describe('Referral form', () => {
       cy.contains('Confirm their personal details').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/service-user-details`)
-      cy.get('h1').contains("Alex's information")
+      cy.get('h1').contains("Review Alex River's information")
       cy.contains('X123456')
-      cy.contains('Mr')
       cy.contains('River')
       cy.contains('1 January 1980')
       cy.contains('Flat 2 Test Walk')
@@ -245,8 +244,11 @@ describe('Referral form', () => {
       cy.contains('English')
       cy.contains('Agnostic')
       cy.contains('Autism')
-      cy.contains("Alex's information").next().contains('Email address').next().contains('alex.river@example.com')
-      cy.contains("Alex's information").next().contains('Phone number').next().contains('0123456789')
+      cy.contains('Address and contact details')
+      cy.contains('Email address')
+      cy.contains('alex.river@example.com')
+      cy.contains('Phone number')
+      cy.contains('0123456789')
 
       cy.contains('Save and continue').click()
 
@@ -411,7 +413,6 @@ describe('Referral form', () => {
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/check-answers`)
 
       cy.contains('X123456')
-      cy.contains('Mr')
       cy.contains('River')
       cy.contains('1 January 1980')
       cy.contains('Flat 2 Test Walk')
@@ -426,6 +427,32 @@ describe('Referral form', () => {
       cy.contains('Autism')
       cy.contains('alex.river@example.com')
 
+      // Alex's risk information
+      cy.contains('Probation Practitioner Details')
+        .parent()
+        .next()
+        .should('contain', 'Name')
+        .should('contain', 'Victor Drake')
+        .contains('Change')
+        .should('have.attr', 'href', `/referrals/${draftReferral.id}/confirm-probation-practitioner-details`)
+
+      cy.contains('Probation Practitioner Details')
+        .parent()
+        .next()
+        .should('contain', 'Email')
+        .should('contain', 'a.b@xyz.com')
+        .contains('Change')
+        .should('have.attr', 'href', `/referrals/${draftReferral.id}/confirm-probation-practitioner-details`)
+
+      cy.contains('Probation Practitioner Details')
+        .parent()
+        .next()
+        .should('contain', 'PDU(probation delivery unit)')
+        .should('contain', 'London')
+        .contains('Change')
+        .should('have.attr', 'href', `/referrals/${draftReferral.id}/confirm-probation-practitioner-details`)
+
+      //
       // Alex's risk information
       cy.contains('Additional information')
         .next()
@@ -508,8 +535,7 @@ describe('Referral form', () => {
         )
 
       cy.contains('Enforceable days')
-        .next()
-        .contains('Maximum number of enforceable days')
+      cy.contains('Maximum number of enforceable days')
         .next()
         .should('contain', '10')
         .next()
@@ -517,17 +543,18 @@ describe('Referral form', () => {
         .should('have.attr', 'href', `/referrals/${draftReferral.id}/enforceable-days`)
 
       cy.contains('Accommodation completion date')
+        .parent()
         .next()
         .contains('Date')
         .next()
-        .should('contain', '24 August 2021')
+        .contains('24 August 2021')
+        .parent()
         .next()
         .contains('Change')
         .should('have.attr', 'href', `/referrals/${draftReferral.id}/completion-deadline`)
 
       cy.contains('Further information')
-        .next()
-        .contains('Further information for the provider')
+      cy.contains('Further information for the provider')
         .next()
         .should('contain', 'Some information about Alex')
         .next()
@@ -712,9 +739,8 @@ describe('Referral form', () => {
       cy.contains('Confirm their personal details').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/service-user-details`)
-      cy.get('h1').contains("Alex's information")
+      cy.get('h1').contains("Review Alex River's information")
       cy.contains('X123456')
-      cy.contains('Mr')
       cy.contains('River')
       cy.contains('1 January 1980')
       cy.contains('Flat 2 Test Walk')
@@ -922,8 +948,7 @@ describe('Referral form', () => {
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/check-answers`)
 
       cy.contains('Service categories')
-        .next()
-        .contains('Selected service categories')
+      cy.contains('Selected service categories')
         .next()
         .should('contain', 'Accommodation')
         .and('contain', 'Social inclusion')
@@ -932,8 +957,7 @@ describe('Referral form', () => {
         .should('have.attr', 'href', `/referrals/${draftReferral.id}/service-categories`)
 
       cy.contains('Accommodation referral details')
-        .next()
-        .contains('Complexity level')
+      cy.contains('Complexity level')
         .next()
         .should('contain', 'Low complexity')
         .and('contain', 'Info about low complexity')
@@ -945,8 +969,7 @@ describe('Referral form', () => {
           `/referrals/${draftReferral.id}/service-category/428ee70f-3001-4399-95a6-ad25eaaede16/complexity-level`
         )
       cy.contains('Accommodation referral details')
-        .next()
-        .contains('Desired outcomes')
+      cy.contains('Desired outcomes')
         .next()
         .should('contain', 'Service user makes progress in obtaining accommodation')
         .and('contain', 'Service user is prevented from becoming homeless')
@@ -959,6 +982,7 @@ describe('Referral form', () => {
         )
 
       cy.contains('Social inclusion referral details')
+        .parent()
         .next()
         .contains('Complexity level')
         .next()
@@ -972,6 +996,7 @@ describe('Referral form', () => {
           `/referrals/${draftReferral.id}/service-category/c036826e-f077-49a5-8b33-601dca7ad479/complexity-level`
         )
       cy.contains('Social inclusion referral details')
+        .parent()
         .next()
         .contains('Desired outcomes')
         .next()

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "express-session": "^1.17.3",
         "express-validator": "^6.14.2",
         "govuk-elements-sass": "^3.1.3",
-        "govuk-frontend": "^4.4.1",
+        "govuk-frontend": "^4.6.0",
         "helmet": "^6.0.1",
         "http-errors": "^2.0.0",
         "http-status-codes": "^2.2.0",
@@ -9175,9 +9175,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
-      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
+      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -13958,15 +13958,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/listenercount": {
@@ -18894,6 +18885,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yaml": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -26098,9 +26098,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
-      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
+      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw=="
     },
     "graceful-fs": {
       "version": "4.2.9",
@@ -29668,12 +29668,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
           "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-          "dev": true
-        },
-        "yaml": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-          "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
           "dev": true
         }
       }
@@ -33427,6 +33421,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "dev": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "express-session": "^1.17.3",
     "express-validator": "^6.14.2",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^4.4.1",
+    "govuk-frontend": "^4.6.0",
     "helmet": "^6.0.1",
     "http-errors": "^2.0.0",
     "http-status-codes": "^2.2.0",

--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -28,6 +28,13 @@ export interface ReferralFields {
   hasExpectedReleaseDate: boolean | null
   expectedReleaseDate: string | null
   expectedReleaseDateMissingReason: string | null
+  ndeliusPPName: string | null
+  ndeliusPPEmailAddress: string | null
+  ndeliusPDU: string | null
+  ppName: string | null
+  ppEmailAddress: string | null
+  ppPdu: string | null
+  ppProbationOffice: string | null
 }
 
 export enum CurrentLocationType {

--- a/server/routes/makeAReferral/check-answers/checkAnswersPresenter.test.ts
+++ b/server/routes/makeAReferral/check-answers/checkAnswersPresenter.test.ts
@@ -419,14 +419,17 @@ describe(CheckAnswersPresenter, () => {
 
         it('lists the service categories chosen in the referral', () => {
           const presenter = new CheckAnswersPresenter(referral, intervention, conviction, deliusServiceUser, prisonList)
-          expect(presenter.serviceCategoriesSummary).toEqual([
-            {
-              key: 'Selected service categories',
-              lines: ['Accommodation'],
-              listStyle: ListStyle.noMarkers,
-              changeLink: `/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/service-categories`,
-            },
-          ])
+          expect(presenter.serviceCategoriesSummary).toEqual({
+            title: 'Service categories',
+            summary: [
+              {
+                key: 'Selected service categories',
+                lines: ['Accommodation'],
+                listStyle: ListStyle.noMarkers,
+                changeLink: `/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/service-categories`,
+              },
+            ],
+          })
         })
       })
 
@@ -438,14 +441,17 @@ describe(CheckAnswersPresenter, () => {
 
         it('lists the service categories chosen in the referral', () => {
           const presenter = new CheckAnswersPresenter(referral, intervention, conviction, deliusServiceUser, prisonList)
-          expect(presenter.serviceCategoriesSummary).toEqual([
-            {
-              key: 'Selected service categories',
-              lines: ['Accommodation', 'Education, training and employment'],
-              listStyle: ListStyle.noMarkers,
-              changeLink: `/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/service-categories`,
-            },
-          ])
+          expect(presenter.serviceCategoriesSummary).toEqual({
+            title: 'Service categories',
+            summary: [
+              {
+                key: 'Selected service categories',
+                lines: ['Accommodation', 'Education, training and employment'],
+                listStyle: ListStyle.noMarkers,
+                changeLink: `/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/service-categories`,
+              },
+            ],
+          })
         })
       })
     })
@@ -477,23 +483,26 @@ describe(CheckAnswersPresenter, () => {
         prisonList
       )
 
-      expect(presenter.sentenceInformationSummary).toEqual([
-        {
-          key: 'Sentence',
-          lines: ['Common and other types of assault'],
-          changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/relevant-sentence',
-        },
-        {
-          key: 'Subcategory',
-          lines: ['Common assault and battery'],
-          changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/relevant-sentence',
-        },
-        {
-          key: 'End of sentence date',
-          lines: ['15 September 2025'],
-          changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/relevant-sentence',
-        },
-      ])
+      expect(presenter.sentenceInformationSummary).toEqual({
+        title: 'Sentence Information',
+        summary: [
+          {
+            key: 'Sentence',
+            lines: ['Common and other types of assault'],
+            changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/relevant-sentence',
+          },
+          {
+            key: 'Subcategory',
+            lines: ['Common assault and battery'],
+            changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/relevant-sentence',
+          },
+          {
+            key: 'End of sentence date',
+            lines: ['15 September 2025'],
+            changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/relevant-sentence',
+          },
+        ],
+      })
     })
   })
 
@@ -539,13 +548,16 @@ describe(CheckAnswersPresenter, () => {
         prisonList
       )
 
-      expect(presenter.enforceableDaysSummary).toEqual([
-        {
-          key: 'Maximum number of enforceable days',
-          lines: ['15'],
-          changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/enforceable-days',
-        },
-      ])
+      expect(presenter.enforceableDaysSummary).toEqual({
+        title: 'Enforceable days',
+        summary: [
+          {
+            key: 'Maximum number of enforceable days',
+            lines: ['15'],
+            changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/enforceable-days',
+          },
+        ],
+      })
     })
   })
 
@@ -565,13 +577,16 @@ describe(CheckAnswersPresenter, () => {
           prisonList
         )
 
-        expect(presenter.furtherInformationSummary).toEqual([
-          {
-            key: 'Further information for the provider',
-            lines: ['Some further information'],
-            changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/further-information',
-          },
-        ])
+        expect(presenter.furtherInformationSummary).toEqual({
+          title: 'Further information',
+          summary: [
+            {
+              key: 'Further information for the provider',
+              lines: ['Some further information'],
+              changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/further-information',
+            },
+          ],
+        })
       })
     })
 
@@ -590,13 +605,16 @@ describe(CheckAnswersPresenter, () => {
           prisonList
         )
 
-        expect(presenter.furtherInformationSummary).toEqual([
-          {
-            key: 'Further information for the provider',
-            lines: ['None'],
-            changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/further-information',
-          },
-        ])
+        expect(presenter.furtherInformationSummary).toEqual({
+          title: 'Further information',
+          summary: [
+            {
+              key: 'Further information for the provider',
+              lines: ['None'],
+              changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/further-information',
+            },
+          ],
+        })
       })
     })
   })

--- a/server/routes/makeAReferral/check-answers/checkAnswersPresenter.ts
+++ b/server/routes/makeAReferral/check-answers/checkAnswersPresenter.ts
@@ -32,11 +32,40 @@ export default class CheckAnswersPresenter {
         this.referral.serviceUser,
         this.deliusServiceUser,
         this.prisons,
+        this.referral.id,
         this.referral?.personCurrentLocationType,
         this.referral?.personCustodyPrisonId,
         this.referral?.expectedReleaseDate,
         this.referral?.expectedReleaseDateMissingReason
       ).summary,
+    }
+  }
+
+  get probationPractitionerDetailSection(): { title: string; summary: SummaryListItem[] } {
+    return {
+      title: `Probation Practitioner Details`,
+      summary: [
+        {
+          key: 'Name',
+          lines: [this.referral.ppName || this.referral.ndeliusPPName || ''],
+          changeLink: `/referrals/${this.referral.id}/confirm-probation-practitioner-details`,
+        },
+        {
+          key: 'Email',
+          lines: [this.referral.ppEmailAddress || this.referral.ndeliusPPEmailAddress || ''],
+          changeLink: `/referrals/${this.referral.id}/confirm-probation-practitioner-details`,
+        },
+        {
+          key: 'PDU(probation delivery unit)',
+          lines: [this.referral.ppPdu || this.referral.ndeliusPDU || ''],
+          changeLink: `/referrals/${this.referral.id}/confirm-probation-practitioner-details`,
+        },
+        {
+          key: 'Probation office',
+          lines: [this.referral.ppProbationOffice || ''],
+          changeLink: `/referrals/${this.referral.id}/confirm-probation-practitioner-details`,
+        },
+      ],
     }
   }
 
@@ -180,7 +209,7 @@ export default class CheckAnswersPresenter {
     })
   }
 
-  get serviceCategoriesSummary(): SummaryListItem[] | null {
+  get serviceCategoriesSummary(): { title: string; summary: SummaryListItem[] } | null {
     if (!new InterventionDecorator(this.intervention).isCohortIntervention) {
       return null
     }
@@ -189,36 +218,42 @@ export default class CheckAnswersPresenter {
       this.intervention.serviceCategories
     )
 
-    return [
-      {
-        key: 'Selected service categories',
-        lines: serviceCategories.map(serviceCategory => utils.convertToProperCase(serviceCategory.name)),
-        listStyle: ListStyle.noMarkers,
-        changeLink: `/referrals/${this.referral.id}/service-categories`,
-      },
-    ]
+    return {
+      title: 'Service categories',
+      summary: [
+        {
+          key: 'Selected service categories',
+          lines: serviceCategories.map(serviceCategory => utils.convertToProperCase(serviceCategory.name)),
+          listStyle: ListStyle.noMarkers,
+          changeLink: `/referrals/${this.referral.id}/service-categories`,
+        },
+      ],
+    }
   }
 
-  get sentenceInformationSummary(): SummaryListItem[] {
+  get sentenceInformationSummary(): { title: string; summary: SummaryListItem[] } {
     const presenter = new SentencePresenter(this.conviction)
 
-    return [
-      {
-        key: 'Sentence',
-        lines: [presenter.category],
-        changeLink: `/referrals/${this.referral.id}/relevant-sentence`,
-      },
-      {
-        key: 'Subcategory',
-        lines: [presenter.subcategory],
-        changeLink: `/referrals/${this.referral.id}/relevant-sentence`,
-      },
-      {
-        key: 'End of sentence date',
-        lines: [presenter.endOfSentenceDate],
-        changeLink: `/referrals/${this.referral.id}/relevant-sentence`,
-      },
-    ]
+    return {
+      title: 'Sentence Information',
+      summary: [
+        {
+          key: 'Sentence',
+          lines: [presenter.category],
+          changeLink: `/referrals/${this.referral.id}/relevant-sentence`,
+        },
+        {
+          key: 'Subcategory',
+          lines: [presenter.subcategory],
+          changeLink: `/referrals/${this.referral.id}/relevant-sentence`,
+        },
+        {
+          key: 'End of sentence date',
+          lines: [presenter.endOfSentenceDate],
+          changeLink: `/referrals/${this.referral.id}/relevant-sentence`,
+        },
+      ],
+    }
   }
 
   get completionDeadlineSection(): { title: string; summary: SummaryListItem[] } {
@@ -240,24 +275,30 @@ export default class CheckAnswersPresenter {
     }
   }
 
-  get enforceableDaysSummary(): SummaryListItem[] {
-    return [
-      {
-        key: 'Maximum number of enforceable days',
-        lines: [this.referral.maximumEnforceableDays ? this.referral.maximumEnforceableDays.toString() : ''],
-        changeLink: `/referrals/${this.referral.id}/enforceable-days`,
-      },
-    ]
+  get enforceableDaysSummary(): { title: string; summary: SummaryListItem[] } {
+    return {
+      title: 'Enforceable days',
+      summary: [
+        {
+          key: 'Maximum number of enforceable days',
+          lines: [this.referral.maximumEnforceableDays ? this.referral.maximumEnforceableDays.toString() : ''],
+          changeLink: `/referrals/${this.referral.id}/enforceable-days`,
+        },
+      ],
+    }
   }
 
-  get furtherInformationSummary(): SummaryListItem[] {
-    return [
-      {
-        key: 'Further information for the provider',
-        lines: [this.referral.furtherInformation?.length ? this.referral.furtherInformation! : 'None'],
-        changeLink: `/referrals/${this.referral.id}/further-information`,
-      },
-    ]
+  get furtherInformationSummary(): { title: string; summary: SummaryListItem[] } {
+    return {
+      title: 'Further information',
+      summary: [
+        {
+          key: 'Further information for the provider',
+          lines: [this.referral.furtherInformation?.length ? this.referral.furtherInformation! : 'None'],
+          changeLink: `/referrals/${this.referral.id}/further-information`,
+        },
+      ],
+    }
   }
 
   private readonly serviceUserName = this.referral.serviceUser?.firstName ?? ''

--- a/server/routes/makeAReferral/check-answers/checkAnswersView.ts
+++ b/server/routes/makeAReferral/check-answers/checkAnswersView.ts
@@ -4,44 +4,64 @@ import ViewUtils from '../../../utils/viewUtils'
 export default class CheckAnswersView {
   constructor(private readonly presenter: CheckAnswersPresenter) {}
 
-  private readonly serviceUserDetailsSummaryListArgs = ViewUtils.summaryListArgs(
-    this.presenter.serviceUserDetailsSection.summary
+  private readonly probationPractitionerDetailsSummaryListArgs = ViewUtils.summaryListArgsWithSummaryCard(
+    this.presenter.probationPractitionerDetailSection.summary,
+    this.presenter.probationPractitionerDetailSection.title
   )
 
-  private readonly needsAndRequirementsSummaryListArgs = ViewUtils.summaryListArgs(
-    this.presenter.needsAndRequirementsSection.summary
+  private readonly serviceUserDetailsSummaryListArgs = ViewUtils.summaryListArgsWithSummaryCard(
+    this.presenter.serviceUserDetailsSection.summary,
+    this.presenter.serviceUserDetailsSection.title
+  )
+
+  private readonly needsAndRequirementsSummaryListArgs = ViewUtils.summaryListArgsWithSummaryCard(
+    this.presenter.needsAndRequirementsSection.summary,
+    this.presenter.needsAndRequirementsSection.title
   )
 
   private readonly referralDetailsSections = this.presenter.referralDetailsSections.map(section => ({
     title: section.title,
-    summaryListArgs: ViewUtils.summaryListArgs(section.summary),
+    summaryListArgs: ViewUtils.summaryListArgsWithSummaryCard(section.summary, section.title),
   }))
 
   private readonly serviceCategoriesSummaryListArgs = this.presenter.serviceCategoriesSummary
-    ? ViewUtils.summaryListArgs(this.presenter.serviceCategoriesSummary)
+    ? ViewUtils.summaryListArgsWithSummaryCard(
+        this.presenter.serviceCategoriesSummary.summary,
+        this.presenter.serviceCategoriesSummary.title
+      )
     : null
 
-  private readonly sentenceInformationSummaryListArgs = ViewUtils.summaryListArgs(
-    this.presenter.sentenceInformationSummary
+  private readonly sentenceInformationSummaryListArgs = ViewUtils.summaryListArgsWithSummaryCard(
+    this.presenter.sentenceInformationSummary.summary,
+    this.presenter.sentenceInformationSummary.title
   )
 
-  private readonly completionDeadlineSummaryListArgs = ViewUtils.summaryListArgs(
-    this.presenter.completionDeadlineSection.summary
+  private readonly completionDeadlineSummaryListArgs = ViewUtils.summaryListArgsWithSummaryCard(
+    this.presenter.completionDeadlineSection.summary,
+    this.presenter.completionDeadlineSection.title
   )
 
-  private readonly enforceableDaysSummaryListArgs = ViewUtils.summaryListArgs(this.presenter.enforceableDaysSummary)
-
-  private readonly furtherInformationSummaryListArgs = ViewUtils.summaryListArgs(
-    this.presenter.furtherInformationSummary
+  private readonly enforceableDaysSummaryListArgs = ViewUtils.summaryListArgsWithSummaryCard(
+    this.presenter.enforceableDaysSummary.summary,
+    this.presenter.enforceableDaysSummary.title
   )
 
-  private readonly riskInformationSummaryListArgs = ViewUtils.summaryListArgs(this.presenter.riskSection.summary)
+  private readonly furtherInformationSummaryListArgs = ViewUtils.summaryListArgsWithSummaryCard(
+    this.presenter.furtherInformationSummary.summary,
+    this.presenter.furtherInformationSummary.title
+  )
+
+  private readonly riskInformationSummaryListArgs = ViewUtils.summaryListArgsWithSummaryCard(
+    this.presenter.riskSection.summary,
+    this.presenter.riskSection.title
+  )
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'makeAReferral/checkAnswers',
       {
         presenter: this.presenter,
+        probationPractitionerDetailsSummaryListArgs: this.probationPractitionerDetailsSummaryListArgs,
         serviceUserDetailsSummaryListArgs: this.serviceUserDetailsSummaryListArgs,
         needsAndRequirementsSummaryListArgs: this.needsAndRequirementsSummaryListArgs,
         referralDetailsSections: this.referralDetailsSections,

--- a/server/routes/makeAReferral/makeAReferralController.test.ts
+++ b/server/routes/makeAReferral/makeAReferralController.test.ts
@@ -282,7 +282,7 @@ describe('GET /referrals/:id/service-user-details', () => {
       .get('/referrals/1/service-user-details')
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain(`Alex&#39;s information`)
+        expect(res.text).toContain(`Review Alex River&#39;s information`)
       })
   })
 })

--- a/server/routes/makeAReferral/makeAReferralController.ts
+++ b/server/routes/makeAReferral/makeAReferralController.ts
@@ -152,7 +152,7 @@ export default class MakeAReferralController {
     const serviceUser = await this.communityApiService.getExpandedServiceUserByCRN(referral.serviceUser.crn)
     const prisons = await this.prisonRegisterService.getPrisons()
 
-    const presenter = new ServiceUserDetailsPresenter(referral.serviceUser, serviceUser, prisons)
+    const presenter = new ServiceUserDetailsPresenter(referral.serviceUser, serviceUser, prisons, referral.id)
     const view = new ServiceUserDetailsView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, serviceUser)

--- a/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.test.ts
@@ -67,13 +67,13 @@ describe(ServiceUserDetailsPresenter, () => {
     it("returns a title for the page with the service user's name", () => {
       const presenter = new ServiceUserDetailsPresenter(serviceUser, deliusServiceUser, prisonList)
 
-      expect(presenter.title).toEqual("Alex's information")
+      expect(presenter.title).toEqual("Review Alex River's information")
     })
 
     it("falls back to an empty string if the service user's name is null", () => {
       const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser, nullFieldsDeliusServiceUser, prisonList)
 
-      expect(presenter.title).toEqual("The person on probation's information")
+      expect(presenter.title).toEqual("Review The person on probation's information")
     })
   })
 
@@ -87,6 +87,7 @@ describe(ServiceUserDetailsPresenter, () => {
         serviceUser,
         deliusServiceUser,
         prisonList,
+        '1',
         CurrentLocationType.custody,
         'aaa',
         tomorrow.format('YYYY-MM-DD')
@@ -200,6 +201,165 @@ describe(ServiceUserDetailsPresenter, () => {
         const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser, user, prisonList)
 
         expect(presenter.summary).toContainEqual({
+          key: 'Email addresses',
+          lines: ['alex.river@example.com', 'a.r@example.com'],
+          listStyle: ListStyle.noMarkers,
+        })
+      })
+    })
+  })
+
+  describe('personalDetailsSummary', () => {
+    const prisonList = prisonFactory.prisonList()
+    prisonRegisterService.getPrisons.mockResolvedValue(prisonList)
+
+    it('returns an array of personalDetails summary list items for each field on the Service user', () => {
+      const tomorrow = moment().add(1, 'days')
+      const presenter = new ServiceUserDetailsPresenter(
+        serviceUser,
+        deliusServiceUser,
+        prisonList,
+        '1',
+        CurrentLocationType.custody,
+        'aaa',
+        tomorrow.format('YYYY-MM-DD')
+      )
+
+      expect(presenter.personalDetailsSummary).toEqual([
+        { key: 'First name', lines: ['Alex'] },
+        { key: 'Last name', lines: ['River'] },
+        { key: 'Date of birth', lines: ['1 Jan 1980 (43 years old)'] },
+        { key: 'Gender', lines: ['Male'] },
+        { key: 'Ethnicity', lines: ['British'] },
+        { key: 'Preferred language', lines: ['English'] },
+        { key: 'Disabilities', lines: ['Autism spectrum condition', 'sciatica'], listStyle: ListStyle.noMarkers },
+        { key: 'Religion or belief', lines: ['Agnostic'] },
+      ])
+    })
+
+    it('returns an empty values in lines for nullable fields on the Service user', () => {
+      const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser, nullFieldsDeliusServiceUser, prisonList)
+
+      expect(presenter.personalDetailsSummary).toEqual([
+        { key: 'First name', lines: [''] },
+        { key: 'Last name', lines: [''] },
+        { key: 'Date of birth', lines: [''] },
+        { key: 'Gender', lines: [''] },
+        { key: 'Ethnicity', lines: [''] },
+        { key: 'Preferred language', lines: [''] },
+        { key: 'Disabilities', lines: [], listStyle: ListStyle.noMarkers },
+        { key: 'Religion or belief', lines: [''] },
+      ])
+    })
+  })
+
+  describe('contactDetailsSummary', () => {
+    const prisonList = prisonFactory.prisonList()
+    prisonRegisterService.getPrisons.mockResolvedValue(prisonList)
+
+    it('returns an array of summary list items for each field on the Service user', () => {
+      const tomorrow = moment().add(1, 'days')
+      const presenter = new ServiceUserDetailsPresenter(
+        serviceUser,
+        deliusServiceUser,
+        prisonList,
+        '1',
+        CurrentLocationType.custody,
+        'aaa',
+        tomorrow.format('YYYY-MM-DD')
+      )
+
+      expect(presenter.contactDetailsSummary).toEqual([
+        {
+          key: 'Address',
+          lines: ['Flat 10 Test Walk', 'London', 'City of London', 'Greater London', 'SW16 1AQ'],
+          listStyle: ListStyle.noMarkers,
+        },
+        { key: 'Phone number', lines: ['0123456789'], listStyle: ListStyle.noMarkers },
+        { key: 'Email address', lines: ['alex.river@example.com'], listStyle: ListStyle.noMarkers },
+        { key: 'Location at time of referral', lines: ['Custody'] },
+        { key: 'Current establishment', lines: ['London'] },
+        { key: 'Expected release date', lines: [DateUtils.formattedDate(tomorrow.format('YYYY-MM-DD'))] },
+      ])
+    })
+
+    it('returns an empty values in lines for nullable fields on the Service user', () => {
+      const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser, nullFieldsDeliusServiceUser, prisonList)
+
+      expect(presenter.contactDetailsSummary).toEqual([
+        {
+          key: 'Address',
+          lines: ['Not found'],
+          listStyle: ListStyle.noMarkers,
+        },
+        { key: 'Phone number', lines: [], listStyle: ListStyle.noMarkers },
+        { key: 'Email address', lines: [], listStyle: ListStyle.noMarkers },
+      ])
+    })
+
+    describe('phone number validation', () => {
+      it('returns an empty values for phone number when number is null', () => {
+        const nullNumberDeliusServiceUser = expandedDeliusServiceUserFactory.build({
+          contactDetails: { emailAddresses: null, phoneNumbers: [{ number: null, type: null }] },
+        })
+        const presenter = new ServiceUserDetailsPresenter(
+          nullFieldsServiceUser,
+          nullNumberDeliusServiceUser,
+          prisonList
+        )
+
+        expect(presenter.contactDetailsSummary).toContainEqual({
+          key: 'Phone number',
+          lines: [],
+          listStyle: ListStyle.noMarkers,
+        })
+      })
+
+      it('returns multiple phone numbers when provided', () => {
+        const user = expandedDeliusServiceUserFactory.build({
+          contactDetails: {
+            phoneNumbers: [
+              { number: '123456789', type: null },
+              { number: '987654321', type: null },
+            ],
+          },
+        })
+        const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser, user, prisonList)
+
+        expect(presenter.contactDetailsSummary).toContainEqual({
+          key: 'Phone numbers',
+          lines: ['123456789', '987654321'],
+          listStyle: ListStyle.noMarkers,
+        })
+      })
+
+      it('filters non-unique phone numbers', () => {
+        const user = expandedDeliusServiceUserFactory.build({
+          contactDetails: {
+            phoneNumbers: [
+              { number: '123456789', type: null },
+              { number: '123456789', type: null },
+            ],
+          },
+        })
+        const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser, user, prisonList)
+
+        expect(presenter.contactDetailsSummary).toContainEqual({
+          key: 'Phone number',
+          lines: ['123456789'],
+          listStyle: ListStyle.noMarkers,
+        })
+      })
+    })
+
+    describe('email validation', () => {
+      it('returns multiple emails when provided', () => {
+        const user = expandedDeliusServiceUserFactory.build({
+          contactDetails: { emailAddresses: ['alex.river@example.com', 'a.r@example.com'] },
+        })
+        const presenter = new ServiceUserDetailsPresenter(nullFieldsServiceUser, user, prisonList)
+
+        expect(presenter.contactDetailsSummary).toContainEqual({
           key: 'Email addresses',
           lines: ['alex.river@example.com', 'a.r@example.com'],
           listStyle: ListStyle.noMarkers,

--- a/server/routes/makeAReferral/service-user-details/serviceUserDetailsView.ts
+++ b/server/routes/makeAReferral/service-user-details/serviceUserDetailsView.ts
@@ -4,8 +4,20 @@ import ServiceUserDetailsPresenter from './serviceUserDetailsPresenter'
 export default class ServiceUserDetailsView {
   constructor(private readonly presenter: ServiceUserDetailsPresenter) {}
 
-  private get summaryListArgs() {
-    return ViewUtils.summaryListArgs(this.presenter.summary)
+  private get contactDetailsSummaryListArgs() {
+    return ViewUtils.summaryListArgsWithSummaryCard(
+      this.presenter.contactDetailsSummary,
+      this.presenter.contactDetailsHeading,
+      { showBorders: true, showTitle: true }
+    )
+  }
+
+  private get personalDetailsSummaryListArgs() {
+    return ViewUtils.summaryListArgsWithSummaryCard(
+      this.presenter.personalDetailsSummary,
+      this.presenter.personDetailsHeading,
+      { showBorders: true, showTitle: true }
+    )
   }
 
   get renderArgs(): [string, Record<string, unknown>] {
@@ -13,7 +25,9 @@ export default class ServiceUserDetailsView {
       'makeAReferral/serviceUserDetails',
       {
         presenter: this.presenter,
-        summaryListArgs: this.summaryListArgs,
+        contactDetailsSummaryListArgs: this.contactDetailsSummaryListArgs,
+        personalDetailsSummaryListArgs: this.personalDetailsSummaryListArgs,
+        backLinkArgs: { href: this.presenter.backLinkUrl },
       },
     ]
   }

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -285,6 +285,7 @@ export default class ShowReferralPresenter {
       this.sentReferral.referral.serviceUser,
       this.deliusServiceUser,
       this.prisons,
+      this.sentReferral.id,
       this.sentReferral.referral.personCurrentLocationType,
       this.sentReferral.referral.personCustodyPrisonId,
       this.sentReferral.referral.expectedReleaseDate,

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1556,6 +1556,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       expectedReleaseDate: moment().add(1, 'days').format('YYYY-MM-DD'),
       expectedReleaseDateMissingReason: null,
       hasExpectedReleaseDate: null,
+      ndeliusPPName: null,
+      ndeliusPPEmailAddress: null,
+      ndeliusPDU: null,
+      ppName: null,
+      ppEmailAddress: null,
+      ppPdu: null,
+      ppProbationOffice: null,
     },
   }
 

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -129,4 +129,13 @@ describe('DateUtils', () => {
       ).toEqual('Midnight to midday')
     })
   })
+
+  describe('age', () => {
+    it('returns the correct age of the person', () => {
+      expect(DateUtils.age('1981-07-29T05:30:00+01:00')).toEqual(41)
+    })
+    it('returns the correct age of the futuristic date', () => {
+      expect(DateUtils.age('2065-07-19T05:30:00+01:00')).toEqual(-43)
+    })
+  })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -84,4 +84,10 @@ export default class DateUtils {
   ): string {
     return `${this.formattedTime(startsAt, options)} to ${this.formattedTime(endsAt)}`
   }
+
+  static age(dateOfBirth: string): number {
+    const calendarDay = new Date(dateOfBirth)
+    const timeDiff = Date.now() - calendarDay.getTime()
+    return Math.floor(timeDiff / (1000 * 3600 * 24) / 365)
+  }
 }

--- a/server/utils/govukFrontendTypes.ts
+++ b/server/utils/govukFrontendTypes.ts
@@ -1560,6 +1560,7 @@ export interface SkipLinkArgs {
 
 // The summary list component is described at https://design-system.service.gov.uk/components/summary-list.
 export interface SummaryListArgs {
+  card?: SummaryListTitle | null
   /*
     Array of row item objects.
   */
@@ -1574,6 +1575,10 @@ export interface SummaryListArgs {
     HTML attributes (for example data attributes) to add to the container.
   */
   attributes?: Record<string, unknown> | null
+}
+
+export interface SummaryListTitle {
+  title?: SummaryListArgsRowKey | null
 }
 
 export interface SummaryListArgsRow {

--- a/server/utils/viewUtils.test.ts
+++ b/server/utils/viewUtils.test.ts
@@ -168,13 +168,106 @@ describe('ViewUtils', () => {
       })
     })
 
-    describe('with provided options', () => {
-      describe('when show borders is set to false', () => {
-        it('should add a hide borders class', () => {
-          expect(ViewUtils.summaryListArgs([], { showBorders: false })).toEqual({
-            classes: 'govuk-summary-list--no-border',
-            rows: [],
-          })
+    it('returns a summary list for service user details args object for passing to the govukSummaryList macro', () => {
+      expect(
+        ViewUtils.summaryListArgsWithSummaryCard(
+          [
+            { key: 'Risks', lines: ['No risk'], changeLink: '/risks' },
+            { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], listStyle: ListStyle.noMarkers },
+            { key: 'Needs', lines: ['Accommodation', 'Social inclusion'], listStyle: ListStyle.bulleted },
+            { key: 'Gender', lines: ['Male'] },
+            { key: 'Address', lines: ['Flat 2', '27 Test Walk', 'SY16 1AQ'] },
+            {
+              key: 'AuthUserDetailsLine',
+              lines: [
+                hmppsAuthUserFactory.build({ firstName: 'firstName', lastName: 'lastName', email: 'user@email.com' }),
+              ],
+            },
+          ],
+          'Personal Details',
+          { showBorders: true, showTitle: true }
+        )
+      ).toEqual({
+        card: {
+          title: {
+            text: 'Personal Details',
+          },
+        },
+        classes: undefined,
+        rows: [
+          {
+            key: {
+              text: 'Risks',
+            },
+            value: {
+              html: '<p class="govuk-body">No risk</p>',
+            },
+            actions: {
+              items: [
+                {
+                  href: '/risks',
+                  text: 'Change',
+                  attributes: { id: `change-link-0` },
+                },
+              ],
+            },
+          },
+          {
+            key: {
+              text: 'Needs',
+            },
+            value: {
+              html: `<ul class="govuk-list"><li>Accommodation</li>\n<li>Social inclusion</li></ul>`,
+            },
+            actions: null,
+          },
+          {
+            key: {
+              text: 'Needs',
+            },
+            value: {
+              html: `<ul class="govuk-list govuk-list--bullet"><li>Accommodation</li>\n<li>Social inclusion</li></ul>`,
+            },
+            actions: null,
+          },
+          {
+            key: {
+              text: 'Gender',
+            },
+            value: {
+              html: '<p class="govuk-body">Male</p>',
+            },
+            actions: null,
+          },
+          {
+            key: {
+              text: 'Address',
+            },
+            value: {
+              html: '<p class="govuk-body">Flat 2</p>\n<p class="govuk-body">27 Test Walk</p>\n<p class="govuk-body">SY16 1AQ</p>',
+            },
+            actions: null,
+          },
+          {
+            key: {
+              text: 'AuthUserDetailsLine',
+            },
+            value: {
+              html: '<p class="govuk-body">firstName lastName (<a href="mailto: user@email.com">user@email.com</a>)</p>',
+            },
+            actions: null,
+          },
+        ],
+      })
+    })
+  })
+
+  describe('with provided options', () => {
+    describe('when show borders is set to false', () => {
+      it('should add a hide borders class', () => {
+        expect(ViewUtils.summaryListArgs([], { showBorders: false })).toEqual({
+          classes: 'govuk-summary-list--no-border',
+          rows: [],
         })
       })
     })

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -106,6 +106,61 @@ export default class ViewUtils {
     }
   }
 
+  static summaryListArgsWithSummaryCard(
+    summaryListItems: SummaryListItem[],
+    heading: string | null | undefined = null,
+    options: { showBorders: boolean; showTitle: boolean } = { showBorders: true, showTitle: true }
+  ): SummaryListArgs {
+    return {
+      card: (() => {
+        if (options.showTitle) {
+          return {
+            title: {
+              text: heading,
+            },
+          }
+        }
+        return null
+      })(),
+      classes: options.showBorders ? undefined : 'govuk-summary-list--no-border',
+      rows: summaryListItems.map((item, index) => {
+        return {
+          key: {
+            text: item.key,
+          },
+          value: (() => {
+            if (item.listStyle !== undefined) {
+              const itemClass = `govuk-list${item.listStyle === ListStyle.bulleted ? ' govuk-list--bullet' : ''}`
+              const html = `<ul class="${itemClass}">${item.lines
+                .map(line => `<li>${ViewUtils.summaryListItemLine(line)}</li>`)
+                .join('\n')}</ul>`
+              return { html }
+            }
+
+            const html = item.lines
+              .map(line => `<p class="govuk-body">${ViewUtils.nl2br(ViewUtils.summaryListItemLine(line))}</p>`)
+              .join('\n')
+            return { html }
+          })(),
+          actions: (() => {
+            if (item.changeLink) {
+              return {
+                items: [
+                  {
+                    href: item.changeLink,
+                    text: 'Change',
+                    attributes: { id: `change-link-${index}` },
+                  },
+                ],
+              }
+            }
+            return null
+          })(),
+        }
+      }),
+    }
+  }
+
   static sortableTable(
     persistentId: string,
     headers: SortableTableHeaders,

--- a/server/views/makeAReferral/checkAnswers.njk
+++ b/server/views/makeAReferral/checkAnswers.njk
@@ -11,43 +11,30 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Check your answers</h1>
 
-      <h2 class="govuk-heading-l">{{ presenter.serviceUserDetailsSection.title }}</h2>
-
+      {{ govukSummaryList(probationPractitionerDetailsSummaryListArgs) }}
+      
       {{ govukSummaryList(serviceUserDetailsSummaryListArgs) }}
 
-      <h2 class="govuk-heading-l">{{ presenter.riskSection.title }}</h2>
-
       {{ govukSummaryList(riskInformationSummaryListArgs) }}
-
-      <h2 class="govuk-heading-l">{{ presenter.needsAndRequirementsSection.title }}</h2>
 
       {{ govukSummaryList(needsAndRequirementsSummaryListArgs) }}
 
       {% if serviceCategoriesSummaryListArgs %}
-        <h2 class="govuk-heading-l">Service categories</h2>
 
         {{ govukSummaryList(serviceCategoriesSummaryListArgs) }}
       {% endif %}
 
-      <h2 class="govuk-heading-l">Sentence information</h2>
 
       {{ govukSummaryList(sentenceInformationSummaryListArgs) }}
 
       {% for section in referralDetailsSections %}
-        <h2 class="govuk-heading-l">{{ section.title }}</h2>
 
         {{ govukSummaryList(section.summaryListArgs) }}
       {% endfor %}
 
-      <h2 class="govuk-heading-l">Enforceable days</h2>
-
       {{ govukSummaryList(enforceableDaysSummaryListArgs) }}
 
-      <h2 class="govuk-heading-l">{{ presenter.completionDeadlineSection.title }}</h2>
-
       {{ govukSummaryList(completionDeadlineSummaryListArgs) }}
-
-      <h2 class="govuk-heading-l">Further information</h2>
 
       {{ govukSummaryList(furtherInformationSummaryListArgs) }}
 

--- a/server/views/makeAReferral/serviceUserDetails.njk
+++ b/server/views/makeAReferral/serviceUserDetails.njk
@@ -1,6 +1,7 @@
 {% extends "../partials/layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = "Make a referral" %}
 {% set pageSubTitle = "The person's information" %}
@@ -8,10 +9,13 @@
 {% block pageContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {{ govukBackLink(backLinkArgs) }}
+      <br>
+      <br>
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>
 
-      {{ govukSummaryList(summaryListArgs) }}
-
+      {{ govukSummaryList(personalDetailsSummaryListArgs) }}
+      {{ govukSummaryList(contactDetailsSummaryListArgs) }} 
       <form method="post">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukButton({ text: "Save and continue" }) }}

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -199,4 +199,11 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   contractTypeName: interventionFactory.build().contractType.name,
   personCurrentLocationType: null,
   personCustodyPrisonId: null,
+  ndeliusPPName: 'Victor Drake',
+  ndeliusPPEmailAddress: 'a.b@xyz.com',
+  ndeliusPDU: 'London',
+  ppName: null,
+  ppEmailAddress: null,
+  ppPdu: null,
+  ppProbationOffice: null,
 }))

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -55,6 +55,13 @@ const exampleReferralFields = () => {
     expectedReleaseDate: moment().add(1, 'days').format('YYYY-MM-DD'),
     expectedReleaseDateMissingReason: null,
     hasExpectedReleaseDate: null,
+    ndeliusPPName: null,
+    ndeliusPPEmailAddress: null,
+    ndeliusPDU: null,
+    ppName: null,
+    ppEmailAddress: null,
+    ppPdu: null,
+    ppProbationOffice: null,
   }
 }
 


### PR DESCRIPTION
## What does this pull request do?

- change the view referral page and check answers page to the new design
- capture the probation practitioner details in the check answers page

## What is the intent behind these changes?

- The designs of the pages got changed in connection with the new requirements of catering different referral types
