### PR TITLE
Introduce conditional display of PDU

### DIFF
--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -134,8 +134,15 @@ export default class ShowReferralPresenter {
     { key: 'Name', lines: [`${this.sentBy.firstName} ${this.sentBy.surname}`] },
     { key: 'Email address', lines: [this.sentBy.email ?? ''] },
     {
-      key: this.sentReferral.referral.ppProbationOffice != null ? 'Probation Office' : 'PDU',
-      lines: [this.sentReferral.referral.ppProbationOffice ?? this.sentReferral.referral.ndeliusPDU ?? ''],
+      key:
+        this.sentReferral.referral.ppProbationOffice !== null && this.sentReferral.referral.ppProbationOffice !== ''
+          ? 'Probation Office'
+          : 'PDU',
+      lines: [
+        this.sentReferral.referral.ppProbationOffice !== null && this.sentReferral.referral.ppProbationOffice !== ''
+          ? this.sentReferral.referral.ppProbationOffice
+          : this.sentReferral.referral.ndeliusPDU || '',
+      ],
     },
   ]
 


### PR DESCRIPTION
## What does this pull request do?

Display PDU when probation office is null or empty for a PP

Second attempt

## What is the intent behind these changes?

Fix minor bug with initial implementation
