### PR TITLE
configuring more ramdelius mocks for local setup

### DIFF
--- a/mockApis/referAndMonitorAndDelius.ts
+++ b/mockApis/referAndMonitorAndDelius.ts
@@ -114,4 +114,20 @@ export default class ReferAndMonitorAndDeliusMocks {
       },
     })
   }
+
+  stubGetUserByUserName = async (username: string, id: string, responseJson: unknown): Promise<unknown> => {
+    return this.wiremock.stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `${this.mockPrefix}/users/${username}/details`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        jsonBody: responseJson,
+      },
+    })
+  }
 }

--- a/mocks.ts
+++ b/mocks.ts
@@ -21,6 +21,8 @@ import PrisonRegisterServiceMocks from './mockApis/prisonRegisterService'
 import PrisonerOffenderSearchMocks from './mockApis/prisonerOffenderSearch'
 import ReferAndMonitorAndDeliusMocks from './mockApis/referAndMonitorAndDelius'
 import deliusUserAccess from './testutils/factories/deliusUserAccess'
+import deliusServiceUser from './testutils/factories/deliusServiceUser'
+import deliusUser from './testutils/factories/deliusUser'
 
 const wiremock = new Wiremock('http://localhost:9092/__admin')
 const interventionsMocks = new InterventionsServiceMocks(wiremock, '')
@@ -70,7 +72,10 @@ export default async function setUpMocks(): Promise<void> {
       supplementaryRiskInformationFactory.build()
     ),
     referAndMonitorAndDeliusMocks.stubGetConvictionsByCrn('CRN24', caseConvictionsFactory.build()),
-    referAndMonitorAndDeliusMocks.stubGetConvictionByCrnAndId('CRN24', '([0-9]+)', caseConvictionFactory.build()),
+    referAndMonitorAndDeliusMocks.stubGetConvictionsByCrn('X320741', caseConvictionsFactory.build()),
+    ['CRN24', 'X320741'].forEach(crn =>
+      referAndMonitorAndDeliusMocks.stubGetConvictionByCrnAndId(crn, '([0-9]+)', caseConvictionFactory.build())
+    ),
     referAndMonitorAndDeliusMocks.stubGetResponsibleOfficer('X320741', deliusResponsibleOfficerFactory.build()),
     interventionsMocks.stubGetActionPlanAppointment(
       '1',
@@ -96,5 +101,7 @@ export default async function setUpMocks(): Promise<void> {
     prisonerOffenderSearchMocks.stubGetPrisonerById(prisonerFactory.build()),
     referAndMonitorAndDeliusMocks.stubSentReferral(),
     referAndMonitorAndDeliusMocks.stubGetCrnUserAccess(deliusUserAccess.build()),
+    referAndMonitorAndDeliusMocks.stubGetCaseDetailsByCrn('X320741', deliusServiceUser.build()),
+    referAndMonitorAndDeliusMocks.stubGetUserByUsername('BERNARD.BEAKS', deliusUser.build()),
   ])
 }

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -297,7 +297,7 @@ describe.each([
       hmppsAuthService.getUserDetailsByUsername.mockResolvedValue(userDetails)
 
       interventionsService.getSentReferral.mockResolvedValue(sentReferral)
-      communityApiService.getServiceUserByCRN.mockResolvedValue(deliusServiceUserFactory.build())
+      ramDeliusApiService.getCaseDetailsByCrn.mockResolvedValue(deliusServiceUserFactory.build())
 
       await request(app)
         .get(`/${user.userType}/case-note/${caseNote.id}`)

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -100,7 +100,7 @@ export default class CaseNotesController {
     const referralId = req.params.id
 
     const referral = await Promise.resolve(this.interventionsService.getSentReferral(accessToken, referralId))
-    const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
+    const serviceUser = await this.ramDeliusApiService.getCaseDetailsByCrn(referral.referral.serviceUser.crn)
 
     const fetchResult = await this.fetchDraftCaseNoteOrRenderMessage(req, res, loggedInUserType)
     if (fetchResult.rendered) {
@@ -150,7 +150,7 @@ export default class CaseNotesController {
     )
 
     const referral = await Promise.resolve(this.interventionsService.getSentReferral(accessToken, caseNote.referralId))
-    const serviceUser = await this.communityApiService.getServiceUserByCRN(referral.referral.serviceUser.crn)
+    const serviceUser = await this.ramDeliusApiService.getCaseDetailsByCrn(referral.referral.serviceUser.crn)
 
     const sentByUserName = sentByUserDetails.name
     const presenter = new CaseNotePresenter(caseNote, sentByUserName, loggedInUserType, backlinkPageNumber)

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -539,7 +539,7 @@ describe('GET /probation-practitioner/referrals/:id/action-plan', () => {
   it('displays information about the latest action plan and service user', async () => {
     const sentReferral = sentReferralFactory.assigned().build()
     const serviceCategory = serviceCategoryFactory.build()
-    const deliusServiceUser = deliusServiceUserFactory.build()
+    const deliusServiceUser = deliusServiceUserFactory.build({ crn: 'X123456' })
     const actionPlan = actionPlanFactory.submitted().build({ referralId: sentReferral.id })
     const approvedActionPlanSummaries = approvedActionPlanSummary.buildList(2)
     sentReferral.actionPlanId = actionPlan.id
@@ -566,7 +566,7 @@ describe('GET /probation-practitioner/action-plan/:actionPlanId', () => {
   it('displays information about the specified action plan and service user', async () => {
     const sentReferral = sentReferralFactory.assigned().build()
     const serviceCategory = serviceCategoryFactory.build()
-    const deliusServiceUser = deliusServiceUserFactory.build()
+    const deliusServiceUser = deliusServiceUserFactory.build({ crn: 'X123456' })
     const actionPlan = actionPlanFactory.approved().build()
     const approvedActionPlanSummaries = approvedActionPlanSummary.buildList(2)
     sentReferral.actionPlanId = actionPlan.id
@@ -605,7 +605,7 @@ describe('POST /probation-practitioner/referrals/:id/action-plan/approve', () =>
   it("redirects back to action-plan if approval hasn't been confirmed", async () => {
     const sentReferral = sentReferralFactory.assigned().build()
     const serviceCategory = serviceCategoryFactory.build()
-    const deliusServiceUser = deliusServiceUserFactory.build()
+    const deliusServiceUser = deliusServiceUserFactory.build({ crn: 'X123456' })
     const actionPlan = actionPlanFactory.submitted().build({ referralId: sentReferral.id })
     sentReferral.actionPlanId = actionPlan.id
 
@@ -631,7 +631,7 @@ describe('POST /probation-practitioner/referrals/:id/action-plan/approve', () =>
 describe('GET /probation-practitioner/referrals/:id/action-plan/approved', () => {
   it('displays a panel and link back to the intervention progress page', async () => {
     const sentReferral = sentReferralFactory.assigned().build()
-    const deliusServiceUser = deliusServiceUserFactory.build()
+    const deliusServiceUser = deliusServiceUserFactory.build({ crn: 'X123456' })
 
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     ramDeliusApiService.getCaseDetailsByCrn.mockResolvedValue(deliusServiceUser)

--- a/testutils/factories/deliusServiceUser.ts
+++ b/testutils/factories/deliusServiceUser.ts
@@ -2,7 +2,7 @@ import { Factory } from 'fishery'
 import DeliusServiceUser from '../../server/models/delius/deliusServiceUser'
 
 export default Factory.define<DeliusServiceUser>(() => ({
-  crn: 'X123456',
+  crn: 'X320741',
   profile: {
     ethnicity: 'British',
     religion: 'Agnostic',

--- a/testutils/factories/deliusUser.ts
+++ b/testutils/factories/deliusUser.ts
@@ -1,0 +1,11 @@
+import { Factory } from 'fishery'
+import { RamDeliusUser } from '../../server/models/delius/deliusUser'
+
+export default Factory.define<RamDeliusUser>(() => ({
+  username: 'b.beaks',
+  name: {
+    forename: 'Bernard',
+    surname: 'Beaks',
+  },
+  email: 'b.beaks@justice.gov.uk',
+}))


### PR DESCRIPTION
## What does this pull request do?

- configures ramdelius api mocks for the local set up to work

## What is the intent behind these changes?

- community api is migrated to ramdelius api. so we need to set up mocks for the application to work
