### PR TITLE
fixing referral details page to get phone details from community manager alone

### DIFF
--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -431,7 +431,7 @@ describe(ShowReferralPresenter, () => {
 
   describe('responsibleOfficerDetails', () => {
     describe('when all fields are present', () => {
-      it('returns a summary list of the responsible officer details in community', () => {
+      it('returns a summary list of the responsible officer details for a service provider', () => {
         const sentReferral = sentReferralFactory.build(referralParams)
         const presenter = new ShowReferralPresenter(
           sentReferral,
@@ -479,7 +479,7 @@ describe(ShowReferralPresenter, () => {
           { key: 'Team email address', lines: ['team@nps.gov.uk'] },
         ])
       })
-      it('returns a summary list of the responsible officer details in custody', () => {
+      it('returns a summary list of the responsible officer details for a probation practitioner', () => {
         const sentReferral = sentReferralFactory.build(referralParams)
         const presenter = new ShowReferralPresenter(
           sentReferral,
@@ -541,11 +541,11 @@ describe(ShowReferralPresenter, () => {
         )
 
         expect(presenter.deliusResponsibleOfficersDetails).toEqual([
-          { key: 'Name', lines: ['Peter Custody'] },
-          { key: 'Phone', lines: ['01234567892'] },
+          { key: 'Name', lines: ['Peter Practitioner'] },
+          { key: 'Phone', lines: ['01234567890'] },
           { key: 'Email address', lines: ['p.practitioner@example.com'] },
-          { key: 'Team phone', lines: ['01141234568'] },
-          { key: 'Team email address', lines: ['custody-team@nps.gov.uk'] },
+          { key: 'Team phone', lines: ['01141234567'] },
+          { key: 'Team email address', lines: ['team@nps.gov.uk'] },
         ])
       })
     })

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -134,9 +134,7 @@ export default class ShowReferralPresenter {
   }
 
   get probationPractitionerDetailsForCommunity(): SummaryListItem[] {
-    const officer = this.deliusResponsibleOfficer?.communityManager.responsibleOfficer
-      ? this.deliusResponsibleOfficer?.communityManager
-      : this.deliusResponsibleOfficer?.prisonManager
+    const officer = this.deliusResponsibleOfficer?.communityManager
     const probationPractitionerDetails: SummaryListItem[] = []
     if (this.sentReferral.referral.ppName || this.sentReferral.referral.ndeliusPPName) {
       probationPractitionerDetails.push(
@@ -221,9 +219,7 @@ export default class ShowReferralPresenter {
 
     const responsibleOfficerDetails: SummaryListItem[] = []
 
-    const officer = this.deliusResponsibleOfficer.communityManager.responsibleOfficer
-      ? this.deliusResponsibleOfficer.communityManager
-      : this.deliusResponsibleOfficer.prisonManager
+    const officer = this.deliusResponsibleOfficer.communityManager
     responsibleOfficerDetails.push({
       key: 'Name',
       lines: [`${officer?.name?.forename || ''} ${officer?.name?.surname || ''}`.trim() || 'Not found'],


### PR DESCRIPTION
## What does this pull request do?

Retrieves the phone number and team phone number from community manager instead of checking who is the responsible officer and getting the details

## What is the intent behind these changes?

Due to some issue in Delius API which is being investigated, we fall back to use community manager details
