### PR TITLE
configure new manage users api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,16 +15,76 @@ services:
     networks:
       - hmpps
     container_name: hmpps-auth
+    depends_on:
+      - auth-db
     ports:
       - '8090:8090'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8090/auth/health']
     environment:
       - SERVER_PORT=8090
-      - SPRING_PROFILES_ACTIVE=dev,delius
+      - SPRING_PROFILES_ACTIVE=dev,delius,local-postgres
       - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
       - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
       - DELIUS_ENDPOINT_URL=http://community-api:8080
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://auth-db:5432/auth-db
+
+  hmpps-manage-users:
+    image: quay.io/hmpps/hmpps-manage-users-api:latest
+    networks:
+      - hmpps
+    container_name: hmpps-manage-users
+    depends_on:
+      - hmpps-auth
+      - nomis-user-roles-api
+      - hmpps-external-users-api
+    ports:
+      - "8096:8096"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8096/health" ]
+    environment:
+      - SERVER_PORT=8096
+      - HMPPS_AUTH_ENDPOINT_URL=http://hmpps-auth:8090/auth
+      - API_BASE_URL_OAUTH=http://hmpps-auth:8090/auth
+      - SPRING_PROFILES_ACTIVE=dev
+      - EXTERNAL_USERS_ENDPOINT_URL=http://hmpps-external-users-api:8098
+      - NOMIS_ENDPOINT_URL=http://nomis-user-roles-api:8097
+      - DELIUS_ENDPOINT_URL=http://community-api:8080
+
+  nomis-user-roles-api:
+    image: quay.io/hmpps/nomis-user-roles-api:latest
+    networks:
+      - hmpps
+    container_name: nomis-user-roles-api
+    depends_on:
+      - hmpps-auth
+    ports:
+      - "8097:8097"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8097/health" ]
+    environment:
+      - SERVER_PORT=8097
+      - SPRING_PROFILES_ACTIVE=dev
+      - API_BASE_URL_OAUTH=http://hmpps-auth:8090/auth
+  
+  hmpps-external-users-api:
+    image: quay.io/hmpps/hmpps-external-users-api:latest
+    networks:
+      - hmpps
+    container_name: hmpps-external-users-api
+    depends_on:
+      - auth-db
+      - hmpps-auth
+    ports:
+      - "8098:8098"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8098/health/ping"]
+    environment:
+      - SERVER_PORT=8098
+      - SPRING_PROFILES_ACTIVE=dev,local-postgres
+      - SPRING_R2DBC_URL=r2dbc:postgresql://auth-db:5432/auth-db?sslmode=prefer
+      - SPRING_FLYWAY_URL=jdbc:postgresql://auth-db:5432/auth-db?sslmode=prefer
+      - API_BASE_URL_OAUTH=http://hmpps-auth:8090/auth
 
   community-api:
     image: quay.io/hmpps/community-api:latest
@@ -69,6 +129,21 @@ services:
       - POSTGRES_PASSWORD=password
     volumes:
       - ./testutils/docker/postgres:/docker-entrypoint-initdb.d:ro
+
+  auth-db:
+    image: postgres:15
+    networks:
+      - hmpps
+    container_name: auth-db
+    restart: always
+    ports:
+      - "5434:5432"
+    environment:
+      - POSTGRES_PASSWORD=admin_password
+      - POSTGRES_USER=admin
+      - POSTGRES_DB=auth-db
+    healthcheck:
+      test: pg_isready -d auth-db
 
   wiremock:
     image: wiremock/wiremock

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,6 +6,7 @@ generic-service:
     INGRESS_URL: "https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
     DEPLOYMENT_ENV: dev
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    HMPPS_MANAGE_USERS_URL: https://manage-users-api-dev.hmpps.service.justice.gov.uk
     COMMUNITY_API_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
     RAM_DELIUS_API_URL: https://refer-and-monitor-and-delius-dev.hmpps.service.justice.gov.uk
     INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,6 +7,7 @@ generic-service:
     INGRESS_URL: "https://hmpps-interventions-ui-preprod.apps.live-1.cloud-platform.service.justice.gov.uk"
     DEPLOYMENT_ENV: preprod
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    HMPPS_MANAGE_USERS_URL: https://manage-users-api-preprod.hmpps.service.justice.gov.uk
     COMMUNITY_API_URL: https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io
     RAM_DELIUS_API_URL: https://refer-and-monitor-and-delius-preprod.hmpps.service.justice.gov.uk
     INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,6 +8,7 @@ generic-service:
     INGRESS_URL: "https://refer-monitor-intervention.service.justice.gov.uk"
     DEPLOYMENT_ENV: prod
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
+    HMPPS_MANAGE_USERS_URL: https://manage-users-api.hmpps.service.justice.gov.uk
     COMMUNITY_API_URL: https://community-api-secure.probation.service.justice.gov.uk
     RAM_DELIUS_API_URL: https://refer-and-monitor-and-delius.hmpps.service.justice.gov.uk
     INTERVENTIONS_SERVICE_URL: https://hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/mockApis/auth.ts
+++ b/mockApis/auth.ts
@@ -121,7 +121,7 @@ export default class AuthServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: '/auth/api/user/me',
+        urlPattern: '/hmpps-manage-users/users/me',
       },
       response: {
         status: 200,
@@ -143,7 +143,7 @@ export default class AuthServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: '/auth/api/user/me/roles',
+        urlPattern: '/hmpps-manage-users/users/me/roles',
       },
       response: {
         status: 200,
@@ -159,7 +159,7 @@ export default class AuthServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: '/auth/api/authuser/\\w+/groups',
+        urlPattern: '/hmpps-manage-users/externalusers/9C2744E3-65CD-4B40-B036-95DBD6F9A871/groups',
       },
       response: {
         status: 200,
@@ -176,7 +176,7 @@ export default class AuthServiceMocks {
       request: {
         method: 'GET',
         // We don’t care about the query (email address)
-        urlPath: '/auth/api/authuser',
+        urlPath: '/hmpps-manage-users/externalusers',
       },
       response: {
         status: 200,
@@ -192,7 +192,7 @@ export default class AuthServiceMocks {
     return this.wiremock.stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/auth/api/authuser/${username}`,
+        urlPattern: `/hmpps-manage-users/externalusers/${username}`,
       },
       response: {
         status: 200,

--- a/mocks.ts
+++ b/mocks.ts
@@ -76,7 +76,10 @@ export default async function setUpMocks(): Promise<void> {
     ['CRN24', 'X320741'].forEach(crn =>
       referAndMonitorAndDeliusMocks.stubGetConvictionByCrnAndId(crn, '([0-9]+)', caseConvictionFactory.build())
     ),
-    referAndMonitorAndDeliusMocks.stubGetResponsibleOfficer('X320741', deliusResponsibleOfficerFactory.build()),
+    ['CRN24', 'X320741'].forEach(crn =>
+      referAndMonitorAndDeliusMocks.stubGetResponsibleOfficer(crn, deliusResponsibleOfficerFactory.build())
+    ),
+
     interventionsMocks.stubGetActionPlanAppointment(
       '1',
       1,
@@ -101,7 +104,9 @@ export default async function setUpMocks(): Promise<void> {
     prisonerOffenderSearchMocks.stubGetPrisonerById(prisonerFactory.build()),
     referAndMonitorAndDeliusMocks.stubSentReferral(),
     referAndMonitorAndDeliusMocks.stubGetCrnUserAccess(deliusUserAccess.build()),
-    referAndMonitorAndDeliusMocks.stubGetCaseDetailsByCrn('X320741', deliusServiceUser.build()),
+    ['CRN24', 'X320741'].forEach(crn =>
+      referAndMonitorAndDeliusMocks.stubGetCaseDetailsByCrn(crn, deliusServiceUser.build())
+    ),
     referAndMonitorAndDeliusMocks.stubGetUserByUsername('BERNARD.BEAKS', deliusUser.build()),
   ])
 }

--- a/server/authentication/passport.ts
+++ b/server/authentication/passport.ts
@@ -59,7 +59,8 @@ export default function passportSetup(app: Application, hmppsAuthService: HmppsA
           // augment the token response from with extra user details
           const user: User = { username, userId, authSource }
           const { name } = await hmppsAuthService.getUserDetails(accessToken)
-          const organizations = await hmppsAuthService.getUserOrganizations(accessToken, user)
+          const clientCredToken = await hmppsAuthService.getApiClientToken()
+          const organizations = await hmppsAuthService.getUserOrganizations(clientCredToken, user)
           const loggedInUser: LoggedInUser = {
             token: {
               accessToken,

--- a/server/config.ts
+++ b/server/config.ts
@@ -119,6 +119,18 @@ export default {
       loginClientId: get('LOGIN_CLIENT_ID', 'interventions', requiredInProduction),
       loginClientSecret: get('LOGIN_CLIENT_SECRET', 'clientsecret', requiredInProduction),
     },
+    hmppsManageUsersApi: {
+      url: get('HMPPS_MANAGE_USERS_URL', 'http://localhost:8096', requiredInProduction),
+      timeout: {
+        response: Number(get('HMPPS_AUTH_TIMEOUT_RESPONSE', 20000)),
+        deadline: Number(get('HMPPS_AUTH_TIMEOUT_DEADLINE', 20000)),
+      },
+      agent: new AgentConfig(),
+      apiClientId: get('API_CLIENT_ID', 'interventions', requiredInProduction),
+      apiClientSecret: get('API_CLIENT_SECRET', 'clientsecret', requiredInProduction),
+      loginClientId: get('LOGIN_CLIENT_ID', 'interventions', requiredInProduction),
+      loginClientSecret: get('LOGIN_CLIENT_SECRET', 'clientsecret', requiredInProduction),
+    },
     interventionsService: {
       url: get('INTERVENTIONS_SERVICE_URL', 'http://localhost:9092', requiredInProduction),
       // the interventions-service <-> community-api worst case timeout is 20s, this is intentionally just slightly higher

--- a/server/services/hmppsAuthService.test.ts
+++ b/server/services/hmppsAuthService.test.ts
@@ -36,9 +36,11 @@ function givenRedisResponse(storedToken: string | null) {
 describe('hmppsAuthService', () => {
   let fakeHmppsAuthApi: nock.Scope
   let hmppsAuthService: HmppsAuthService
+  let fakeManagerUsersApi: nock.Scope
 
   beforeEach(() => {
     fakeHmppsAuthApi = nock(config.apis.hmppsAuth.url)
+    fakeManagerUsersApi = nock(config.apis.hmppsManageUsersApi.url)
     hmppsAuthService = new HmppsAuthService()
   })
 
@@ -50,8 +52,8 @@ describe('hmppsAuthService', () => {
     it('should return data from api', async () => {
       const response = { data: 'data' }
 
-      fakeHmppsAuthApi
-        .get('/api/user/me')
+      fakeManagerUsersApi
+        .get('/users/me')
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(200, response)
 
@@ -65,8 +67,8 @@ describe('hmppsAuthService', () => {
       const response = { username: 'user_1' }
       const username = 'user_1'
 
-      fakeHmppsAuthApi
-        .get('/api/user/user_1')
+      fakeManagerUsersApi
+        .get('/users/user_1')
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(200, response)
 
@@ -117,8 +119,8 @@ describe('hmppsAuthService', () => {
           },
         ]
 
-        fakeHmppsAuthApi
-          .get('/api/authuser')
+        fakeManagerUsersApi
+          .get('/externalusers')
           .query({ email: 'user@example.com' })
           .matchHeader('authorization', `Bearer ${token.access_token}`)
           .reply(200, response)
@@ -131,8 +133,8 @@ describe('hmppsAuthService', () => {
     describe('when no user is found with the requested email address', () => {
       it('should raise an error', async () => {
         const noUserResponse = {}
-        fakeHmppsAuthApi
-          .get('/api/authuser')
+        fakeManagerUsersApi
+          .get('/externalusers')
           .query({ email: 'user@example.com' })
           .matchHeader('authorization', `Bearer ${token.access_token}`)
           .reply(204, noUserResponse)
@@ -180,8 +182,8 @@ describe('hmppsAuthService', () => {
             lastLoggedIn: '01/01/2001',
           },
         ]
-        fakeHmppsAuthApi
-          .get('/api/authuser')
+        fakeManagerUsersApi
+          .get('/externalusers')
           .query({ email: 'user@example.com' })
           .matchHeader('authorization', `Bearer ${token.access_token}`)
           .reply(200, invalidUserResponse)
@@ -207,8 +209,8 @@ describe('hmppsAuthService', () => {
         lastLoggedIn: '01/01/2001',
       }
 
-      fakeHmppsAuthApi
-        .get('/api/authuser/AUTH_ADM')
+      fakeManagerUsersApi
+        .get('/externalusers/AUTH_ADM')
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(200, response)
 
@@ -229,8 +231,8 @@ describe('hmppsAuthService', () => {
         lastLoggedIn: undefined,
       }
 
-      fakeHmppsAuthApi
-        .get('/api/authuser/MISSING')
+      fakeManagerUsersApi
+        .get('/externalusers/MISSING')
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(404, {})
 
@@ -239,8 +241,8 @@ describe('hmppsAuthService', () => {
     })
 
     it('raises an error if required and the response is 404', async () => {
-      fakeHmppsAuthApi
-        .get('/api/authuser/MISSING')
+      fakeManagerUsersApi
+        .get('/externalusers/MISSING')
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(404, {})
 
@@ -250,8 +252,8 @@ describe('hmppsAuthService', () => {
     })
 
     it('raises an error if not required but response is non-404 4xx', async () => {
-      fakeHmppsAuthApi
-        .get('/api/authuser/MISSING')
+      fakeManagerUsersApi
+        .get('/externalusers/MISSING')
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(400, {})
 
@@ -263,8 +265,8 @@ describe('hmppsAuthService', () => {
 
   describe('getUserRoles', () => {
     it('should return data from api', async () => {
-      fakeHmppsAuthApi
-        .get('/api/user/me/roles')
+      fakeManagerUsersApi
+        .get('/users/me/roles')
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
 
@@ -318,8 +320,8 @@ describe('hmppsAuthService', () => {
           groupName: 'Better Ltd.',
         },
       ]
-      fakeHmppsAuthApi
-        .get(`/api/authuser/${authUser.username}/groups`)
+      fakeManagerUsersApi
+        .get(`/externalusers/${authUser.userId}/groups`)
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(200, groups)
     })

--- a/test.env
+++ b/test.env
@@ -1,5 +1,6 @@
 PORT=3007
 HMPPS_AUTH_URL=http://localhost:9091/auth
+HMPPS_MANAGE_USERS_URL=http://localhost:9091/hmpps-manage-users
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 INTERVENTIONS_SERVICE_URL=http://localhost:9091/interventions
 COMMUNITY_API_URL=http://localhost:9091/community-api


### PR DESCRIPTION
## What does this pull request do?

- configure hmpps-manage-users to authenticate and authorise external users

## What is the intent behind these changes?

- hmpps-auth has been rearchitected which caused their api is to be split into multiple apis.