### PR TITLE
fixing referral details showing responsible officer and referring officer

### DIFF
--- a/integration_tests/integration/amend-referral.cy.js
+++ b/integration_tests/integration/amend-referral.cy.js
@@ -7,6 +7,7 @@ import supplementaryRiskInformation from '../../testutils/factories/supplementar
 import riskSummary from '../../testutils/factories/riskSummary'
 import deliusOffenderManager from '../../testutils/factories/deliusOffenderManager'
 import serviceCategoryFactory from '../../testutils/factories/serviceCategory'
+import deliusResponsibleOfficerFactory from '../../testutils/factories/deliusResponsibleOfficer'
 
 context('Amend a referral', () => {
   beforeEach(() => {
@@ -37,6 +38,7 @@ context('Amend a referral', () => {
       cy.stubGetRiskSummary(crn, riskSummary.build())
       cy.stubGetResponsibleOfficerForServiceUser(crn, [deliusOffenderManager.build()])
       cy.stubGetApprovedActionPlanSummaries(sentReferral.id, [])
+      cy.stubGetResponsibleOfficer(crn, [deliusResponsibleOfficerFactory.build()])
     }
 
     describe('as a probation practitioner', () => {
@@ -126,6 +128,7 @@ context('Amend a referral', () => {
       cy.stubGetSupplementaryRiskInformation(sentReferral.supplementaryRiskId, supplementaryRiskInformation.build())
       cy.stubGetRiskSummary(crn, riskSummary.build())
       cy.stubGetResponsibleOfficerForServiceUser(crn, [deliusOffenderManager.build()])
+      cy.stubGetResponsibleOfficer(crn, [deliusResponsibleOfficerFactory.build()])
       cy.stubGetApprovedActionPlanSummaries(sentReferral.id, [])
     }
 
@@ -226,6 +229,7 @@ context('Amend a referral', () => {
       cy.stubGetRiskSummary(crn, riskSummary.build())
       cy.stubGetResponsibleOfficerForServiceUser(crn, [deliusOffenderManager.build()])
       cy.stubGetApprovedActionPlanSummaries(sentReferral.id, [])
+      cy.stubGetResponsibleOfficer(crn, [deliusResponsibleOfficerFactory.build()])
     }
 
     describe('as a probation practitioner', () => {
@@ -368,6 +372,7 @@ context('Amend a referral', () => {
       cy.stubGetUserByUsername(pp.username, pp)
       cy.stubGetSupplementaryRiskInformation(sentReferral.supplementaryRiskId, supplementaryRiskInformation.build())
       cy.stubGetResponsibleOfficerForServiceUser(crn, [deliusOffenderManager.build()])
+      cy.stubGetResponsibleOfficer(crn, [deliusResponsibleOfficerFactory.build()])
       cy.stubGetApprovedActionPlanSummaries(sentReferral.id, [])
       cy.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory)
       cy.stubGetServiceCategory(socialInclusionServiceCategory.id, socialInclusionServiceCategory)
@@ -609,6 +614,7 @@ context('Amend a referral', () => {
       cy.stubGetUserByUsername(pp.username, pp)
       cy.stubGetSupplementaryRiskInformation(sentReferral.supplementaryRiskId, supplementaryRiskInformation.build())
       cy.stubGetResponsibleOfficerForServiceUser(crn, [deliusOffenderManager.build()])
+      cy.stubGetResponsibleOfficer(crn, [deliusResponsibleOfficerFactory.build()])
       cy.stubGetApprovedActionPlanSummaries(sentReferral.id, [])
       cy.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory)
       cy.stubGetServiceCategory(socialInclusionServiceCategory.id, socialInclusionServiceCategory)

--- a/integration_tests/integration/referral.cy.js
+++ b/integration_tests/integration/referral.cy.js
@@ -675,7 +675,6 @@ describe('Referral form', () => {
 
       const sentReferral = sentReferralFactory.fromFields(completedDraftReferral).build()
       const prisons = prisonFactory.prisonList()
-      const responsibleOfficer = deliusResponsibleOfficerFactory.build()
 
       cy.stubGetServiceUserByCRN('X123456', deliusServiceUser)
       cy.stubCreateDraftReferral(draftReferral)
@@ -693,7 +692,7 @@ describe('Referral form', () => {
       cy.stubSetDesiredOutcomesForServiceCategory(draftReferral.id, draftReferral)
       cy.stubSetComplexityLevelForServiceCategory(draftReferral.id, draftReferral)
       cy.stubGetRiskSummary(draftReferral.serviceUser.crn, riskSummaryFactory.build())
-      cy.stubGetResponsibleOfficer(responsibleOfficer)
+      cy.stubGetResponsibleOfficer(draftReferral.serviceUser.crn, deliusResponsibleOfficerFactory.build())
 
       cy.login()
 

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -17,6 +17,7 @@ import initialAssessmentAppointmentFactory from '../../testutils/factories/initi
 import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
 import actionPlanActivityFactory from '../../testutils/factories/actionPlanActivity'
 import pageFactory from '../../testutils/factories/page'
+import deliusResponsibleOfficerFactory from '../../testutils/factories/deliusResponsibleOfficer'
 
 describe('Service provider referrals dashboard', () => {
   beforeEach(() => {
@@ -204,6 +205,7 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetConvictionById(referralToSelect.referral.serviceUser.crn, conviction.convictionId, conviction)
     cy.stubGetSupplementaryRiskInformation(referralToSelect.supplementaryRiskId, supplementaryRiskInformation)
     cy.stubGetResponsibleOfficerForServiceUser(referralToSelect.referral.serviceUser.crn, [responsibleOfficer])
+    cy.stubGetResponsibleOfficer(referralToSelect.referral.serviceUser.crn, deliusResponsibleOfficerFactory.build())
 
     cy.login()
 
@@ -274,17 +276,17 @@ describe('Service provider referrals dashboard', () => {
       .last()
       .children()
       .should('contain', 'Name')
-      .should('contain', 'Peter Practitioner')
+      .should('contain', 'Bob Alice')
       .should('contain', 'Phone')
-      .should('contain', '01234567890')
+      .should('contain', '98454243243')
       .should('contain', 'Email address')
-      .should('contain', 'p.practitioner@justice.gov.uk')
+      .should('contain', 'bobalice@example.com')
       .should('contain', 'Team phone')
-      .should('contain', '07890 123456')
+      .should('contain', '044-2545453442')
       .should('contain', 'Team email address')
-      .should('contain', 'probation-team4692@justice.gov.uk')
+      .should('contain', 'r.m@digital.justice.gov.uk')
 
-    cy.contains(`Jenny Jones's probation practitioner`)
+    cy.contains(`Referring probation practitioner details`)
       .parent()
       .parent()
       .children()
@@ -294,8 +296,6 @@ describe('Service provider referrals dashboard', () => {
       .should('contain', 'Bernard Beaks')
       .should('contain', 'Email address')
       .should('contain', 'bernard.beaks@justice.gov.uk')
-      .should('contain', 'Probation Office')
-      .should('contain', 'London')
 
     cy.contains(`Jenny Jones's location and expected release date`)
       .parent()
@@ -402,6 +402,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetResponsibleOfficerForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
       cy.stubGetSupplierAssessment(referral.id, supplierAssessmentFactory.build())
       cy.stubGetApprovedActionPlanSummaries(referral.id, [])
+      cy.stubGetResponsibleOfficer(referral.referral.serviceUser.crn, deliusResponsibleOfficerFactory.build())
 
       cy.login()
 
@@ -499,6 +500,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetConvictionById(referral.referral.serviceUser.crn, conviction.convictionId, conviction)
       cy.stubGetSupplementaryRiskInformation(referral.supplementaryRiskId, supplementaryRiskInformation)
       cy.stubGetResponsibleOfficerForServiceUser(referral.referral.serviceUser.crn, [responsibleOfficer])
+      cy.stubGetResponsibleOfficer(referral.referral.serviceUser.crn, deliusResponsibleOfficerFactory.build())
 
       cy.login()
 

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -52,7 +52,7 @@ export default on => {
     },
 
     stubGetResponsibleOfficer: arg => {
-      return ramDeliusApi.stubGetResponsibleOfficer(arg.responseJson)
+      return ramDeliusApi.stubGetResponsibleOfficer(arg.crn, arg.responseJson)
     },
 
     stubGetUserByUsername: arg => {

--- a/integration_tests/support/commands.js
+++ b/integration_tests/support/commands.js
@@ -3,6 +3,7 @@ import deliusConvictionFactory from '../../testutils/factories/deliusConviction'
 import supplementaryRiskInformationFactory from '../../testutils/factories/supplementaryRiskInformation'
 import expandedDeliusServiceUserFactory from '../../testutils/factories/expandedDeliusServiceUser'
 import deliusOffenderManagerFactory from '../../testutils/factories/deliusOffenderManager'
+import deliusResponsibleOfficerFactory from '../../testutils/factories/deliusResponsibleOfficer'
 
 Cypress.Commands.add('login', (redirectUrl = '/') => {
   cy.request(redirectUrl)
@@ -37,6 +38,7 @@ Cypress.Commands.add('stubViewReferralDetails', referralToView => {
   cy.stubGetResponsibleOfficerForServiceUser(referralToView.referral.serviceUser.crn, [
     deliusOffenderManagerFactory.build(),
   ])
+  cy.stubGetResponsibleOfficer(referralToView.referral.serviceUser.crn, [deliusResponsibleOfficerFactory.build()])
 })
 
 const getTable = (subject, options = {}) => {

--- a/integration_tests/support/ramDeliusApiStubs.js
+++ b/integration_tests/support/ramDeliusApiStubs.js
@@ -1,5 +1,5 @@
-Cypress.Commands.add('stubGetResponsibleOfficer', responseJson => {
-  cy.task('stubGetResponsibleOfficer', { responseJson })
+Cypress.Commands.add('stubGetResponsibleOfficer', (crn, responseJson) => {
+  cy.task('stubGetResponsibleOfficer', { crn, responseJson })
 })
 
 Cypress.Commands.add('stubGetCrnUserAccess', responseJson => {

--- a/mockApis/referAndMonitorAndDelius.ts
+++ b/mockApis/referAndMonitorAndDelius.ts
@@ -19,11 +19,11 @@ export default class ReferAndMonitorAndDeliusMocks {
     })
   }
 
-  stubGetResponsibleOfficer = async (responseJson: unknown): Promise<unknown> => {
+  stubGetResponsibleOfficer = async (crn: string, responseJson: unknown): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `${this.mockPrefix}/probation-case/([a-zA-Z0-9]*)/responsible-officer`,
+        urlPattern: `${this.mockPrefix}/probation-case/${crn}/responsible-officer`,
       },
       response: {
         status: 200,

--- a/mocks.ts
+++ b/mocks.ts
@@ -34,103 +34,6 @@ const referAndMonitorAndDeliusMocks = new ReferAndMonitorAndDeliusMocks(wiremock
 export default async function setUpMocks(): Promise<void> {
   await wiremock.resetStubs()
 
-  /*
-  const accommodationServiceCategory = serviceCategoryFactory.build({ name: 'accommodation' })
-  const socialInclusionServiceCategory = serviceCategoryFactory.build({ name: 'social inclusion' })
-
-  const sentBy = {
-    username: 'BERNARD.BEAKS',
-    authSource: 'delius',
-  }
-
-  const actionPlan = actionPlanFactory.notSubmitted().build()
-
-  const sentReferrals = [
-    sentReferralFactory.build({
-      sentAt: '2021-01-26T13:00:00.000000Z',
-      referenceNumber: 'ABCABCA1',
-      referral: {
-        serviceCategoryId: accommodationServiceCategory.id,
-        serviceUser: { firstName: 'Aadland', lastName: 'Bertrand', crn: 'X320741' },
-        desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
-      },
-      sentBy,
-      actionPlanId: actionPlan.id,
-    }),
-    sentReferralFactory.build({
-      sentAt: '2020-09-13T13:00:00.000000Z',
-      referenceNumber: 'ABCABCA2',
-      referral: {
-        serviceCategoryId: socialInclusionServiceCategory.id,
-        serviceUser: { firstName: 'George', lastName: 'Michael', crn: 'X320741' },
-        desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
-      },
-      sentBy,
-    }),
-    sentReferralFactory.build({
-      sentAt: '2021-02-10:00:00.000000Z',
-      referenceNumber: 'ABCABCA3',
-      referral: {
-        serviceCategoryId: socialInclusionServiceCategory.id,
-        serviceUser: { firstName: 'Jenny', lastName: 'Jones', crn: 'X320741' },
-        desiredOutcomesIds: ['65924ac6-9724-455b-ad30-906936291421', 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d'],
-      },
-      sentBy,
-    }),
-  ]
-
-  const interventions = [
-    {
-      id: '98a42c61-c30f-4beb-8062-04033c376e2d',
-      title: 'Better solutions (anger management)',
-      categoryName: 'thinking and behaviour',
-    },
-    {
-      id: 'd57a2c90-e8cd-489a-b62d-e8f01474f7b0',
-      title: 'HELP (domestic violence for males)',
-      categoryName: 'relationships',
-      description:
-        'HELP - the Healthy Relationships programme, is a new, preventative approach to domestic abuse.' +
-        'The course aims to help create successful relationships. Those who complete the group will have' +
-        'skills and strategies to manage situations differently and avoid problems escalating into violence.',
-      npsRegion: null,
-    },
-  ].map(params => {
-    return interventionFactory.build({
-      id: params.id,
-      title: params.title,
-      serviceCategory: { name: params.categoryName },
-      description: params.description,
-      npsRegion: params.npsRegion,
-    })
-  })
-
-  const deliusUser = deliusUserFactory.build({
-    username: 'AUTH_ADM',
-    email: 'auth_test@digital.justice.gov.uk',
-    userId: '10ea6b98-88ab-45c5-8917-f5ca1814b787',
-  })
-
-  const assignedSentReferrals = sentReferrals.map(referral => {
-    return { ...referral, assignedTo: deliusUser }
-  })
-
-  await Promise.all([
-    interventionsMocks.stubGetServiceCategory(accommodationServiceCategory.id, accommodationServiceCategory),
-    interventionsMocks.stubGetServiceCategory(socialInclusionServiceCategory.id, socialInclusionServiceCategory),
-    Promise.all(sentReferrals.map(referral => interventionsMocks.stubGetSentReferral(referral.id, referral))),
-    interventionsMocks.stubGetSentReferralsForUserToken(assignedSentReferrals),
-    interventionsMocks.stubGetInterventions(interventions),
-    // Adding mocks for assigning locally is a bit tricky - it's very hard to mock a real assignment here due to the state transition.
-    // I've opted to just mark these as assigned to unblock the next story for now.
-    assignedSentReferrals.forEach(async referral => {
-      await interventionsMocks.stubAssignSentReferral(referral.id, referral)
-      await interventionsMocks.stubGetSentReferral(referral.id, referral)
-    }),
-    interventionsMocks.stubGetActionPlan(actionPlan.id, actionPlan),
-  ])
-  */
-
   const accommodationServiceCategory = serviceCategoryFactory.build({
     name: 'accommodation',
     id: '5fd9e664-0a73-4476-9f05-a330f556f34a',
@@ -171,7 +74,7 @@ export default async function setUpMocks(): Promise<void> {
     communityApiMocks.stubGetActiveConvictionsByCRN('CRN24', [deliusConvictionFactory.build()]),
     communityApiMocks.stubGetServiceUserByCRN('CRN24', deliusServiceUser.build({ otherIds: { crn: 'CRN24' } })),
     communityApiMocks.stubGetConvictionById('CRN24', '([0-9]+)', deliusConvictionFactory.build()),
-    referAndMonitorAndDeliusMocks.stubGetResponsibleOfficer(deliusResponsibleOfficerFactory.build()),
+    referAndMonitorAndDeliusMocks.stubGetResponsibleOfficer('X320741', deliusResponsibleOfficerFactory.build()),
     interventionsMocks.stubGetActionPlanAppointment(
       '1',
       1,

--- a/server/models/delius/deliusResponsibleOfficer.ts
+++ b/server/models/delius/deliusResponsibleOfficer.ts
@@ -6,10 +6,12 @@ export interface DeliusResponsibleOfficer {
 interface Manager {
   code: string
   name: Name
-  username: string
-  email: string
+  username?: string | null
+  email?: string | null
+  telephoneNumber?: string | null
   responsibleOfficer: boolean
   pdu: Pdu
+  team: Team
 }
 
 interface Name {
@@ -20,4 +22,11 @@ interface Name {
 interface Pdu {
   code: string
   description: string
+}
+
+interface Team {
+  code: string
+  description: string
+  email?: string | null
+  telephoneNumber?: string | null
 }

--- a/server/routes/makeAReferral/confirm-probation-practitioner-details/confirmProbationPractitionerDetailsForm.test.ts
+++ b/server/routes/makeAReferral/confirm-probation-practitioner-details/confirmProbationPractitionerDetailsForm.test.ts
@@ -14,8 +14,10 @@ describe('ConfirmProbationPractitionerDetailsForm', () => {
       name: { forename: 'Bob', surname: 'Alice' },
       username: 'bobalice',
       email: 'bobalice@example.com',
+      telephoneNumber: '07595025281',
       responsibleOfficer: true,
       pdu: { code: 'L', description: 'London' },
+      team: { code: 'R and M', description: 'R and M team', telephoneNumber: '07595025281', email: 'a.b@xyz.com' },
     },
   }
 

--- a/server/routes/makeAReferral/confirm-probation-practitioner-details/confirmProbationPractitionerDetailsPresenter.test.ts
+++ b/server/routes/makeAReferral/confirm-probation-practitioner-details/confirmProbationPractitionerDetailsPresenter.test.ts
@@ -8,8 +8,10 @@ describe('ConfirmProbationPractitionerDetailsPresenter', () => {
       name: { forename: 'Bob', surname: 'Alice' },
       username: 'bobalice',
       email: 'bobalice@example.com',
+      telephoneNumber: '07595025281',
       responsibleOfficer: true,
       pdu: { code: 'L', description: 'London' },
+      team: { code: 'R and M', description: 'R and M team', telephoneNumber: '07595025281', email: 'a.b@xyz.com' },
     },
   }
 

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -18,7 +18,8 @@ export default function probationPractitionerRoutes(router: Router, services: Se
     services.draftsService,
     services.referenceDataService,
     services.userDataService,
-    services.prisonRegisterService
+    services.prisonRegisterService,
+    services.ramDeliusApiService
   )
   const appointmentsController = new AppointmentsController(
     services.interventionsService,

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -64,6 +64,7 @@ import DashboardWithoutPaginationView from '../deprecated/dashboardWithoutPagina
 import FeatureFlagService from '../../services/featureFlagService'
 import UserDataService from '../../services/userDataService'
 import PrisonRegisterService from '../../services/prisonRegisterService'
+import RamDeliusApiService from '../../services/ramDeliusApiService'
 
 export interface DraftAssignmentData {
   email: string | null
@@ -82,7 +83,8 @@ export default class ServiceProviderReferralsController {
     private readonly draftsService: DraftsService,
     private readonly referenceDataService: ReferenceDataService,
     private readonly userDataService: UserDataService,
-    private readonly prisonRegisterService: PrisonRegisterService
+    private readonly prisonRegisterService: PrisonRegisterService,
+    private readonly ramDeliusApiService: RamDeliusApiService
   ) {
     this.deliusOfficeLocationFilter = new DeliusOfficeLocationFilter(referenceDataService)
   }
@@ -290,8 +292,8 @@ export default class ServiceProviderReferralsController {
       conviction,
       riskInformation,
       riskSummary,
-      responsibleOfficer,
       prisons,
+      deliusResponsibleOfficer,
     ] = await Promise.all([
       this.interventionsService.getIntervention(accessToken, sentReferral.referral.interventionId),
       this.communityApiService.getUserByUsername(sentReferral.sentBy.username),
@@ -299,8 +301,8 @@ export default class ServiceProviderReferralsController {
       this.communityApiService.getConvictionById(crn, sentReferral.referral.relevantSentenceId),
       this.assessRisksAndNeedsService.getSupplementaryRiskInformation(sentReferral.supplementaryRiskId, accessToken),
       this.assessRisksAndNeedsService.getRiskSummary(crn, accessToken),
-      this.communityApiService.getResponsibleOfficerForServiceUser(crn),
       this.prisonRegisterService.getPrisons(),
+      this.ramDeliusApiService.getResponsibleOfficer(sentReferral.referral.serviceUser.crn),
     ])
 
     const assignee =
@@ -335,7 +337,7 @@ export default class ServiceProviderReferralsController {
       true,
       expandedServiceUser,
       riskSummary,
-      responsibleOfficer,
+      deliusResponsibleOfficer,
       false,
       req.session.dashboardOriginPage
     )

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -17,7 +17,8 @@ export default function serviceProviderRoutes(router: Router, services: Services
     services.draftsService,
     services.referenceDataService,
     services.userDataService,
-    services.prisonRegisterService
+    services.prisonRegisterService,
+    services.ramDeliusApiService
   )
   const appointmentsController = new AppointmentsController(
     services.interventionsService,

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -12,9 +12,9 @@ import supplementaryRiskInformationFactory from '../../../testutils/factories/su
 import expandedDeliusServiceUserFactory from '../../../testutils/factories/expandedDeliusServiceUser'
 import riskSummaryFactory from '../../../testutils/factories/riskSummary'
 import prisonFactory from '../../../testutils/factories/prison'
-import deliusOffenderManagerFactory from '../../../testutils/factories/deliusOffenderManager'
 import { CurrentLocationType } from '../../models/draftReferral'
 import PrisonRegisterService from '../../services/prisonRegisterService'
+import deliusResponsibleOfficerFactory from '../../../testutils/factories/deliusResponsibleOfficer'
 
 jest.mock('../../services/prisonRegisterService')
 
@@ -41,6 +41,8 @@ describe(ShowReferralPresenter, () => {
       serviceCategoryIds: [serviceCategory.id],
       serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
       personCurrentLocationType: CurrentLocationType.community,
+      ppName: 'Bernard Beaks',
+      ppEmailAddress: 'bernard.beaks@justice.gov.uk',
     },
   }
   const deliusUser = deliusUserFactory.build({
@@ -52,7 +54,7 @@ describe(ShowReferralPresenter, () => {
 
   const supplementaryRiskInformation = supplementaryRiskInformationFactory.build()
   const riskSummary = riskSummaryFactory.build()
-  const responsibleOfficer = deliusOffenderManagerFactory.build()
+  const deliusRoOfficer = deliusResponsibleOfficerFactory.build()
 
   const prisonList = prisonFactory.prisonList()
   prisonRegisterService.getPrisons.mockResolvedValue(prisonList)
@@ -75,7 +77,7 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        responsibleOfficer
+        deliusRoOfficer
       )
       expect(presenter.canShowFullSupplementaryRiskInformation).toBeFalsy()
     })
@@ -95,7 +97,7 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        responsibleOfficer
+        deliusRoOfficer
       )
       expect(presenter.canShowFullSupplementaryRiskInformation).toBeTruthy()
     })
@@ -118,7 +120,7 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        responsibleOfficer
+        deliusRoOfficer
       )
 
       expect(presenter.assignmentFormAction).toEqual(`/service-provider/referrals/${referral.id}/assignment/start`)
@@ -144,7 +146,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer
+          deliusRoOfficer
         )
 
         expect(presenter.assignedCaseworkerFullName).toEqual(null)
@@ -169,7 +171,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer
+          deliusRoOfficer
         )
 
         expect(presenter.assignedCaseworkerFullName).toEqual('Liam Johnson')
@@ -196,7 +198,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer
+          deliusRoOfficer
         )
 
         expect(presenter.assignedCaseworkerFullName).toEqual(null)
@@ -221,7 +223,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer
+          deliusRoOfficer
         )
 
         expect(presenter.assignedCaseworkerEmail).toEqual('liam.johnson@justice.gov.uk')
@@ -245,10 +247,10 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        responsibleOfficer
+        deliusRoOfficer
       )
 
-      expect(presenter.probationPractitionerDetails).toEqual([
+      expect(presenter.probationPractitionerDetailsForCommunity).toEqual([
         { key: 'Name', lines: ['Bernard Beaks'] },
         { key: 'Email address', lines: ['bernard.beaks@justice.gov.uk'] },
         { key: 'Probation Office', lines: ['London'] },
@@ -272,7 +274,7 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        responsibleOfficer
+        deliusRoOfficer
       )
 
       expect(presenter.serviceUserLocationDetails).toEqual([
@@ -304,7 +306,7 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        responsibleOfficer
+        deliusRoOfficer
       )
 
       expect(presenter.serviceUserLocationDetails).toEqual([
@@ -338,21 +340,32 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          deliusOffenderManagerFactory.build({
-            staff: {
-              forenames: 'Peter',
-              surname: 'Practitioner',
+          deliusResponsibleOfficerFactory.build({
+            communityManager: {
+              code: 'abc',
+              name: {
+                forename: 'Peter',
+                surname: 'Practitioner',
+              },
+              username: 'bobalice',
               email: 'p.practitioner@example.com',
-              phoneNumber: '01234567890',
-            },
-            team: {
-              telephone: '01141234567',
-              emailAddress: 'team@nps.gov.uk',
+              telephoneNumber: '01234567890',
+              responsibleOfficer: true,
+              pdu: {
+                code: '97',
+                description: 'Hackney and City',
+              },
+              team: {
+                code: 'RM',
+                description: 'R and M team',
+                email: 'team@nps.gov.uk',
+                telephoneNumber: '01141234567',
+              },
             },
           })
         )
 
-        expect(presenter.responsibleOfficersDetails).toEqual([
+        expect(presenter.deliusResponsibleOfficersDetails).toEqual([
           { key: 'Name', lines: ['Peter Practitioner'] },
           { key: 'Phone', lines: ['01234567890'] },
           { key: 'Email address', lines: ['p.practitioner@example.com'] },
@@ -378,18 +391,32 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          {
-            isResponsibleOfficer: true,
-            staff: {
-              forenames: 'Peter',
-              surname: undefined,
-              email: undefined,
-              phoneNumber: undefined,
+          deliusResponsibleOfficerFactory.build({
+            communityManager: {
+              code: 'abc',
+              name: {
+                forename: 'Peter',
+                surname: undefined,
+              },
+              username: 'bobalice',
+              email: null,
+              telephoneNumber: null,
+              responsibleOfficer: true,
+              pdu: {
+                code: '97',
+                description: 'Hackney and City',
+              },
+              team: {
+                code: 'RM',
+                description: 'R and M team',
+                email: null,
+                telephoneNumber: null,
+              },
             },
-          }
+          })
         )
 
-        expect(presenter.responsibleOfficersDetails).toEqual([
+        expect(presenter.deliusResponsibleOfficersDetails).toEqual([
           { key: 'Name', lines: ['Peter'] },
           { key: 'Phone', lines: ['Not found'] },
           {
@@ -421,7 +448,7 @@ describe(ShowReferralPresenter, () => {
           null
         )
 
-        expect(presenter.responsibleOfficersDetails).toEqual([])
+        expect(presenter.deliusResponsibleOfficersDetails).toEqual([])
       })
     })
   })
@@ -497,7 +524,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer
+          deliusRoOfficer
         )
 
         expect(presenter.interventionDetails).toEqual([
@@ -588,7 +615,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer
+          deliusRoOfficer
         )
 
         expect(presenter.interventionDetails).toEqual([
@@ -645,7 +672,7 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        responsibleOfficer
+        deliusRoOfficer
       )
       expect(
         presenter.serviceCategorySection(cohortServiceCategories[0], (args: TagArgs): string => {
@@ -684,7 +711,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer,
+          deliusRoOfficer,
           true,
           'dashboardOriginPage',
           false
@@ -719,7 +746,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer,
+          deliusRoOfficer,
           true,
           'dashboardOriginPage',
           true
@@ -754,7 +781,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer,
+          deliusRoOfficer,
           true,
           'dashboardOriginPage',
           false
@@ -791,18 +818,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          deliusOffenderManagerFactory.build({
-            staff: {
-              forenames: 'Peter',
-              surname: 'Practitioner',
-              email: 'p.practitioner@example.com',
-              phoneNumber: '01234567890',
-            },
-            team: {
-              telephone: '01141234567',
-              emailAddress: 'team@nps.gov.uk',
-            },
-          }),
+          deliusRoOfficer,
           false,
           undefined,
           false
@@ -841,18 +857,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          deliusOffenderManagerFactory.build({
-            staff: {
-              forenames: 'Peter',
-              surname: 'Practitioner',
-              email: 'p.practitioner@example.com',
-              phoneNumber: '01234567890',
-            },
-            team: {
-              telephone: '01141234567',
-              emailAddress: 'team@nps.gov.uk',
-            },
-          }),
+          deliusRoOfficer,
           false,
           undefined,
           true
@@ -895,18 +900,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          deliusOffenderManagerFactory.build({
-            staff: {
-              forenames: 'Peter',
-              surname: 'Practitioner',
-              email: 'p.practitioner@example.com',
-              phoneNumber: '01234567890',
-            },
-            team: {
-              telephone: '01141234567',
-              emailAddress: 'team@nps.gov.uk',
-            },
-          }),
+          deliusRoOfficer,
           false,
           undefined,
           false
@@ -953,7 +947,7 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        responsibleOfficer
+        deliusRoOfficer
       )
 
       expect(presenter.personalDetailSummary).toEqual([
@@ -985,7 +979,7 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        responsibleOfficer
+        deliusRoOfficer
       )
 
       expect(presenter.contactDetailsSummary).toEqual([
@@ -1019,7 +1013,7 @@ describe(ShowReferralPresenter, () => {
         true,
         deliusServiceUser,
         riskSummary,
-        responsibleOfficer
+        deliusRoOfficer
       )
 
       expect(presenter.serviceUserRisks).toEqual([
@@ -1087,7 +1081,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer
+          deliusRoOfficer
         )
 
         expect(presenter.serviceUserNeeds).toEqual([
@@ -1175,7 +1169,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer
+          deliusRoOfficer
         )
 
         expect(presenter.serviceUserNeeds).toEqual([
@@ -1231,7 +1225,7 @@ describe(ShowReferralPresenter, () => {
           true,
           deliusServiceUser,
           riskSummary,
-          responsibleOfficer
+          deliusRoOfficer
         )
 
         expect(presenter.text).toMatchObject({

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -148,7 +148,7 @@ export default class ShowReferralPresenter {
       lines: [
         this.sentReferral.referral.ppProbationOffice !== null && this.sentReferral.referral.ppProbationOffice !== ''
           ? this.sentReferral.referral.ppProbationOffice
-          : this.sentReferral.referral.ndeliusPDU || '',
+          : this.sentReferral.referral.ppPdu || this.sentReferral.referral.ndeliusPDU || '',
       ],
     },
   ]

--- a/server/routes/shared/showReferralView.ts
+++ b/server/routes/shared/showReferralView.ts
@@ -21,14 +21,18 @@ export default class ShowReferralView {
 
   private get probationPractitionerSummaryListArgs() {
     return ViewUtils.summaryListArgsWithSummaryCard(
-      this.presenter.probationPractitionerDetails,
-      this.presenter.probationPractitionerDetailsHeading,
+      this.presenter.isCustodyReferral
+        ? this.presenter.probationPractitionerDetailsForCustody
+        : this.presenter.probationPractitionerDetailsForCommunity,
+      this.presenter.isCustodyReferral
+        ? 'Referring probation practitioner details'
+        : this.presenter.probationPractitionerDetailsHeading,
       { showBorders: true, showTitle: true }
     )
   }
 
   private readonly responsibleOfficerSummaryListArgs = ViewUtils.summaryListArgsWithSummaryCard(
-    this.presenter.responsibleOfficersDetails,
+    this.presenter.deliusResponsibleOfficersDetails,
     this.presenter.responsibleOfficerDetailsHeading,
     { showBorders: true, showTitle: true }
   )

--- a/server/views/shared/referralDetails.njk
+++ b/server/views/shared/referralDetails.njk
@@ -34,11 +34,9 @@
       {%  for section in serviceCategorySections %}
         {{ govukSummaryList(section.summaryListArgs(govukTag)) }}
       {% endfor %}
-      {%  if responsibleOfficerSummaryListArgs | length %}
+      {%  if (responsibleOfficerSummaryListArgs | length)  and  (presenter.isCustodyReferral) %}
           {{ govukSummaryList(responsibleOfficerSummaryListArgs) }}
-      {% else %}
-          <p class="govuk-body">No responsible officer details found in nDelius. Email notifications for this referral will be sent to the referring officer.</p>
-      {% endif %}     
+      {% endif %}
 
       {{ govukSummaryList(probationPractitionerSummaryListArgs) }}
 

--- a/testutils/factories/deliusResponsibleOfficer.ts
+++ b/testutils/factories/deliusResponsibleOfficer.ts
@@ -10,10 +10,17 @@ export default Factory.define<DeliusResponsibleOfficer>(() => ({
     },
     username: 'bobalice',
     email: 'bobalice@example.com',
+    telephoneNumber: '98454243243',
     responsibleOfficer: true,
     pdu: {
       code: '97',
       description: 'Hackney and City',
+    },
+    team: {
+      code: 'RM',
+      description: 'R and M team',
+      email: 'r.m@digital.justice.gov.uk',
+      telephoneNumber: '044-2545453442',
     },
   },
 }))


### PR DESCRIPTION
## What does this pull request do?

- Shows the responsible officer with the information captured from the confirm probation practitioner page
- Shows the referring probation practitioner details only when there is a custody

## What is the intent behind these changes?

- When community with com was released the referring probation practitioner was not showing the right information
- The probation practitioner summary card was showing wrong information. So this PR is to correct it
