### PR TITLE
New appointment feedback fields

### DIFF
--- a/integration_tests/integration/monitor.cy.js
+++ b/integration_tests/integration/monitor.cy.js
@@ -240,7 +240,7 @@ describe('Probation Practitioner monitor journey', () => {
           {
             'Session details': 'Session 3',
             'Date and time': '10:02am on 31 May 2021',
-            Status: 'awaiting feedback',
+            Status: 'needs feedback',
             Action: '',
           },
           {
@@ -352,7 +352,7 @@ describe('Probation Practitioner monitor journey', () => {
           expect(result[2]).to.deep.include({
             'Session details': 'Session 3',
             'Date and time': '10:02am on 31 Jul 2021',
-            Status: 'awaiting feedback',
+            Status: 'needs feedback',
             Action: '',
           })
           expect(result[3]).to.contains(/^Session 2 history/gi)
@@ -412,13 +412,13 @@ describe('Probation Practitioner monitor journey', () => {
       const appointmentsWithSubmittedFeedback = [
         actionPlanAppointmentFactory.scheduled().build({
           sessionNumber: 1,
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'yes',
-              additionalAttendanceInformation: 'Alex attended the session',
             },
-            behaviour: {
-              behaviourDescription: 'Alex was well-behaved',
+            sessionFeedback: {
+              sessionSummary: 'stub session summary',
+              sessionResponse: 'stub session response',
               notifyProbationPractitioner: false,
             },
             submitted: true,
@@ -443,9 +443,13 @@ describe('Probation Practitioner monitor journey', () => {
       cy.contains('View feedback form').click()
 
       cy.contains('John Smith (john.smith@email.com)')
-      cy.contains('Alex attended the session')
-      cy.contains('Yes, they were on time')
-      cy.contains('Alex was well-behaved')
+      cy.contains('Did Alex River come to the session?')
+      cy.contains('Session Feedback')
+      cy.contains('What did you do in the session?')
+      cy.contains('stub session summary')
+      cy.contains('How did Alex River respond to the session?')
+      cy.contains('stub session response')
+      cy.contains('Did anything concern you about Alex River?')
       cy.contains('No')
     })
   })

--- a/integration_tests/integration/probationPractitionerReferrals.cy.js
+++ b/integration_tests/integration/probationPractitionerReferrals.cy.js
@@ -218,7 +218,7 @@ describe('Probation practitioner referrals dashboard', () => {
               .contains('The appointment has been scheduled by the supplier')
               .next()
               .within(() => {
-                cy.contains('Appointment status').next().contains('awaiting feedback')
+                cy.contains('Appointment status').next().contains('needs feedback')
                 cy.contains('To do').next().contains('View appointment details').click()
                 cy.location('pathname').should(
                   'equal',

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -2561,7 +2561,7 @@ describe('Service provider referrals dashboard', () => {
           const appointmentWithAttendanceFeedback = initialAssessmentAppointmentFactory.build({
             appointmentTime: '2021-03-24T09:02:02Z',
             durationInMinutes: 75,
-            appointmentDeliveryType: 'PHONE_CALL',
+            appointmentDeliveryType: 'VIDEO_CALL',
             appointmentFeedback: {
               attendanceFeedback: {
                 attended: 'no',
@@ -2583,7 +2583,7 @@ describe('Service provider referrals dashboard', () => {
           )
 
           cy.contains('Session Details')
-          cy.contains('The phone call was with caseworker Case Worker at 9:02am on 24 March 2021.')
+          cy.contains('The video call was with caseworker Case Worker at 9:02am on 24 March 2021.')
           cy.contains('Did Alex River come to the session?')
           cy.contains('No')
           cy.contains('Add how you tried to contact Alex River and anything you know about why they did not attend.')

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -1597,7 +1597,9 @@ describe('Service provider referrals dashboard', () => {
       cy.get('form').contains('Confirm').click()
 
       cy.contains('Session feedback added')
-      cy.contains('The probation practitioner will be able to view the feedback in the service.')
+      cy.contains(
+        'The probation practitioner will get an email about Alex River not attending. They’ll also be able to view the feedback in the service.'
+      )
 
       cy.get('[data-cy=session-table]')
         .getTable()
@@ -2621,7 +2623,9 @@ describe('Service provider referrals dashboard', () => {
           cy.get('form').contains('Confirm').click()
 
           cy.contains('Session feedback added')
-          cy.contains('The probation practitioner will be able to view the feedback in the service.')
+          cy.contains(
+            'The probation practitioner will get an email about Alex River not attending. They’ll also be able to view the feedback in the service.'
+          )
 
           cy.location('pathname').should('equal', `/service-provider/referrals/${sentReferral.id}/progress`)
 

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -1159,20 +1159,27 @@ describe('Service provider referrals dashboard', () => {
 
             // Attendance page
             cy.contains('Yes').click()
-            cy.contains("Add additional information about Alex's attendance").type('Alex attended the session')
             cy.contains('Save and continue').click()
 
-            cy.contains('Add behaviour feedback')
-
-            cy.contains("Describe Alex's behaviour in this session").type('Alex was well behaved')
+            cy.contains('What did you do in the session?').type('Discussed accommodation')
+            cy.contains('Add details about what you did, anything that was achieved and what came out of the session.')
+            cy.contains('How did Alex River respond to the session?').type('Engaged well')
+            cy.contains(
+              'Add whether Alex River seemed engaged, including any progress or positive changes. This helps the probation practitioner to support Alex.'
+            )
             cy.get('input[name="notify-probation-practitioner"][value="no"]').click()
 
             cy.contains('Save and continue').click()
 
-            cy.contains('Confirm feedback')
-            cy.contains('Alex attended the session')
+            cy.contains('Confirm session feedback')
+            cy.contains('Session Attendance')
+            cy.contains('Did Alex River come to the session?')
             cy.contains('Yes, they were on time')
-            cy.contains('Alex was well behaved')
+            cy.contains('What did you do in the session?')
+            cy.contains('Discussed accommodation')
+            cy.contains('How did Alex River respond to the session?')
+            cy.contains('Engaged well')
+            cy.contains('Did anything concern you about Alex River?')
             cy.contains('No')
 
             const scheduledAppointment = actionPlanAppointmentFactory.build({
@@ -1183,13 +1190,13 @@ describe('Service provider referrals dashboard', () => {
               appointmentDeliveryType: 'PHONE_CALL',
               appointmentDeliveryAddress: null,
               npsOfficeCode: null,
-              sessionFeedback: {
-                attendance: {
+              appointmentFeedback: {
+                attendanceFeedback: {
                   attended: 'yes',
-                  additionalAttendanceInformation: 'Alex attended the session',
                 },
-                behaviour: {
-                  behaviourDescription: 'Alex was well behaved',
+                sessionFeedback: {
+                  sessionSummary: 'stub session summary',
+                  sessionResponse: 'stub session response',
                   notifyProbationPractitioner: false,
                 },
                 submitted: true,
@@ -1200,13 +1207,45 @@ describe('Service provider referrals dashboard', () => {
                 },
               },
             })
+
+            const accommodationIntervention = interventionFactory.build({
+              contractType: { code: 'SOC', name: 'Social inclusion' },
+              serviceCategories: [serviceCategory],
+            })
+            const serviceProvider = hmppsAuthUserFactory.build({
+              firstName: 'Case',
+              lastName: 'Worker',
+              username: 'case.worker',
+            })
+            const referralParams = {
+              id: '2',
+              referral: { interventionId: accommodationIntervention.id, serviceCategoryIds: [serviceCategory.id] },
+            }
+
+            const assignedReferral = sentReferralFactory.assigned().build({
+              ...referralParams,
+              assignedTo: { username: serviceProvider.username },
+              actionPlanId: actionPlan.id,
+            })
+
+            cy.stubGetApprovedActionPlanSummaries(assignedReferral.id, [
+              { id: actionPlan.id, submittedAt: actionPlan.submittedAt, approvedAt: actionPlan.approvedAt },
+            ])
+            cy.stubGetServiceUserByCRN(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+            cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
+            cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
+            cy.stubGetAuthUserByUsername(serviceProvider.username, serviceProvider)
+            cy.stubGetActionPlan(actionPlan.id, actionPlan)
+            cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+            cy.stubGetActionPlanAppointments(actionPlan.id, [scheduledAppointment])
             cy.stubGetActionPlanAppointment(actionPlan.id, 1, scheduledAppointment)
             cy.stubGetActionPlanAppointment(actionPlan.id, 2, scheduledAppointment)
             cy.stubUpdateActionPlanAppointment(actionPlan.id, 1, scheduledAppointment)
+
             cy.get('form').contains('Confirm').click()
 
-            cy.contains('Session feedback added and submitted to the probation practitioner')
-            cy.contains('You can now deliver the next session scheduled for 24 March 2021.')
+            cy.contains('Session feedback added')
+            cy.contains('The probation practitioner will be able to view the feedback in the service.')
           })
         })
       })
@@ -1269,7 +1308,7 @@ describe('Service provider referrals dashboard', () => {
   })
 
   describe('Recording post session feedback', () => {
-    it('user records the Service user as having attended, and fills out behaviour screen', () => {
+    it('user records the Service user as having attended, and fills out session feedback screen', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const accommodationIntervention = interventionFactory.build({
         contractType: { code: 'SOC', name: 'Social inclusion' },
@@ -1336,36 +1375,35 @@ describe('Service provider referrals dashboard', () => {
 
       const appointmentWithAttendanceRecorded = {
         ...appointments[0],
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'yes',
-            additionalAttendanceInformation: 'Alex attended the session',
           },
         },
       }
 
-      const appointmentWithBehaviourRecorded = {
+      const appointmentWithSessionFeedbackRecorded = {
         ...appointmentWithAttendanceRecorded,
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'yes',
-            additionalAttendanceInformation: 'Alex attended the session',
           },
-          behaviour: {
-            behaviourDescription: 'Alex was well-behaved',
+          sessionFeedback: {
+            sessionSummary: 'Discussed accommodation',
+            sessionResponse: 'Engaged well',
             notifyProbationPractitioner: false,
           },
         },
       }
       const appointmentWithSubmittedFeedback = {
-        ...appointmentWithBehaviourRecorded,
-        sessionFeedback: {
-          attendance: {
+        ...appointmentWithSessionFeedbackRecorded,
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'yes',
-            additionalAttendanceInformation: 'Alex attended the session',
           },
-          behaviour: {
-            behaviourDescription: 'Alex was well-behaved',
+          sessionFeedback: {
+            sessionSummary: 'Discussed accommodation',
+            sessionResponse: 'Engaged well',
             notifyProbationPractitioner: false,
           },
           submitted: true,
@@ -1379,39 +1417,48 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('Give feedback').click()
 
       cy.contains('Yes').click()
-      cy.contains("Add additional information about Alex's attendance").type('Alex attended the session')
 
       cy.stubRecordActionPlanAppointmentAttendance(actionPlan.id, 1, appointmentWithAttendanceRecorded)
 
       cy.contains('Save and continue').click()
 
-      cy.contains('Add behaviour feedback')
+      cy.contains('Add session feedback')
 
-      cy.contains("Describe Alex's behaviour in this session").type('Alex was well behaved')
+      cy.contains('What did you do in the session?').type('Discussed accommodation')
+      cy.contains('Add details about what you did, anything that was achieved and what came out of the session.')
+      cy.contains('How did Alex River respond to the session?').type('Engaged well')
+      cy.contains(
+        'Add whether Alex River seemed engaged, including any progress or positive changes. This helps the probation practitioner to support Alex.'
+      )
+
       cy.get('input[name="notify-probation-practitioner"][value="no"]').click()
 
-      cy.stubRecordActionPlanAppointmentBehavior(actionPlan.id, 1, appointmentWithBehaviourRecorded)
+      cy.stubRecordActionPlanAppointmentSessionFeedback(actionPlan.id, 1, appointmentWithSessionFeedbackRecorded)
 
-      cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointmentWithBehaviourRecorded)
+      cy.stubGetActionPlanAppointment(actionPlan.id, 1, appointmentWithSessionFeedbackRecorded)
 
       cy.contains('Save and continue').click()
 
-      cy.contains('Confirm feedback')
-      cy.contains('Alex attended the session')
+      cy.contains('Confirm session feedback')
+      cy.contains('Session Attendance')
+      cy.contains('Did Alex River come to the session?')
       cy.contains('Yes, they were on time')
-      cy.contains('Alex was well-behaved')
+      cy.contains('What did you do in the session?')
+      cy.contains('Discussed accommodation')
+      cy.contains('How did Alex River respond to the session?')
+      cy.contains('Engaged well')
+      cy.contains('Did anything concern you about Alex River?')
       cy.contains('No')
 
       cy.stubSubmitActionPlanSessionFeedback(actionPlan.id, 1, appointmentWithSubmittedFeedback)
+      const updatedAppointments = [appointmentWithSubmittedFeedback, appointments[1]]
+      cy.stubGetActionPlanAppointments(actionPlan.id, updatedAppointments)
 
       cy.get('form').contains('Confirm').click()
 
-      cy.contains('Session feedback added and submitted to the probation practitioner')
-      cy.contains('You can now deliver the next session scheduled for 31 March 2021.')
+      cy.contains('Session feedback added')
+      cy.contains('The probation practitioner will be able to view the feedback in the service.')
 
-      const updatedAppointments = [appointmentWithSubmittedFeedback, appointments[1]]
-      cy.stubGetActionPlanAppointments(actionPlan.id, updatedAppointments)
-      cy.contains('Return to service progress').click().getTable()
       cy.get('[data-cy=session-table]')
         .getTable()
         .should(result => {
@@ -1425,13 +1472,13 @@ describe('Service provider referrals dashboard', () => {
           expect(result[1]).to.deep.include({
             'Session details': 'Session 2',
             'Date and time': '10:02am on 31 Mar 2021',
-            Status: 'awaiting feedback',
+            Status: 'needs feedback',
           })
           expect(result[1]).to.contains(/^Reschedule session[\n|\t]*Give feedback$/)
         })
     })
 
-    it('user records the Service user as having not attended, and skips behaviour screen', () => {
+    it('user records the Service user as having not attended, and skips session feedback screen', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const intervention = interventionFactory.build({
         contractType: { code: 'ACC', name: 'accommodation' },
@@ -1497,13 +1544,13 @@ describe('Service provider referrals dashboard', () => {
 
       const appointmentWithAttendanceRecorded = {
         ...appointments[0],
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'no',
-            additionalAttendanceInformation: "Alex didn't attend",
           },
-          behaviour: {
-            behaviourDescription: null,
+          sessionFeedback: {
+            sessionSummary: null,
+            sessionResponse: null,
             notifyProbationPractitioner: null,
           },
         },
@@ -1511,13 +1558,13 @@ describe('Service provider referrals dashboard', () => {
 
       const appointmentWithSubmittedFeedback = {
         ...appointmentWithAttendanceRecorded,
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'no',
-            additionalAttendanceInformation: "Alex didn't attend",
           },
-          behaviour: {
-            behaviourDescription: null,
+          sessionFeedback: {
+            sessionSummary: null,
+            sessionConcerns: null,
             notifyProbationPractitioner: null,
           },
           submitted: true,
@@ -1531,7 +1578,6 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('Give feedback').click()
 
       cy.get('input[name="attended"][value="no"]').click()
-      cy.contains("Add additional information about Alex's attendance").type("Alex didn't attend")
 
       cy.stubRecordActionPlanAppointmentAttendance(actionPlan.id, 1, appointmentWithAttendanceRecorded)
 
@@ -1539,21 +1585,19 @@ describe('Service provider referrals dashboard', () => {
 
       cy.contains('Save and continue').click()
 
-      cy.contains('Confirm feedback')
+      cy.contains('Confirm session feedback')
+      cy.contains('The phone call was with caseworker Case Worker at 9:02am on 24 March 2021.')
+      cy.contains('Did Alex River come to the session?')
       cy.contains('No')
-      cy.contains("Alex didn't attend")
 
       cy.stubSubmitActionPlanSessionFeedback(actionPlan.id, 1, appointmentWithSubmittedFeedback)
-
-      cy.get('form').contains('Confirm').click()
-
-      cy.contains('Session feedback added and submitted to the probation practitioner')
-      cy.contains('You can now deliver the next session scheduled for 31 March 2021.')
-
       const updatedAppointments = [appointmentWithSubmittedFeedback, appointments[1]]
       cy.stubGetActionPlanAppointments(actionPlan.id, updatedAppointments)
 
-      cy.contains('Return to service progress').click()
+      cy.get('form').contains('Confirm').click()
+
+      cy.contains('Session feedback added')
+      cy.contains('The probation practitioner will be able to view the feedback in the service.')
 
       cy.get('[data-cy=session-table]')
         .getTable()
@@ -1568,12 +1612,12 @@ describe('Service provider referrals dashboard', () => {
           expect(result[1]).to.deep.include({
             'Session details': 'Session 2',
             'Date and time': '10:02am on 31 Mar 2021',
-            Status: 'awaiting feedback',
+            Status: 'needs feedback',
           })
           expect(result[1]).to.contain(/^Reschedule session[\n|\t]*Give feedback$/)
         })
     })
-    it('user records the Service user as having not attended, and skips behaviour screen with session history', () => {
+    it('user records the Service user as having not attended, and skips session feedback screen with session history', () => {
       const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
       const intervention = interventionFactory.build({
         contractType: { code: 'ACC', name: 'accommodation' },
@@ -1669,14 +1713,14 @@ describe('Service provider referrals dashboard', () => {
           expect(result[0]).to.deep.include({
             'Session details': 'Session 1',
             'Date and time': '9:02am on 24 Mar 2021',
-            Status: 'awaiting feedback',
+            Status: 'needs feedback',
           })
           expect(result[0]).to.contains(/^Reschedule session[\n|\n]*Give feedback$/)
           expect(result[1]).to.contains(/^Session 1 history/gi)
           expect(result[2]).to.deep.include({
             'Session details': 'Session 2',
             'Date and time': '10:02am on 31 Aug 2021',
-            Status: 'awaiting feedback',
+            Status: 'needs feedback',
           })
           expect(result[2]).to.contains(/^Reschedule session[\n|\n]*Give feedback$/)
           expect(result[3]).to.contains(/^Session 2 history/gi)
@@ -1723,13 +1767,13 @@ describe('Service provider referrals dashboard', () => {
     const appointmentsWithSubmittedFeedback = [
       actionPlanAppointmentFactory.scheduled().build({
         sessionNumber: 1,
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'yes',
-            additionalAttendanceInformation: 'Alex attended the session',
           },
-          behaviour: {
-            behaviourDescription: 'Alex was well-behaved',
+          sessionFeedback: {
+            sessionSummary: 'Discussed accommodation',
+            sessionResponse: 'Engaged well',
             notifyProbationPractitioner: false,
           },
           submitted: true,
@@ -1810,9 +1854,16 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('View feedback form').click()
       cy.contains('Current caseworker').next().contains('Case Worker (auth.user@someagency.justice.gov.uk)')
       cy.contains('Feedback submitted by').next().contains('Case Worker (auth.user@someagency.justice.gov.uk)')
-      cy.contains('Alex attended the session')
+      cy.contains('Session Attendance')
+      cy.contains('Session Details')
+      cy.contains('Did Alex River come to the session?')
       cy.contains('Yes, they were on time')
-      cy.contains('Alex was well-behaved')
+      cy.contains('Session Feedback')
+      cy.contains('What did you do in the session?')
+      cy.contains('Discussed accommodation')
+      cy.contains('How did Alex River respond to the session?')
+      cy.contains('Engaged well')
+      cy.contains('Did anything concern you about Alex River?')
       cy.contains('No')
     })
   })
@@ -2123,20 +2174,25 @@ describe('Service provider referrals dashboard', () => {
 
             // Attendance page
             cy.contains('Yes').click()
-            cy.contains("Add additional information about Alex's attendance").type('Alex attended the session')
             cy.contains('Save and continue').click()
 
-            cy.contains('Add behaviour feedback')
+            cy.contains('Add session feedback')
 
-            cy.contains("Describe Alex's behaviour in the assessment appointment").type('Alex was well behaved')
+            cy.contains('What did you do in the session?').type('Discussed his mental health')
+            cy.contains('How did Alex River respond to the session?').type('Engaged well')
             cy.get('input[name="notify-probation-practitioner"][value="no"]').click()
 
             cy.contains('Save and continue').click()
 
-            cy.contains('Confirm feedback')
-            cy.contains('Alex attended the session')
+            cy.contains('Confirm session feedback')
+            cy.contains('Session Attendance')
             cy.contains('Yes, they were on time')
-            cy.contains('Alex was well behaved')
+            cy.contains('Session Feedback')
+            cy.contains('What did you do in the session?')
+            cy.contains('Discussed his mental health')
+            cy.contains('How did Alex River respond to the session?')
+            cy.contains('Engaged well')
+            cy.contains('Did anything concern you about Alex River?')
             cy.contains('No')
 
             const time = new Date()
@@ -2154,14 +2210,14 @@ describe('Service provider referrals dashboard', () => {
                 county: 'Lancashire',
                 postCode: 'SY4 0RE',
               },
-              sessionFeedback: {
-                attendance: {
+              appointmentFeedback: {
+                attendanceFeedback: {
                   attended: 'yes',
-                  additionalAttendanceInformation: 'Alex attended the session',
                 },
-                behaviour: {
-                  behaviourDescription: 'Alex was well behaved',
-                  notifyProbationPractitioner: false,
+                sessionFeedback: {
+                  sessionSummary: 'Discussed accommodation',
+                  sessionResponse: 'Engaged well',
+                  notifyProbationPractitioner: true,
                 },
                 submitted: true,
                 submittedBy: {
@@ -2174,7 +2230,8 @@ describe('Service provider referrals dashboard', () => {
 
             cy.stubScheduleSupplierAssessmentAppointment(supplierAssessment.id, scheduledAppointment)
             cy.get('form').contains('Confirm').click()
-            cy.contains('Initial assessment feedback added')
+            cy.contains('Session feedback added')
+            cy.contains('The probation practitioner will be able to view the feedback in the service.')
           })
         })
         describe('that happened before today', () => {
@@ -2489,7 +2546,7 @@ describe('Service provider referrals dashboard', () => {
             .next()
             .contains('Feedback needs to be added on the same day the assessment is delivered.')
 
-          cy.get('[data-cy=supplier-assessment-table]').contains('awaiting feedback')
+          cy.get('[data-cy=supplier-assessment-table]').contains('needs feedback')
           cy.get('[data-cy=supplier-assessment-table]').contains('Mark attendance and add feedback').click()
           cy.location('pathname').should(
             'equal',
@@ -2497,16 +2554,18 @@ describe('Service provider referrals dashboard', () => {
           )
 
           cy.get('[data-cy=supplier-assessment-attendance-radios]').contains('No').click()
-          cy.contains("Add additional information about Alex's attendance").type('Alex did not attend the session')
+          cy.contains(
+            'Add how you tried to contact Alex River and anything you know about why they did not attend.'
+          ).type('Alex did not answer his phone')
 
           const appointmentWithAttendanceFeedback = initialAssessmentAppointmentFactory.build({
             appointmentTime: '2021-03-24T09:02:02Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'no',
-                additionalAttendanceInformation: 'Alex did not attend the session',
+                attendanceFailureInformation: 'Alex did not answer his phone',
               },
             },
           })
@@ -2523,17 +2582,12 @@ describe('Service provider referrals dashboard', () => {
             `/service-provider/referrals/${sentReferral.id}/supplier-assessment/post-assessment-feedback/check-your-answers`
           )
 
-          cy.contains('24 March 2021')
-          cy.contains('9:02am to 10:17am')
-          cy.contains('Did Alex attend the supplier assessment appointment?')
+          cy.contains('Session Details')
+          cy.contains('The phone call was with caseworker Case Worker at 9:02am on 24 March 2021.')
+          cy.contains('Did Alex River come to the session?')
           cy.contains('No')
-          cy.contains("Add additional information about Alex's attendance:")
-          cy.contains('Alex did not attend the session')
-
-          cy.stubSubmitSupplierAssessmentAppointmentFeedback(sentReferral.id, appointmentWithAttendanceFeedback)
-          cy.get('form').contains('Confirm').click()
-
-          cy.contains('Initial assessment feedback added')
+          cy.contains('Add how you tried to contact Alex River and anything you know about why they did not attend.')
+          cy.contains('Alex did not answer his phone')
 
           const hmppsAuthUser = hmppsAuthUserFactory.build({
             firstName: 'John',
@@ -2545,10 +2599,13 @@ describe('Service provider referrals dashboard', () => {
             appointmentTime: '2021-03-24T09:02:02Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'no',
-                additionalAttendanceInformation: 'Alex did not attend this session',
+              },
+              sessionFeedback: {
+                sessionSummary: 'Discussed accommodation',
+                sessionResponse: 'Engaged well',
               },
               submitted: true,
               submittedBy: { username: hmppsAuthUser.username, userId: hmppsAuthUser.username, authSource: 'auth' },
@@ -2559,7 +2616,13 @@ describe('Service provider referrals dashboard', () => {
             currentAppointmentId: submittedAppointment.id,
           })
           cy.stubGetSupplierAssessment(sentReferral.id, supplierAssessment)
-          cy.contains('Return to progress').click()
+
+          cy.stubSubmitSupplierAssessmentAppointmentFeedback(sentReferral.id, appointmentWithAttendanceFeedback)
+          cy.get('form').contains('Confirm').click()
+
+          cy.contains('Session feedback added')
+          cy.contains('The probation practitioner will be able to view the feedback in the service.')
+
           cy.location('pathname').should('equal', `/service-provider/referrals/${sentReferral.id}/progress`)
 
           cy.contains('Supplier assessment appointment')
@@ -2586,10 +2649,10 @@ describe('Service provider referrals dashboard', () => {
             appointmentTime: '2022-03-24T09:02:02Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'no',
-                additionalAttendanceInformation: 'Alex did not attend the session',
+                attendanceFailureInformation: 'Alex did not answer his phone',
               },
               submitted: true,
               submittedBy: { username: hmppsAuthUser.username, userId: hmppsAuthUser.username, authSource: 'auth' },
@@ -2624,9 +2687,10 @@ describe('Service provider referrals dashboard', () => {
 
           cy.contains('24 March 2022')
           cy.contains('9:02am to 10:17am')
-          cy.contains('Did Alex attend the supplier assessment appointment?')
+          cy.contains('Did Alex River come to the session?')
           cy.contains('No')
-          cy.contains('Alex did not attend the session')
+          cy.contains('Add how you tried to contact Alex River and anything you know about why they did not attend.')
+          cy.contains('Alex did not answer his phone')
 
           cy.contains('Back').click()
 
@@ -2673,7 +2737,7 @@ describe('Service provider referrals dashboard', () => {
       })
 
       describe('when user records the attendance as attended', () => {
-        it('should allow user to add attendance, add behaviour, check their answers and submit the referral', () => {
+        it('should allow user to add attendance, add session feedback, check their answers and submit the referral', () => {
           const appointmentWithNoFeedback = initialAssessmentAppointmentFactory.inThePast.build({
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
@@ -2692,7 +2756,7 @@ describe('Service provider referrals dashboard', () => {
             .next()
             .contains('Feedback needs to be added on the same day the assessment is delivered.')
 
-          cy.get('[data-cy=supplier-assessment-table]').contains('awaiting feedback')
+          cy.get('[data-cy=supplier-assessment-table]').contains('needs feedback')
           cy.get('[data-cy=supplier-assessment-table]').contains('Mark attendance and add feedback').click()
 
           cy.location('pathname').should(
@@ -2700,7 +2764,6 @@ describe('Service provider referrals dashboard', () => {
             `/service-provider/referrals/${sentReferral.id}/supplier-assessment/post-assessment-feedback/attendance`
           )
           cy.contains('Yes').click()
-          cy.contains("Add additional information about Alex's attendance").type('Alex attended the session')
 
           const appointmentWithAttendanceFeedback = initialAssessmentAppointmentFactory.build({
             appointmentTime: '2021-03-24T09:02:02Z',
@@ -2726,66 +2789,67 @@ describe('Service provider referrals dashboard', () => {
             `/service-provider/referrals/${sentReferral.id}/supplier-assessment/post-assessment-feedback/behaviour`
           )
 
-          cy.contains("Describe Alex's behaviour in the assessment appointment").type(
+          cy.contains('What did you do in the session?').type('Discussed his mental health')
+          cy.contains('How did Alex River respond to the session?').type("Wasn't engaged")
+          cy.contains('Did anything concern you about Alex River?')
+          cy.contains('Yes').click()
+          cy.contains('Add enough detail to help the probation practitioner to know what happened').type(
             'Alex was acting very suspicious.'
           )
-          cy.contains('Yes').click()
 
-          const appointmentWithBehaviourFeedback = initialAssessmentAppointmentFactory.build({
+          const appointmentWithSessionFeedback = initialAssessmentAppointmentFactory.build({
             appointmentTime: '2021-03-24T09:02:02Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'yes',
-                additionalAttendanceInformation: 'Alex attended the session',
               },
-              behaviour: {
-                behaviourDescription: 'Alex was acting very suspicious.',
+              sessionFeedback: {
+                sessionSummary: 'Discussed his mental health',
+                sessionResponse: "Wasn't engaged",
+                sessionConcerns: 'Alex was acting very suspicious.',
                 notifyProbationPractitioner: true,
               },
             },
           })
           supplierAssessment = supplierAssessmentFactory.build({
-            appointments: [appointmentWithBehaviourFeedback],
-            currentAppointmentId: appointmentWithBehaviourFeedback.id,
+            appointments: [appointmentWithSessionFeedback],
+            currentAppointmentId: appointmentWithSessionFeedback.id,
           })
 
           cy.stubGetSupplierAssessment(sentReferral.id, supplierAssessment)
-          cy.stubRecordSupplierAssessmentAppointmentBehaviour(sentReferral.id, appointmentWithBehaviourFeedback)
+          cy.stubRecordSupplierAssessmentAppointmentSessionFeedback(sentReferral.id, appointmentWithSessionFeedback)
 
           cy.contains('Save and continue').click()
           cy.location('pathname').should(
             'equal',
             `/service-provider/referrals/${sentReferral.id}/supplier-assessment/post-assessment-feedback/check-your-answers`
           )
-          cy.contains('24 March 2021')
-          cy.contains('9:02am to 10:17am')
-          cy.contains('Did Alex attend the supplier assessment appointment?')
+          cy.contains('Session Attendance')
+          cy.contains('Session Details')
+          cy.contains('The phone call was with caseworker Case Worker at 9:02am on 24 March 2021.')
+          cy.contains('Did Alex River come to the session?')
           cy.contains('Yes, they were on time')
-          cy.contains("Add additional information about Alex's attendance:")
-          cy.contains('Alex attended the session')
-          cy.contains("Describe Alex's behaviour in the assessment appointment")
-          cy.contains('Alex was acting very suspicious.')
-          cy.contains('If you described poor behaviour, do you want to notify the probation practitioner?')
-          cy.contains('Yes')
-
-          cy.stubSubmitSupplierAssessmentAppointmentFeedback(sentReferral.id, appointmentWithBehaviourFeedback)
-          cy.get('form').contains('Confirm').click()
-
-          cy.contains('Initial assessment feedback added')
+          cy.contains('Session Feedback')
+          cy.contains('What did you do in the session?')
+          cy.contains('Discussed his mental health')
+          cy.contains('How did Alex River respond to the session?')
+          cy.contains("Wasn't engaged")
+          cy.contains('Did anything concern you about Alex River?')
+          cy.contains('Yes - Alex was acting very suspicious.')
 
           const submittedAppointment = initialAssessmentAppointmentFactory.build({
             appointmentTime: '2021-03-24T09:02:02Z',
             durationInMinutes: 75,
             appointmentDeliveryType: 'PHONE_CALL',
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'yes',
-                additionalAttendanceInformation: 'Alex attended the session',
               },
-              behaviour: {
-                behaviourDescription: 'Alex was acting very suspicious.',
+              sessionFeedback: {
+                sessionSummary: 'Discussed accommodation',
+                sessionResponse: 'Engaged well',
                 notifyProbationPractitioner: true,
               },
               submitted: true,
@@ -2796,7 +2860,12 @@ describe('Service provider referrals dashboard', () => {
             currentAppointmentId: submittedAppointment.id,
           })
           cy.stubGetSupplierAssessment(sentReferral.id, supplierAssessment)
-          cy.contains('Return to progress').click()
+
+          cy.stubSubmitSupplierAssessmentAppointmentFeedback(sentReferral.id, appointmentWithSessionFeedback)
+          cy.get('form').contains('Confirm').click()
+
+          cy.contains('Session feedback added')
+
           cy.location('pathname').should('equal', `/service-provider/referrals/${sentReferral.id}/progress`)
 
           cy.contains('Supplier assessment appointment')

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -174,8 +174,8 @@ export default on => {
       )
     },
 
-    stubRecordActionPlanAppointmentBehavior: arg => {
-      return interventionsService.stubRecordActionPlanAppointmentBehavior(
+    stubRecordActionPlanAppointmentSessionFeedback: arg => {
+      return interventionsService.stubRecordActionPlanAppointmentSessionFeedback(
         arg.actionPlanId,
         arg.sessionNumber,
         arg.responseJson
@@ -238,8 +238,11 @@ export default on => {
       return interventionsService.stubRecordSupplierAssessmentAppointmentAttendance(arg.referralId, arg.responseJson)
     },
 
-    stubRecordSupplierAssessmentAppointmentBehaviour: arg => {
-      return interventionsService.stubRecordSupplierAssessmentAppointmentBehaviour(arg.referralId, arg.responseJson)
+    stubRecordSupplierAssessmentAppointmentSessionFeedback: arg => {
+      return interventionsService.stubRecordSupplierAssessmentAppointmentSessionFeedback(
+        arg.referralId,
+        arg.responseJson
+      )
     },
 
     stubGetSupplierAssessment: arg => {

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -98,8 +98,8 @@ Cypress.Commands.add('stubRecordActionPlanAppointmentAttendance', (actionPlanId,
   cy.task('stubRecordActionPlanAppointmentAttendance', { actionPlanId, sessionNumber, responseJson })
 })
 
-Cypress.Commands.add('stubRecordActionPlanAppointmentBehavior', (actionPlanId, sessionNumber, responseJson) => {
-  cy.task('stubRecordActionPlanAppointmentBehavior', { actionPlanId, sessionNumber, responseJson })
+Cypress.Commands.add('stubRecordActionPlanAppointmentSessionFeedback', (actionPlanId, sessionNumber, responseJson) => {
+  cy.task('stubRecordActionPlanAppointmentSessionFeedback', { actionPlanId, sessionNumber, responseJson })
 })
 
 Cypress.Commands.add('stubGetActionPlanAppointments', (id, responseJson) => {
@@ -150,8 +150,8 @@ Cypress.Commands.add('stubRecordSupplierAssessmentAppointmentAttendance', (refer
   cy.task('stubRecordSupplierAssessmentAppointmentAttendance', { referralId, responseJson })
 })
 
-Cypress.Commands.add('stubRecordSupplierAssessmentAppointmentBehaviour', (referralId, responseJson) => {
-  cy.task('stubRecordSupplierAssessmentAppointmentBehaviour', { referralId, responseJson })
+Cypress.Commands.add('stubRecordSupplierAssessmentAppointmentSessionFeedback', (referralId, responseJson) => {
+  cy.task('stubRecordSupplierAssessmentAppointmentSessionFeedback', { referralId, responseJson })
 })
 
 Cypress.Commands.add('stubGetSupplierAssessment', (referralId, responseJson) => {

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -403,7 +403,7 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubRecordActionPlanAppointmentBehavior = async (
+  stubRecordActionPlanAppointmentSessionFeedback = async (
     actionPlanId: string,
     sessionNumber: string,
     responseJson: unknown
@@ -411,7 +411,7 @@ export default class InterventionsServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'POST',
-        urlPattern: `${this.mockPrefix}/action-plan/${actionPlanId}/appointment/${sessionNumber}/record-behaviour`,
+        urlPattern: `${this.mockPrefix}/action-plan/${actionPlanId}/appointment/${sessionNumber}/record-session-feedback`,
       },
       response: {
         status: 200,
@@ -622,14 +622,14 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubRecordSupplierAssessmentAppointmentBehaviour = async (
+  stubRecordSupplierAssessmentAppointmentSessionFeedback = async (
     referralId: string,
     responseJson: unknown
   ): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'PUT',
-        urlPattern: `${this.mockPrefix}/referral/${referralId}/supplier-assessment/record-behaviour`,
+        urlPattern: `${this.mockPrefix}/referral/${referralId}/supplier-assessment/record-session-feedback`,
       },
       response: {
         status: 200,

--- a/server/models/appointment.ts
+++ b/server/models/appointment.ts
@@ -1,7 +1,8 @@
 import Address from './address'
 import { AppointmentDeliveryType } from './appointmentDeliveryType'
-import SessionFeedback from './sessionFeedback'
+import SessionFeedback from './appointmentFeedback'
 import { SessionType } from './sessionType'
+import AppointmentFeedback from "./appointmentFeedback";
 
 export interface InitialAssessmentAppointment extends Appointment {
   id: string
@@ -14,7 +15,7 @@ export interface ActionPlanAppointment extends Appointment {
 
 interface Appointment extends AppointmentSchedulingDetails {
   id?: string
-  sessionFeedback: SessionFeedback
+  appointmentFeedback: AppointmentFeedback
 }
 
 export interface AppointmentSchedulingDetails {

--- a/server/models/appointment.ts
+++ b/server/models/appointment.ts
@@ -1,8 +1,7 @@
 import Address from './address'
 import { AppointmentDeliveryType } from './appointmentDeliveryType'
-import SessionFeedback from './appointmentFeedback'
 import { SessionType } from './sessionType'
-import AppointmentFeedback from "./appointmentFeedback";
+import AppointmentFeedback from './appointmentFeedback'
 
 export interface InitialAssessmentAppointment extends Appointment {
   id: string

--- a/server/models/appointmentAttendance.ts
+++ b/server/models/appointmentAttendance.ts
@@ -2,5 +2,6 @@ export type Attended = 'yes' | 'no' | 'late' | null
 
 export default interface AppointmentAttendance {
   attended: Attended
-  additionalAttendanceInformation: string | null
+  additionalAttendanceInformation?: string | null
+  attendanceFailureInformation: string | null
 }

--- a/server/models/appointmentBehaviour.ts
+++ b/server/models/appointmentBehaviour.ts
@@ -1,7 +1,0 @@
-export default interface AppointmentBehaviour {
-  behaviourDescription: string | null //deprecated
-  notifyProbationPractitioner: boolean | null
-  sessionSummary: string | null
-  sessionResponse: string | null
-  sessionConcerns: string | null
-}

--- a/server/models/appointmentBehaviour.ts
+++ b/server/models/appointmentBehaviour.ts
@@ -1,4 +1,7 @@
 export default interface AppointmentBehaviour {
-  behaviourDescription: string | null
+  behaviourDescription: string | null //deprecated
   notifyProbationPractitioner: boolean | null
+  sessionSummary: string | null
+  sessionResponse: string | null
+  sessionConcerns: string | null
 }

--- a/server/models/appointmentFeedback.ts
+++ b/server/models/appointmentFeedback.ts
@@ -1,6 +1,6 @@
 import AppointmentAttendance from './appointmentAttendance'
 import User from './hmppsAuth/user'
-import SessionFeedback from "./sessionFeedback";
+import SessionFeedback from './sessionFeedback'
 
 export default interface AppointmentFeedback {
   attendanceFeedback: AppointmentAttendance

--- a/server/models/appointmentFeedback.ts
+++ b/server/models/appointmentFeedback.ts
@@ -1,0 +1,10 @@
+import AppointmentAttendance from './appointmentAttendance'
+import User from './hmppsAuth/user'
+import SessionFeedback from "./sessionFeedback";
+
+export default interface AppointmentFeedback {
+  attendanceFeedback: AppointmentAttendance
+  sessionFeedback: SessionFeedback
+  submitted: boolean
+  submittedBy: User | null
+}

--- a/server/models/sessionFeedback.ts
+++ b/server/models/sessionFeedback.ts
@@ -3,4 +3,5 @@ export default interface SessionFeedback {
   sessionSummary: string | null
   sessionResponse: string | null
   sessionConcerns: string | null
+  behaviourDescription?: string | null //deprecated
 }

--- a/server/models/sessionFeedback.ts
+++ b/server/models/sessionFeedback.ts
@@ -3,5 +3,5 @@ export default interface SessionFeedback {
   sessionSummary: string | null
   sessionResponse: string | null
   sessionConcerns: string | null
-  behaviourDescription?: string | null //deprecated
+  behaviourDescription?: string | null
 }

--- a/server/models/sessionFeedback.ts
+++ b/server/models/sessionFeedback.ts
@@ -1,10 +1,6 @@
-import AppointmentAttendance from './appointmentAttendance'
-import AppointmentBehaviour from './appointmentBehaviour'
-import User from './hmppsAuth/user'
-
 export default interface SessionFeedback {
-  attendance: AppointmentAttendance
-  behaviour: AppointmentBehaviour
-  submitted: boolean
-  submittedBy: User | null
+  notifyProbationPractitioner: boolean | null
+  sessionSummary: string | null
+  sessionResponse: string | null
+  sessionConcerns: string | null
 }

--- a/server/routes/appointments/appointmentSummary.test.ts
+++ b/server/routes/appointments/appointmentSummary.test.ts
@@ -3,6 +3,9 @@ import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 import { AppointmentDeliveryType } from '../../models/appointmentDeliveryType'
 import AppointmentSummary from './appointmentSummary'
 import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
+import CalendarDay from '../../utils/calendarDay'
+import ClockTime from '../../utils/clockTime'
+import DateUtils from '../../utils/dateUtils'
 
 describe(AppointmentSummary, () => {
   describe('appointmentDetails', () => {
@@ -48,6 +51,28 @@ describe(AppointmentSummary, () => {
         const summaryComponent = new AppointmentSummary(appointment, null)
 
         expect(summaryComponent.appointmentSummaryList[2]).toEqual({ key: 'Method', lines: [expectedDisplayValue] })
+      })
+
+      it('contains the session details of the appointment', () => {
+        const appointment = initialAssessmentAppointmentFactory.build({ appointmentDeliveryType: deliveryType })
+        const summaryComponent = new AppointmentSummary(
+          appointment,
+          hmppsAuthUserFactory.build({
+            firstName: 'firstName',
+            lastName: 'lastName',
+            email: 'email',
+          })
+        )
+
+        const day = CalendarDay.britishDayForDate(new Date(appointment.appointmentTime!))
+        const formattedDay = DateUtils.formattedDate(day)
+        const time = ClockTime.britishTimeForDate(new Date(appointment.appointmentTime!))
+        const formattedTime = DateUtils.formattedTime(time)
+
+        expect(summaryComponent.sessionDetails).toEqual({
+          question: `Session Details`,
+          answer: `The ${expectedDisplayValue.toLowerCase()} was with caseworker firstName lastName at ${formattedTime} on ${formattedDay}.`,
+        })
       })
     })
 

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -6,6 +6,7 @@ import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
 import DateUtils from '../../utils/dateUtils'
 import { AppointmentSchedulingDetails } from '../../models/appointment'
 import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
+import ViewUtils from "../../utils/viewUtils";
 
 export default class AppointmentSummary {
   constructor(
@@ -100,5 +101,17 @@ export default class AppointmentSummary {
       address.county,
       address.postCode,
     ].flatMap(val => (val === null ? [] : [val]))
+  }
+
+  get sessionDetails(): { question: string; answer: string }{
+    const date = DateUtils.formattedDate(this.appointmentDecorator.britishDay!);
+    const time =  DateUtils.formattedTime(this.appointmentDecorator.britishTime!)
+    const caseworkerName = this.assignedCaseworker instanceof String ? this.assignedCaseworker :
+        `${(<AuthUserDetails>this.assignedCaseworker).firstName} ${(<AuthUserDetails>this.assignedCaseworker).lastName}`
+
+    return {
+      question: `Session Details`,
+      answer: `The phone call was with caseworker ${caseworkerName} at ${time} on ${date}.`,
+    }
   }
 }

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -106,10 +106,13 @@ export default class AppointmentSummary {
     const date = DateUtils.formattedDate(this.appointmentDecorator.britishDay!)
     const time = DateUtils.formattedTime(this.appointmentDecorator.britishTime!)
     const caseworkerName = this.assignedCaseworker ? this.caseworkerName() : ''
+    const deliveryMethod = this.appointment.appointmentDeliveryType
+      ? this.deliveryMethod(this.appointment.appointmentDeliveryType).toLowerCase()
+      : ''
 
     return {
       question: `Session Details`,
-      answer: `The phone call was with caseworker ${caseworkerName} at ${time} on ${date}.`,
+      answer: `The ${deliveryMethod} was with caseworker ${caseworkerName} at ${time} on ${date}.`,
     }
   }
 

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -105,16 +105,17 @@ export default class AppointmentSummary {
   get sessionDetails(): { question: string; answer: string } {
     const date = DateUtils.formattedDate(this.appointmentDecorator.britishDay!)
     const time = DateUtils.formattedTime(this.appointmentDecorator.britishTime!)
-    const caseworkerName =
-      this.assignedCaseworker instanceof String
-        ? this.assignedCaseworker
-        : `${(<AuthUserDetails>this.assignedCaseworker).firstName} ${
-            (<AuthUserDetails>this.assignedCaseworker).lastName
-          }`
+    const caseworkerName = this.assignedCaseworker ? this.caseworkerName() : ''
 
     return {
       question: `Session Details`,
       answer: `The phone call was with caseworker ${caseworkerName} at ${time} on ${date}.`,
     }
+  }
+
+  private caseworkerName(): string {
+    return typeof this.assignedCaseworker === 'string'
+      ? this.assignedCaseworker
+      : `${(<AuthUserDetails>this.assignedCaseworker).firstName} ${(<AuthUserDetails>this.assignedCaseworker).lastName}`
   }
 }

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -6,7 +6,6 @@ import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
 import DateUtils from '../../utils/dateUtils'
 import { AppointmentSchedulingDetails } from '../../models/appointment'
 import AuthUserDetails from '../../models/hmppsAuth/authUserDetails'
-import ViewUtils from "../../utils/viewUtils";
 
 export default class AppointmentSummary {
   constructor(
@@ -103,11 +102,15 @@ export default class AppointmentSummary {
     ].flatMap(val => (val === null ? [] : [val]))
   }
 
-  get sessionDetails(): { question: string; answer: string }{
-    const date = DateUtils.formattedDate(this.appointmentDecorator.britishDay!);
-    const time =  DateUtils.formattedTime(this.appointmentDecorator.britishTime!)
-    const caseworkerName = this.assignedCaseworker instanceof String ? this.assignedCaseworker :
-        `${(<AuthUserDetails>this.assignedCaseworker).firstName} ${(<AuthUserDetails>this.assignedCaseworker).lastName}`
+  get sessionDetails(): { question: string; answer: string } {
+    const date = DateUtils.formattedDate(this.appointmentDecorator.britishDay!)
+    const time = DateUtils.formattedTime(this.appointmentDecorator.britishTime!)
+    const caseworkerName =
+      this.assignedCaseworker instanceof String
+        ? this.assignedCaseworker
+        : `${(<AuthUserDetails>this.assignedCaseworker).firstName} ${
+            (<AuthUserDetails>this.assignedCaseworker).lastName
+          }`
 
     return {
       question: `Session Details`,

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -1115,6 +1115,7 @@ describe('Adding supplier assessment feedback', () => {
       const deliusServiceUser = deliusServiceUserFactory.build()
       const referral = sentReferralFactory.assigned().build()
       const appointment = initialAssessmentAppointmentFactory.build({
+        appointmentDeliveryType: 'IN_PERSON_MEETING_PROBATION_OFFICE',
         appointmentTime: '2021-02-01T13:00:00Z',
         appointmentFeedback: {
           attendanceFeedback: {
@@ -1151,7 +1152,7 @@ describe('Adding supplier assessment feedback', () => {
         .expect(res => {
           expect(res.text).toContain('Session Details')
           expect(res.text).toContain(
-            'The phone call was with caseworker caseworkerFirstName caseworkerLastName at 1:00pm on 1 February 2021.'
+            'The in-person meeting (probation office) was with caseworker caseworkerFirstName caseworkerLastName at 1:00pm on 1 February 2021.'
           )
           expect(res.text).toContain('Confirm session feedback')
           expect(res.text).toContain('Did Alex River come to the session?')
@@ -1623,9 +1624,7 @@ describe('Adding post delivery session feedback', () => {
 
           const actionPlan = actionPlanFactory.build()
 
-          const draftAppointment: DraftAppointment = draftAppointmentFactory
-            .withAttendanceFeedback('no', "I haven't heard from Alex")
-            .build()
+          const draftAppointment: DraftAppointment = draftAppointmentFactory.withAttendanceFeedback('no').build()
 
           const draftAppointmentResult = draftAppointmentBookingFactory.build({
             data: draftAppointment,

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -2013,7 +2013,7 @@ describe('Adding post delivery session feedback', () => {
             sessionType: draftAppointment!.sessionType,
             appointmentDeliveryAddress: draftAppointment!.appointmentDeliveryAddress,
             npsOfficeCode: draftAppointment!.npsOfficeCode,
-            appointmentAttendance: { ...draftAppointment!.session!.attendance },
+            appointmentAttendance: { ...draftAppointment!.session!.attendanceFeedback },
             // appointmentBehaviour: { ...draftAppointment!.session!.behaviour },
           }
         )

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -496,13 +496,15 @@ describe('viewing supplier assessment feedback', () => {
         const referral = sentReferralFactory.assigned().build()
         const appointment = initialAssessmentAppointmentFactory.build({
           appointmentTime: '2021-02-01T13:00:00Z',
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'yes',
               additionalAttendanceInformation: 'He was punctual',
             },
-            behaviour: {
-              behaviourDescription: 'Acceptable',
+            sessionFeedback: {
+              sessionSummary: '',
+              sessionResponse: '',
+              sessionConcerns: '',
             },
             submitted: false,
           },
@@ -903,8 +905,8 @@ describe('Adding supplier assessment feedback', () => {
         const appointment = initialAssessmentAppointmentFactory.build()
         const updatedAppointment = initialAssessmentAppointmentFactory.build({
           ...appointment,
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'yes',
               additionalAttendanceInformation: 'Alex made the session on time',
             },
@@ -939,8 +941,8 @@ describe('Adding supplier assessment feedback', () => {
         const appointment = initialAssessmentAppointmentFactory.build()
         const updatedAppointment = initialAssessmentAppointmentFactory.build({
           ...appointment,
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'no',
               additionalAttendanceInformation: "I haven't heard from Alex",
             },
@@ -1043,10 +1045,11 @@ describe('Adding supplier assessment feedback', () => {
         const appointment = initialAssessmentAppointmentFactory.build()
         const updatedAppointment = initialAssessmentAppointmentFactory.build({
           ...appointment,
-          sessionFeedback: {
-            behaviour: {
-              behaviourDescription: 'They were very respectful and polite.',
-              notifyProbationPractitioner: false,
+          appointmentFeedback: {
+            sessionFeedback: {
+              sessionSummary: '',
+              sessionResponse: '',
+              sessionConcerns: '',
             },
           },
         })
@@ -1098,13 +1101,15 @@ describe('Adding supplier assessment feedback', () => {
       const referral = sentReferralFactory.assigned().build()
       const appointment = initialAssessmentAppointmentFactory.build({
         appointmentTime: '2021-02-01T13:00:00Z',
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'yes',
             additionalAttendanceInformation: 'He was punctual',
           },
-          behaviour: {
-            behaviourDescription: 'Acceptable',
+          sessionFeedback: {
+            sessionSummary: '',
+            sessionResponse: '',
+            sessionConcerns: '',
           },
           submitted: false,
         },
@@ -1216,13 +1221,15 @@ describe('Adding supplier assessment feedback', () => {
       const referral = sentReferralFactory.assigned().build()
       const appointment = initialAssessmentAppointmentFactory.build({
         appointmentTime: '2021-02-01T13:00:00Z',
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'yes',
             additionalAttendanceInformation: 'He was punctual',
           },
-          behaviour: {
-            behaviourDescription: 'Acceptable',
+          sessionFeedback: {
+            sessionSummary: '',
+            sessionResponse: '',
+            sessionConcerns: '',
           },
           submitted: false,
         },
@@ -1271,8 +1278,8 @@ describe('Adding supplier assessment feedback', () => {
       const referral = sentReferralFactory.assigned().build()
       const appointment = initialAssessmentAppointmentFactory.build({
         appointmentTime: '2021-02-01T13:00:00Z',
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'no',
             additionalAttendanceInformation: 'They missed the bus',
           },
@@ -1431,8 +1438,8 @@ describe('Adding post delivery session feedback', () => {
       it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the behaviour page', async () => {
         const updatedAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 1,
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'yes',
               additionalAttendanceInformation: 'Alex made the session on time',
             },
@@ -1464,8 +1471,8 @@ describe('Adding post delivery session feedback', () => {
       it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the check-your-answers page', async () => {
         const updatedAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 1,
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'no',
               additionalAttendanceInformation: "I haven't heard from Alex",
             },
@@ -1500,8 +1507,8 @@ describe('Adding post delivery session feedback', () => {
         it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the behaviour page', async () => {
           const updatedAppointment = actionPlanAppointmentFactory.build({
             sessionNumber: 1,
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'yes',
                 additionalAttendanceInformation: 'Alex made the session on time',
               },
@@ -1540,8 +1547,8 @@ describe('Adding post delivery session feedback', () => {
         it('makes a request to the interventions service to record the Service user‘s attendance and redirects to the check-your-answers page', async () => {
           const updatedAppointment = actionPlanAppointmentFactory.build({
             sessionNumber: 1,
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'no',
                 additionalAttendanceInformation: "I haven't heard from Alex",
               },
@@ -1585,8 +1592,8 @@ describe('Adding post delivery session feedback', () => {
       it('renders a no longer available page', async () => {
         const updatedAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 1,
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'yes',
               additionalAttendanceInformation: 'Alex made the session on time',
             },
@@ -1728,10 +1735,11 @@ describe('Adding post delivery session feedback', () => {
     it('makes a request to the interventions service to record the Service user‘s behaviour and redirects to the check your answers page', async () => {
       const updatedAppointment = actionPlanAppointmentFactory.build({
         sessionNumber: 1,
-        sessionFeedback: {
-          behaviour: {
-            behaviourDescription: 'Alex was well-behaved',
-            notifyProbationPractitioner: false,
+        appointmentFeedback: {
+          sessionFeedback: {
+            sessionSummary: '',
+            sessionResponse: '',
+            sessionConcerns: '',
           },
         },
       })
@@ -1762,10 +1770,11 @@ describe('Adding post delivery session feedback', () => {
       it('makes a request to the interventions service to record the Service user‘s behaviour and redirects to the check your answers page', async () => {
         const updatedAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 1,
-          sessionFeedback: {
-            behaviour: {
-              behaviourDescription: 'Alex was well-behaved',
-              notifyProbationPractitioner: false,
+          appointmentFeedback: {
+            sessionFeedback: {
+              sessionSummary: '',
+              sessionResponse: '',
+              sessionConcerns: '',
             },
           },
         })
@@ -1802,10 +1811,11 @@ describe('Adding post delivery session feedback', () => {
       it('renders a no longer available page', async () => {
         const updatedAppointment = actionPlanAppointmentFactory.build({
           sessionNumber: 1,
-          sessionFeedback: {
-            behaviour: {
-              behaviourDescription: 'Alex was well-behaved',
-              notifyProbationPractitioner: false,
+          appointmentFeedback: {
+            sessionFeedback: {
+              sessionSummary: '',
+              sessionResponse: '',
+              sessionConcerns: '',
             },
           },
         })
@@ -2003,8 +2013,8 @@ describe('Adding post delivery session feedback', () => {
             sessionType: draftAppointment!.sessionType,
             appointmentDeliveryAddress: draftAppointment!.appointmentDeliveryAddress,
             npsOfficeCode: draftAppointment!.npsOfficeCode,
-            appointmentAttendance: { ...draftAppointment!.sessionFeedback!.attendance },
-            appointmentBehaviour: { ...draftAppointment!.sessionFeedback!.behaviour },
+            appointmentAttendance: { ...draftAppointment!.session!.attendance },
+            // appointmentBehaviour: { ...draftAppointment!.session!.behaviour },
           }
         )
       })
@@ -2171,14 +2181,15 @@ describe('Adding post delivery session feedback', () => {
             durationInMinutes: 60,
             appointmentDeliveryType: 'PHONE_CALL',
             sessionNumber: 1,
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'yes',
                 additionalAttendanceInformation: 'They were early to the session',
               },
-              behaviour: {
-                behaviourDescription: 'Alex was well-behaved',
-                notifyProbationPractitioner: false,
+              sessionFeedback: {
+                sessionSummary: '',
+                sessionResponse: '',
+                sessionConcerns: '',
               },
               submitted: true,
             },
@@ -2222,14 +2233,15 @@ describe('Adding post delivery session feedback', () => {
             durationInMinutes: 60,
             appointmentDeliveryType: 'PHONE_CALL',
             sessionNumber: 1,
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'yes',
                 additionalAttendanceInformation: 'They were early to the session',
               },
-              behaviour: {
-                behaviourDescription: 'Alex was well-behaved',
-                notifyProbationPractitioner: false,
+              sessionFeedback: {
+                sessionSummary: '',
+                sessionResponse: '',
+                sessionConcerns: '',
               },
               submitted: true,
             },
@@ -2283,14 +2295,15 @@ describe('Adding post delivery session feedback', () => {
             durationInMinutes: 60,
             appointmentDeliveryType: 'PHONE_CALL',
             sessionNumber: 1,
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'yes',
                 additionalAttendanceInformation: 'They were early to the session',
               },
-              behaviour: {
-                behaviourDescription: 'Alex was well-behaved',
-                notifyProbationPractitioner: false,
+              sessionFeedback: {
+                sessionSummary: '',
+                sessionResponse: '',
+                sessionConcerns: '',
               },
               submitted: true,
             },

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -871,8 +871,8 @@ describe('Adding supplier assessment feedback', () => {
         .get(`/service-provider/referrals/${referral.id}/supplier-assessment/post-assessment-feedback/attendance`)
         .expect(200)
         .expect(res => {
-          expect(res.text).toContain('Add feedback')
-          expect(res.text).toContain('Appointment details')
+          expect(res.text).toContain('Add attendance feedback')
+          expect(res.text).toContain('Session details')
           expect(res.text).toContain('1 February 2021')
           expect(res.text).toContain('1:00pm to 2:00pm')
         })
@@ -1058,7 +1058,7 @@ describe('Adding supplier assessment feedback', () => {
           currentAppointmentId: appointment.id,
         })
         interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessment)
-        interventionsService.recordSupplierAssessmentAppointmentBehaviour.mockResolvedValue(updatedAppointment)
+        interventionsService.recordSupplierAssessmentAppointmentSessionFeedback.mockResolvedValue(updatedAppointment)
         await request(app)
           .post(`/service-provider/referrals/${referral.id}/supplier-assessment/post-assessment-feedback/behaviour`)
           .type('form')

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -717,8 +717,11 @@ export default class AppointmentsController {
       await this.interventionsService.submitSupplierAssessmentAppointmentFeedback(accessToken, referralId)
     }
     const notifyPP = appointment.appointmentFeedback.sessionFeedback.notifyProbationPractitioner
+    const didNotAttend = appointment.appointmentFeedback.attendanceFeedback.attended === 'no'
 
-    res.redirect(`/service-provider/referrals/${referralId}/progress?showFeedbackBanner=true&notifyPP=${notifyPP}`)
+    res.redirect(
+      `/service-provider/referrals/${referralId}/progress?showFeedbackBanner=true&notifyPP=${notifyPP}&dna=${didNotAttend}`
+    )
   }
 
   async viewSupplierAssessmentFeedback(
@@ -1028,9 +1031,10 @@ export default class AppointmentsController {
       await this.interventionsService.submitActionPlanSessionFeedback(accessToken, actionPlanId, Number(sessionNumber))
     }
     const notifyPP = appointment.appointmentFeedback.sessionFeedback.notifyProbationPractitioner
+    const didNotAttend = appointment.appointmentFeedback.attendanceFeedback.attended === 'no'
 
     res.redirect(
-      `/service-provider/referrals/${actionPlan.referralId}/progress?showFeedbackBanner=true&notifyPP=${notifyPP}`
+      `/service-provider/referrals/${actionPlan.referralId}/progress?showFeedbackBanner=true&notifyPP=${notifyPP}&dna=${didNotAttend}`
     )
   }
 

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -722,23 +722,24 @@ export default class AppointmentsController {
     } else {
       await this.interventionsService.submitSupplierAssessmentAppointmentFeedback(accessToken, referralId)
     }
+    const notifyPP = appointment.appointmentFeedback.sessionFeedback.notifyProbationPractitioner
 
-    res.redirect(`/service-provider/referrals/${referralId}/supplier-assessment/post-assessment-feedback/confirmation`)
+    res.redirect(`/service-provider/referrals/${referralId}/progress?showFeedbackBanner=true&notifyPP=${notifyPP}`)
   }
 
-  async showSupplierAssessmentFeedbackConfirmation(req: Request, res: Response): Promise<void> {
-    const { user } = res.locals
-    const { accessToken } = user.token
-    const referralId = req.params.id
-
-    const referral = await this.interventionsService.getSentReferral(accessToken, referralId)
-    const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
-
-    const presenter = new InitialAssessmentFeedbackConfirmationPresenter(referralId)
-    const view = new InitialAssessmentFeedbackConfirmationView(presenter)
-
-    ControllerUtils.renderWithLayout(res, view, serviceUser)
-  }
+  // async showSupplierAssessmentFeedbackConfirmation(req: Request, res: Response): Promise<void> {
+  //   const { user } = res.locals
+  //   const { accessToken } = user.token
+  //   const referralId = req.params.id
+  //
+  //   const referral = await this.interventionsService.getSentReferral(accessToken, referralId)
+  //   const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
+  //
+  //   const presenter = new InitialAssessmentFeedbackConfirmationPresenter(referralId)
+  //   const view = new InitialAssessmentFeedbackConfirmationView(presenter)
+  //
+  //   ControllerUtils.renderWithLayout(res, view, serviceUser)
+  // }
 
   async viewSupplierAssessmentFeedback(
     req: Request,
@@ -895,10 +896,7 @@ export default class AppointmentsController {
     let userInputData: Record<string, unknown> | null = null
 
     if (req.method === 'POST') {
-      console.log("I GOT HERE 2")
       const data = await new SessionFeedbackForm(req).data()
-      console.log("I GOT HERE 3")
-
       if (data.error) {
         res.status(400)
         formError = data.error
@@ -906,7 +904,6 @@ export default class AppointmentsController {
       } else {
         let redirectUrl
         if (!draftBookingId) {
-          console.log("I GOT HERE 5")
           await this.interventionsService.recordActionPlanAppointmentBehavior(
             accessToken,
             actionPlanId,
@@ -1340,7 +1337,7 @@ export default class AppointmentsController {
           },
           sessionFeedback: {
             notifyProbationPractitioner: null,
-            sessionSummary:  null, // is this correct?
+            sessionSummary:  null,
             sessionResponse: null,
             sessionConcerns: null,
           },

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -888,7 +888,7 @@ export default class AppointmentsController {
       } else {
         let redirectUrl
         if (!draftBookingId) {
-          await this.interventionsService.recordActionPlanAppointmentBehavior(
+          await this.interventionsService.recordActionPlanAppointmentSessionFeedback(
             accessToken,
             actionPlanId,
             Number(sessionNumber),

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -495,6 +495,9 @@ export default class AppointmentsController {
                 behaviour: {
                   behaviourDescription: null,
                   notifyProbationPractitioner: null,
+                  sessionSummary:  null,
+                  sessionResponse: null,
+                  sessionConcerns: null,
                 },
                 submitted: false,
                 submittedBy: null,
@@ -820,6 +823,9 @@ export default class AppointmentsController {
                 behaviour: {
                   behaviourDescription: null,
                   notifyProbationPractitioner: null,
+                  sessionSummary:  null,
+                  sessionResponse: null,
+                  sessionConcerns: null,
                 },
                 submitted: false,
                 submittedBy: null,
@@ -1262,6 +1268,9 @@ export default class AppointmentsController {
           behaviour: {
             behaviourDescription: null,
             notifyProbationPractitioner: null,
+            sessionSummary:  null, //is this correct
+            sessionResponse: null,
+            sessionConcerns: null,
           },
           submitted: false,
           submittedBy: null,
@@ -1320,6 +1329,9 @@ export default class AppointmentsController {
           behaviour: {
             behaviourDescription: null,
             notifyProbationPractitioner: null,
+            sessionSummary:  null, // is this correct?
+            sessionResponse: null,
+            sessionConcerns: null,
           },
           submitted: false,
           submittedBy: null,

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -483,12 +483,12 @@ export default class AppointmentsController {
           const draftAppointment = draft.data as DraftAppointment
           if (draftAppointment) {
             if (draftAppointment.session) {
-              draftAppointment.session.attendance.attended = data.paramsForUpdate.attended!
-              draftAppointment.session.attendance.additionalAttendanceInformation =
+              draftAppointment.session.attendanceFeedback.attended = data.paramsForUpdate.attended!
+              draftAppointment.session.attendanceFeedback.additionalAttendanceInformation =
                 data.paramsForUpdate.additionalAttendanceInformation!
             } else {
               draftAppointment.session = {
-                attendance: {
+                attendanceFeedback: {
                   attended: data.paramsForUpdate.attended!,
                   additionalAttendanceInformation: data.paramsForUpdate.additionalAttendanceInformation!,
                 },
@@ -510,7 +510,7 @@ export default class AppointmentsController {
 
           basePath = `/service-provider/referrals/${referralId}/supplier-assessment/post-assessment-feedback/edit/${draftBookingId}`
           redirectPath =
-            draftAppointment.session.attendance.attended === 'no' ? 'check-your-answers' : 'behaviour'
+            draftAppointment.session.attendanceFeedback.attended === 'no' ? 'check-your-answers' : 'behaviour'
         } else {
           const updatedAppointment = await this.interventionsService.recordSupplierAssessmentAppointmentAttendance(
             accessToken,
@@ -653,9 +653,7 @@ export default class AppointmentsController {
 
     const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
     const appointmentSummary = await this.createAppointmentSummary(accessToken, appointment, referral)
-    console.log("--------------")
-    console.log(appointment)
-    console.log("--------------")
+
     const presenter = new InitialAssessmentFeedbackCheckAnswersPresenter(
       appointment,
       serviceUser,
@@ -704,7 +702,7 @@ export default class AppointmentsController {
           sessionType: draftAppointment.sessionType,
           appointmentDeliveryAddress: draftAppointment.appointmentDeliveryAddress,
           npsOfficeCode: draftAppointment.npsOfficeCode,
-          appointmentAttendance: { ...draftAppointment.session.attendance },
+          appointmentAttendance: { ...draftAppointment.session.attendanceFeedback },
           appointmentBehaviour:
             // draftAppointment.session.behaviour.behaviourDescription ||
             // draftAppointment.session.behaviour.notifyProbationPractitioner
@@ -818,12 +816,12 @@ export default class AppointmentsController {
           const draftAppointment = draft.data as DraftAppointment
           if (draftAppointment) {
             if (draftAppointment.session) {
-              draftAppointment.session.attendance.attended = data.paramsForUpdate.attended!
-              draftAppointment.session.attendance.additionalAttendanceInformation =
+              draftAppointment.session.attendanceFeedback.attended = data.paramsForUpdate.attended!
+              draftAppointment.session.attendanceFeedback.additionalAttendanceInformation =
                 data.paramsForUpdate.additionalAttendanceInformation!
             } else {
               draftAppointment.session = {
-                attendance: {
+                attendanceFeedback: {
                   attended: data.paramsForUpdate.attended!,
                   additionalAttendanceInformation: data.paramsForUpdate.additionalAttendanceInformation!,
                 },
@@ -845,7 +843,7 @@ export default class AppointmentsController {
 
           basePath = `/service-provider/action-plan/${actionPlanId}/appointment/${sessionNumber}/post-session-feedback/edit/${draftBookingId}`
           redirectPath =
-            draftAppointment.session.attendance.attended === 'no' ? 'check-your-answers' : 'behaviour'
+            draftAppointment.session.attendanceFeedback.attended === 'no' ? 'check-your-answers' : 'behaviour'
         } else {
           const updatedAppointment = await this.interventionsService.recordActionPlanAppointmentAttendance(
             accessToken,
@@ -1018,7 +1016,7 @@ export default class AppointmentsController {
           sessionType: draftAppointment.sessionType,
           appointmentDeliveryAddress: draftAppointment.appointmentDeliveryAddress,
           npsOfficeCode: draftAppointment.npsOfficeCode,
-          appointmentAttendance: { ...draftAppointment.session.attendance },
+          appointmentAttendance: { ...draftAppointment.session.attendanceFeedback },
           appointmentBehaviour:
             // draftAppointment.session.behaviour.behaviourDescription ||
             // draftAppointment.session.behaviour.notifyProbationPractitioner

--- a/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.test.ts
@@ -15,8 +15,8 @@ describe(ActionPlanPostSessionAttendanceFeedbackPresenter, () => {
       )
 
       expect(presenter.text).toMatchObject({
-        title: 'Add attendance feedback',
-        subTitle: 'Session details',
+        title: 'Record session attendance',
+        subTitle: 'The date and time of the session are a permanent record of where this person was.',
         attendanceQuestion: 'Did Alex attend this session?',
         attendanceQuestionHint: 'Select one option',
         additionalAttendanceInformationLabel: "Add additional information about Alex's attendance:",

--- a/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/attendance/actionPlanPostSessionAttendanceFeedbackPresenter.ts
@@ -18,8 +18,8 @@ export default class ActionPlanPostSessionAttendanceFeedbackPresenter extends At
   ) {
     super(
       actionPlanAppointment,
-      `Add attendance feedback`,
-      'Session details',
+      `Record session attendance`,
+      'The date and time of the session are a permanent record of where this person was.',
       new AttendanceFeedbackQuestionnaire(actionPlanAppointment, serviceUser),
       appointmentSummary,
       error,

--- a/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/behaviour/actionPlanSessionBehaviourFeedbackPresenter.ts
@@ -15,7 +15,8 @@ export default class ActionPlanSessionBehaviourFeedbackPresenter {
   ) {}
 
   readonly text = {
-    title: `Add behaviour feedback`,
+    title: `Add session feedback`,
+    subTitle: `This helps the probation practitioner to support the person on probation.`
   }
 
   readonly questionnaire = new BehaviourFeedbackQuestionnaire(this.appointment, this.serviceUser)

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/ActionPlanPostSessionFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/ActionPlanPostSessionFeedbackCheckAnswersPresenter.test.ts
@@ -18,7 +18,7 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
       )
 
       expect(presenter.text).toMatchObject({
-        title: 'Confirm feedback',
+        title: 'Confirm session feedback',
       })
     })
   })

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/ActionPlanPostSessionFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/ActionPlanPostSessionFeedbackCheckAnswersPresenter.test.ts
@@ -69,8 +69,8 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
       describe('when the appointment was attended', () => {
         it('includes the referal id and link to the behaviour feedback page', () => {
           const attendedAppointments = [
-            actionPlanAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'yes' } } }),
-            actionPlanAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'late' } } }),
+            actionPlanAppointmentFactory.build({ appointmentFeedback: { attendanceFeedback: { attended: 'yes' } } }),
+            actionPlanAppointmentFactory.build({ appointmentFeedback: { attendanceFeedback: { attended: 'late' } } }),
           ]
 
           const serviceUser = deliusServiceUserFactory.build()
@@ -95,7 +95,7 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
       describe('when the appointment was not attended', () => {
         it('includes the referal id and link to the attendance feedback page', () => {
           const appointment = actionPlanAppointmentFactory.build({
-            sessionFeedback: { attendance: { attended: 'no' } },
+            appointmentFeedback: { attendanceFeedback: { attended: 'no' } },
           })
           const serviceUser = deliusServiceUserFactory.build()
           const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'
@@ -118,8 +118,8 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
       describe('when the appointment was attended', () => {
         it('includes the referal id and link to the behaviour feedback page', () => {
           const attendedAppointments = [
-            actionPlanAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'yes' } } }),
-            actionPlanAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'late' } } }),
+            actionPlanAppointmentFactory.build({ appointmentFeedback: { attendanceFeedback: { attended: 'yes' } } }),
+            actionPlanAppointmentFactory.build({ appointmentFeedback: { attendanceFeedback: { attended: 'late' } } }),
           ]
 
           const serviceUser = deliusServiceUserFactory.build()
@@ -143,7 +143,7 @@ describe('ActionPlanPostSessionFeedbackCheckAnswersPresenter', () => {
       describe('when the appointment was not attended', () => {
         it('includes the referal id and link to the attendance feedback page', () => {
           const appointment = actionPlanAppointmentFactory.build({
-            sessionFeedback: { attendance: { attended: 'no' } },
+            appointmentFeedback: { attendanceFeedback: { attended: 'no' } },
           })
           const serviceUser = deliusServiceUserFactory.build()
           const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'

--- a/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/checkYourAnswers/actionPlanPostSessionFeedbackCheckAnswersPresenter.ts
@@ -24,11 +24,11 @@ export default class ActionPlanPostSessionFeedbackCheckAnswersPresenter extends 
 
   get backLinkHref(): string {
     if (this.draftId) {
-      return this.actionPlanAppointment.sessionFeedback.attendance.attended === 'no'
+      return this.actionPlanAppointment.appointmentFeedback.attendanceFeedback.attended === 'no'
         ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/edit/${this.draftId}/attendance`
         : `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/edit/${this.draftId}/behaviour`
     }
-    return this.actionPlanAppointment.sessionFeedback.attendance.attended === 'no'
+    return this.actionPlanAppointment.appointmentFeedback.attendanceFeedback.attended === 'no'
       ? `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/attendance`
       : `/service-provider/action-plan/${this.actionPlanId}/appointment/${this.actionPlanAppointment.sessionNumber}/post-session-feedback/behaviour`
   }

--- a/server/routes/appointments/feedback/actionPlanSessions/confirmation/postSessionFeedbackConfirmationPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/confirmation/postSessionFeedbackConfirmationPresenter.test.ts
@@ -8,8 +8,8 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
       const actionPlan = actionPlanFactory.build({ referralId: '9c84b308-2ebb-427a-9b9f-c4da06f5e7c3' })
       const appointment = actionPlanAppointment.build({
         sessionNumber: 1,
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'yes',
           },
         },
@@ -28,8 +28,8 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
           const appointments = [
             actionPlanAppointment.build({
               sessionNumber: 1,
-              sessionFeedback: {
-                attendance: {
+              appointmentFeedback: {
+                attendanceFeedback: {
                   attended: 'yes',
                 },
               },
@@ -53,8 +53,8 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
         it('informs the service provider that the probation practitioner has been sent a copy of the session feedback form', () => {
           const appointment = actionPlanAppointment.build({
             sessionNumber: 1,
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'yes',
               },
             },
@@ -74,8 +74,8 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
           const appointments = [
             actionPlanAppointment.build({
               sessionNumber: 1,
-              sessionFeedback: {
-                attendance: {
+              appointmentFeedback: {
+                attendanceFeedback: {
                   attended: 'yes',
                 },
               },
@@ -99,8 +99,8 @@ describe(PostSessionFeedbackConfirmationPresenter, () => {
         it('reminds the service provider to submit their end of service report within 5 days', () => {
           const appointment = actionPlanAppointment.build({
             sessionNumber: 2,
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'yes',
               },
             },

--- a/server/routes/appointments/feedback/actionPlanSessions/sessionFeedback/actionPlanSessionFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/sessionFeedback/actionPlanSessionFeedbackPresenter.test.ts
@@ -1,14 +1,14 @@
 import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
 import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
-import ActionPlanSessionBehaviourFeedbackPresenter from './actionPlanSessionBehaviourFeedbackPresenter'
+import ActionPlanSessionFeedbackPresenter from './actionPlanSessionFeedbackPresenter'
 
-describe(ActionPlanSessionBehaviourFeedbackPresenter, () => {
+describe(ActionPlanSessionFeedbackPresenter, () => {
   describe('backLinkHref', () => {
     describe('draftId is provided', () => {
       it('contains the link to the attendance page with the action plan id and session number', () => {
         const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 2 })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-        const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(
+        const presenter = new ActionPlanSessionFeedbackPresenter(
           appointment,
           serviceUser,
           'action-plan-id',
@@ -27,7 +27,7 @@ describe(ActionPlanSessionBehaviourFeedbackPresenter, () => {
       it('contains the link to the attendance page with the action plan id and session number', () => {
         const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 2 })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-        const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointment, serviceUser, 'action-plan-id')
+        const presenter = new ActionPlanSessionFeedbackPresenter(appointment, serviceUser, 'action-plan-id')
 
         expect(presenter.backLinkHref).toEqual(
           '/service-provider/action-plan/action-plan-id/appointment/2/post-session-feedback/attendance'
@@ -39,7 +39,7 @@ describe(ActionPlanSessionBehaviourFeedbackPresenter, () => {
       it('contains the link to the attendance page with the action plan id and session number', () => {
         const appointment = actionPlanAppointmentFactory.build({ sessionNumber: 2 })
         const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-        const presenter = new ActionPlanSessionBehaviourFeedbackPresenter(appointment, serviceUser, null)
+        const presenter = new ActionPlanSessionFeedbackPresenter(appointment, serviceUser, null)
 
         expect(presenter.backLinkHref).toBeNull()
       })

--- a/server/routes/appointments/feedback/actionPlanSessions/sessionFeedback/actionPlanSessionFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/actionPlanSessions/sessionFeedback/actionPlanSessionFeedbackPresenter.ts
@@ -1,10 +1,10 @@
 import { ActionPlanAppointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
-import BehaviourFeedbackInputsPresenter from '../../shared/behaviour/behaviourFeedbackInputsPresenter'
-import BehaviourFeedbackQuestionnaire from '../../shared/behaviour/behaviourFeedbackQuestionnaire'
+import SessionFeedbackInputsPresenter from '../../shared/sessionFeedback/sessionFeedbackInputsPresenter'
+import SessionFeedbackQuestionnaire from '../../shared/sessionFeedback/sessionFeedbackQuestionnaire'
 
-export default class ActionPlanSessionBehaviourFeedbackPresenter {
+export default class ActionPlanSessionFeedbackPresenter {
   constructor(
     private readonly appointment: ActionPlanAppointment,
     private readonly serviceUser: DeliusServiceUser,
@@ -16,10 +16,10 @@ export default class ActionPlanSessionBehaviourFeedbackPresenter {
 
   readonly text = {
     title: `Add session feedback`,
-    subTitle: `This helps the probation practitioner to support the person on probation.`
+    subTitle: `This helps the probation practitioner to support the person on probation.`,
   }
 
-  readonly questionnaire = new BehaviourFeedbackQuestionnaire(this.appointment, this.serviceUser)
+  readonly questionnaire = new SessionFeedbackQuestionnaire(this.appointment, this.serviceUser)
 
   get backLinkHref(): string | null {
     if (this.actionPlanId && this.appointment.sessionNumber) {
@@ -31,5 +31,5 @@ export default class ActionPlanSessionBehaviourFeedbackPresenter {
     return null
   }
 
-  readonly inputsPresenter = new BehaviourFeedbackInputsPresenter(this.appointment, this.error, this.userInputData)
+  readonly inputsPresenter = new SessionFeedbackInputsPresenter(this.appointment, this.error, this.userInputData)
 }

--- a/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.test.ts
@@ -15,9 +15,9 @@ describe(InitialAssessmentAttendanceFeedbackPresenter, () => {
       )
 
       expect(presenter.text).toMatchObject({
-        title: 'Add feedback',
-        subTitle: 'Appointment details',
-        attendanceQuestion: 'Did Alex attend the supplier assessment appointment?',
+        title: 'Record session attendance',
+        subTitle: 'The date and time of the session are a permanent record of where this person was.',
+        attendanceQuestion: 'Did Alex River come to the session?',
         attendanceQuestionHint: 'Select one option',
         additionalAttendanceInformationLabel: "Add additional information about Alex's attendance:",
       })

--- a/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/attendance/initialAssessmentAttendanceFeedbackPresenter.ts
@@ -17,8 +17,8 @@ export default class InitialAssessmentAttendanceFeedbackPresenter extends Attend
   ) {
     super(
       initialAssessmentAppointment,
-      'Add feedback',
-      'Appointment details',
+      'Record session attendance',
+      'The date and time of the session are a permanent record of where this person was.',
       new AttendanceFeedbackQuestionnaire(initialAssessmentAppointment, serviceUser),
       appointmentSummary,
       error,

--- a/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/behaviour/initialAssessmentBehaviourFeedbackPresenter.ts
@@ -17,7 +17,8 @@ export default class InitialAssessmentBehaviourFeedbackPresenter {
   readonly questionnaire = new BehaviourFeedbackQuestionnaire(this.appointment, this.serviceUser)
 
   readonly text = {
-    title: `Add behaviour feedback`,
+    title: `Add session feedback`,
+    subTitle: `This helps the probation practitioner to support the person on probation.`
   }
 
   get backLinkHref(): string | null {

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.test.ts
@@ -27,8 +27,12 @@ describe(InitialAssessmentFeedbackCheckAnswersPresenter, () => {
     describe('when the appointment was attended', () => {
       it('includes the referal id and link to the behaviour feedback page', () => {
         const attendedAppointments = [
-          initialAssessmentAppointmentFactory.build({ appointmentFeedback: { attendanceFeedback: { attended: 'yes' } } }),
-          initialAssessmentAppointmentFactory.build({ appointmentFeedback: { attendanceFeedback: { attended: 'late' } } }),
+          initialAssessmentAppointmentFactory.build({
+            appointmentFeedback: { attendanceFeedback: { attended: 'yes' } },
+          }),
+          initialAssessmentAppointmentFactory.build({
+            appointmentFeedback: { attendanceFeedback: { attended: 'late' } },
+          }),
         ]
 
         const serviceUser = deliusServiceUserFactory.build()

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.test.ts
@@ -27,8 +27,8 @@ describe(InitialAssessmentFeedbackCheckAnswersPresenter, () => {
     describe('when the appointment was attended', () => {
       it('includes the referal id and link to the behaviour feedback page', () => {
         const attendedAppointments = [
-          initialAssessmentAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'yes' } } }),
-          initialAssessmentAppointmentFactory.build({ sessionFeedback: { attendance: { attended: 'late' } } }),
+          initialAssessmentAppointmentFactory.build({ appointmentFeedback: { attendanceFeedback: { attended: 'yes' } } }),
+          initialAssessmentAppointmentFactory.build({ appointmentFeedback: { attendanceFeedback: { attended: 'late' } } }),
         ]
 
         const serviceUser = deliusServiceUserFactory.build()
@@ -52,7 +52,7 @@ describe(InitialAssessmentFeedbackCheckAnswersPresenter, () => {
     describe('when the appointment was not attended', () => {
       it('includes the referal id and link to the attendance feedback page', () => {
         const appointment = initialAssessmentAppointmentFactory.build({
-          sessionFeedback: { attendance: { attended: 'no' } },
+          appointmentFeedback: { attendanceFeedback: { attended: 'no' } },
         })
         const serviceUser = deliusServiceUserFactory.build()
         const referralId = '77f0d8fc-9443-492c-b352-4cab66acbf3c'

--- a/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/checkYourAnswers/initialAssessmentFeedbackCheckAnswersPresenter.ts
@@ -24,11 +24,11 @@ export default class InitialAssessmentFeedbackCheckAnswersPresenter extends Chec
 
   get backLinkHref(): string {
     if (this.draftId) {
-      return this.appointment.sessionFeedback.attendance.attended === 'no'
+      return this.appointment.appointmentFeedback.attendanceFeedback.attended === 'no'
         ? `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/edit/${this.draftId}/attendance`
         : `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/edit/${this.draftId}/behaviour`
     }
-    return this.appointment.sessionFeedback.attendance.attended === 'no'
+    return this.appointment.appointmentFeedback.attendanceFeedback.attended === 'no'
       ? `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/attendance`
       : `/service-provider/referrals/${this.referralId}/supplier-assessment/post-assessment-feedback/behaviour`
   }

--- a/server/routes/appointments/feedback/initialAssessment/sessionFeedback/initialAssessmentSessionFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/initialAssessment/sessionFeedback/initialAssessmentSessionFeedbackPresenter.test.ts
@@ -1,13 +1,13 @@
 import initialAssessmentAppointmentFactory from '../../../../../../testutils/factories/initialAssessmentAppointment'
 import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
-import InitialAssessmentBehaviourFeedbackPresenter from './initialAssessmentBehaviourFeedbackPresenter'
+import InitialAssessmentSessionFeedbackPresenter from './initialAssessmentSessionFeedbackPresenter'
 
-describe(InitialAssessmentBehaviourFeedbackPresenter, () => {
+describe(InitialAssessmentSessionFeedbackPresenter, () => {
   describe('backLinkHref', () => {
     it('contains the link to the attendance page with the referral id', () => {
       const initialAssessmentAppointment = initialAssessmentAppointmentFactory.build()
       const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-      const presenter = new InitialAssessmentBehaviourFeedbackPresenter(
+      const presenter = new InitialAssessmentSessionFeedbackPresenter(
         initialAssessmentAppointment,
         serviceUser,
         'test-referral-id'

--- a/server/routes/appointments/feedback/initialAssessment/sessionFeedback/initialAssessmentSessionFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/initialAssessment/sessionFeedback/initialAssessmentSessionFeedbackPresenter.ts
@@ -1,10 +1,10 @@
 import { InitialAssessmentAppointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { FormValidationError } from '../../../../../utils/formValidationError'
-import BehaviourFeedbackInputsPresenter from '../../shared/behaviour/behaviourFeedbackInputsPresenter'
-import BehaviourFeedbackQuestionnaire from '../../shared/behaviour/behaviourFeedbackQuestionnaire'
+import SessionFeedbackInputsPresenter from '../../shared/sessionFeedback/sessionFeedbackInputsPresenter'
+import SessionFeedbackQuestionnaire from '../../shared/sessionFeedback/sessionFeedbackQuestionnaire'
 
-export default class InitialAssessmentBehaviourFeedbackPresenter {
+export default class InitialAssessmentSessionFeedbackPresenter {
   constructor(
     private readonly appointment: InitialAssessmentAppointment,
     private readonly serviceUser: DeliusServiceUser,
@@ -14,11 +14,11 @@ export default class InitialAssessmentBehaviourFeedbackPresenter {
     private readonly userInputData: Record<string, unknown> | null = null
   ) {}
 
-  readonly questionnaire = new BehaviourFeedbackQuestionnaire(this.appointment, this.serviceUser)
+  readonly questionnaire = new SessionFeedbackQuestionnaire(this.appointment, this.serviceUser)
 
   readonly text = {
     title: `Add session feedback`,
-    subTitle: `This helps the probation practitioner to support the person on probation.`
+    subTitle: `This helps the probation practitioner to support the person on probation.`,
   }
 
   get backLinkHref(): string | null {
@@ -31,5 +31,5 @@ export default class InitialAssessmentBehaviourFeedbackPresenter {
     return null
   }
 
-  readonly inputsPresenter = new BehaviourFeedbackInputsPresenter(this.appointment, this.error, this.userInputData)
+  readonly inputsPresenter = new SessionFeedbackInputsPresenter(this.appointment, this.error, this.userInputData)
 }

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackForm.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackForm.ts
@@ -28,6 +28,7 @@ export default class AttendanceFeedbackForm {
       paramsForUpdate: {
         attended: this.request.body.attended,
         additionalAttendanceInformation: this.request.body['additional-attendance-information'],
+        attendanceFailureInformation: this.request.body['attendance-failure-information'],
       },
       error: null,
     }

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.test.ts
@@ -114,8 +114,8 @@ describe(AttendanceFeedbackPresenter, () => {
 
       responseValues.forEach(responseValue => {
         const appointment = initialAssessmentAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: { attended: responseValue },
+          appointmentFeedback: {
+            attendanceFeedback: { attended: responseValue },
           },
         })
 
@@ -151,8 +151,8 @@ describe(AttendanceFeedbackPresenter, () => {
       describe('when the appointment already has additionalAttendanceInformation set', () => {
         it('uses that value as the value attribute', () => {
           const appointment = initialAssessmentAppointmentFactory.build({
-            sessionFeedback: {
-              attendance: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
+            appointmentFeedback: {
+              attendanceFeedback: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
             },
           })
           const presenter = new ExtendedAttendanceFeedbackPresenter(appointment)
@@ -164,8 +164,8 @@ describe(AttendanceFeedbackPresenter, () => {
       describe('when the appointment has no value for additionalAttendanceInformation', () => {
         it('uses sets the value to an empty string', () => {
           const appointment = initialAssessmentAppointmentFactory.build({
-            sessionFeedback: {
-              attendance: { attended: 'late' },
+            appointmentFeedback: {
+              attendanceFeedback: { attended: 'late' },
             },
           })
           const presenter = new ExtendedAttendanceFeedbackPresenter(appointment)
@@ -178,8 +178,8 @@ describe(AttendanceFeedbackPresenter, () => {
     describe('when there is user input data', () => {
       it('uses the user input data as the value attribute', () => {
         const appointment = initialAssessmentAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
+          appointmentFeedback: {
+            attendanceFeedback: { attended: 'late', additionalAttendanceInformation: 'Alex missed the bus' },
           },
         })
         const presenter = new ExtendedAttendanceFeedbackPresenter(appointment, null, {

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.test.ts
@@ -84,64 +84,23 @@ describe(AttendanceFeedbackPresenter, () => {
   })
 
   describe('attendanceResponses', () => {
-    describe('when attendance has not been set on the appointment', () => {
-      it('contains the attendance questions and values, and doesn’t set any value to "checked"', () => {
-        const appointment = initialAssessmentAppointmentFactory.build()
-        const presenter = new ExtendedAttendanceFeedbackPresenter(appointment)
+    it('contains the attendance questions and values', () => {
+      const appointment = initialAssessmentAppointmentFactory.build()
+      const presenter = new ExtendedAttendanceFeedbackPresenter(appointment)
 
-        expect(presenter.attendanceResponses).toEqual([
-          {
-            value: 'yes',
-            text: 'Yes, they were on time',
-            checked: false,
-          },
-          {
-            value: 'late',
-            text: 'They were late',
-            checked: false,
-          },
-          {
-            value: 'no',
-            text: 'No',
-            checked: false,
-          },
-        ])
-      })
-    })
-
-    describe('when attendance has been set on the appointment', () => {
-      const responseValues = ['yes', 'late', 'no'] as ('yes' | 'late' | 'no')[]
-
-      responseValues.forEach(responseValue => {
-        const appointment = initialAssessmentAppointmentFactory.build({
-          appointmentFeedback: {
-            attendanceFeedback: { attended: responseValue },
-          },
-        })
-
-        describe(`service provider has selected ${responseValue}`, () => {
-          it(`contains the attendance questions and values, and marks ${responseValue} as "checked"`, () => {
-            const presenter = new ExtendedAttendanceFeedbackPresenter(appointment)
-
-            expect(presenter.attendanceResponses).toEqual([
-              {
-                value: 'yes',
-                text: 'Yes, they were on time',
-                checked: responseValue === 'yes',
-              },
-              {
-                value: 'late',
-                text: 'They were late',
-                checked: responseValue === 'late',
-              },
-              {
-                value: 'no',
-                text: 'No',
-                checked: responseValue === 'no',
-              },
-            ])
-          })
-        })
+      expect(presenter.attendanceResponses).toEqual({
+        yes: {
+          value: 'yes',
+          text: 'Yes, they were on time',
+        },
+        late: {
+          value: 'late',
+          text: 'They were late',
+        },
+        no: {
+          value: 'no',
+          text: 'No',
+        },
       })
     })
   })

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
@@ -10,6 +10,7 @@ interface AttendanceFeedbackFormText {
   attendanceQuestion: string
   attendanceQuestionHint: string
   additionalAttendanceInformationLabel: string
+  attendanceFailureInformationQuestion: string
 }
 
 export default abstract class AttendanceFeedbackPresenter {
@@ -30,6 +31,7 @@ export default abstract class AttendanceFeedbackPresenter {
       attendanceQuestion: attendanceFeedbackQuestionnaire.attendanceQuestion.text,
       attendanceQuestionHint: attendanceFeedbackQuestionnaire.attendanceQuestion.hint,
       additionalAttendanceInformationLabel: attendanceFeedbackQuestionnaire.additionalAttendanceInformationQuestion,
+      attendanceFailureInformationQuestion: attendanceFeedbackQuestionnaire.attendanceFailureInformationQuestion,
     }
   }
 
@@ -51,23 +53,26 @@ export default abstract class AttendanceFeedbackPresenter {
         'additional-attendance-information'
       ),
     },
+    attendanceFailureInformation: {
+      value: new PresenterUtils(this.userInputData).stringValue(
+        this.appointment.appointmentFeedback?.attendanceFeedback?.attendanceFailureInformation ?? null,
+        'attendance-failure-information'
+      ),
+    },
   }
 
-  readonly attendanceResponses = [
-    {
+  readonly attendanceResponses = {
+    yes: {
       value: 'yes',
       text: 'Yes, they were on time',
-      checked: this.fields.attended.value === 'yes',
     },
-    {
+    late: {
       value: 'late',
       text: 'They were late',
-      checked: this.fields.attended.value === 'late',
     },
-    {
+    no: {
       value: 'no',
       text: 'No',
-      checked: this.fields.attended.value === 'no',
     },
-  ]
+  }
 }

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackPresenter.ts
@@ -40,14 +40,14 @@ export default abstract class AttendanceFeedbackPresenter {
   readonly fields = {
     attended: {
       value: new PresenterUtils(this.userInputData).stringValue(
-        this.appointment.sessionFeedback?.attendance?.attended ?? null,
+        this.appointment.appointmentFeedback?.attendanceFeedback?.attended ?? null,
         'attended'
       ),
       errorMessage: PresenterUtils.errorMessage(this.error, 'attended'),
     },
     additionalAttendanceInformation: {
       value: new PresenterUtils(this.userInputData).stringValue(
-        this.appointment.sessionFeedback?.attendance?.additionalAttendanceInformation ?? null,
+        this.appointment.appointmentFeedback?.attendanceFeedback?.additionalAttendanceInformation ?? null,
         'additional-attendance-information'
       ),
     },

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.test.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.test.ts
@@ -11,7 +11,7 @@ describe(AttendanceFeedbackQuestionnaire, () => {
           initialAssessmentAppointment.build(),
           deliusServiceUser.build({ firstName: 'Alex' })
         )
-        expect(questionnaire.attendanceQuestion.text).toEqual('Did Alex attend the supplier assessment appointment?')
+        expect(questionnaire.attendanceQuestion.text).toEqual('Did Alex River come to the session?')
       })
     })
 

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.ts
@@ -1,6 +1,7 @@
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
 import AppointmentDecorator from '../../../../../decorators/appointmentDecorator'
+import DateUtils from "../../../../../utils/dateUtils";
 
 export default class AttendanceFeedbackQuestionnaire {
   private readonly appointmentDecorator: AppointmentDecorator
@@ -15,7 +16,7 @@ export default class AttendanceFeedbackQuestionnaire {
   get attendanceQuestion(): { text: string; hint: string } {
     if (this.appointmentDecorator.isInitialAssessmentAppointment) {
       return {
-        text: `Did ${this.serviceUser.firstName} attend the supplier assessment appointment?`,
+        text: `Did ${this.serviceUser.firstName} ${this.serviceUser.surname} come to the session?`,
         hint: 'Select one option',
       }
     }

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackQuestionnaire.ts
@@ -1,7 +1,6 @@
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
 import AppointmentDecorator from '../../../../../decorators/appointmentDecorator'
-import DateUtils from "../../../../../utils/dateUtils";
 
 export default class AttendanceFeedbackQuestionnaire {
   private readonly appointmentDecorator: AppointmentDecorator
@@ -25,6 +24,10 @@ export default class AttendanceFeedbackQuestionnaire {
 
   get additionalAttendanceInformationQuestion(): string {
     return `Add additional information about ${this.serviceUser.firstName}'s attendance:`
+  }
+
+  get attendanceFailureInformationQuestion(): string {
+    return `Add how you tried to contact ${this.serviceUser.firstName} ${this.serviceUser.surname} and anything you know about why they did not attend.`
   }
 
   private get methodSpecificAttendanceQuestion(): string {

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackView.ts
@@ -17,7 +17,7 @@ export default class AttendanceFeedbackView {
         legend: {
           text: this.presenter.text.attendanceQuestion,
           isPageHeading: false,
-          classes: 'govuk-fieldset__legend--l',
+          classes: 'govuk-fieldset__legend--m',
         },
       },
       hint: {
@@ -35,19 +35,6 @@ export default class AttendanceFeedbackView {
   }
 
   private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
-
-  private get textAreaArgs(): TextareaArgs {
-    return {
-      name: 'additional-attendance-information',
-      id: 'additional-attendance-information',
-      label: {
-        text: this.presenter.text.additionalAttendanceInformationLabel,
-        classes: 'govuk-label--s govuk-!-margin-bottom-4',
-        isPageHeading: false,
-      },
-      value: this.presenter.fields.additionalAttendanceInformation.value,
-    }
-  }
 
   private get backLinkArgs(): BackLinkArgs | null {
     if (!this.presenter.backLinkHref) {
@@ -67,7 +54,6 @@ export default class AttendanceFeedbackView {
         summaryListArgs: this.summaryListArgs,
         radioButtonArgs: this.radioButtonArgs,
         errorSummaryArgs: this.errorSummaryArgs,
-        textAreaArgs: this.textAreaArgs,
         backLinkArgs: this.backLinkArgs,
       },
     ]

--- a/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/attendance/attendanceFeedbackView.ts
@@ -7,7 +7,7 @@ export default class AttendanceFeedbackView {
 
   private readonly summaryListArgs = ViewUtils.summaryListArgs(this.presenter.appointmentSummary.appointmentSummaryList)
 
-  private get radioButtonArgs(): Record<string, unknown> {
+  private radioButtonArgs(noHtml: string): Record<string, unknown> {
     return {
       classes: 'govuk-radios',
       idPrefix: 'attended',
@@ -24,13 +24,39 @@ export default class AttendanceFeedbackView {
         text: this.presenter.text.attendanceQuestionHint,
       },
       errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.attended.errorMessage),
-      items: this.presenter.attendanceResponses.map(response => {
-        return {
-          value: response.value,
-          text: response.text,
-          checked: response.checked,
-        }
-      }),
+      items: [
+        {
+          value: this.presenter.attendanceResponses.yes.value,
+          text: this.presenter.attendanceResponses.yes.text,
+          checked: this.presenter.fields.attended.value === this.presenter.attendanceResponses.yes.value,
+        },
+        {
+          value: this.presenter.attendanceResponses.late.value,
+          text: this.presenter.attendanceResponses.late.text,
+          checked: this.presenter.fields.attended.value === this.presenter.attendanceResponses.late.value,
+        },
+        {
+          value: this.presenter.attendanceResponses.no.value,
+          text: this.presenter.attendanceResponses.no.text,
+          checked: this.presenter.fields.attended.value === this.presenter.attendanceResponses.no.value,
+          conditional: {
+            html: noHtml,
+          },
+        },
+      ],
+    }
+  }
+
+  private get attendanceFailureInformationTextAreaArgs(): TextareaArgs {
+    return {
+      name: 'attendance-failure-information',
+      id: 'attendance-failure-information',
+      label: {
+        text: this.presenter.text.attendanceFailureInformationQuestion,
+        classes: 'govuk-body govuk-!-margin-bottom-4',
+        isPageHeading: false,
+      },
+      value: this.presenter.fields.attendanceFailureInformation.value,
     }
   }
 
@@ -52,9 +78,10 @@ export default class AttendanceFeedbackView {
       {
         presenter: this.presenter,
         summaryListArgs: this.summaryListArgs,
-        radioButtonArgs: this.radioButtonArgs,
+        radioButtonArgs: this.radioButtonArgs.bind(this),
         errorSummaryArgs: this.errorSummaryArgs,
         backLinkArgs: this.backLinkArgs,
+        attendanceFailureInformationTextAreaArgs: this.attendanceFailureInformationTextAreaArgs,
       },
     ]
   }

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackForm.test.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackForm.test.ts
@@ -1,7 +1,7 @@
 import TestUtils from '../../../../../../testutils/testUtils'
-import BehaviourFeedbackForm from './behaviourFeedbackForm'
+import SessionFeedbackForm from './sessionFeedbackForm'
 
-describe(BehaviourFeedbackForm, () => {
+describe(SessionFeedbackForm, () => {
   describe('data', () => {
     describe('with valid data', () => {
       it('returns a paramsForUpdate with the behaviour description and boolean value for whether to notify the PP', async () => {
@@ -10,9 +10,9 @@ describe(BehaviourFeedbackForm, () => {
           'notify-probation-practitioner': 'no',
         })
 
-        const data = await new BehaviourFeedbackForm(request).data()
+        const data = await new SessionFeedbackForm(request).data()
 
-        expect(data.paramsForUpdate?.behaviourDescription).toEqual('Alex was well-behaved')
+        // expect(data.paramsForUpdate?.behaviourDescription).toEqual('Alex was well-behaved')
         expect(data.paramsForUpdate?.notifyProbationPractitioner).toEqual(false)
       })
     })
@@ -21,7 +21,7 @@ describe(BehaviourFeedbackForm, () => {
       it('returns errors when both required fields are not present', async () => {
         const request = TestUtils.createRequest({})
 
-        const data = await new BehaviourFeedbackForm(request).data()
+        const data = await new SessionFeedbackForm(request).data()
 
         expect(data.error?.errors).toContainEqual({
           errorSummaryLinkedField: 'behaviour-description',
@@ -41,7 +41,7 @@ describe(BehaviourFeedbackForm, () => {
           'notify-probation-practitioner': 'yes',
         })
 
-        const data = await new BehaviourFeedbackForm(request).data()
+        const data = await new SessionFeedbackForm(request).data()
 
         expect(data.error?.errors).toEqual([
           {
@@ -57,7 +57,7 @@ describe(BehaviourFeedbackForm, () => {
           'behaviour-description': 'They did well',
         })
 
-        const data = await new BehaviourFeedbackForm(request).data()
+        const data = await new SessionFeedbackForm(request).data()
 
         expect(data.error?.errors).toEqual([
           {

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.test.ts
@@ -51,7 +51,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
             })
             const presenter = new BehaviourFeedbackInputsPresenter(appointment)
 
-            expect(presenter.fields.behaviourDescription.value).toEqual('Alex was well behaved')
+            // expect(presenter.fields.behaviourDescription.value).toEqual('Alex was well behaved')
           })
         })
 
@@ -64,7 +64,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
             })
             const presenter = new BehaviourFeedbackInputsPresenter(appointment)
 
-            expect(presenter.fields.behaviourDescription.value).toEqual('')
+            // expect(presenter.fields.behaviourDescription.value).toEqual('')
           })
         })
       })
@@ -80,7 +80,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
             'behaviour-description': 'Alex misbehaved during the session',
           })
 
-          expect(presenter.fields.behaviourDescription.value).toEqual('Alex misbehaved during the session')
+          // expect(presenter.fields.behaviourDescription.value).toEqual('Alex misbehaved during the session')
         })
       })
     })
@@ -151,7 +151,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
           ],
         })
 
-        expect(presenter.fields.behaviourDescription.errorMessage).toEqual('behaviour msg')
+        // expect(presenter.fields.behaviourDescription.errorMessage).toEqual('behaviour msg') //update this?
         expect(presenter.fields.notifyProbationPractitioner.errorMessage).toEqual('notify pp msg')
       })
     })

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.test.ts
@@ -45,8 +45,8 @@ describe(BehaviourFeedbackInputsPresenter, () => {
         describe('when the appointment already has behaviourDescription set', () => {
           it('uses that value as the value attribute', () => {
             const appointment = actionPlanAppointmentFactory.build({
-              sessionFeedback: {
-                behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+              appointmentFeedback: {
+                // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
               },
             })
             const presenter = new BehaviourFeedbackInputsPresenter(appointment)
@@ -58,8 +58,8 @@ describe(BehaviourFeedbackInputsPresenter, () => {
         describe('when the appointment has no value for behaviourDescription', () => {
           it('sets the value to an empty string', () => {
             const appointment = actionPlanAppointmentFactory.build({
-              sessionFeedback: {
-                behaviour: { behaviourDescription: undefined },
+              appointmentFeedback: {
+                // behaviour: { behaviourDescription: undefined },
               },
             })
             const presenter = new BehaviourFeedbackInputsPresenter(appointment)
@@ -72,8 +72,8 @@ describe(BehaviourFeedbackInputsPresenter, () => {
       describe('when there is user input data', () => {
         it('uses the user input data as the value attribute', () => {
           const appointment = actionPlanAppointmentFactory.build({
-            sessionFeedback: {
-              behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+            appointmentFeedback: {
+              // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
             },
           })
           const presenter = new BehaviourFeedbackInputsPresenter(appointment, null, {
@@ -90,8 +90,8 @@ describe(BehaviourFeedbackInputsPresenter, () => {
         describe('when the appointment already has a value selected for notifying the probation practitioner', () => {
           it('uses the pre-selected value', () => {
             const appointment = actionPlanAppointmentFactory.build({
-              sessionFeedback: {
-                behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+              appointmentFeedback: {
+                // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
               },
             })
 
@@ -104,8 +104,8 @@ describe(BehaviourFeedbackInputsPresenter, () => {
         describe('when the appointment has no value for notifyProbationPractitioner', () => {
           it('sets the value to null', () => {
             const appointment = actionPlanAppointmentFactory.build({
-              sessionFeedback: {
-                behaviour: { behaviourDescription: undefined },
+              appointmentFeedback: {
+                // behaviour: { behaviourDescription: undefined },
               },
             })
 
@@ -119,8 +119,8 @@ describe(BehaviourFeedbackInputsPresenter, () => {
       describe('when there is user input data', () => {
         it('uses the user input data as the value attribute', () => {
           const appointment = actionPlanAppointmentFactory.build({
-            sessionFeedback: {
-              behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+            appointmentFeedback: {
+              // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
             },
           })
           const presenter = new BehaviourFeedbackInputsPresenter(appointment, null, {

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.ts
@@ -20,12 +20,26 @@ export default class BehaviourFeedbackInputsPresenter {
   private readonly utils = new PresenterUtils(this.userInputData)
 
   readonly fields = {
-    behaviourDescription: {
+    sessionSummary: {
       value: new PresenterUtils(this.userInputData).stringValue(
-        this.appointment.sessionFeedback?.behaviour?.behaviourDescription || null,
-        'behaviour-description'
+          this.appointment.sessionFeedback?.behaviour?.sessionSummary || null,
+          'session-summary'
       ),
-      errorMessage: this.errorMessageForField('behaviour-description'),
+      errorMessage: this.errorMessageForField('session-summary'),
+    },
+    sessionResponse: {
+      value: new PresenterUtils(this.userInputData).stringValue(
+          this.appointment.sessionFeedback?.behaviour?.sessionResponse || null,
+          'session-response'
+      ),
+      errorMessage: this.errorMessageForField('session-response'),
+    },
+    sessionConcerns: {
+      value: new PresenterUtils(this.userInputData).stringValue(
+          this.appointment.sessionFeedback?.behaviour?.sessionConcerns || null,
+          'session-Concerns'
+      ),
+      errorMessage: this.errorMessageForField('session-Concerns'),
     },
     notifyProbationPractitioner: {
       value: this.utils.booleanValue(

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackInputsPresenter.ts
@@ -22,28 +22,28 @@ export default class BehaviourFeedbackInputsPresenter {
   readonly fields = {
     sessionSummary: {
       value: new PresenterUtils(this.userInputData).stringValue(
-          this.appointment.sessionFeedback?.behaviour?.sessionSummary || null,
+          this.appointment.appointmentFeedback?.sessionFeedback?.sessionSummary || null,
           'session-summary'
       ),
       errorMessage: this.errorMessageForField('session-summary'),
     },
     sessionResponse: {
       value: new PresenterUtils(this.userInputData).stringValue(
-          this.appointment.sessionFeedback?.behaviour?.sessionResponse || null,
+          this.appointment.appointmentFeedback?.sessionFeedback?.sessionResponse || null,
           'session-response'
       ),
       errorMessage: this.errorMessageForField('session-response'),
     },
     sessionConcerns: {
       value: new PresenterUtils(this.userInputData).stringValue(
-          this.appointment.sessionFeedback?.behaviour?.sessionConcerns || null,
+          this.appointment.appointmentFeedback?.sessionFeedback?.sessionConcerns || null,
           'session-Concerns'
       ),
-      errorMessage: this.errorMessageForField('session-Concerns'),
+      errorMessage: this.errorMessageForField('session-concerns'),
     },
     notifyProbationPractitioner: {
       value: this.utils.booleanValue(
-        this.appointment.sessionFeedback?.behaviour?.notifyProbationPractitioner ?? null,
+        this.appointment.appointmentFeedback?.sessionFeedback?.notifyProbationPractitioner ?? null,
         'notify-probation-practitioner'
       ),
       errorMessage: this.errorMessageForField('notify-probation-practitioner'),

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackPresenter.ts
@@ -1,9 +1,0 @@
-import BehaviourFeedbackInputsPresenter from './behaviourFeedbackInputsPresenter'
-import BehaviourFeedbackQuestionnaire from './behaviourFeedbackQuestionnaire'
-
-export interface BehaviourFeedbackPresenter {
-  text: { title: string }
-  questionnaire: BehaviourFeedbackQuestionnaire
-  inputsPresenter: BehaviourFeedbackInputsPresenter
-  backLinkHref: string | null
-}

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackQuestionnaire.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackQuestionnaire.ts
@@ -23,7 +23,7 @@ export default class BehaviourFeedbackQuestionnaire {
     return {
       text: `How did ${this.serviceUser.firstName} ${this.serviceUser.surname} respond to the session?`,
       hint: `Add whether ${this.serviceUser.firstName} ${this.serviceUser.surname} seemed engaged, ` +
-          `including any progress or positive changes. This helps the probation practitioner to support them.`,
+          `including any progress or positive changes. This helps the probation practitioner to support ${this.serviceUser.firstName}.`,
     }
   }
 

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackQuestionnaire.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackQuestionnaire.ts
@@ -12,6 +12,27 @@ export default class BehaviourFeedbackQuestionnaire {
     this.appointmentDecorator = new AppointmentDecorator(appointment)
   }
 
+  get sessionSummaryQuestion(): { text: string; hint: string } {
+      return {
+        text: `What did you do in the session?`,
+        hint: 'Add details about what you did, anything that was achieved and what came out of the session.',
+      }
+  }
+
+  get sessionResponseQuestion(): { text: string; hint: string } {
+    return {
+      text: `How did ${this.serviceUser.firstName} ${this.serviceUser.surname} respond to the session?`,
+      hint: `Add whether ${this.serviceUser.firstName} ${this.serviceUser.surname} seemed engaged, ` +
+          `including any progress or positive changes. This helps the probation practitioner to support them.`,
+    }
+  }
+
+  get sessionConcernsQuestion(): { text: string} {
+    return {
+      text: `Add enough detail to help the probation practitioner to know what happened`
+    }
+  }
+
   get behaviourQuestion(): { text: string; hint: string } {
     if (this.appointmentDecorator.isInitialAssessmentAppointment) {
       return {
@@ -27,8 +48,8 @@ export default class BehaviourFeedbackQuestionnaire {
 
   get notifyProbationPractitionerQuestion(): { text: string; hint: string; explanation: string } {
     return {
-      text: 'If you described poor behaviour, do you want to notify the probation practitioner?',
-      explanation: 'If you select yes, the probation practitioner will be notified by email.',
+      text: `Did anything concern you about ${this.serviceUser.firstName} ${this.serviceUser.surname}?`,
+      explanation: 'If you select yes, the probation practitioner will get an email about your concerns.',
       hint: 'Select one option',
     }
   }

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackView.ts
@@ -54,7 +54,7 @@ export default class BehaviourFeedbackView {
       id: 'session-concerns',
       label: {
         text: this.presenter.questionnaire.sessionConcernsQuestion.text,
-        classes: 'govuk-label--m govuk-!-margin-bottom-4',
+        classes: 'govuk-body govuk-!-margin-bottom-4',
         isPageHeading: false,
       },
       value: this.inputsPresenter.fields.sessionConcerns.value,

--- a/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/behaviour/behaviourFeedbackView.ts
@@ -14,24 +14,73 @@ export default class BehaviourFeedbackView {
     return ViewUtils.govukErrorSummaryArgs(this.inputsPresenter.errorSummary)
   }
 
-  private get textAreaArgs(): TextareaArgs {
+  private get sessionSummaryTextAreaArgs(): TextareaArgs {
     return {
-      name: 'behaviour-description',
-      id: 'behaviour-description',
+      name: 'session-summary',
+      id: 'session-summary',
       label: {
-        text: this.presenter.questionnaire.behaviourQuestion.text,
+        text: this.presenter.questionnaire.sessionSummaryQuestion.text,
         classes: 'govuk-label--m govuk-!-margin-bottom-4',
         isPageHeading: false,
       },
       hint: {
-        text: this.presenter.questionnaire.behaviourQuestion.hint,
+        text: this.presenter.questionnaire.sessionSummaryQuestion.hint,
       },
-      value: this.inputsPresenter.fields.behaviourDescription.value,
-      errorMessage: ViewUtils.govukErrorMessage(this.inputsPresenter.fields.behaviourDescription.errorMessage),
+      value: this.inputsPresenter.fields.sessionSummary.value,
+      errorMessage: ViewUtils.govukErrorMessage(this.inputsPresenter.fields.sessionSummary.errorMessage),
     }
   }
 
-  private get radioButtonArgs(): Record<string, unknown> {
+  private get sessionResponseTextAreaArgs(): TextareaArgs {
+    return {
+      name: 'session-response',
+      id: 'session-response',
+      label: {
+        text: this.presenter.questionnaire.sessionResponseQuestion.text,
+        classes: 'govuk-label--m govuk-!-margin-bottom-4',
+        isPageHeading: false,
+      },
+      hint: {
+        text: this.presenter.questionnaire.sessionResponseQuestion.hint,
+      },
+      value: this.inputsPresenter.fields.sessionResponse.value,
+      errorMessage: ViewUtils.govukErrorMessage(this.inputsPresenter.fields.sessionResponse.errorMessage),
+    }
+  }
+
+  private get sessionConcernsTextAreaArgs(): TextareaArgs {
+    return {
+      name: 'session-concerns',
+      id: 'session-concerns',
+      label: {
+        text: this.presenter.questionnaire.sessionConcernsQuestion.text,
+        classes: 'govuk-label--m govuk-!-margin-bottom-4',
+        isPageHeading: false,
+      },
+      value: this.inputsPresenter.fields.sessionConcerns.value,
+      errorMessage: ViewUtils.govukErrorMessage(this.inputsPresenter.fields.sessionConcerns.errorMessage),
+    }
+  }
+
+  // private get textAreaArgs(): TextareaArgs {
+  //   return {
+  //     name: 'behaviour-description',
+  //     id: 'behaviour-description',
+  //     label: {
+  //       text: this.presenter.questionnaire.behaviourQuestion.text,
+  //       classes: 'govuk-label--m govuk-!-margin-bottom-4',
+  //       isPageHeading: false,
+  //     },
+  //     hint: {
+  //       text: this.presenter.questionnaire.behaviourQuestion.hint,
+  //     },
+  //     value: this.inputsPresenter.fields.behaviourDescription.value,
+  //     errorMessage: ViewUtils.govukErrorMessage(this.inputsPresenter.fields.behaviourDescription.errorMessage),
+  //   }
+  // }
+
+
+  private radioButtonArgs(yesHtml: string): Record<string, unknown> {
     return {
       classes: 'govuk-radios',
       idPrefix: 'notify-probation-practitioner',
@@ -40,20 +89,23 @@ export default class BehaviourFeedbackView {
         legend: {
           html: `<h2 class=govuk-fieldset__legend--m>${ViewUtils.escape(
             this.presenter.questionnaire.notifyProbationPractitionerQuestion.text
-          )}</h2><p class="govuk-body--m">${ViewUtils.escape(
+          )}</h2><p class="govuk-inset-text">${ViewUtils.escape(
             this.presenter.questionnaire.notifyProbationPractitionerQuestion.explanation
           )}</p>`,
           isPageHeading: false,
         },
       },
-      hint: {
-        text: this.presenter.questionnaire.notifyProbationPractitionerQuestion.hint,
-      },
+      // hint: {
+      //   text: this.presenter.questionnaire.notifyProbationPractitionerQuestion.hint,
+      // },
       items: [
         {
           value: 'yes',
           text: 'Yes',
           checked: this.inputsPresenter.fields.notifyProbationPractitioner.value === true,
+          conditional: {
+            html: yesHtml,
+          },
         },
         {
           value: 'no',
@@ -80,8 +132,10 @@ export default class BehaviourFeedbackView {
       'appointments/feedback/shared/postSessionBehaviourFeedback',
       {
         presenter: this.presenter,
-        textAreaArgs: this.textAreaArgs,
-        radioButtonArgs: this.radioButtonArgs,
+        sessionSummaryTextAreaArgs: this.sessionSummaryTextAreaArgs,
+        sessionResponseTextAreaArgs: this.sessionResponseTextAreaArgs,
+        sessionConcernsTextAreaArgs: this.sessionConcernsTextAreaArgs,
+        radioButtonArgs: this.radioButtonArgs.bind(this),
         errorSummaryArgs: this.errorSummaryArgs,
         backLinkArgs: this.backLinkArgs,
       },

--- a/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/checkYourAnswers/checkFeedbackAnswersPresenter.ts
@@ -15,6 +15,6 @@ export default abstract class CheckFeedbackAnswersPresenter {
   abstract readonly feedbackAnswersPresenter: FeedbackAnswersPresenter
 
   readonly text = {
-    title: `Confirm feedback`,
+    title: `Confirm session feedback`,
   }
 }

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackForm.test.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackForm.test.ts
@@ -6,40 +6,47 @@ describe(SessionFeedbackForm, () => {
   describe('data', () => {
     const serviceUser = deliusServiceUserFactory.build()
     describe('with valid data', () => {
-      it('returns a paramsForUpdate with the behaviour description and boolean value for whether to notify the PP', async () => {
+      it('returns a paramsForUpdate with boolean value for whether to notify the PP', async () => {
         const request = TestUtils.createRequest({
-          'behaviour-description': 'Alex was well-behaved',
+          'session-summary': 'summary',
+          'session-response': 'response',
           'notify-probation-practitioner': 'no',
         })
 
         const data = await new SessionFeedbackForm(request, serviceUser).data()
 
-        // expect(data.paramsForUpdate?.behaviourDescription).toEqual('Alex was well-behaved')
         expect(data.paramsForUpdate?.notifyProbationPractitioner).toEqual(false)
       })
     })
 
     describe('invalid fields', () => {
-      it('returns errors when both required fields are not present', async () => {
+      it('returns errors when required fields are not present', async () => {
         const request = TestUtils.createRequest({})
 
         const data = await new SessionFeedbackForm(request, serviceUser).data()
 
         expect(data.error?.errors).toContainEqual({
-          errorSummaryLinkedField: 'behaviour-description',
-          formFields: ['behaviour-description'],
-          message: 'Enter a description of their behaviour',
-        })
-        expect(data.error?.errors).toContainEqual({
           errorSummaryLinkedField: 'notify-probation-practitioner',
           formFields: ['notify-probation-practitioner'],
           message: 'Select whether to notify the probation practitioner or not',
         })
+        expect(data.error?.errors).toContainEqual({
+          errorSummaryLinkedField: 'session-summary',
+          formFields: ['session-summary'],
+          message: 'Enter what you did in the session',
+        })
+        expect(data.error?.errors).toContainEqual({
+          errorSummaryLinkedField: 'session-response',
+          formFields: ['session-response'],
+          message: 'Enter how Alex River responded to the session',
+        })
       })
 
-      it('returns the error when behaviour description is invalid', async () => {
+      it('returns the error when yes is selected for notify probation practitioner but session concerns is empty', async () => {
         const request = TestUtils.createRequest({
-          'behaviour-description': '',
+          'session-summary': 'summary',
+          'session-response': 'response',
+          'session-concerns': '',
           'notify-probation-practitioner': 'yes',
         })
 
@@ -47,16 +54,17 @@ describe(SessionFeedbackForm, () => {
 
         expect(data.error?.errors).toEqual([
           {
-            errorSummaryLinkedField: 'behaviour-description',
-            formFields: ['behaviour-description'],
-            message: 'Enter a description of their behaviour',
+            errorSummaryLinkedField: 'session-concerns',
+            formFields: ['session-concerns'],
+            message: 'Enter a description of what concerned you',
           },
         ])
       })
 
       it('returns the error when notify probation practitioner value is missing', async () => {
         const request = TestUtils.createRequest({
-          'behaviour-description': 'They did well',
+          'session-summary': 'summary',
+          'session-response': 'response',
         })
 
         const data = await new SessionFeedbackForm(request, serviceUser).data()

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackForm.test.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackForm.test.ts
@@ -1,8 +1,10 @@
 import TestUtils from '../../../../../../testutils/testUtils'
 import SessionFeedbackForm from './sessionFeedbackForm'
+import deliusServiceUserFactory from '../../../../../../testutils/factories/deliusServiceUser'
 
 describe(SessionFeedbackForm, () => {
   describe('data', () => {
+    const serviceUser = deliusServiceUserFactory.build()
     describe('with valid data', () => {
       it('returns a paramsForUpdate with the behaviour description and boolean value for whether to notify the PP', async () => {
         const request = TestUtils.createRequest({
@@ -10,7 +12,7 @@ describe(SessionFeedbackForm, () => {
           'notify-probation-practitioner': 'no',
         })
 
-        const data = await new SessionFeedbackForm(request).data()
+        const data = await new SessionFeedbackForm(request, serviceUser).data()
 
         // expect(data.paramsForUpdate?.behaviourDescription).toEqual('Alex was well-behaved')
         expect(data.paramsForUpdate?.notifyProbationPractitioner).toEqual(false)
@@ -21,7 +23,7 @@ describe(SessionFeedbackForm, () => {
       it('returns errors when both required fields are not present', async () => {
         const request = TestUtils.createRequest({})
 
-        const data = await new SessionFeedbackForm(request).data()
+        const data = await new SessionFeedbackForm(request, serviceUser).data()
 
         expect(data.error?.errors).toContainEqual({
           errorSummaryLinkedField: 'behaviour-description',
@@ -41,7 +43,7 @@ describe(SessionFeedbackForm, () => {
           'notify-probation-practitioner': 'yes',
         })
 
-        const data = await new SessionFeedbackForm(request).data()
+        const data = await new SessionFeedbackForm(request, serviceUser).data()
 
         expect(data.error?.errors).toEqual([
           {
@@ -57,7 +59,7 @@ describe(SessionFeedbackForm, () => {
           'behaviour-description': 'They did well',
         })
 
-        const data = await new SessionFeedbackForm(request).data()
+        const data = await new SessionFeedbackForm(request, serviceUser).data()
 
         expect(data.error?.errors).toEqual([
           {

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackInputsPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackInputsPresenter.test.ts
@@ -1,12 +1,12 @@
 import actionPlanAppointmentFactory from '../../../../../../testutils/factories/actionPlanAppointment'
-import BehaviourFeedbackInputsPresenter from './behaviourFeedbackInputsPresenter'
+import SessionFeedbackInputsPresenter from './sessionFeedbackInputsPresenter'
 
-describe(BehaviourFeedbackInputsPresenter, () => {
+describe(SessionFeedbackInputsPresenter, () => {
   describe('errorSummary', () => {
     describe('when error is null', () => {
       it('returns null', () => {
         const appointment = actionPlanAppointmentFactory.build()
-        const presenter = new BehaviourFeedbackInputsPresenter(appointment)
+        const presenter = new SessionFeedbackInputsPresenter(appointment)
 
         expect(presenter.errorSummary).toBeNull()
       })
@@ -16,7 +16,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
       it('returns a summary of the errors sorted into the order their fields appear on the page', () => {
         const appointment = actionPlanAppointmentFactory.build()
 
-        const presenter = new BehaviourFeedbackInputsPresenter(appointment, {
+        const presenter = new SessionFeedbackInputsPresenter(appointment, {
           errors: [
             {
               formFields: ['behaviour-description'],
@@ -49,7 +49,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
                 // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
               },
             })
-            const presenter = new BehaviourFeedbackInputsPresenter(appointment)
+            const presenter = new SessionFeedbackInputsPresenter(appointment)
 
             // expect(presenter.fields.behaviourDescription.value).toEqual('Alex was well behaved')
           })
@@ -62,7 +62,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
                 // behaviour: { behaviourDescription: undefined },
               },
             })
-            const presenter = new BehaviourFeedbackInputsPresenter(appointment)
+            const presenter = new SessionFeedbackInputsPresenter(appointment)
 
             // expect(presenter.fields.behaviourDescription.value).toEqual('')
           })
@@ -76,7 +76,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
               // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
             },
           })
-          const presenter = new BehaviourFeedbackInputsPresenter(appointment, null, {
+          const presenter = new SessionFeedbackInputsPresenter(appointment, null, {
             'behaviour-description': 'Alex misbehaved during the session',
           })
 
@@ -95,7 +95,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
               },
             })
 
-            const presenter = new BehaviourFeedbackInputsPresenter(appointment)
+            const presenter = new SessionFeedbackInputsPresenter(appointment)
 
             expect(presenter.fields.notifyProbationPractitioner.value).toEqual(false)
           })
@@ -109,7 +109,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
               },
             })
 
-            const presenter = new BehaviourFeedbackInputsPresenter(appointment)
+            const presenter = new SessionFeedbackInputsPresenter(appointment)
 
             expect(presenter.fields.notifyProbationPractitioner.value).toEqual(null)
           })
@@ -123,7 +123,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
               // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
             },
           })
-          const presenter = new BehaviourFeedbackInputsPresenter(appointment, null, {
+          const presenter = new SessionFeedbackInputsPresenter(appointment, null, {
             'behaviour-description': 'Alex misbehaved during the session',
             'notify-probation-practitioner': 'yes',
           })
@@ -136,7 +136,7 @@ describe(BehaviourFeedbackInputsPresenter, () => {
     describe('errors', () => {
       it('populates the error messages for the fields with errors', () => {
         const appointment = actionPlanAppointmentFactory.build()
-        const presenter = new BehaviourFeedbackInputsPresenter(appointment, {
+        const presenter = new SessionFeedbackInputsPresenter(appointment, {
           errors: [
             {
               formFields: ['behaviour-description'],

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackInputsPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackInputsPresenter.test.ts
@@ -19,9 +19,19 @@ describe(SessionFeedbackInputsPresenter, () => {
         const presenter = new SessionFeedbackInputsPresenter(appointment, {
           errors: [
             {
-              formFields: ['behaviour-description'],
-              errorSummaryLinkedField: 'behaviour-description',
-              message: 'behaviour msg',
+              formFields: ['session-summary'],
+              errorSummaryLinkedField: 'session-summary',
+              message: 'summary error msg',
+            },
+            {
+              formFields: ['session-response'],
+              errorSummaryLinkedField: 'session-response',
+              message: 'response error msg',
+            },
+            {
+              formFields: ['session-concerns'],
+              errorSummaryLinkedField: 'session-concerns',
+              message: 'concerns error msg',
             },
             {
               formFields: ['notify-probation-practitioner'],
@@ -32,7 +42,9 @@ describe(SessionFeedbackInputsPresenter, () => {
         })
 
         expect(presenter.errorSummary).toEqual([
-          { field: 'behaviour-description', message: 'behaviour msg' },
+          { field: 'session-summary', message: 'summary error msg' },
+          { field: 'session-response', message: 'response error msg' },
+          { field: 'session-concerns', message: 'concerns error msg' },
           { field: 'notify-probation-practitioner', message: 'notify pp msg' },
         ])
       })
@@ -40,31 +52,31 @@ describe(SessionFeedbackInputsPresenter, () => {
   })
 
   describe('fields', () => {
-    describe('behaviourDescriptionValue', () => {
+    describe('session feedback values', () => {
       describe('when there is no user input data', () => {
-        describe('when the appointment already has behaviourDescription set', () => {
+        describe('when the appointment already has sessionSummary set', () => {
           it('uses that value as the value attribute', () => {
             const appointment = actionPlanAppointmentFactory.build({
               appointmentFeedback: {
-                // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+                sessionFeedback: { sessionSummary: 'Discussed accommodation', notifyProbationPractitioner: false },
               },
             })
             const presenter = new SessionFeedbackInputsPresenter(appointment)
 
-            // expect(presenter.fields.behaviourDescription.value).toEqual('Alex was well behaved')
+            expect(presenter.fields.sessionSummary.value).toEqual('Discussed accommodation')
           })
         })
 
-        describe('when the appointment has no value for behaviourDescription', () => {
+        describe('when the appointment has no value for sessionConcerns', () => {
           it('sets the value to an empty string', () => {
             const appointment = actionPlanAppointmentFactory.build({
               appointmentFeedback: {
-                // behaviour: { behaviourDescription: undefined },
+                sessionFeedback: { sessionConcerns: undefined },
               },
             })
             const presenter = new SessionFeedbackInputsPresenter(appointment)
 
-            // expect(presenter.fields.behaviourDescription.value).toEqual('')
+            expect(presenter.fields.sessionConcerns.value).toEqual('')
           })
         })
       })
@@ -73,14 +85,18 @@ describe(SessionFeedbackInputsPresenter, () => {
         it('uses the user input data as the value attribute', () => {
           const appointment = actionPlanAppointmentFactory.build({
             appointmentFeedback: {
-              // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+              sessionFeedback: {
+                sessionSummary: 'Discussed his mental health',
+                sessionResponse: 'Engaged well',
+                notifyProbationPractitioner: false,
+              },
             },
           })
           const presenter = new SessionFeedbackInputsPresenter(appointment, null, {
-            'behaviour-description': 'Alex misbehaved during the session',
+            'session-summary': 'Discussed accommodation',
           })
 
-          // expect(presenter.fields.behaviourDescription.value).toEqual('Alex misbehaved during the session')
+          expect(presenter.fields.sessionSummary.value).toEqual('Discussed accommodation')
         })
       })
     })
@@ -91,7 +107,11 @@ describe(SessionFeedbackInputsPresenter, () => {
           it('uses the pre-selected value', () => {
             const appointment = actionPlanAppointmentFactory.build({
               appointmentFeedback: {
-                // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+                sessionFeedback: {
+                  sessionSummary: 'Summary of the session',
+                  sessionResponse: 'Alex was well behaved',
+                  notifyProbationPractitioner: false,
+                },
               },
             })
 
@@ -103,11 +123,7 @@ describe(SessionFeedbackInputsPresenter, () => {
 
         describe('when the appointment has no value for notifyProbationPractitioner', () => {
           it('sets the value to null', () => {
-            const appointment = actionPlanAppointmentFactory.build({
-              appointmentFeedback: {
-                // behaviour: { behaviourDescription: undefined },
-              },
-            })
+            const appointment = actionPlanAppointmentFactory.build()
 
             const presenter = new SessionFeedbackInputsPresenter(appointment)
 
@@ -120,14 +136,21 @@ describe(SessionFeedbackInputsPresenter, () => {
         it('uses the user input data as the value attribute', () => {
           const appointment = actionPlanAppointmentFactory.build({
             appointmentFeedback: {
-              // behaviour: { behaviourDescription: 'Alex was well behaved', notifyProbationPractitioner: false },
+              sessionFeedback: {
+                sessionSummary: 'Discussed accommodation',
+                sessionResponse: 'Engaged well',
+                notifyProbationPractitioner: false,
+              },
             },
           })
           const presenter = new SessionFeedbackInputsPresenter(appointment, null, {
-            'behaviour-description': 'Alex misbehaved during the session',
+            'session-summary': 'Discussed accommodation',
+            'session-response': 'Engaged well',
             'notify-probation-practitioner': 'yes',
           })
 
+          expect(presenter.fields.sessionSummary.value).toEqual('Discussed accommodation')
+          expect(presenter.fields.sessionResponse.value).toEqual('Engaged well')
           expect(presenter.fields.notifyProbationPractitioner.value).toEqual(true)
         })
       })
@@ -139,9 +162,19 @@ describe(SessionFeedbackInputsPresenter, () => {
         const presenter = new SessionFeedbackInputsPresenter(appointment, {
           errors: [
             {
-              formFields: ['behaviour-description'],
-              errorSummaryLinkedField: 'behaviour-description',
-              message: 'behaviour msg',
+              formFields: ['session-summary'],
+              errorSummaryLinkedField: 'session-summary',
+              message: 'summary error msg',
+            },
+            {
+              formFields: ['session-response'],
+              errorSummaryLinkedField: 'session-response',
+              message: 'response error msg',
+            },
+            {
+              formFields: ['session-concerns'],
+              errorSummaryLinkedField: 'session-concerns',
+              message: 'concerns error msg',
             },
             {
               formFields: ['notify-probation-practitioner'],
@@ -151,7 +184,9 @@ describe(SessionFeedbackInputsPresenter, () => {
           ],
         })
 
-        // expect(presenter.fields.behaviourDescription.errorMessage).toEqual('behaviour msg') //update this?
+        expect(presenter.fields.sessionSummary.errorMessage).toEqual('summary error msg')
+        expect(presenter.fields.sessionResponse.errorMessage).toEqual('response error msg')
+        expect(presenter.fields.sessionConcerns.errorMessage).toEqual('concerns error msg')
         expect(presenter.fields.notifyProbationPractitioner.errorMessage).toEqual('notify pp msg')
       })
     })

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackInputsPresenter.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackInputsPresenter.ts
@@ -2,7 +2,7 @@ import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../..
 import { FormValidationError } from '../../../../../utils/formValidationError'
 import PresenterUtils from '../../../../../utils/presenterUtils'
 
-export default class BehaviourFeedbackInputsPresenter {
+export default class SessionFeedbackInputsPresenter {
   constructor(
     private readonly appointment: ActionPlanAppointment | InitialAssessmentAppointment,
     private readonly error: FormValidationError | null = null,
@@ -22,22 +22,22 @@ export default class BehaviourFeedbackInputsPresenter {
   readonly fields = {
     sessionSummary: {
       value: new PresenterUtils(this.userInputData).stringValue(
-          this.appointment.appointmentFeedback?.sessionFeedback?.sessionSummary || null,
-          'session-summary'
+        this.appointment.appointmentFeedback?.sessionFeedback?.sessionSummary || null,
+        'session-summary'
       ),
       errorMessage: this.errorMessageForField('session-summary'),
     },
     sessionResponse: {
       value: new PresenterUtils(this.userInputData).stringValue(
-          this.appointment.appointmentFeedback?.sessionFeedback?.sessionResponse || null,
-          'session-response'
+        this.appointment.appointmentFeedback?.sessionFeedback?.sessionResponse || null,
+        'session-response'
       ),
       errorMessage: this.errorMessageForField('session-response'),
     },
     sessionConcerns: {
       value: new PresenterUtils(this.userInputData).stringValue(
-          this.appointment.appointmentFeedback?.sessionFeedback?.sessionConcerns || null,
-          'session-Concerns'
+        this.appointment.appointmentFeedback?.sessionFeedback?.sessionConcerns || null,
+        'session-Concerns'
       ),
       errorMessage: this.errorMessageForField('session-concerns'),
     },

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackInputsPresenter.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackInputsPresenter.ts
@@ -14,7 +14,7 @@ export default class SessionFeedbackInputsPresenter {
   }
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error, {
-    fieldOrder: ['behaviour-description', 'notify-probation-practitioner'],
+    fieldOrder: ['session-summary', 'session-response', 'session-concerns', 'notify-probation-practitioner'],
   })
 
   private readonly utils = new PresenterUtils(this.userInputData)
@@ -37,7 +37,7 @@ export default class SessionFeedbackInputsPresenter {
     sessionConcerns: {
       value: new PresenterUtils(this.userInputData).stringValue(
         this.appointment.appointmentFeedback?.sessionFeedback?.sessionConcerns || null,
-        'session-Concerns'
+        'session-concerns'
       ),
       errorMessage: this.errorMessageForField('session-concerns'),
     },

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackPresenter.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackPresenter.ts
@@ -1,0 +1,9 @@
+import SessionFeedbackInputsPresenter from './sessionFeedbackInputsPresenter'
+import SessionFeedbackQuestionnaire from './sessionFeedbackQuestionnaire'
+
+export interface SessionFeedbackPresenter {
+  text: { title: string }
+  questionnaire: SessionFeedbackQuestionnaire
+  inputsPresenter: SessionFeedbackInputsPresenter
+  backLinkHref: string | null
+}

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackQuestionnaire.test.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackQuestionnaire.test.ts
@@ -1,13 +1,13 @@
-import BehaviourFeedbackQuestionnaire from './behaviourFeedbackQuestionnaire'
+import SessionFeedbackQuestionnaire from './sessionFeedbackQuestionnaire'
 import initialAssessmentAppointment from '../../../../../../testutils/factories/initialAssessmentAppointment'
 import deliusServiceUser from '../../../../../../testutils/factories/deliusServiceUser'
 import actionPlanAppointment from '../../../../../../testutils/factories/actionPlanAppointment'
 
-describe(BehaviourFeedbackQuestionnaire, () => {
+describe(SessionFeedbackQuestionnaire, () => {
   describe('behaviourQuestion', () => {
     describe('when the appointment is an initial assessment', () => {
       it('should produce a question specific to initial assessment', () => {
-        const questionnaire = new BehaviourFeedbackQuestionnaire(
+        const questionnaire = new SessionFeedbackQuestionnaire(
           initialAssessmentAppointment.build(),
           deliusServiceUser.build({ firstName: 'Alex' })
         )
@@ -17,7 +17,7 @@ describe(BehaviourFeedbackQuestionnaire, () => {
 
     describe('when the appointment is an action plan session', () => {
       it('should produce a question specific to action plan session', () => {
-        const questionnaire = new BehaviourFeedbackQuestionnaire(
+        const questionnaire = new SessionFeedbackQuestionnaire(
           actionPlanAppointment.build(),
           deliusServiceUser.build({ firstName: 'Alex' })
         )

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackQuestionnaire.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackQuestionnaire.ts
@@ -2,7 +2,7 @@ import AppointmentDecorator from '../../../../../decorators/appointmentDecorator
 import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 
-export default class BehaviourFeedbackQuestionnaire {
+export default class SessionFeedbackQuestionnaire {
   private readonly appointmentDecorator: AppointmentDecorator
 
   constructor(
@@ -13,23 +13,24 @@ export default class BehaviourFeedbackQuestionnaire {
   }
 
   get sessionSummaryQuestion(): { text: string; hint: string } {
-      return {
-        text: `What did you do in the session?`,
-        hint: 'Add details about what you did, anything that was achieved and what came out of the session.',
-      }
+    return {
+      text: `What did you do in the session?`,
+      hint: 'Add details about what you did, anything that was achieved and what came out of the session.',
+    }
   }
 
   get sessionResponseQuestion(): { text: string; hint: string } {
     return {
       text: `How did ${this.serviceUser.firstName} ${this.serviceUser.surname} respond to the session?`,
-      hint: `Add whether ${this.serviceUser.firstName} ${this.serviceUser.surname} seemed engaged, ` +
-          `including any progress or positive changes. This helps the probation practitioner to support ${this.serviceUser.firstName}.`,
+      hint:
+        `Add whether ${this.serviceUser.firstName} ${this.serviceUser.surname} seemed engaged, ` +
+        `including any progress or positive changes. This helps the probation practitioner to support ${this.serviceUser.firstName}.`,
     }
   }
 
-  get sessionConcernsQuestion(): { text: string} {
+  get sessionConcernsQuestion(): { text: string } {
     return {
-      text: `Add enough detail to help the probation practitioner to know what happened`
+      text: `Add enough detail to help the probation practitioner to know what happened`,
     }
   }
 

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackView.ts
@@ -1,12 +1,12 @@
 import { BackLinkArgs, ErrorSummaryArgs, TextareaArgs } from '../../../../../utils/govukFrontendTypes'
 import ViewUtils from '../../../../../utils/viewUtils'
-import BehaviourFeedbackInputsPresenter from './behaviourFeedbackInputsPresenter'
-import { BehaviourFeedbackPresenter } from './behaviourFeedbackPresenter'
+import SessionFeedbackInputsPresenter from './sessionFeedbackInputsPresenter'
+import { SessionFeedbackPresenter } from './sessionFeedbackPresenter'
 
-export default class BehaviourFeedbackView {
-  inputsPresenter: BehaviourFeedbackInputsPresenter
+export default class SessionFeedbackView {
+  inputsPresenter: SessionFeedbackInputsPresenter
 
-  constructor(private readonly presenter: BehaviourFeedbackPresenter) {
+  constructor(private readonly presenter: SessionFeedbackPresenter) {
     this.inputsPresenter = this.presenter.inputsPresenter
   }
 
@@ -62,24 +62,6 @@ export default class BehaviourFeedbackView {
     }
   }
 
-  // private get textAreaArgs(): TextareaArgs {
-  //   return {
-  //     name: 'behaviour-description',
-  //     id: 'behaviour-description',
-  //     label: {
-  //       text: this.presenter.questionnaire.behaviourQuestion.text,
-  //       classes: 'govuk-label--m govuk-!-margin-bottom-4',
-  //       isPageHeading: false,
-  //     },
-  //     hint: {
-  //       text: this.presenter.questionnaire.behaviourQuestion.hint,
-  //     },
-  //     value: this.inputsPresenter.fields.behaviourDescription.value,
-  //     errorMessage: ViewUtils.govukErrorMessage(this.inputsPresenter.fields.behaviourDescription.errorMessage),
-  //   }
-  // }
-
-
   private radioButtonArgs(yesHtml: string): Record<string, unknown> {
     return {
       classes: 'govuk-radios',
@@ -129,7 +111,7 @@ export default class BehaviourFeedbackView {
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [
-      'appointments/feedback/shared/postSessionBehaviourFeedback',
+      'appointments/feedback/shared/postSessionFeedback',
       {
         presenter: this.presenter,
         sessionSummaryTextAreaArgs: this.sessionSummaryTextAreaArgs,

--- a/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackView.ts
+++ b/server/routes/appointments/feedback/shared/sessionFeedback/sessionFeedbackView.ts
@@ -77,9 +77,6 @@ export default class SessionFeedbackView {
           isPageHeading: false,
         },
       },
-      // hint: {
-      //   text: this.presenter.questionnaire.notifyProbationPractitionerQuestion.hint,
-      // },
       items: [
         {
           value: 'yes',

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
@@ -24,7 +24,7 @@ describe(FeedbackAnswersPresenter, () => {
       const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
       expect(presenter.attendedAnswers).toEqual({
-        question: 'Did Alex attend this session?',
+        question: 'Did Alex River come to the session?',
         answer: 'Yes, they were on time',
       })
     })
@@ -80,33 +80,6 @@ describe(FeedbackAnswersPresenter, () => {
       })
     })
 
-    describe('when there is no answer for AdditionalAttendanceInformation', () => {
-      it('returns an object with "None" as the answer', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          appointmentFeedback: {
-            attendanceFeedback: {
-              attended: 'late',
-              additionalAttendanceInformation: '',
-            },
-            sessionFeedback: {
-              sessionSummary: null,
-              sessionResponse: null,
-              notifyProbationPractitioner: null,
-              sessionConcerns: null,
-            },
-          },
-        })
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
-
-        expect(presenter.additionalAttendanceAnswers).toEqual({
-          question: "Add additional information about Alex's attendance:",
-          answer: 'None',
-        })
-      })
-    })
-
     describe('when there is a null value for AdditionalAttendanceInformation', () => {
       it('returns null', () => {
         const appointment = actionPlanAppointmentFactory.build({
@@ -148,7 +121,7 @@ describe(FeedbackAnswersPresenter, () => {
         const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
         expect(presenter.notifyProbationPractitionerAnswers).toEqual({
-          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+          question: 'Did anything concern you about Alex River?',
           answer: 'Yes',
         })
       })
@@ -159,7 +132,6 @@ describe(FeedbackAnswersPresenter, () => {
         const appointment = actionPlanAppointmentFactory.build({
           appointmentFeedback: {
             sessionFeedback: {
-              // behaviourDescription: 'Alex had a good attitude',
               notifyProbationPractitioner: false,
             },
           },
@@ -170,7 +142,7 @@ describe(FeedbackAnswersPresenter, () => {
         const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
 
         expect(presenter.notifyProbationPractitionerAnswers).toEqual({
-          question: 'If you described poor behaviour, do you want to notify the probation practitioner?',
+          question: 'Did anything concern you about Alex River?',
           answer: 'No',
         })
       })

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
@@ -7,13 +7,15 @@ describe(FeedbackAnswersPresenter, () => {
   describe('attendedAnswers', () => {
     it('returns an object with the question and answer given', () => {
       const appointment = actionPlanAppointmentFactory.build({
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'yes',
           },
-          behaviour: {
-            behaviourDescription: null,
+          sessionFeedback: {
+            sessionSummary: null,
+            sessionResponse: null,
             notifyProbationPractitioner: null,
+            sessionConcerns: null,
           },
         },
       })
@@ -30,13 +32,15 @@ describe(FeedbackAnswersPresenter, () => {
     describe('when there is no value for attended', () => {
       it('returns null', () => {
         const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: null,
             },
-            behaviour: {
-              behaviourDescription: null,
+            sessionFeedback: {
+              sessionSummary: null,
+              sessionResponse: null,
               notifyProbationPractitioner: null,
+              sessionConcerns: null,
             },
           },
         })
@@ -52,14 +56,16 @@ describe(FeedbackAnswersPresenter, () => {
     describe('when there is an answer for AdditionalAttendanceInformation', () => {
       it('returns an object with the question and answer given', () => {
         const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'late',
               additionalAttendanceInformation: 'Alex missed the bus',
             },
-            behaviour: {
-              behaviourDescription: null,
+            sessionFeedback: {
+              sessionSummary: null,
+              sessionResponse: null,
               notifyProbationPractitioner: null,
+              sessionConcerns: null,
             },
           },
         })
@@ -77,14 +83,16 @@ describe(FeedbackAnswersPresenter, () => {
     describe('when there is no answer for AdditionalAttendanceInformation', () => {
       it('returns an object with "None" as the answer', () => {
         const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'late',
               additionalAttendanceInformation: '',
             },
-            behaviour: {
-              behaviourDescription: null,
+            sessionFeedback: {
+              sessionSummary: null,
+              sessionResponse: null,
               notifyProbationPractitioner: null,
+              sessionConcerns: null,
             },
           },
         })
@@ -102,14 +110,16 @@ describe(FeedbackAnswersPresenter, () => {
     describe('when there is a null value for AdditionalAttendanceInformation', () => {
       it('returns null', () => {
         const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'late',
               additionalAttendanceInformation: null,
             },
-            behaviour: {
-              behaviourDescription: null,
+            sessionFeedback: {
+              sessionSummary: null,
+              sessionResponse: null,
               notifyProbationPractitioner: null,
+              sessionConcerns: null,
             },
           },
         })
@@ -121,60 +131,13 @@ describe(FeedbackAnswersPresenter, () => {
     })
   })
 
-  describe('behaviourDescriptionAnswers', () => {
-    describe('if the behaviour question was answered', () => {
-      it('returns an object with the question and answer given', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
-              attended: 'yes',
-            },
-            behaviour: {
-              behaviourDescription: 'Alex had a bad attitude',
-              notifyProbationPractitioner: true,
-            },
-          },
-        })
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
-
-        expect(presenter.behaviourDescriptionAnswers).toEqual({
-          question: "Describe Alex's behaviour in this session",
-          answer: 'Alex had a bad attitude',
-        })
-      })
-    })
-
-    describe('if the behaviour question was not answered', () => {
-      it('returns null', () => {
-        const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            attendance: {
-              attended: 'yes',
-            },
-            behaviour: {
-              behaviourDescription: null,
-              notifyProbationPractitioner: null,
-            },
-          },
-        })
-        const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex' })
-
-        const presenter = new FeedbackAnswersPresenter(appointment, serviceUser)
-
-        expect(presenter.behaviourDescriptionAnswers).toBeNull()
-      })
-    })
-  })
-
   describe('notifyProbationPractitionerAnswers', () => {
     describe('if the behaviour question was answered with yes', () => {
       it('returns an object with the question and answer given, converting the boolean value into a "yes"', () => {
         const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            behaviour: {
-              behaviourDescription: 'Alex had a bad attitude',
+          appointmentFeedback: {
+            sessionFeedback: {
+              // behaviourDescription: 'Alex had a bad attitude',
               notifyProbationPractitioner: true,
             },
           },
@@ -194,9 +157,9 @@ describe(FeedbackAnswersPresenter, () => {
     describe('if the behaviour question was answered with no', () => {
       it('returns an object with the question and answer given, converting the boolean value into a "no"', () => {
         const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            behaviour: {
-              behaviourDescription: 'Alex had a good attitude',
+          appointmentFeedback: {
+            sessionFeedback: {
+              // behaviourDescription: 'Alex had a good attitude',
               notifyProbationPractitioner: false,
             },
           },
@@ -216,9 +179,9 @@ describe(FeedbackAnswersPresenter, () => {
     describe('if the behaviour question was not answered', () => {
       it('returns null', () => {
         const appointment = actionPlanAppointmentFactory.build({
-          sessionFeedback: {
-            behaviour: {
-              behaviourDescription: null,
+          appointmentFeedback: {
+            sessionFeedback: {
+              // behaviourDescription: null,
               notifyProbationPractitioner: null,
             },
           },

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.test.ts
@@ -110,7 +110,6 @@ describe(FeedbackAnswersPresenter, () => {
         const appointment = actionPlanAppointmentFactory.build({
           appointmentFeedback: {
             sessionFeedback: {
-              // behaviourDescription: 'Alex had a bad attitude',
               notifyProbationPractitioner: true,
             },
           },
@@ -153,7 +152,6 @@ describe(FeedbackAnswersPresenter, () => {
         const appointment = actionPlanAppointmentFactory.build({
           appointmentFeedback: {
             sessionFeedback: {
-              // behaviourDescription: null,
               notifyProbationPractitioner: null,
             },
           },

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
@@ -27,7 +27,7 @@ export default class FeedbackAnswersPresenter {
       return null
     }
     return {
-      question: this.attendanceFeedbackQuestionnaire.attendanceQuestion.text,
+      question: `Did ${this.serviceUser.firstName} ${this.serviceUser.surname} come to the session?`,
       answer: selected.text,
     }
   }
@@ -60,16 +60,16 @@ export default class FeedbackAnswersPresenter {
     }
   }
 
-  // get behaviourDescriptionAnswers(): { question: string; answer: string } | null {
-  //   if (this.appointment.appointmentFeedback.sessionFeedback.behaviourDescription === null) {
-  //     return null
-  //   }
-  //
-  //   return {
-  //     question: this.behaviourFeedbackQuestionnaire.behaviourQuestion.text,
-  //     answer: this.appointment.appointmentFeedback.sessionFeedback.behaviourDescription,
-  //   }
-  // }
+  get behaviourDescriptionAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.appointmentFeedback.sessionFeedback.behaviourDescription === null) {
+      return null
+    }
+
+    return {
+      question: this.behaviourFeedbackQuestionnaire.behaviourQuestion.text,
+      answer: this.appointment.appointmentFeedback.sessionFeedback.behaviourDescription,
+    }
+  }
 
   get notifyProbationPractitionerAnswers(): { question: string; answer: string } | null {
     if (this.appointment.appointmentFeedback.sessionFeedback.notifyProbationPractitioner === null) {
@@ -79,6 +79,44 @@ export default class FeedbackAnswersPresenter {
     return {
       question: this.behaviourFeedbackQuestionnaire.notifyProbationPractitionerQuestion.text,
       answer: this.appointment.appointmentFeedback.sessionFeedback.notifyProbationPractitioner ? 'Yes' : 'No',
+    }
+  }
+
+  get sessionSummaryAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.appointmentFeedback.sessionFeedback.sessionSummary === null) {
+      return null
+    }
+
+    return {
+      question: this.behaviourFeedbackQuestionnaire.sessionSummaryQuestion.text,
+      answer: this.appointment.appointmentFeedback.sessionFeedback.sessionSummary || 'None',
+    }
+  }
+
+  get sessionResponseAnswers(): { question: string; answer: string } | null {
+    if (this.appointment.appointmentFeedback.sessionFeedback.sessionResponse === null) {
+      return null
+    }
+
+    return {
+      question: this.behaviourFeedbackQuestionnaire.sessionResponseQuestion.text,
+      answer: this.appointment.appointmentFeedback.sessionFeedback.sessionResponse || 'None',
+    }
+  }
+
+  get sessionConcernsAnswers(): { question: string; answer: string } | null {
+    const notifyPP = this.appointment.appointmentFeedback.sessionFeedback.notifyProbationPractitioner ? 'Yes' : 'No'
+
+    if(notifyPP == 'Yes' && this.appointment.appointmentFeedback.sessionFeedback.sessionConcerns){
+      return {
+        question: this.behaviourFeedbackQuestionnaire.notifyProbationPractitionerQuestion.text,
+        answer: `${notifyPP} - ${this.appointment.appointmentFeedback.sessionFeedback.sessionConcerns}`,
+      }
+    }
+
+    return {
+      question: this.behaviourFeedbackQuestionnaire.notifyProbationPractitionerQuestion.text,
+      answer: `${notifyPP}`,
     }
   }
 }

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
@@ -17,11 +17,11 @@ export default class FeedbackAnswersPresenter {
   }
 
   get attendedAnswers(): { question: string; answer: string } | null {
-    if (this.appointment.sessionFeedback.attendance.attended === null) {
+    if (this.appointment.appointmentFeedback.attendanceFeedback.attended === null) {
       return null
     }
     const selected = this.possibleAttendanceAnswers.find(
-      selection => selection.value === this.appointment.sessionFeedback.attendance.attended
+      selection => selection.value === this.appointment.appointmentFeedback.attendanceFeedback.attended
     )
     if (!selected) {
       return null
@@ -50,35 +50,35 @@ export default class FeedbackAnswersPresenter {
   }
 
   get additionalAttendanceAnswers(): { question: string; answer: string } | null {
-    if (this.appointment.sessionFeedback.attendance.additionalAttendanceInformation === null) {
+    if (this.appointment.appointmentFeedback.attendanceFeedback.additionalAttendanceInformation === null) {
       return null
     }
 
     return {
       question: this.attendanceFeedbackQuestionnaire.additionalAttendanceInformationQuestion,
-      answer: this.appointment.sessionFeedback.attendance.additionalAttendanceInformation || 'None',
+      answer: this.appointment.appointmentFeedback.attendanceFeedback.additionalAttendanceInformation || 'None',
     }
   }
 
-  get behaviourDescriptionAnswers(): { question: string; answer: string } | null {
-    if (this.appointment.sessionFeedback.behaviour.behaviourDescription === null) {
-      return null
-    }
-
-    return {
-      question: this.behaviourFeedbackQuestionnaire.behaviourQuestion.text,
-      answer: this.appointment.sessionFeedback.behaviour.behaviourDescription,
-    }
-  }
+  // get behaviourDescriptionAnswers(): { question: string; answer: string } | null {
+  //   if (this.appointment.appointmentFeedback.sessionFeedback.behaviourDescription === null) {
+  //     return null
+  //   }
+  //
+  //   return {
+  //     question: this.behaviourFeedbackQuestionnaire.behaviourQuestion.text,
+  //     answer: this.appointment.appointmentFeedback.sessionFeedback.behaviourDescription,
+  //   }
+  // }
 
   get notifyProbationPractitionerAnswers(): { question: string; answer: string } | null {
-    if (this.appointment.sessionFeedback.behaviour.notifyProbationPractitioner === null) {
+    if (this.appointment.appointmentFeedback.sessionFeedback.notifyProbationPractitioner === null) {
       return null
     }
 
     return {
       question: this.behaviourFeedbackQuestionnaire.notifyProbationPractitionerQuestion.text,
-      answer: this.appointment.sessionFeedback.behaviour.notifyProbationPractitioner ? 'Yes' : 'No',
+      answer: this.appointment.appointmentFeedback.sessionFeedback.notifyProbationPractitioner ? 'Yes' : 'No',
     }
   }
 }

--- a/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
+++ b/server/routes/appointments/feedback/shared/viewFeedback/feedbackAnswersPresenter.ts
@@ -1,19 +1,19 @@
 import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../../../../models/appointment'
 import AttendanceFeedbackQuestionnaire from '../attendance/attendanceFeedbackQuestionnaire'
-import BehaviourFeedbackQuestionnaire from '../behaviour/behaviourFeedbackQuestionnaire'
+import SessionFeedbackQuestionnaire from '../sessionFeedback/sessionFeedbackQuestionnaire'
 import DeliusServiceUser from '../../../../../models/delius/deliusServiceUser'
 
 export default class FeedbackAnswersPresenter {
   private readonly attendanceFeedbackQuestionnaire: AttendanceFeedbackQuestionnaire
 
-  private readonly behaviourFeedbackQuestionnaire: BehaviourFeedbackQuestionnaire
+  private readonly behaviourFeedbackQuestionnaire: SessionFeedbackQuestionnaire
 
   constructor(
     private readonly appointment: ActionPlanAppointment | InitialAssessmentAppointment,
     private readonly serviceUser: DeliusServiceUser
   ) {
     this.attendanceFeedbackQuestionnaire = new AttendanceFeedbackQuestionnaire(appointment, serviceUser)
-    this.behaviourFeedbackQuestionnaire = new BehaviourFeedbackQuestionnaire(appointment, serviceUser)
+    this.behaviourFeedbackQuestionnaire = new SessionFeedbackQuestionnaire(appointment, serviceUser)
   }
 
   get attendedAnswers(): { question: string; answer: string } | null {
@@ -50,7 +50,7 @@ export default class FeedbackAnswersPresenter {
   }
 
   get additionalAttendanceAnswers(): { question: string; answer: string } | null {
-    if (this.appointment.appointmentFeedback.attendanceFeedback.additionalAttendanceInformation === null) {
+    if (!this.appointment.appointmentFeedback.attendanceFeedback.additionalAttendanceInformation) {
       return null
     }
 
@@ -60,8 +60,19 @@ export default class FeedbackAnswersPresenter {
     }
   }
 
+  get attendanceFailureInformationAnswers(): { question: string; answer: string } | null {
+    if (!this.appointment.appointmentFeedback.attendanceFeedback.attendanceFailureInformation) {
+      return null
+    }
+
+    return {
+      question: this.attendanceFeedbackQuestionnaire.attendanceFailureInformationQuestion,
+      answer: this.appointment.appointmentFeedback.attendanceFeedback.attendanceFailureInformation || 'None',
+    }
+  }
+
   get behaviourDescriptionAnswers(): { question: string; answer: string } | null {
-    if (this.appointment.appointmentFeedback.sessionFeedback.behaviourDescription === null) {
+    if (!this.appointment.appointmentFeedback.sessionFeedback.behaviourDescription) {
       return null
     }
 
@@ -107,7 +118,7 @@ export default class FeedbackAnswersPresenter {
   get sessionConcernsAnswers(): { question: string; answer: string } | null {
     const notifyPP = this.appointment.appointmentFeedback.sessionFeedback.notifyProbationPractitioner ? 'Yes' : 'No'
 
-    if(notifyPP == 'Yes' && this.appointment.appointmentFeedback.sessionFeedback.sessionConcerns){
+    if (notifyPP === 'Yes' && this.appointment.appointmentFeedback.sessionFeedback.sessionConcerns) {
       return {
         question: this.behaviourFeedbackQuestionnaire.notifyProbationPractitionerQuestion.text,
         answer: `${notifyPP} - ${this.appointment.appointmentFeedback.sessionFeedback.sessionConcerns}`,

--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.test.ts
@@ -112,7 +112,7 @@ describe(InterventionProgressPresenter, () => {
       })
 
       describe('and the appointment is in the past', () => {
-        it('populates the table with formatted session information, with "Awaiting feedback" status', () => {
+        it('populates the table with formatted session information, with "Needs feedback" status', () => {
           const referral = sentReferralFactory.build()
           const intervention = interventionFactory.build()
           const supplierAssessment = supplierAssessmentFactory.build()
@@ -137,7 +137,7 @@ describe(InterventionProgressPresenter, () => {
               sessionNumber: 1,
               appointmentTime: '1:00pm on 7 Dec 1920',
               tagArgs: {
-                text: 'awaiting feedback',
+                text: 'needs feedback',
                 classes: 'govuk-tag--red',
               },
               link: null,

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -106,7 +106,7 @@ export default function probationPractitionerRoutes(router: Router, services: Se
   get(
     router,
     '/referrals/:referralId/session/:sessionNumber/appointment/:appointmentId/post-session-feedback',
-    (req, res) => appointmentsController.viewSubmittedPostSessionFeedback(req, res, 'probation-practitioner')
+    (req, res) => appointmentsController.viewSubmittedActionPlanSessionFeedback(req, res, 'probation-practitioner')
   )
   get(router, '/action-plan/:actionPlanId', (req, res) =>
     probationPractitionerReferralsController.viewActionPlanById(req, res)

--- a/server/routes/serviceProviderReferrals/draftAppointment.ts
+++ b/server/routes/serviceProviderReferrals/draftAppointment.ts
@@ -2,7 +2,7 @@ import { DraftAppointmentFeedbackDetails } from './draftAppointmentFeedback'
 import { AppointmentSchedulingDetails } from '../../models/appointment'
 
 export type AppointmentDetails = DraftAppointmentBooking & {
-  sessionFeedback?: DraftAppointmentFeedbackDetails
+  session?: DraftAppointmentFeedbackDetails
 }
 
 export type DraftAppointment = null | AppointmentDetails

--- a/server/routes/serviceProviderReferrals/draftAppointmentFeedback.ts
+++ b/server/routes/serviceProviderReferrals/draftAppointmentFeedback.ts
@@ -1,6 +1,6 @@
 import User from '../../models/hmppsAuth/user'
 
-// Warning: We have copied from sessionFeedback.ts because it decouples the model from the REDIS draft object.
+// Warning: We have copied from appointmentFeedback.ts because it decouples the model from the REDIS draft object.
 // The REDIS draft object may have some drafts in flight when making changes, so care must be taken to ensure that the object
 // is never modified only appended to.
 export interface DraftAppointmentFeedbackDetails {
@@ -8,8 +8,8 @@ export interface DraftAppointmentFeedbackDetails {
     attended: 'yes' | 'no' | 'late' | null
     additionalAttendanceInformation: string | null
   }
-  behaviour: {
-    behaviourDescription: string | null
+  sessionFeedback: {
+    // behaviourDescription: string | null
     notifyProbationPractitioner: boolean | null
     sessionSummary:  string | null //is this correct?
     sessionResponse: string | null

--- a/server/routes/serviceProviderReferrals/draftAppointmentFeedback.ts
+++ b/server/routes/serviceProviderReferrals/draftAppointmentFeedback.ts
@@ -6,12 +6,11 @@ import User from '../../models/hmppsAuth/user'
 export interface DraftAppointmentFeedbackDetails {
   attendanceFeedback: {
     attended: 'yes' | 'no' | 'late' | null
-    additionalAttendanceInformation: string | null
+    attendanceFailureInformation: string | null
   }
   sessionFeedback: {
-    // behaviourDescription: string | null
     notifyProbationPractitioner: boolean | null
-    sessionSummary:  string | null //is this correct?
+    sessionSummary: string | null
     sessionResponse: string | null
     sessionConcerns: string | null
   }

--- a/server/routes/serviceProviderReferrals/draftAppointmentFeedback.ts
+++ b/server/routes/serviceProviderReferrals/draftAppointmentFeedback.ts
@@ -4,7 +4,7 @@ import User from '../../models/hmppsAuth/user'
 // The REDIS draft object may have some drafts in flight when making changes, so care must be taken to ensure that the object
 // is never modified only appended to.
 export interface DraftAppointmentFeedbackDetails {
-  attendance: {
+  attendanceFeedback: {
     attended: 'yes' | 'no' | 'late' | null
     additionalAttendanceInformation: string | null
   }

--- a/server/routes/serviceProviderReferrals/draftAppointmentFeedback.ts
+++ b/server/routes/serviceProviderReferrals/draftAppointmentFeedback.ts
@@ -11,6 +11,9 @@ export interface DraftAppointmentFeedbackDetails {
   behaviour: {
     behaviourDescription: string | null
     notifyProbationPractitioner: boolean | null
+    sessionSummary:  string | null //is this correct?
+    sessionResponse: string | null
+    sessionConcerns: string | null
   }
   submitted: boolean
   submittedBy: User | null

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -9,6 +9,9 @@ import initialAssessmentAppointmentFactory from '../../../testutils/factories/in
 import SessionStatusPresenter from '../shared/sessionStatusPresenter'
 import { SessionStatus } from '../../utils/sessionStatus'
 import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
+import deliusServiceUserFactory from '../../../testutils/factories/deliusServiceUser'
+
+const serviceUser = deliusServiceUserFactory.build({ firstName: 'Alex', surname: 'River' })
 
 describe(InterventionProgressPresenter, () => {
   describe('referralEnded', () => {
@@ -22,6 +25,7 @@ describe(InterventionProgressPresenter, () => {
         [],
         [],
         supplierAssessmentFactory.build(),
+        serviceUser,
         null
       )
 
@@ -37,6 +41,7 @@ describe(InterventionProgressPresenter, () => {
         [],
         [],
         supplierAssessmentFactory.build(),
+        serviceUser,
         null
       )
 
@@ -55,6 +60,7 @@ describe(InterventionProgressPresenter, () => {
         [],
         [],
         supplierAssessmentFactory.build(),
+        serviceUser,
         null
       )
 
@@ -72,6 +78,7 @@ describe(InterventionProgressPresenter, () => {
         [],
         [],
         supplierAssessmentFactory.build(),
+        serviceUser,
         null
       )
 
@@ -92,6 +99,7 @@ describe(InterventionProgressPresenter, () => {
         [],
         [],
         supplierAssessmentFactory.build(),
+        serviceUser,
         null
       )
 
@@ -114,6 +122,7 @@ describe(InterventionProgressPresenter, () => {
             actionPlanAppointmentFactory.build({ sessionNumber: 1 }),
           ],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
         expect(presenter.sessionTableRows.map(row => row.sessionNumber)).toEqual([1, 2, 3])
@@ -137,6 +146,7 @@ describe(InterventionProgressPresenter, () => {
             actionPlanAppointmentFactory.build({ sessionNumber: 1 }),
           ],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
         expect(actionPlan.numberOfSessions).toEqual(presenter.sessionTableRows.length)
@@ -155,6 +165,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [actionPlanAppointmentFactory.newlyCreated().build()],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
         expect(presenter.sessionTableRows).toEqual([
@@ -192,6 +203,7 @@ describe(InterventionProgressPresenter, () => {
             }),
           ],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
         expect(presenter.sessionTableRows).toEqual([
@@ -233,6 +245,7 @@ describe(InterventionProgressPresenter, () => {
             }),
           ],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
         expect(presenter.sessionTableRows).toEqual([
@@ -266,6 +279,7 @@ describe(InterventionProgressPresenter, () => {
               actionPlanAppointmentFactory.attended('late').build({ sessionNumber: 2, id: '2' }),
             ],
             supplierAssessmentFactory.build(),
+            serviceUser,
             null
           )
 
@@ -310,6 +324,7 @@ describe(InterventionProgressPresenter, () => {
               actionPlanAppointmentFactory.attended('late').build({ id: '2', sessionNumber: 1 }),
             ],
             supplierAssessmentFactory.build(),
+            serviceUser,
             null
           )
 
@@ -342,6 +357,7 @@ describe(InterventionProgressPresenter, () => {
             [],
             [actionPlanAppointmentFactory.attended('no').build({ id: '1' })],
             supplierAssessmentFactory.build(),
+            serviceUser,
             null
           )
 
@@ -380,6 +396,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -401,6 +418,7 @@ describe(InterventionProgressPresenter, () => {
             [],
             [],
             supplierAssessmentFactory.build(),
+            serviceUser,
             null
           )
 
@@ -420,6 +438,7 @@ describe(InterventionProgressPresenter, () => {
             [],
             [],
             supplierAssessmentFactory.build(),
+            serviceUser,
             null
           )
 
@@ -439,6 +458,7 @@ describe(InterventionProgressPresenter, () => {
             [],
             [],
             supplierAssessmentFactory.build(),
+            serviceUser,
             null
           )
 
@@ -462,6 +482,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -483,6 +504,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           assignee
         )
 
@@ -505,6 +527,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -526,6 +549,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           assignee
         )
 
@@ -548,6 +572,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -569,6 +594,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           assignee
         )
 
@@ -589,6 +615,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -608,6 +635,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -627,6 +655,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -647,6 +676,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -667,6 +697,7 @@ describe(InterventionProgressPresenter, () => {
             [],
             [],
             supplierAssessmentFactory.build(),
+            serviceUser,
             null
           )
 
@@ -686,6 +717,7 @@ describe(InterventionProgressPresenter, () => {
             [],
             [],
             supplierAssessmentFactory.build(),
+            serviceUser,
             null
           )
 
@@ -707,6 +739,7 @@ describe(InterventionProgressPresenter, () => {
             [],
             [],
             supplierAssessmentFactory.build(),
+            serviceUser,
             null
           )
 
@@ -728,6 +761,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -747,6 +781,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -766,6 +801,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -786,6 +822,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -805,6 +842,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -824,6 +862,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -850,6 +889,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build({ appointments: [firstScheduledAppointment, secondScheduledAppointment] }),
+          serviceUser,
           null
         )
 
@@ -869,6 +909,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentWithNoAppointmentScheduled,
+          serviceUser,
           null
         )
 
@@ -888,6 +929,7 @@ describe(InterventionProgressPresenter, () => {
             [],
             [],
             supplierAssessmentFactory.build({ appointments: [] }),
+            serviceUser,
             null
           )
 
@@ -914,6 +956,7 @@ describe(InterventionProgressPresenter, () => {
               [],
               [],
               supplierAssessmentFactory.withAnAppointment(appointment).build(),
+              serviceUser,
               null
             )
 
@@ -938,6 +981,7 @@ describe(InterventionProgressPresenter, () => {
               [],
               [],
               supplierAssessmentFactory.withAnAppointment(appointment).build(),
+              serviceUser,
               null
             )
 
@@ -963,6 +1007,7 @@ describe(InterventionProgressPresenter, () => {
             [],
             [],
             supplierAssessmentFactory.withAnAppointment(appointment).build(),
+            serviceUser,
             null
           )
 
@@ -988,6 +1033,7 @@ describe(InterventionProgressPresenter, () => {
               [],
               [],
               supplierAssessmentFactory.withAnAppointment(appointment).build({ currentAppointmentId: appointment.id }),
+              serviceUser,
               null
             )
 
@@ -1016,6 +1062,7 @@ describe(InterventionProgressPresenter, () => {
               [],
               [],
               supplierAssessmentFactory.build({ appointments: [appointment] }),
+              serviceUser,
               null
             )
 
@@ -1027,6 +1074,83 @@ describe(InterventionProgressPresenter, () => {
             ])
           })
         })
+      })
+    })
+  })
+
+  describe('sessionFeedbackAddedNotificationBannerText', () => {
+    describe('when feedback has been submitted and user has attended with no concerns', () => {
+      it('shows the feedback banner confirming the probation practitioner will be able to view the feedback in the service', () => {
+        const referral = sentReferralFactory.build()
+
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          interventionFactory.build(),
+          null,
+          [],
+          [],
+          supplierAssessmentFactory.build(),
+          serviceUser,
+          null,
+          undefined,
+          true,
+          null,
+          false
+        )
+
+        expect(presenter.sessionFeedbackAddedNotificationBannerText).toEqual(
+          'The probation practitioner will be able to view the feedback in the service.'
+        )
+      })
+    })
+
+    describe('when feedback has been submitted and user has attended with concerns', () => {
+      it('shows the feedback banner confirming the probation practitioner has been emailed with about the concerns will be able to view the feedback in the service', () => {
+        const referral = sentReferralFactory.build()
+
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          interventionFactory.build(),
+          null,
+          [],
+          [],
+          supplierAssessmentFactory.build(),
+          serviceUser,
+          null,
+          undefined,
+          true,
+          true,
+          false
+        )
+
+        expect(presenter.sessionFeedbackAddedNotificationBannerText).toEqual(
+          'The probation practitioner has been emailed about your concerns. They’ll also be able to view the feedback in the service.'
+        )
+      })
+    })
+
+    describe('when feedback has been submitted and user has not attended', () => {
+      it('shows the feedback banner confirming the probation practitioner has been emailed about service users non attendance and will be able to view the feedback in the service', () => {
+        const referral = sentReferralFactory.build()
+
+        const presenter = new InterventionProgressPresenter(
+          referral,
+          interventionFactory.build(),
+          null,
+          [],
+          [],
+          supplierAssessmentFactory.build(),
+          serviceUser,
+          null,
+          undefined,
+          true,
+          null,
+          true
+        )
+
+        expect(presenter.sessionFeedbackAddedNotificationBannerText).toEqual(
+          'The probation practitioner will get an email about Alex River not attending. They’ll also be able to view the feedback in the service.'
+        )
       })
     })
   })
@@ -1043,6 +1167,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.build(),
+          serviceUser,
           null
         )
 
@@ -1064,6 +1189,7 @@ describe(InterventionProgressPresenter, () => {
             [],
             [],
             supplierAssessmentFactory.withAnAppointment(initialAssessmentAppointmentFactory.inThePast.build()).build(),
+            serviceUser,
             null
           )
 
@@ -1086,6 +1212,7 @@ describe(InterventionProgressPresenter, () => {
             supplierAssessmentFactory
               .withAnAppointment(initialAssessmentAppointmentFactory.inTheFuture.build())
               .build(),
+            serviceUser,
             null
           )
 
@@ -1107,6 +1234,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.withAttendedAppointment.build(),
+          serviceUser,
           null
         )
 
@@ -1127,6 +1255,7 @@ describe(InterventionProgressPresenter, () => {
           [],
           [],
           supplierAssessmentFactory.withNonAttendedAppointment.build(),
+          serviceUser,
           null
         )
 
@@ -1148,6 +1277,7 @@ describe(InterventionProgressPresenter, () => {
         [],
         [],
         supplierAssessmentFactory.build(),
+        serviceUser,
         null,
         undefined
       )
@@ -1165,6 +1295,7 @@ describe(InterventionProgressPresenter, () => {
         [],
         [],
         supplierAssessmentFactory.build(),
+        serviceUser,
         null,
         '/service-provider/dashboard/backlink'
       )

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -12,6 +12,7 @@ import { ActionPlanAppointment, InitialAssessmentAppointment } from '../../model
 import AuthUserDetails, { authUserFullName } from '../../models/hmppsAuth/authUserDetails'
 import ActionPlanProgressPresenter from '../shared/action-plan/actionPlanProgressPresenter'
 import ApprovedActionPlanSummary from '../../models/approvedActionPlanSummary'
+import DeliusServiceUser from '../../models/delius/deliusServiceUser'
 
 interface EndedFields {
   endRequestedAt: string | null
@@ -51,10 +52,12 @@ export default class InterventionProgressPresenter {
     private readonly approvedActionPlanSummaries: ApprovedActionPlanSummary[],
     private readonly actionPlanAppointments: ActionPlanAppointment[],
     private readonly supplierAssessment: SupplierAssessment,
+    private readonly serviceUser: DeliusServiceUser,
     private readonly assignee: AuthUserDetails | null,
     private readonly dashboardOriginPage?: string,
     readonly showFeedbackBanner: boolean | null = null,
-    readonly notifyPP: boolean | null = null
+    readonly notifyPP: boolean | null = null,
+    readonly dna: boolean | null = null
   ) {
     const subNavUrlPrefix = 'service-provider'
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(
@@ -355,6 +358,15 @@ export default class InterventionProgressPresenter {
       default:
         throw new Error('unexpected status')
     }
+  }
+
+  get sessionFeedbackAddedNotificationBannerText(): string {
+    if (this.dna) {
+      return `The probation practitioner will get an email about ${this.serviceUser.firstName} ${this.serviceUser.surname} not attending. They’ll also be able to view the feedback in the service.`
+    }
+    return this.notifyPP === true
+      ? 'The probation practitioner has been emailed about your concerns. They’ll also be able to view the feedback in the service.'
+      : 'The probation practitioner will be able to view the feedback in the service.'
   }
 
   private supplierAssessmentAppointmentStatusPresenter(

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -52,7 +52,9 @@ export default class InterventionProgressPresenter {
     private readonly actionPlanAppointments: ActionPlanAppointment[],
     private readonly supplierAssessment: SupplierAssessment,
     private readonly assignee: AuthUserDetails | null,
-    private readonly dashboardOriginPage?: string
+    private readonly dashboardOriginPage?: string,
+    readonly showFeedbackBanner: boolean | null = null,
+    readonly notifyPP: boolean | null = null
   ) {
     const subNavUrlPrefix = 'service-provider'
     this.referralOverviewPagePresenter = new ReferralOverviewPagePresenter(

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -50,6 +50,20 @@ export default class InterventionProgressView {
     }
   }
 
+  get sessionFeedbackAddedNotificationBannerArgs(): NotificationBannerArgs {
+    const text = this.presenter.notifyPP === true ?
+        'The probation practitioner has been emailed about your concerns. They’ll also be able to view the feedback in the service.' :
+        'Text to be shown in the pp does not need to be notified.'
+    const html = `<h1 class="govuk-notification-banner__heading">Session feedback added</h1>
+                  <p class="govuk-body-m">${text}</p>`
+
+    return {
+      titleText: 'Success',
+      html,
+      classes: 'govuk-notification-banner--success',
+    }
+  }
+
   private supplierAssessmentAppointmentsTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
     return {
       head: this.presenter.supplierAssessmentTableHeaders.map((header: string) => ({ text: header })),
@@ -131,6 +145,7 @@ export default class InterventionProgressView {
         backLinkArgs: this.backLinkArgs,
         endOfServiceReportSummaryListArgs: this.endOfServiceReportSummaryListArgs.bind(this),
         cancelledReferralNotificationBannerArgs: this.cancelledReferralNotificationBannerArgs,
+        sessionFeedbackAddedNotificationBannerArgs: this.sessionFeedbackAddedNotificationBannerArgs
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -51,12 +51,8 @@ export default class InterventionProgressView {
   }
 
   get sessionFeedbackAddedNotificationBannerArgs(): NotificationBannerArgs {
-    const text =
-      this.presenter.notifyPP === true
-        ? 'The probation practitioner has been emailed about your concerns. They’ll also be able to view the feedback in the service.'
-        : 'The probation practitioner will be able to view the feedback in the service.'
     const html = `<h1 class="govuk-notification-banner__heading">Session feedback added</h1>
-                  <p class="govuk-body-m">${text}</p>`
+                  <p class="govuk-body-m">${this.presenter.sessionFeedbackAddedNotificationBannerText}</p>`
 
     return {
       titleText: 'Success',

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -51,9 +51,10 @@ export default class InterventionProgressView {
   }
 
   get sessionFeedbackAddedNotificationBannerArgs(): NotificationBannerArgs {
-    const text = this.presenter.notifyPP === true ?
-        'The probation practitioner has been emailed about your concerns. They’ll also be able to view the feedback in the service.' :
-        'Text to be shown in the pp does not need to be notified.'
+    const text =
+      this.presenter.notifyPP === true
+        ? 'The probation practitioner has been emailed about your concerns. They’ll also be able to view the feedback in the service.'
+        : 'The probation practitioner will be able to view the feedback in the service.'
     const html = `<h1 class="govuk-notification-banner__heading">Session feedback added</h1>
                   <p class="govuk-body-m">${text}</p>`
 
@@ -145,7 +146,7 @@ export default class InterventionProgressView {
         backLinkArgs: this.backLinkArgs,
         endOfServiceReportSummaryListArgs: this.endOfServiceReportSummaryListArgs.bind(this),
         cancelledReferralNotificationBannerArgs: this.cancelledReferralNotificationBannerArgs,
-        sessionFeedbackAddedNotificationBannerArgs: this.sessionFeedbackAddedNotificationBannerArgs
+        sessionFeedbackAddedNotificationBannerArgs: this.sessionFeedbackAddedNotificationBannerArgs,
       },
     ]
   }

--- a/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
+++ b/server/routes/serviceProviderReferrals/scheduleAppointmentPresenter.ts
@@ -55,7 +55,7 @@ export default class ScheduleAppointmentPresenter {
     if (this.appointmentDecorator !== null) {
       // Remove this check once action plan appointments allow rescheduling
       if (this.appointmentDecorator.isInitialAssessmentAppointment) {
-        return this.currentAppointment!.sessionFeedback.submitted
+        return this.currentAppointment!.appointmentFeedback.submitted
       }
     }
     return false

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -967,8 +967,8 @@ describe('GET /service-provider/referrals/:id/progress', () => {
       sessionType: 'ONE_TO_ONE',
       appointmentDeliveryType: 'PHONE_CALL',
       appointmentDeliveryAddress: null,
-      sessionFeedback: {
-        attendance: {
+      appointmentFeedback: {
+        attendanceFeedback: {
           attended: 'yes',
         },
       },
@@ -981,8 +981,8 @@ describe('GET /service-provider/referrals/:id/progress', () => {
       sessionType: 'ONE_TO_ONE',
       appointmentDeliveryType: 'PHONE_CALL',
       appointmentDeliveryAddress: null,
-      sessionFeedback: {
-        attendance: {
+      appointmentFeedback: {
+        attendanceFeedback: {
           attended: 'yes',
         },
       },

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -346,6 +346,7 @@ export default class ServiceProviderReferralsController {
     const { id } = req.params
     const { showFeedbackBanner } = req.query
     const { notifyPP } = req.query
+    const { dna } = req.query
 
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, id)
 
@@ -405,10 +406,12 @@ export default class ServiceProviderReferralsController {
       approvedActionPlanSummaries,
       actionPlanAppointments,
       supplierAssessment,
+      serviceUser,
       assignee,
       req.session.dashboardOriginPage,
       showFeedbackBanner === 'true',
-      notifyPP === 'true'
+      notifyPP === 'true',
+      dna === 'true'
     )
     const view = new InterventionProgressView(presenter)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -344,6 +344,9 @@ export default class ServiceProviderReferralsController {
   async showInterventionProgress(req: Request, res: Response): Promise<void> {
     const { accessToken } = res.locals.user.token
     const { id } = req.params
+    const showFeedbackBanner = req.query.showFeedbackBanner
+    const notifyPP = req.query.notifyPP
+
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, id)
 
     const serviceUserPromise = this.communityApiService.getServiceUserByCRN(sentReferral.referral.serviceUser.crn)
@@ -403,7 +406,9 @@ export default class ServiceProviderReferralsController {
       actionPlanAppointments,
       supplierAssessment,
       assignee,
-      req.session.dashboardOriginPage
+      req.session.dashboardOriginPage,
+      (showFeedbackBanner === "true"),
+      (notifyPP === "true")
     )
     const view = new InterventionProgressView(presenter)
 

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -344,8 +344,8 @@ export default class ServiceProviderReferralsController {
   async showInterventionProgress(req: Request, res: Response): Promise<void> {
     const { accessToken } = res.locals.user.token
     const { id } = req.params
-    const showFeedbackBanner = req.query.showFeedbackBanner
-    const notifyPP = req.query.notifyPP
+    const { showFeedbackBanner } = req.query
+    const { notifyPP } = req.query
 
     const sentReferral = await this.interventionsService.getSentReferral(accessToken, id)
 
@@ -407,8 +407,8 @@ export default class ServiceProviderReferralsController {
       supplierAssessment,
       assignee,
       req.session.dashboardOriginPage,
-      (showFeedbackBanner === "true"),
-      (notifyPP === "true")
+      showFeedbackBanner === 'true',
+      notifyPP === 'true'
     )
     const view = new InterventionProgressView(presenter)
 

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -273,9 +273,9 @@ export default function serviceProviderRoutes(router: Router, services: Services
   post(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/edit/:draftBookingId/submit', (req, res) =>
     appointmentsController.submitSupplierAssessmentFeedback(req, res)
   )
-  get(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/confirmation', (req, res) =>
-    appointmentsController.showSupplierAssessmentFeedbackConfirmation(req, res)
-  )
+  // get(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/confirmation', (req, res) =>
+  //   appointmentsController.showSupplierAssessmentFeedbackConfirmation(req, res)
+  // )
   get(router, '/referrals/:referralId/supplier-assessment/post-assessment-feedback', (req, res) =>
     appointmentsController.viewSupplierAssessmentFeedback(req, res, 'service-provider')
   )

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -116,65 +116,62 @@ export default function serviceProviderRoutes(router: Router, services: Services
 
   // START delivery session appointment feedback
   get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', (req, res) =>
-    appointmentsController.addPostSessionAttendanceFeedback(req, res)
+    appointmentsController.addActionPlanSessionAppointmentAttendanceFeedback(req, res)
   )
   get(
     router,
     '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/attendance',
-    (req, res) => appointmentsController.addPostSessionAttendanceFeedback(req, res)
+    (req, res) => appointmentsController.addActionPlanSessionAppointmentAttendanceFeedback(req, res)
   )
   post(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/attendance', (req, res) =>
-    appointmentsController.addPostSessionAttendanceFeedback(req, res)
+    appointmentsController.addActionPlanSessionAppointmentAttendanceFeedback(req, res)
   )
 
   post(
     router,
     '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/attendance',
-    (req, res) => appointmentsController.addPostSessionAttendanceFeedback(req, res)
+    (req, res) => appointmentsController.addActionPlanSessionAppointmentAttendanceFeedback(req, res)
   )
 
   get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', (req, res) =>
-    appointmentsController.addPostSessionBehaviourFeedback(req, res)
+    appointmentsController.addActionPlanSessionAppointmentSessionFeedback(req, res)
   )
   post(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/behaviour', (req, res) =>
-    appointmentsController.addPostSessionBehaviourFeedback(req, res)
+    appointmentsController.addActionPlanSessionAppointmentSessionFeedback(req, res)
   )
   get(
     router,
     '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/behaviour',
-    (req, res) => appointmentsController.addPostSessionBehaviourFeedback(req, res)
+    (req, res) => appointmentsController.addActionPlanSessionAppointmentSessionFeedback(req, res)
   )
   post(
     router,
     '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/behaviour',
-    (req, res) => appointmentsController.addPostSessionBehaviourFeedback(req, res)
+    (req, res) => appointmentsController.addActionPlanSessionAppointmentSessionFeedback(req, res)
   )
   get(
     router,
     '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/check-your-answers',
-    (req, res) => appointmentsController.checkPostSessionFeedbackAnswers(req, res)
+    (req, res) => appointmentsController.checkActionPlanSessionFeedbackAnswers(req, res)
   )
   get(
     router,
     '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/check-your-answers',
-    (req, res) => appointmentsController.checkPostSessionFeedbackAnswers(req, res)
+    (req, res) => appointmentsController.checkActionPlanSessionFeedbackAnswers(req, res)
   )
   post(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/submit', (req, res) =>
-    appointmentsController.submitPostSessionFeedback(req, res)
+    appointmentsController.submitActionPlanSessionFeedback(req, res)
   )
   post(
     router,
     '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/submit',
-    (req, res) => appointmentsController.submitPostSessionFeedback(req, res)
+    (req, res) => appointmentsController.submitActionPlanSessionFeedback(req, res)
   )
 
-  get(router, '/action-plan/:actionPlanId/appointment/:sessionNumber/post-session-feedback/confirmation', (req, res) =>
-    appointmentsController.showPostSessionFeedbackConfirmation(req, res)
-  )
   get(
     router,
     '/action-plan/:actionPlanId/session/:sessionNumber/appointment/:appointmentId/post-session-feedback',
-    (req, res) => appointmentsController.viewSubmittedPostSessionFeedback(req, res, 'service-provider')
+    (req, res) => appointmentsController.viewSubmittedActionPlanSessionFeedback(req, res, 'service-provider')
   )
   get(router, '/end-of-service-report/:id', (req, res) =>
     serviceProviderReferralsController.viewEndOfServiceReport(req, res)
@@ -244,20 +241,20 @@ export default function serviceProviderRoutes(router: Router, services: Services
     (req, res) => appointmentsController.addSupplierAssessmentAttendanceFeedback(req, res)
   )
   get(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/behaviour', (req, res) =>
-    appointmentsController.addSupplierAssessmentBehaviourFeedback(req, res)
+    appointmentsController.addSupplierAssessmentSessionFeedback(req, res)
   )
   get(
     router,
     '/referrals/:id/supplier-assessment/post-assessment-feedback/edit/:draftBookingId/behaviour',
-    (req, res) => appointmentsController.addSupplierAssessmentBehaviourFeedback(req, res)
+    (req, res) => appointmentsController.addSupplierAssessmentSessionFeedback(req, res)
   )
   post(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/behaviour', (req, res) =>
-    appointmentsController.addSupplierAssessmentBehaviourFeedback(req, res)
+    appointmentsController.addSupplierAssessmentSessionFeedback(req, res)
   )
   post(
     router,
     '/referrals/:id/supplier-assessment/post-assessment-feedback/edit/:draftBookingId/behaviour',
-    (req, res) => appointmentsController.addSupplierAssessmentBehaviourFeedback(req, res)
+    (req, res) => appointmentsController.addSupplierAssessmentSessionFeedback(req, res)
   )
   get(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/check-your-answers', (req, res) =>
     appointmentsController.checkSupplierAssessmentFeedbackAnswers(req, res)

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -270,9 +270,6 @@ export default function serviceProviderRoutes(router: Router, services: Services
   post(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/edit/:draftBookingId/submit', (req, res) =>
     appointmentsController.submitSupplierAssessmentFeedback(req, res)
   )
-  // get(router, '/referrals/:id/supplier-assessment/post-assessment-feedback/confirmation', (req, res) =>
-  //   appointmentsController.showSupplierAssessmentFeedbackConfirmation(req, res)
-  // )
   get(router, '/referrals/:referralId/supplier-assessment/post-assessment-feedback', (req, res) =>
     appointmentsController.viewSupplierAssessmentFeedback(req, res, 'service-provider')
   )

--- a/server/routes/shared/sessionStatusPresenter.test.ts
+++ b/server/routes/shared/sessionStatusPresenter.test.ts
@@ -16,7 +16,7 @@ describe(SessionStatusPresenter, () => {
       },
       {
         status: SessionStatus.awaitingFeedback,
-        text: 'awaiting feedback',
+        text: 'needs feedback',
         tagClass: 'govuk-tag--red',
       },
       {

--- a/server/routes/shared/sessionStatusPresenter.ts
+++ b/server/routes/shared/sessionStatusPresenter.ts
@@ -10,7 +10,7 @@ export default class SessionStatusPresenter {
       case SessionStatus.scheduled:
         return 'scheduled'
       case SessionStatus.awaitingFeedback:
-        return 'awaiting feedback'
+        return 'needs feedback'
       case SessionStatus.completed:
         return 'completed'
       default:

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -3137,13 +3137,15 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
                 postCode: 'SY40RE',
               },
               npsOfficeCode: null,
-              appointmentAttendance: {
+              attendanceFeedback: {
                 attended: 'yes',
-                additionalAttendanceInformation: 'attendance information',
+                attendanceFailureInformation: 'attendance failure information',
               },
-              appointmentBehaviour: {
+              sessionFeedback: {
                 notifyProbationPractitioner: false,
-                behaviourDescription: 'they were good',
+                sessionSummary: 'they were good',
+                sessionResponse: 'they were good',
+                sessionConcerns: 'they were good',
               },
             }
           )
@@ -3289,7 +3291,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         }
       )
       expect(appointment.appointmentFeedback!.attendanceFeedback!.attended).toEqual('late')
-      expect(appointment.appointmentFeedback!.attendanceFeedback!.additionalAttendanceInformation).toEqual('Alex missed the bus')
+      expect(appointment.appointmentFeedback!.attendanceFeedback!.additionalAttendanceInformation).toEqual(
+        'Alex missed the bus'
+      )
     })
   })
 
@@ -3783,7 +3787,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         }
       )
       expect(result.appointmentFeedback!.attendanceFeedback!.attended).toEqual('late')
-      expect(result.appointmentFeedback!.attendanceFeedback!.additionalAttendanceInformation).toEqual('Alex missed the bus')
+      expect(result.appointmentFeedback!.attendanceFeedback!.additionalAttendanceInformation).toEqual(
+        'Alex missed the bus'
+      )
     })
   })
 
@@ -3834,7 +3840,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const result = await interventionsService.recordSupplierAssessmentAppointmentBehaviour(
+      const result = await interventionsService.recordSupplierAssessmentAppointmentSessionFeedback(
         probationPractitionerToken,
         'caac2a85-578f-4b0b-996d-2893311eb60e',
         {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -3742,13 +3742,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         appointmentFeedback: {
           attendanceFeedback: {
             attended: 'late',
-            additionalAttendanceInformation: 'Alex missed the bus',
+            additionalAttendanceInformation: null,
           },
           sessionFeedback: {
-            sessionSummary: '',
-            sessionResponse: '',
+            sessionSummary: null,
+            sessionResponse: null,
             sessionConcerns: null,
-            notifyProbationPractitioner: false,
+            notifyProbationPractitioner: null,
           },
           submitted: false,
           submittedBy: null,
@@ -3765,7 +3765,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           path: '/referral/58963698-0f2e-4d6e-a072-0e2cf351f3b2/supplier-assessment/record-attendance',
           body: {
             attended: 'late',
-            additionalAttendanceInformation: 'Alex missed the bus',
           },
           headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -3062,7 +3062,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           appointmentFeedback: {
             attendanceFeedback: {
               attended: 'yes',
-              additionalAttendanceInformation: 'attendance information',
             },
             sessionFeedback: {
               sessionSummary: 'stub session summary',
@@ -3799,7 +3798,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         appointmentFeedback: {
           attendanceFeedback: {
             attended: 'late',
-            additionalAttendanceInformation: 'Alex missed the bus',
+            additionalAttendanceInformation: null,
           },
           sessionFeedback: {
             sessionSummary: 'Discussed accommodation',
@@ -3862,7 +3861,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         appointmentFeedback: {
           attendanceFeedback: {
             attended: 'late',
-            additionalAttendanceInformation: 'Alex missed the bus',
           },
           sessionFeedback: {
             sessionSummary: '',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -3065,8 +3065,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
               additionalAttendanceInformation: 'attendance information',
             },
             sessionFeedback: {
+              sessionSummary: 'stub session summary',
+              sessionResponse: 'stub session response',
               notifyProbationPractitioner: false,
-              // behaviourDescription: 'they were good',
             },
             submittedBy: {
               authSource: 'auth',
@@ -3098,13 +3099,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
                 postCode: 'SY40RE',
               },
               npsOfficeCode: null,
-              appointmentAttendance: {
+              attendanceFeedback: {
                 attended: 'yes',
-                additionalAttendanceInformation: 'attendance information',
               },
-              appointmentBehaviour: {
+              sessionFeedback: {
+                sessionSummary: 'stub session summary',
+                sessionResponse: 'stub session response',
                 notifyProbationPractitioner: false,
-                behaviourDescription: 'they were good',
               },
             },
             headers: { Accept: 'application/json', Authorization: `Bearer ${serviceProviderToken}` },
@@ -3139,13 +3140,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
               npsOfficeCode: null,
               attendanceFeedback: {
                 attended: 'yes',
-                attendanceFailureInformation: 'attendance failure information',
+                attendanceFailureInformation: '',
               },
               sessionFeedback: {
                 notifyProbationPractitioner: false,
-                sessionSummary: 'they were good',
-                sessionResponse: 'they were good',
-                sessionConcerns: 'they were good',
+                sessionSummary: 'stub session summary',
+                sessionResponse: 'stub session response',
+                sessionConcerns: '',
               },
             }
           )
@@ -3243,7 +3244,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           path: '/action-plan/345059d4-1697-467b-8914-fedec9957279/appointment/2/record-attendance',
           body: {
             attended: 'late',
-            additionalAttendanceInformation: 'Alex missed the bus',
           },
           headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
         },
@@ -3262,13 +3262,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
               county: 'Lancashire',
               postCode: 'SY40RE',
             },
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'late',
-                additionalAttendanceInformation: 'Alex missed the bus',
               },
-              behaviour: {
-                behaviourDescription: null,
+              sessionFeedback: {
+                sessionSummary: null,
+                sessionResponse: null,
+                sessionConcerns: null,
                 notifyProbationPractitioner: null,
               },
               submitted: false,
@@ -3287,31 +3288,28 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         2,
         {
           attended: 'late',
-          additionalAttendanceInformation: 'Alex missed the bus',
         }
       )
       expect(appointment.appointmentFeedback!.attendanceFeedback!.attended).toEqual('late')
-      expect(appointment.appointmentFeedback!.attendanceFeedback!.additionalAttendanceInformation).toEqual(
-        'Alex missed the bus'
-      )
     })
   })
 
-  describe('recordActionPlanAppointmentBehavior', () => {
+  describe('recordActionPlanAppointmentSessoinFeedback', () => {
     const appointmentTime = new Date()
     appointmentTime.setMonth(appointmentTime.getMonth() + 4)
 
-    it('returns an updated action plan appointment with the service user‘s behaviour', async () => {
+    it('returns an updated action plan appointment with the session feedback', async () => {
       await provider.addInteraction({
         state:
           'an action plan with ID 81987e8b-aeb9-4fbf-8ecb-1a054ad74b2d exists with 1 appointment with recorded attendance',
         uponReceiving:
-          'a POST request to set the behaviour for the appointment on action plan with ID 81987e8b-aeb9-4fbf-8ecb-1a054ad74b2d',
+          'a POST request to set the session feedback for the appointment on action plan with ID 81987e8b-aeb9-4fbf-8ecb-1a054ad74b2d',
         withRequest: {
           method: 'POST',
-          path: '/action-plan/81987e8b-aeb9-4fbf-8ecb-1a054ad74b2d/appointment/1/record-behaviour',
+          path: '/action-plan/81987e8b-aeb9-4fbf-8ecb-1a054ad74b2d/appointment/1/record-session-feedback',
           body: {
-            behaviourDescription: 'Alex was well behaved',
+            sessionSummary: 'Discussed accommodation',
+            sessionResponse: 'Engaged well',
             notifyProbationPractitioner: false,
           },
           headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
@@ -3322,13 +3320,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             sessionNumber: 1,
             appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
             durationInMinutes: 120,
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'late',
-                additionalAttendanceInformation: 'Alex missed the bus',
               },
-              behaviour: {
-                behaviourDescription: 'Alex was well behaved',
+              sessionFeedback: {
+                sessionSummary: 'Discussed accommodation',
+                sessionResponse: 'Engaged well',
                 notifyProbationPractitioner: false,
               },
               submitted: false,
@@ -3341,16 +3339,18 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         },
       })
 
-      const appointment = await interventionsService.recordActionPlanAppointmentBehavior(
+      const appointment = await interventionsService.recordActionPlanAppointmentSessionFeedback(
         probationPractitionerToken,
         '81987e8b-aeb9-4fbf-8ecb-1a054ad74b2d',
         1,
         {
-          // behaviourDescription: 'Alex was well behaved',
+          sessionSummary: 'Discussed accommodation',
+          sessionResponse: 'Engaged well',
           notifyProbationPractitioner: false,
         }
       )
-      // expect(appointment.sessionFeedback!.behaviour!.behaviourDescription).toEqual('Alex was well behaved')
+      expect(appointment.appointmentFeedback!.sessionFeedback!.sessionSummary).toEqual('Discussed accommodation')
+      expect(appointment.appointmentFeedback!.sessionFeedback!.sessionResponse).toEqual('Engaged well')
       expect(appointment.appointmentFeedback!.sessionFeedback!.notifyProbationPractitioner).toEqual(false)
     })
   })
@@ -3359,10 +3359,10 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     const appointmentTime = new Date()
     appointmentTime.setMonth(appointmentTime.getMonth() + 4)
 
-    it('submits attendance and behaviour feedback to the PP', async () => {
+    it('submits attendance and session feedback to the PP', async () => {
       await provider.addInteraction({
         state:
-          'an action plan with ID 0f5afe04-e323-4699-9423-fb6122580638 exists with 1 appointment with recorded attendance and behaviour',
+          'an action plan with ID 0f5afe04-e323-4699-9423-fb6122580638 exists with 1 appointment with recorded attendance and session feedback',
         uponReceiving:
           'a POST request to submit the feedback for appointment 1 on action plan with ID 0f5afe04-e323-4699-9423-fb6122580638',
         withRequest: {
@@ -3376,13 +3376,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             sessionNumber: 1,
             appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
             durationInMinutes: 120,
-            sessionFeedback: {
-              attendance: {
+            appointmentFeedback: {
+              attendanceFeedback: {
                 attended: 'late',
-                additionalAttendanceInformation: 'Alex missed the bus',
               },
-              behaviour: {
-                behaviourDescription: 'Alex was well behaved',
+              sessionFeedback: {
+                sessionSummary: 'Discussed accommodation',
+                sessionResponse: 'Engaged well',
                 notifyProbationPractitioner: false,
               },
               submitted: true,
@@ -3793,11 +3793,11 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     })
   })
 
-  describe('recordSupplierAssessmentAppointmentBehaviour', () => {
+  describe('recordSupplierAssessmentAppointmentSessionFeedback', () => {
     const appointmentTime = new Date()
     appointmentTime.setMonth(appointmentTime.getMonth() + 4)
 
-    it('returns an supplier with the service user‘s behaviour', async () => {
+    it('returns an supplier with the session feedback', async () => {
       const appointment = initialAssessmentAppointmentFactory.build({
         appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
         durationInMinutes: 120,
@@ -3807,8 +3807,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             additionalAttendanceInformation: 'Alex missed the bus',
           },
           sessionFeedback: {
-            sessionSummary: '',
-            sessionResponse: '',
+            sessionSummary: 'Discussed accommodation',
+            sessionResponse: 'Engaged well',
             sessionConcerns: null,
             notifyProbationPractitioner: false,
           },
@@ -3821,12 +3821,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         state:
           'There is an existing sent referral with ID caac2a85-578f-4b0b-996d-2893311eb60e and the supplier assessment attendance details have been recorded',
         uponReceiving:
-          'a PUT request to set the behaviour for the supplier assessment appointment for referral with ID caac2a85-578f-4b0b-996d-2893311eb60e',
+          'a PUT request to set the session feedback for the supplier assessment appointment for referral with ID caac2a85-578f-4b0b-996d-2893311eb60e',
         withRequest: {
           method: 'PUT',
-          path: '/referral/caac2a85-578f-4b0b-996d-2893311eb60e/supplier-assessment/record-behaviour',
+          path: '/referral/caac2a85-578f-4b0b-996d-2893311eb60e/supplier-assessment/record-session-feedback',
           body: {
-            behaviourDescription: 'Alex was well behaved',
+            sessionSummary: 'Discussed accommodation',
+            sessionResponse: 'Engaged well',
             notifyProbationPractitioner: false,
           },
           headers: { Accept: 'application/json', Authorization: `Bearer ${probationPractitionerToken}` },
@@ -3844,11 +3845,13 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         probationPractitionerToken,
         'caac2a85-578f-4b0b-996d-2893311eb60e',
         {
-          // behaviourDescription: 'Alex was well behaved',
+          sessionSummary: 'Discussed accommodation',
+          sessionResponse: 'Engaged well',
           notifyProbationPractitioner: false,
         }
       )
-      // expect(result.appointmentFeedback!.behaviour!.behaviourDescription).toEqual('Alex was well behaved')
+      expect(result.appointmentFeedback!.sessionFeedback!.sessionSummary).toEqual('Discussed accommodation')
+      expect(result.appointmentFeedback!.sessionFeedback!.sessionResponse).toEqual('Engaged well')
       expect(result.appointmentFeedback!.sessionFeedback!.notifyProbationPractitioner).toEqual(false)
     })
   })
@@ -3857,7 +3860,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     const appointmentTime = new Date()
     appointmentTime.setMonth(appointmentTime.getMonth() + 4)
 
-    it('submits attendance and behaviour feedback', async () => {
+    it('submits attendance and session feedback', async () => {
       const appointment = initialAssessmentAppointmentFactory.build({
         appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
         durationInMinutes: 120,
@@ -3883,7 +3886,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
 
       await provider.addInteraction({
         state:
-          'There is an existing sent referral with ID cd8f46a2-78f2-457b-ab14-7d77adce73d1 and the supplier assessment attendance and behaviour details have been recorded',
+          'There is an existing sent referral with ID cd8f46a2-78f2-457b-ab14-7d77adce73d1 and the supplier assessment attendance and session feedback have been recorded',
         uponReceiving:
           'a POST request to submit the feedback for the supplier assessment appointment for referral with ID cd8f46a2-78f2-457b-ab14-7d77adce73d1',
         withRequest: {

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -3782,13 +3782,9 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         '58963698-0f2e-4d6e-a072-0e2cf351f3b2',
         {
           attended: 'late',
-          additionalAttendanceInformation: 'Alex missed the bus',
         }
       )
       expect(result.appointmentFeedback!.attendanceFeedback!.attended).toEqual('late')
-      expect(result.appointmentFeedback!.attendanceFeedback!.additionalAttendanceInformation).toEqual(
-        'Alex missed the bus'
-      )
     })
   })
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -3059,14 +3059,14 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
             county: 'Lancashire',
             postCode: 'SY40RE',
           },
-          sessionFeedback: {
-            attendance: {
+          appointmentFeedback: {
+            attendanceFeedback: {
               attended: 'yes',
               additionalAttendanceInformation: 'attendance information',
             },
-            behaviour: {
+            sessionFeedback: {
               notifyProbationPractitioner: false,
-              behaviourDescription: 'they were good',
+              // behaviourDescription: 'they were good',
             },
             submittedBy: {
               authSource: 'auth',
@@ -3288,8 +3288,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           additionalAttendanceInformation: 'Alex missed the bus',
         }
       )
-      expect(appointment.sessionFeedback!.attendance!.attended).toEqual('late')
-      expect(appointment.sessionFeedback!.attendance!.additionalAttendanceInformation).toEqual('Alex missed the bus')
+      expect(appointment.appointmentFeedback!.attendanceFeedback!.attended).toEqual('late')
+      expect(appointment.appointmentFeedback!.attendanceFeedback!.additionalAttendanceInformation).toEqual('Alex missed the bus')
     })
   })
 
@@ -3342,12 +3342,12 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         '81987e8b-aeb9-4fbf-8ecb-1a054ad74b2d',
         1,
         {
-          behaviourDescription: 'Alex was well behaved',
+          // behaviourDescription: 'Alex was well behaved',
           notifyProbationPractitioner: false,
         }
       )
-      expect(appointment.sessionFeedback!.behaviour!.behaviourDescription).toEqual('Alex was well behaved')
-      expect(appointment.sessionFeedback!.behaviour!.notifyProbationPractitioner).toEqual(false)
+      // expect(appointment.sessionFeedback!.behaviour!.behaviourDescription).toEqual('Alex was well behaved')
+      expect(appointment.appointmentFeedback!.sessionFeedback!.notifyProbationPractitioner).toEqual(false)
     })
   })
 
@@ -3400,7 +3400,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         '0f5afe04-e323-4699-9423-fb6122580638',
         1
       )
-      expect(appointment.sessionFeedback!.submitted).toEqual(true)
+      expect(appointment.appointmentFeedback!.submitted).toEqual(true)
     })
   })
 
@@ -3735,14 +3735,16 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       const appointment = initialAssessmentAppointmentFactory.build({
         appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
         durationInMinutes: 60,
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'late',
             additionalAttendanceInformation: 'Alex missed the bus',
           },
-          behaviour: {
-            behaviourDescription: null,
-            notifyProbationPractitioner: null,
+          sessionFeedback: {
+            sessionSummary: '',
+            sessionResponse: '',
+            sessionConcerns: null,
+            notifyProbationPractitioner: false,
           },
           submitted: false,
           submittedBy: null,
@@ -3780,8 +3782,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
           additionalAttendanceInformation: 'Alex missed the bus',
         }
       )
-      expect(result.sessionFeedback!.attendance!.attended).toEqual('late')
-      expect(result.sessionFeedback!.attendance!.additionalAttendanceInformation).toEqual('Alex missed the bus')
+      expect(result.appointmentFeedback!.attendanceFeedback!.attended).toEqual('late')
+      expect(result.appointmentFeedback!.attendanceFeedback!.additionalAttendanceInformation).toEqual('Alex missed the bus')
     })
   })
 
@@ -3793,13 +3795,15 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       const appointment = initialAssessmentAppointmentFactory.build({
         appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
         durationInMinutes: 120,
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'late',
             additionalAttendanceInformation: 'Alex missed the bus',
           },
-          behaviour: {
-            behaviourDescription: 'Alex was well behaved',
+          sessionFeedback: {
+            sessionSummary: '',
+            sessionResponse: '',
+            sessionConcerns: null,
             notifyProbationPractitioner: false,
           },
           submitted: false,
@@ -3834,12 +3838,12 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         probationPractitionerToken,
         'caac2a85-578f-4b0b-996d-2893311eb60e',
         {
-          behaviourDescription: 'Alex was well behaved',
+          // behaviourDescription: 'Alex was well behaved',
           notifyProbationPractitioner: false,
         }
       )
-      expect(result.sessionFeedback!.behaviour!.behaviourDescription).toEqual('Alex was well behaved')
-      expect(result.sessionFeedback!.behaviour!.notifyProbationPractitioner).toEqual(false)
+      // expect(result.appointmentFeedback!.behaviour!.behaviourDescription).toEqual('Alex was well behaved')
+      expect(result.appointmentFeedback!.sessionFeedback!.notifyProbationPractitioner).toEqual(false)
     })
   })
 
@@ -3851,13 +3855,15 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       const appointment = initialAssessmentAppointmentFactory.build({
         appointmentTime: `${appointmentTime.toISOString().split('T')[0]}T12:30:00Z`,
         durationInMinutes: 120,
-        sessionFeedback: {
-          attendance: {
+        appointmentFeedback: {
+          attendanceFeedback: {
             attended: 'late',
             additionalAttendanceInformation: 'Alex missed the bus',
           },
-          behaviour: {
-            behaviourDescription: 'Alex was well behaved',
+          sessionFeedback: {
+            sessionSummary: '',
+            sessionResponse: '',
+            sessionConcerns: null,
             notifyProbationPractitioner: false,
           },
           submitted: true,
@@ -3892,8 +3898,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
         probationPractitionerToken,
         'cd8f46a2-78f2-457b-ab14-7d77adce73d1'
       )
-      expect(result.sessionFeedback!.submitted).toEqual(true)
-      expect(result.sessionFeedback!.submittedBy).not.toBeNull()
+      expect(result.appointmentFeedback!.submitted).toEqual(true)
+      expect(result.appointmentFeedback!.submittedBy).not.toBeNull()
     })
   })
 

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -12,7 +12,7 @@ import CancellationReason from '../models/cancellationReason'
 import ServiceCategory from '../models/serviceCategory'
 import ActionPlan from '../models/actionPlan'
 import AppointmentAttendance from '../models/appointmentAttendance'
-import AppointmentBehaviour from '../models/appointmentBehaviour'
+import AppointmentSession from '../models/sessionFeedback'
 import DraftReferral from '../models/draftReferral'
 import SentReferral from '../models/sentReferral'
 import SentReferralSummaries from '../models/sentReferralSummaries'
@@ -37,6 +37,7 @@ import AmendNeedsAndRequirements from '../models/amendNeedsAndRequirements'
 import { NeedsAndRequirementsType } from '../models/needsAndRequirementsType'
 import ChangelogDetail from '../models/changelogDetail'
 import { AmendOtherNeeds } from '../models/OtherNeeds'
+import SessionFeedback from "../models/sessionFeedback";
 
 export interface InterventionsServiceValidationError {
   field: string
@@ -599,7 +600,7 @@ export default class InterventionsService {
     token: string,
     actionPlanId: string,
     sessionNumber: number,
-    appointmentBehaviourUpdate: Partial<AppointmentBehaviour>
+    appointmentBehaviourUpdate: Partial<AppointmentSession>
   ): Promise<ActionPlanAppointment> {
     const restClient = this.createRestClient(token)
 
@@ -749,12 +750,11 @@ export default class InterventionsService {
   async recordSupplierAssessmentAppointmentBehaviour(
     token: string,
     referralId: string,
-    appointmentBehaviourUpdate: Partial<AppointmentBehaviour>
+    appointmentBehaviourUpdate: Partial<SessionFeedback>
   ): Promise<InitialAssessmentAppointment> {
     const restClient = this.createRestClient(token)
-
     return (await restClient.put({
-      path: `/referral/${referralId}/supplier-assessment/record-behaviour`,
+      path: `/referral/${referralId}/supplier-assessment/record-session-feedback`,
       headers: { Accept: 'application/json' },
       data: appointmentBehaviourUpdate,
     })) as InitialAssessmentAppointment

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -597,7 +597,7 @@ export default class InterventionsService {
     })) as ActionPlanAppointment
   }
 
-  async recordActionPlanAppointmentBehavior(
+  async recordActionPlanAppointmentSessionFeedback(
     token: string,
     actionPlanId: string,
     sessionNumber: number,

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -12,7 +12,6 @@ import CancellationReason from '../models/cancellationReason'
 import ServiceCategory from '../models/serviceCategory'
 import ActionPlan from '../models/actionPlan'
 import AppointmentAttendance from '../models/appointmentAttendance'
-import AppointmentSession from '../models/sessionFeedback'
 import DraftReferral from '../models/draftReferral'
 import SentReferral from '../models/sentReferral'
 import SentReferralSummaries from '../models/sentReferralSummaries'
@@ -37,7 +36,7 @@ import AmendNeedsAndRequirements from '../models/amendNeedsAndRequirements'
 import { NeedsAndRequirementsType } from '../models/needsAndRequirementsType'
 import ChangelogDetail from '../models/changelogDetail'
 import { AmendOtherNeeds } from '../models/OtherNeeds'
-import SessionFeedback from "../models/sessionFeedback";
+import SessionFeedback from '../models/sessionFeedback'
 
 export interface InterventionsServiceValidationError {
   field: string
@@ -111,12 +110,14 @@ export interface CreateCaseNoteParams {
 }
 
 export type CreateAppointmentSchedulingAndFeedback = AppointmentSchedulingDetails & {
-  appointmentAttendance: {
+  attendanceFeedback: {
     attended: 'yes' | 'no' | 'late' | null
-    additionalAttendanceInformation: string | null
+    attendanceFailureInformation: string | null
   }
-  appointmentBehaviour: {
-    behaviourDescription: string | null
+  sessionFeedback: {
+    sessionSummary: string | null
+    sessionResponse: string | null
+    sessionConcerns: string | null
     notifyProbationPractitioner: boolean | null
   } | null
 }
@@ -600,14 +601,14 @@ export default class InterventionsService {
     token: string,
     actionPlanId: string,
     sessionNumber: number,
-    appointmentBehaviourUpdate: Partial<AppointmentSession>
+    sessionFeedbackUpdate: Partial<SessionFeedback>
   ): Promise<ActionPlanAppointment> {
     const restClient = this.createRestClient(token)
 
     return (await restClient.post({
-      path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}/record-behaviour`,
+      path: `/action-plan/${actionPlanId}/appointment/${sessionNumber}/record-session-feedback`,
       headers: { Accept: 'application/json' },
-      data: appointmentBehaviourUpdate,
+      data: sessionFeedbackUpdate,
     })) as ActionPlanAppointment
   }
 
@@ -747,16 +748,16 @@ export default class InterventionsService {
     })) as InitialAssessmentAppointment
   }
 
-  async recordSupplierAssessmentAppointmentBehaviour(
+  async recordSupplierAssessmentAppointmentSessionFeedback(
     token: string,
     referralId: string,
-    appointmentBehaviourUpdate: Partial<SessionFeedback>
+    sessionFeedbackUpdate: Partial<SessionFeedback>
   ): Promise<InitialAssessmentAppointment> {
     const restClient = this.createRestClient(token)
     return (await restClient.put({
       path: `/referral/${referralId}/supplier-assessment/record-session-feedback`,
       headers: { Accept: 'application/json' },
-      data: appointmentBehaviourUpdate,
+      data: sessionFeedbackUpdate,
     })) as InitialAssessmentAppointment
   }
 

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -179,8 +179,14 @@ export default {
   attendedAppointment: {
     empty: 'Select whether they attended or not',
   },
-  appointmentBehaviour: {
-    descriptionEmpty: 'Enter a description of their behaviour',
+  sessionSummary: {
+    empty: 'Enter what you did in the session',
+  },
+  sessionResponse: {
+    empty: (name: string) => `Enter how ${name} responded to the session`,
+  },
+  sessionConcerns: {
+    empty: 'Enter a description of what concerned you',
     notifyProbationPractitionerNotSelected: 'Select whether to notify the probation practitioner or not',
   },
   scheduleAppointment: {

--- a/server/utils/sessionStatus.test.ts
+++ b/server/utils/sessionStatus.test.ts
@@ -5,9 +5,9 @@ import sessionStatus, { SessionStatus } from './sessionStatus'
 describe(sessionStatus.forAppointment, () => {
   describe('when the appointment was not attended', () => {
     const appointment = initialAssessmentAppointmentFactory.build({
-      sessionFeedback: {
+      appointmentFeedback: {
         submitted: true,
-        attendance: {
+        attendanceFeedback: {
           attended: 'no',
         },
       },
@@ -20,18 +20,18 @@ describe(sessionStatus.forAppointment, () => {
 
   describe('when the appointment was attended or the user was late', () => {
     const onTimeAppointment = initialAssessmentAppointmentFactory.build({
-      sessionFeedback: {
+      appointmentFeedback: {
         submitted: true,
-        attendance: {
+        attendanceFeedback: {
           attended: 'yes',
         },
       },
     })
 
     const lateAppointment = initialAssessmentAppointmentFactory.build({
-      sessionFeedback: {
+      appointmentFeedback: {
         submitted: true,
-        attendance: {
+        attendanceFeedback: {
           attended: 'yes',
         },
       },
@@ -78,9 +78,9 @@ describe(sessionStatus.forAppointment, () => {
 
   describe('when the appointment does have feedback, but it has not been submitted', () => {
     const scheduledAppointment = initialAssessmentAppointmentFactory.build({
-      sessionFeedback: {
+      appointmentFeedback: {
         submitted: false,
-        attendance: {
+        attendanceFeedback: {
           attended: 'yes',
         },
       },

--- a/server/utils/sessionStatus.ts
+++ b/server/utils/sessionStatus.ts
@@ -14,12 +14,14 @@ export default {
       return SessionStatus.notScheduled
     }
     const appointmentDecorator = new AppointmentDecorator(appointment)
-    if (appointment.sessionFeedback.submitted) {
-      const sessionFeedbackAttendance = appointment.sessionFeedback.attendance
+    console.log(appointment)
+    if (appointment.appointmentFeedback.submitted) {
+      console.log("got here 1")
+      const sessionFeedbackAttendance = appointment.appointmentFeedback.attendanceFeedback
       if (sessionFeedbackAttendance.attended === 'no') {
         return SessionStatus.didNotAttend
       }
-
+      console.log("got here 2")
       if (sessionFeedbackAttendance.attended === 'yes' || sessionFeedbackAttendance.attended === 'late') {
         return SessionStatus.completed
       }

--- a/server/utils/sessionStatus.ts
+++ b/server/utils/sessionStatus.ts
@@ -14,14 +14,11 @@ export default {
       return SessionStatus.notScheduled
     }
     const appointmentDecorator = new AppointmentDecorator(appointment)
-    console.log(appointment)
     if (appointment.appointmentFeedback.submitted) {
-      console.log("got here 1")
       const sessionFeedbackAttendance = appointment.appointmentFeedback.attendanceFeedback
       if (sessionFeedbackAttendance.attended === 'no') {
         return SessionStatus.didNotAttend
       }
-      console.log("got here 2")
       if (sessionFeedbackAttendance.attended === 'yes' || sessionFeedbackAttendance.attended === 'late') {
         return SessionStatus.completed
       }

--- a/server/views/appointments/feedback/shared/postSessionAttendanceFeedback.njk
+++ b/server/views/appointments/feedback/shared/postSessionAttendanceFeedback.njk
@@ -7,7 +7,7 @@
 {% extends "../../../serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk" %}
 
 {% set pageTitle = "Appointment feedback" %}
-{% set pageSubTitle = "Add attendance feedback" %}
+{% set pageSubTitle = "Record session attendance" %}
 
 {% block formSection %}
     <h2 class="govuk-heading-m">Session details</h2>
@@ -15,7 +15,12 @@
 
   <form method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukRadios(radioButtonArgs) }}
+
+    {% set attendanceFailureInformationHtml %}
+        {{ govukTextarea(attendanceFailureInformationTextAreaArgs) }}
+    {% endset -%}
+
+    {{ govukRadios(radioButtonArgs(attendanceFailureInformationHtml)) }}
 
     {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
   </form>

--- a/server/views/appointments/feedback/shared/postSessionAttendanceFeedback.njk
+++ b/server/views/appointments/feedback/shared/postSessionAttendanceFeedback.njk
@@ -10,13 +10,12 @@
 {% set pageSubTitle = "Add attendance feedback" %}
 
 {% block formSection %}
+    <h2 class="govuk-heading-m">Session details</h2>
   {{ govukSummaryList(summaryListArgs) }}
 
   <form method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukRadios(radioButtonArgs) }}
-
-    {{ govukTextarea(textAreaArgs) }}
 
     {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
   </form>

--- a/server/views/appointments/feedback/shared/postSessionBehaviourFeedback.njk
+++ b/server/views/appointments/feedback/shared/postSessionBehaviourFeedback.njk
@@ -11,9 +11,24 @@
 {% block formSection %}
   <form method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukTextarea(textAreaArgs) }}
 
-    {{ govukRadios(radioButtonArgs) }}
+    {#
+    {{ govukTextarea(textAreaArgs) }}
+    #}
+
+
+    {# new stuff #}
+    {% set hasConcernsHtml %}
+        {{ govukTextarea(sessionConcernsTextAreaArgs) }}
+    {% endset -%}
+
+    {{ govukTextarea(sessionSummaryTextAreaArgs) }}
+    {{ govukTextarea(sessionResponseTextAreaArgs) }}
+
+
+    {# end of new stuff #}
+
+    {{ govukRadios(radioButtonArgs(hasConcernsHtml)) }}
 
     {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
   </form>

--- a/server/views/appointments/feedback/shared/postSessionFeedback.njk
+++ b/server/views/appointments/feedback/shared/postSessionFeedback.njk
@@ -6,7 +6,7 @@
 {% extends "../../../serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk" %}
 
 {% set pageTitle = "Appointment feedback" %}
-{% set pageSubTitle = "Add behaviour feedback" %}
+{% set pageSubTitle = "Add session feedback" %}
 
 {% block formSection %}
   <form method="post">
@@ -16,17 +16,12 @@
     {{ govukTextarea(textAreaArgs) }}
     #}
 
-
-    {# new stuff #}
     {% set hasConcernsHtml %}
         {{ govukTextarea(sessionConcernsTextAreaArgs) }}
     {% endset -%}
 
     {{ govukTextarea(sessionSummaryTextAreaArgs) }}
     {{ govukTextarea(sessionResponseTextAreaArgs) }}
-
-
-    {# end of new stuff #}
 
     {{ govukRadios(radioButtonArgs(hasConcernsHtml)) }}
 

--- a/server/views/appointments/feedback/shared/postSessionFeedbackCheckAnswers.njk
+++ b/server/views/appointments/feedback/shared/postSessionFeedbackCheckAnswers.njk
@@ -7,8 +7,10 @@
 {% set pageSubTitle = "Confirm answers" %}
 
 {% block formSection %}
-  {{ govukSummaryList(summaryListArgs) }}
 
+  {#
+    {{ govukSummaryList(summaryListArgs) }}
+  #}
   <br>
 
   {% include "../../../partials/postSessionFeedbackResponses.njk" %}

--- a/server/views/partials/postSessionFeedbackResponses.njk
+++ b/server/views/partials/postSessionFeedbackResponses.njk
@@ -12,10 +12,14 @@
   <p>{{ feedbackAnswersPresenter.attendedAnswers.answer | escape | nl2br }}</p>
 {% endif %}
 
-{# Old Question #}
 {% if feedbackAnswersPresenter.additionalAttendanceAnswers %}
   <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.additionalAttendanceAnswers.question }}</h3>
   <p>{{ feedbackAnswersPresenter.additionalAttendanceAnswers.answer | escape | nl2br }}</p>
+{% endif %}
+
+{% if feedbackAnswersPresenter.attendanceFailureInformationAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.attendanceFailureInformationAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.attendanceFailureInformationAnswers.answer | escape | nl2br }}</p>
 {% endif %}
 
 <br>
@@ -34,9 +38,11 @@
   <p>{{ feedbackAnswersPresenter.sessionResponseAnswers.answer }}</p>
 {% endif %}
 
-{% if feedbackAnswersPresenter.sessionConcernsAnswers %}
-  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.sessionConcernsAnswers.question }}</h3>
-  <p>{{ feedbackAnswersPresenter.sessionConcernsAnswers.answer }}</p>
+{% if feedbackAnswersPresenter.notifyProbationPractitionerAnswers %}
+    {% if feedbackAnswersPresenter.sessionConcernsAnswers %}
+        <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.sessionConcernsAnswers.question }}</h3>
+        <p>{{ feedbackAnswersPresenter.sessionConcernsAnswers.answer }}</p>
+    {% endif %}
 {% endif %}
 
 {% if feedbackAnswersPresenter.behaviourDescriptionAnswers %}

--- a/server/views/partials/postSessionFeedbackResponses.njk
+++ b/server/views/partials/postSessionFeedbackResponses.njk
@@ -1,12 +1,42 @@
+{% if presenter.appointment.appointmentFeedback.sessionFeedback.sessionSummary %}
+    <h1 class="govuk-heading-m">Session Attendance</h1>
+{% endif %}
+
+{% if feedbackAnswersPresenter.attendedAnswers %}
+  <h3 class="govuk-heading-s">{{ presenter.appointmentSummary.sessionDetails.question }}</h3>
+  <p>{{ presenter.appointmentSummary.sessionDetails.answer | escape | nl2br }}</p>
+{% endif %}
 
 {% if feedbackAnswersPresenter.attendedAnswers %}
   <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.attendedAnswers.question }}</h3>
   <p>{{ feedbackAnswersPresenter.attendedAnswers.answer | escape | nl2br }}</p>
 {% endif %}
 
+{# Old Question #}
 {% if feedbackAnswersPresenter.additionalAttendanceAnswers %}
   <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.additionalAttendanceAnswers.question }}</h3>
   <p>{{ feedbackAnswersPresenter.additionalAttendanceAnswers.answer | escape | nl2br }}</p>
+{% endif %}
+
+<br>
+
+{% if presenter.appointment.appointmentFeedback.sessionFeedback.sessionSummary %}
+<h1 class="govuk-heading-m">Session Feedback</h1>
+{% endif %}
+
+{% if feedbackAnswersPresenter.sessionSummaryAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.sessionSummaryAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.sessionSummaryAnswers.answer }}</p>
+{% endif %}
+
+{% if feedbackAnswersPresenter.sessionResponseAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.sessionResponseAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.sessionResponseAnswers.answer }}</p>
+{% endif %}
+
+{% if feedbackAnswersPresenter.sessionConcernsAnswers %}
+  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.sessionConcernsAnswers.question }}</h3>
+  <p>{{ feedbackAnswersPresenter.sessionConcernsAnswers.answer }}</p>
 {% endif %}
 
 {% if feedbackAnswersPresenter.behaviourDescriptionAnswers %}
@@ -14,7 +44,3 @@
   <p>{{ feedbackAnswersPresenter.behaviourDescriptionAnswers.answer | escape | nl2br }}</p>
 {% endif %}
 
-{% if feedbackAnswersPresenter.notifyProbationPractitionerAnswers %}
-  <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.notifyProbationPractitionerAnswers.question }}</h3>
-  <p>{{ feedbackAnswersPresenter.notifyProbationPractitionerAnswers.answer }}</p>
-{% endif %}

--- a/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
+++ b/server/views/serviceProviderReferrals/actionPlan/actionPlanFormTemplate.njk
@@ -15,11 +15,12 @@
         {{ govukBackLink(backLinkArgs) }}
       {% endif %}
 
-      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+      <h1 class="govuk-heading-l">{{ presenter.text.title }}</h1>
 
       {% if presenter.text.subTitle %}
-        <h2 class="govuk-heading-l">{{ presenter.text.subTitle }}</h2>
+        <p class="govuk-body">{{ presenter.text.subTitle }}</p>
       {% endif %}
+      <br>
 
       {% block formSection %}{% endblock %}
     </div>

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -9,6 +9,9 @@
 {% if presenter.referralEnded %}
 {{ govukNotificationBanner(cancelledReferralNotificationBannerArgs) }}
 {% endif %}
+{% if presenter.showFeedbackBanner %}
+{{ govukNotificationBanner(sessionFeedbackAddedNotificationBannerArgs) }}
+{% endif %}
 {% if presenter.referralAssigned %}
 <p class="govuk-body">This intervention is assigned to <strong>{{ presenter.assignedCaseworkerFullName }}</strong> (<a href="mailto:{{ presenter.assignedCaseworkerEmail }}">{{ presenter.assignedCaseworkerEmail }}</a>).</p>
 {% endif %}

--- a/testutils/factories/actionPlanAppointment.ts
+++ b/testutils/factories/actionPlanAppointment.ts
@@ -16,7 +16,7 @@ class ActionPlanAppointmentFactory extends Factory<ActionPlanAppointment> {
 
   attended(attendance: Attended) {
     return this.params({
-      sessionFeedback: initialAssessmentAppointmentFactory.attended(attendance).build().sessionFeedback,
+      appointmentFeedback: initialAssessmentAppointmentFactory.attended(attendance).build().appointmentFeedback,
     })
   }
 }
@@ -28,6 +28,6 @@ export default ActionPlanAppointmentFactory.define(() => ({
   sessionType: null,
   appointmentDeliveryType: null,
   appointmentDeliveryAddress: null,
-  sessionFeedback: initialAssessmentAppointmentFactory.newlyBooked().build().sessionFeedback,
+  appointmentFeedback: initialAssessmentAppointmentFactory.newlyBooked().build().appointmentFeedback,
   npsOfficeCode: null,
 }))

--- a/testutils/factories/draftAppointment.ts
+++ b/testutils/factories/draftAppointment.ts
@@ -15,7 +15,6 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
       session: {
         attendanceFeedback: {
           attended,
-          additionalAttendanceInformation,
         },
         sessionFeedback: {
           sessionSummary: null,
@@ -39,7 +38,6 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
       session: {
         attendanceFeedback: {
           attended,
-          additionalAttendanceInformation,
         },
         sessionFeedback: {
           sessionSummary: null,
@@ -65,7 +63,6 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
       session: {
         attendanceFeedback: {
           attended,
-          additionalAttendanceInformation,
         },
         sessionFeedback: {
           sessionSummary: null,
@@ -98,7 +95,7 @@ export default DraftAppointmentFactory.define(() => ({
     behaviour: {
       behaviourDescription: null,
       notifyProbationPractitioner: null,
-      sessionSummary:  null,
+      sessionSummary: null,
       sessionResponse: null,
       sessionConcerns: null,
     },

--- a/testutils/factories/draftAppointment.ts
+++ b/testutils/factories/draftAppointment.ts
@@ -92,6 +92,9 @@ export default DraftAppointmentFactory.define(() => ({
     behaviour: {
       behaviourDescription: null,
       notifyProbationPractitioner: null,
+      sessionSummary:  null,
+      sessionResponse: null,
+      sessionConcerns: null,
     },
     submitted: false,
     submittedBy: null,

--- a/testutils/factories/draftAppointment.ts
+++ b/testutils/factories/draftAppointment.ts
@@ -7,10 +7,7 @@ import userDetailsFactory from './userDetails'
 import User from '../../server/models/hmppsAuth/user'
 
 class DraftAppointmentFactory extends Factory<DraftAppointment> {
-  withAttendanceFeedback(
-    attended: Attended = 'yes',
-    additionalAttendanceInformation = 'Alex made the session on time'
-  ) {
+  withAttendanceFeedback(attended: Attended = 'yes') {
     return this.params({
       session: {
         attendanceFeedback: {
@@ -28,12 +25,7 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
     })
   }
 
-  withBehaviourFeedback(
-    attended: Attended = 'yes',
-    additionalAttendanceInformation = 'Alex made the session on time',
-    behaviourDescription = 'Alex was well-behaved',
-    notifyProbationPractitioner = false
-  ) {
+  withBehaviourFeedback(attended: Attended = 'yes') {
     return this.params({
       session: {
         attendanceFeedback: {
@@ -53,8 +45,8 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
 
   withSubmittedFeedback(
     attended: Attended = 'yes',
-    additionalAttendanceInformation = 'Alex made the session on time',
-    behaviourDescription = 'Alex was well-behaved',
+    sessionSummary = 'stub session summary',
+    sessionResponse = 'stub session summary',
     notifyProbationPractitioner = false,
     submitted = true,
     submittedBy: User = userDetailsFactory.build()
@@ -65,9 +57,9 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
           attended,
         },
         sessionFeedback: {
-          sessionSummary: null,
-          sessionResponse: null,
-          notifyProbationPractitioner: null,
+          sessionSummary,
+          sessionResponse,
+          notifyProbationPractitioner,
           sessionConcerns: null,
         },
         submitted,
@@ -88,11 +80,11 @@ export default DraftAppointmentFactory.define(() => ({
   npsOfficeCode: null,
   sessionType: defaultSessionType,
   sessionFeedback: {
-    attendance: {
+    attendanceFeedback: {
       attended: null,
-      additionalAttendanceInformation: null,
+      attendanceFailureInformation: null,
     },
-    behaviour: {
+    sessionFeedback: {
       behaviourDescription: null,
       notifyProbationPractitioner: null,
       sessionSummary: null,

--- a/testutils/factories/draftAppointment.ts
+++ b/testutils/factories/draftAppointment.ts
@@ -12,14 +12,16 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
     additionalAttendanceInformation = 'Alex made the session on time'
   ) {
     return this.params({
-      sessionFeedback: {
+      session: {
         attendance: {
           attended,
           additionalAttendanceInformation,
         },
-        behaviour: {
-          behaviourDescription: null,
+        sessionFeedback: {
+          sessionSummary: null,
+          sessionResponse: null,
           notifyProbationPractitioner: null,
+          sessionConcerns: null,
         },
         submitted: false,
         submittedBy: null,
@@ -34,14 +36,16 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
     notifyProbationPractitioner = false
   ) {
     return this.params({
-      sessionFeedback: {
+      session: {
         attendance: {
           attended,
           additionalAttendanceInformation,
         },
-        behaviour: {
-          behaviourDescription,
-          notifyProbationPractitioner,
+        sessionFeedback: {
+          sessionSummary: null,
+          sessionResponse: null,
+          notifyProbationPractitioner: null,
+          sessionConcerns: null,
         },
         submitted: false,
         submittedBy: null,
@@ -58,14 +62,16 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
     submittedBy: User = userDetailsFactory.build()
   ) {
     return this.params({
-      sessionFeedback: {
+      session: {
         attendance: {
           attended,
           additionalAttendanceInformation,
         },
-        behaviour: {
-          behaviourDescription,
-          notifyProbationPractitioner,
+        sessionFeedback: {
+          sessionSummary: null,
+          sessionResponse: null,
+          notifyProbationPractitioner: null,
+          sessionConcerns: null,
         },
         submitted,
         submittedBy,

--- a/testutils/factories/draftAppointment.ts
+++ b/testutils/factories/draftAppointment.ts
@@ -13,7 +13,7 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
   ) {
     return this.params({
       session: {
-        attendance: {
+        attendanceFeedback: {
           attended,
           additionalAttendanceInformation,
         },
@@ -37,7 +37,7 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
   ) {
     return this.params({
       session: {
-        attendance: {
+        attendanceFeedback: {
           attended,
           additionalAttendanceInformation,
         },
@@ -63,7 +63,7 @@ class DraftAppointmentFactory extends Factory<DraftAppointment> {
   ) {
     return this.params({
       session: {
-        attendance: {
+        attendanceFeedback: {
           attended,
           additionalAttendanceInformation,
         },

--- a/testutils/factories/initialAssessmentAppointment.ts
+++ b/testutils/factories/initialAssessmentAppointment.ts
@@ -94,6 +94,9 @@ export default InitialAssessmentAppointmentFactory.define(({ sequence }) => ({
     behaviour: {
       behaviourDescription: null,
       notifyProbationPractitioner: null,
+      sessionSummary:  null,
+      sessionResponse: null,
+      sessionConcerns: null,
     },
     submitted: false,
     submittedBy: null,

--- a/testutils/factories/initialAssessmentAppointment.ts
+++ b/testutils/factories/initialAssessmentAppointment.ts
@@ -92,11 +92,12 @@ export default InitialAssessmentAppointmentFactory.define(({ sequence }) => ({
     attendanceFeedback: {
       attended: null,
       additionalAttendanceInformation: null,
+      attendanceFailureInformation: null,
     },
     sessionFeedback: {
       behaviourDescription: null,
       notifyProbationPractitioner: null,
-      sessionSummary:  null,
+      sessionSummary: null,
       sessionResponse: null,
       sessionConcerns: null,
     },

--- a/testutils/factories/initialAssessmentAppointment.ts
+++ b/testutils/factories/initialAssessmentAppointment.ts
@@ -11,13 +11,15 @@ class InitialAssessmentAppointmentFactory extends Factory<InitialAssessmentAppoi
 
   attended(attendance: Attended) {
     return this.params({
-      sessionFeedback: {
-        attendance: {
+      appointmentFeedback: {
+        attendanceFeedback: {
           attended: attendance,
           additionalAttendanceInformation: '',
         },
-        behaviour: {
-          behaviourDescription: '',
+        sessionFeedback: {
+          sessionSummary: '',
+          sessionResponse: '',
+          sessionConcerns: null,
           notifyProbationPractitioner: false,
         },
         submitted: true,
@@ -86,12 +88,12 @@ export default InitialAssessmentAppointmentFactory.define(({ sequence }) => ({
   appointmentDeliveryType: defaultAppointmentDeliveryType,
   appointmentDeliveryAddress: null,
   npsOfficeCode: null,
-  sessionFeedback: {
-    attendance: {
+  appointmentFeedback: {
+    attendanceFeedback: {
       attended: null,
       additionalAttendanceInformation: null,
     },
-    behaviour: {
+    sessionFeedback: {
       behaviourDescription: null,
       notifyProbationPractitioner: null,
       sessionSummary:  null,

--- a/testutils/factories/initialAssessmentAppointment.ts
+++ b/testutils/factories/initialAssessmentAppointment.ts
@@ -95,7 +95,6 @@ export default InitialAssessmentAppointmentFactory.define(({ sequence }) => ({
       attendanceFailureInformation: null,
     },
     sessionFeedback: {
-      behaviourDescription: null,
       notifyProbationPractitioner: null,
       sessionSummary: null,
       sessionResponse: null,


### PR DESCRIPTION
## What does this pull request do?

Updates the appointment feedback forms content and flow:

- Adds new sessionSummary, sessionResponse and sessionConcerns and attendanceFailureInformation fields.
- Replaces the confirmation page with a confirmation banner.

## What is the intent behind these changes?

To capture better session feedback.
