### PR TITLE
fix class on case note message

### DIFF
--- a/server/views/caseNotes/caseNotes.njk
+++ b/server/views/caseNotes/caseNotes.njk
@@ -13,9 +13,9 @@
     </form>
 
     {% if presenter.tableRows.length == 0 %}
-        <h2 class="govuk-heading-m">There are no case notes about {{ serviceUserName }} for this intervention.</h2>
+        <p class="govuk-body">There are no case notes about {{ serviceUserName }} for this intervention.</p>
     {% else %}
-        <p class="govuk-body">All case notes</p>
+        <h2 class="govuk-heading-m">All case notes</h2>
     {% endif %}
 
     {{ govukTable(tableArgs(mojBadge)) }}


### PR DESCRIPTION
## What does this pull request do?

fixes the class on case note headings

## What is the intent behind these changes?

Currently the heading classes are the wrong way round.