### PR TITLE
Minor bugfix to display PDU in referral details for SP

### DIFF
--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -133,7 +133,10 @@ export default class ShowReferralPresenter {
   readonly probationPractitionerDetails: SummaryListItem[] = [
     { key: 'Name', lines: [`${this.sentBy.firstName} ${this.sentBy.surname}`] },
     { key: 'Email address', lines: [this.sentBy.email ?? ''] },
-    { key: 'Probation Office', lines: [this.sentReferral.referral.ppProbationOffice ?? ''] },
+    {
+      key: this.sentReferral.referral.ppProbationOffice != null ? 'Probation Office' : 'PDU',
+      lines: [this.sentReferral.referral.ppProbationOffice ?? this.sentReferral.referral.ndeliusPDU ?? ''],
+    },
   ]
 
   get responsibleOfficersDetails(): SummaryListItem[] {


### PR DESCRIPTION

## What does this pull request do?

Ensures a PDU is displayed in the event that a probation office isn't available

## What is the intent behind these changes?

Ensure SP users know which PDU / region a case is from
