### PR TITLE
update cancelled banner message

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -1766,11 +1766,9 @@ describe('Service provider referrals dashboard', () => {
       cy.visit(`/service-provider/referrals/${endedReferral.id}/progress`)
       cy.contains('Intervention ended')
       cy.contains(
-        'The probation practitioner ended this intervention on 28 April 2021 with reason: Service user was recalled'
+        'The probation practitioner ended this intervention on 28 April 2021 because: Service user was recalled'
       )
-      cy.contains('Please note that an end of service report must still be submitted within 10 working days.').should(
-        'not.exist'
-      )
+      cy.contains('An end of service report needs to be submitted within 5 working days.').should('not.exist')
       cy.contains("Additional information: you'll be seeing alex again soon i'm sure!")
     })
 
@@ -1787,7 +1785,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetApprovedActionPlanSummaries(endedReferral.id, [])
       cy.login()
       cy.visit(`/service-provider/referrals/${endedReferral.id}/progress`)
-      cy.contains('Please note that an end of service report must still be submitted within 10 working days.')
+      cy.contains('An end of service report needs to be submitted within 5 working days.')
     })
 
     it('allows users to click through to a page to view session feedback', () => {

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -27,7 +27,7 @@ export default class InterventionProgressView {
       cancellationReasonHTML = `
         <p>
             The probation practitioner ended this intervention on ${formattedEndDate} 
-            with reason: ${ViewUtils.escape(this.presenter.referralEndedFields.endRequestedReason)}.
+            because: ${ViewUtils.escape(this.presenter.referralEndedFields.endRequestedReason)}.
         </p>`
     }
     if (this.presenter.referralEndedFields.endRequestedComments) {
@@ -39,7 +39,7 @@ export default class InterventionProgressView {
     if (!this.presenter.isConcluded) {
       notConcludedWarningHTML = `
             <p>
-                Please note that an end of service report must still be submitted within 10 working days.
+                An end of service report needs to be submitted within 5 working days.
             </p>`
     }
     const html = `<div>${cancellationReasonHTML}${notConcludedWarningHTML}${cancellationCommentsHTML}</div>`


### PR DESCRIPTION
## What does this pull request do?

Updates the content within the intervention ended banner.

![image](https://github.com/ministryofjustice/hmpps-interventions-ui/assets/22861624/7f0e77ea-da45-41cc-8ebb-bb10efeeb327)


## What is the intent behind these changes?

The current message displays that an eosr needs to be completed within 10 days, which is incorrect. This should be 5 days.
