### PR TITLE
reintroduce appointment summary table for session feedback

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -1659,7 +1659,6 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('Save and continue').click()
 
       cy.contains('Confirm session feedback')
-      cy.contains('The phone call was with caseworker Case Worker at 9:02am on 24 March 2021.')
       cy.contains('Did Alex River come to the session?')
       cy.contains('No')
 
@@ -1926,7 +1925,7 @@ describe('Service provider referrals dashboard', () => {
       cy.contains('Intervention cancelled').should('not.exist')
       cy.contains('View feedback form').click()
       cy.contains('Session attendance')
-      cy.contains('Session details')
+      cy.contains('Session feedback')
       cy.contains('Did Alex River come to the session?')
       cy.contains('Yes, they were on time')
       cy.contains('Session feedback')
@@ -2653,8 +2652,7 @@ describe('Service provider referrals dashboard', () => {
             `/service-provider/referrals/${sentReferral.id}/supplier-assessment/post-assessment-feedback/check-your-answers`
           )
 
-          cy.contains('Session details')
-          cy.contains('The video call was with caseworker Case Worker at 9:02am on 24 March 2021.')
+          cy.contains('Confirm session feedback')
           cy.contains('Did Alex River come to the session?')
           cy.contains('No')
           cy.contains('Add how you tried to contact Alex River and anything you know about why they did not attend.')
@@ -2899,8 +2897,7 @@ describe('Service provider referrals dashboard', () => {
             `/service-provider/referrals/${sentReferral.id}/supplier-assessment/post-assessment-feedback/check-your-answers`
           )
           cy.contains('Session attendance')
-          cy.contains('Session details')
-          cy.contains('The phone call was with caseworker Case Worker at 9:02am on 24 March 2021.')
+          cy.contains('Session feedback')
           cy.contains('Did Alex River come to the session?')
           cy.contains('Yes, they were on time')
           cy.contains('Session feedback')

--- a/server/routes/appointments/appointmentSummary.test.ts
+++ b/server/routes/appointments/appointmentSummary.test.ts
@@ -3,9 +3,6 @@ import hmppsAuthUserFactory from '../../../testutils/factories/hmppsAuthUser'
 import { AppointmentDeliveryType } from '../../models/appointmentDeliveryType'
 import AppointmentSummary from './appointmentSummary'
 import DeliusOfficeLocation from '../../models/deliusOfficeLocation'
-import CalendarDay from '../../utils/calendarDay'
-import ClockTime from '../../utils/clockTime'
-import DateUtils from '../../utils/dateUtils'
 
 describe(AppointmentSummary, () => {
   describe('appointmentDetails', () => {
@@ -51,28 +48,6 @@ describe(AppointmentSummary, () => {
         const summaryComponent = new AppointmentSummary(appointment, null)
 
         expect(summaryComponent.appointmentSummaryList[2]).toEqual({ key: 'Method', lines: [expectedDisplayValue] })
-      })
-
-      it('contains the session details of the appointment', () => {
-        const appointment = initialAssessmentAppointmentFactory.build({ appointmentDeliveryType: deliveryType })
-        const summaryComponent = new AppointmentSummary(
-          appointment,
-          hmppsAuthUserFactory.build({
-            firstName: 'firstName',
-            lastName: 'lastName',
-            email: 'email',
-          })
-        )
-
-        const day = CalendarDay.britishDayForDate(new Date(appointment.appointmentTime!))
-        const formattedDay = DateUtils.formattedDate(day)
-        const time = ClockTime.britishTimeForDate(new Date(appointment.appointmentTime!))
-        const formattedTime = DateUtils.formattedTime(time)
-
-        expect(summaryComponent.sessionDetails).toEqual({
-          question: `Session details`,
-          answer: `The ${expectedDisplayValue.toLowerCase()} was with caseworker firstName lastName at ${formattedTime} on ${formattedDay}.`,
-        })
       })
     })
 

--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -106,23 +106,23 @@ export default class AppointmentSummary {
     ].flatMap(val => (val === null ? [] : [val]))
   }
 
-  get sessionDetails(): { question: string; answer: string } {
-    const date = DateUtils.formattedDate(this.appointmentDecorator.britishDay!)
-    const time = DateUtils.formattedTime(this.appointmentDecorator.britishTime!)
-    const caseworkerName = this.assignedCaseworker ? this.caseworkerName() : ''
-    const deliveryMethod = this.appointment.appointmentDeliveryType
-      ? this.deliveryMethod(this.appointment.appointmentDeliveryType).toLowerCase()
-      : ''
-
-    return {
-      question: `Session details`,
-      answer: `The ${deliveryMethod} was with caseworker ${caseworkerName} at ${time} on ${date}.`,
-    }
-  }
-
-  private caseworkerName(): string {
-    return typeof this.assignedCaseworker === 'string'
-      ? this.assignedCaseworker
-      : `${(<AuthUserDetails>this.assignedCaseworker).firstName} ${(<AuthUserDetails>this.assignedCaseworker).lastName}`
-  }
+  // get sessionDetails(): { question: string; answer: string } {
+  //   const date = DateUtils.formattedDate(this.appointmentDecorator.britishDay!)
+  //   const time = DateUtils.formattedTime(this.appointmentDecorator.britishTime!)
+  //   const caseworkerName = this.assignedCaseworker ? this.caseworkerName() : ''
+  //   const deliveryMethod = this.appointment.appointmentDeliveryType
+  //     ? this.deliveryMethod(this.appointment.appointmentDeliveryType).toLowerCase()
+  //     : ''
+  //
+  //   return {
+  //     question: `Session details`,
+  //     answer: `The ${deliveryMethod} was with caseworker ${caseworkerName} at ${time} on ${date}.`,
+  //   }
+  // }
+  //
+  // private caseworkerName(): string {
+  //   return typeof this.assignedCaseworker === 'string'
+  //     ? this.assignedCaseworker
+  //     : `${(<AuthUserDetails>this.assignedCaseworker).firstName} ${(<AuthUserDetails>this.assignedCaseworker).lastName}`
+  // }
 }

--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -1148,10 +1148,8 @@ describe('Adding supplier assessment feedback', () => {
         )
         .expect(200)
         .expect(res => {
-          expect(res.text).toContain('Session details')
-          expect(res.text).toContain(
-            'The in-person meeting (probation office) was with caseworker caseworkerFirstName caseworkerLastName at 1:00pm on 1 February 2021.'
-          )
+          expect(res.text).toContain('session feedback')
+          expect(res.text).toContain('In-person meeting (probation office)')
           expect(res.text).toContain('Confirm session feedback')
           expect(res.text).toContain('Did Alex River come to the session?')
           expect(res.text).toContain('Yes, they were on time')

--- a/server/views/appointments/feedback/shared/postSessionFeedbackCheckAnswers.njk
+++ b/server/views/appointments/feedback/shared/postSessionFeedbackCheckAnswers.njk
@@ -7,6 +7,7 @@
 {% set pageSubTitle = "Confirm answers" %}
 
 {% block formSection %}
+  {{ govukSummaryList(summaryListArgs) }}
   <br>
   {% include "../../../partials/postSessionFeedbackResponses.njk" %}
 

--- a/server/views/partials/postSessionFeedbackResponses.njk
+++ b/server/views/partials/postSessionFeedbackResponses.njk
@@ -2,10 +2,12 @@
     <h1 class="govuk-heading-m">Session attendance</h1>
 {% endif %}
 
+{#
 {% if feedbackAnswersPresenter.attendedAnswers %}
   <h3 class="govuk-heading-s">{{ presenter.appointmentSummary.sessionDetails.question }}</h3>
   <p>{{ presenter.appointmentSummary.sessionDetails.answer | escape | nl2br }}</p>
 {% endif %}
+#}
 
 {% if feedbackAnswersPresenter.attendedAnswers %}
   <h3 class="govuk-heading-s">{{ feedbackAnswersPresenter.attendedAnswers.question }}</h3>

--- a/server/views/shared/viewSubmittedPostSessionFeedback.njk
+++ b/server/views/shared/viewSubmittedPostSessionFeedback.njk
@@ -6,5 +6,7 @@
 {% set pageSubTitle = "View" %}
 
 {% block formSection %}
+  {{ govukSummaryList(summaryListArgs) }}
+  <br>
   {% include "../partials/postSessionFeedbackResponses.njk" %}
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Reintroduces the appointment summary table on the feedback summary pages.

## What is the intent behind these changes?

The design removed this when it should have stayed.
