### PR TITLE
use feedback submitted by rather than assigned caseworker for appointment feedback page

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -2882,6 +2882,7 @@ describe('Service provider referrals dashboard', () => {
                 sessionResponse: "Wasn't engaged",
                 sessionConcerns: 'Alex was acting very suspicious.',
                 notifyProbationPractitioner: true,
+                submittedBy: hmppsAuthUserFactory.build(),
               },
             },
           })

--- a/server/routes/appointments/appointmentSummary.test.ts
+++ b/server/routes/appointments/appointmentSummary.test.ts
@@ -61,6 +61,12 @@ describe(AppointmentSummary, () => {
             firstName: 'firstName',
             lastName: 'lastName',
             email: 'email',
+          }),
+          null,
+          hmppsAuthUserFactory.build({
+            firstName: 'firstName',
+            lastName: 'lastName',
+            email: 'email',
           })
         )
 

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -109,7 +109,7 @@ export default class AppointmentSummary {
   get sessionDetails(): { question: string; answer: string } {
     const date = DateUtils.formattedDate(this.appointmentDecorator.britishDay!)
     const time = DateUtils.formattedTime(this.appointmentDecorator.britishTime!)
-    const caseworkerName = this.assignedCaseworker ? this.caseworkerName() : ''
+    const caseworkerName = this.feedbackSubmittedBy ? this.caseworkerName() : ''
     const deliveryMethod = this.appointment.appointmentDeliveryType
       ? this.deliveryMethod(this.appointment.appointmentDeliveryType).toLowerCase()
       : ''
@@ -121,8 +121,10 @@ export default class AppointmentSummary {
   }
 
   private caseworkerName(): string {
-    return typeof this.assignedCaseworker === 'string'
-      ? this.assignedCaseworker
-      : `${(<AuthUserDetails>this.assignedCaseworker).firstName} ${(<AuthUserDetails>this.assignedCaseworker).lastName}`
+    return typeof this.feedbackSubmittedBy === 'string'
+      ? this.feedbackSubmittedBy
+      : `${(<AuthUserDetails>this.feedbackSubmittedBy).firstName} ${
+          (<AuthUserDetails>this.feedbackSubmittedBy).lastName
+        }`
   }
 }

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -1125,6 +1125,7 @@ describe('Adding supplier assessment feedback', () => {
             notifyProbationPractitioner: false,
           },
           submitted: false,
+          submittedBy: hmppsAuthUserFactory.build(),
         },
       })
       const supplierAssessment = supplierAssessmentFactory.build({
@@ -2271,6 +2272,7 @@ describe('Adding post delivery session feedback', () => {
                 notifyProbationPractitioner: false,
               },
               submitted: true,
+              submittedBy: hmppsAuthUserFactory.build(),
             },
           })
 
@@ -2335,6 +2337,7 @@ describe('Adding post delivery session feedback', () => {
                 notifyProbationPractitioner: false,
               },
               submitted: true,
+              submittedBy: hmppsAuthUserFactory.build(),
             },
           })
 


### PR DESCRIPTION
## What does this pull request do?

Displays the caseworker that submitted the feedback for an appointment, rather than the currently assigned caseworker.

## What is the intent behind these changes?

Currently the wrong caseworker is displayed on the check your answers and feedback page.
