### PR TITLE
Fix NPE when submitting feedback with late attendance

### DIFF
--- a/server/routes/appointments/appointmentsController.test.ts
+++ b/server/routes/appointments/appointmentsController.test.ts
@@ -2093,6 +2093,82 @@ describe('Adding post delivery session feedback', () => {
 
   describe('POST /service-provider/action-plan:actionPlanId/appointment/:sessionNumber/post-session-feedback/edit/:draftBookingId/submit', () => {
     describe('When the draft booking is found', () => {
+      it("updates the appointment with session feedback when attended is set to 'either 'yes' or 'late'", async () => {
+        const sessionNumber = 2
+
+        const draftAppointment: DraftAppointment = draftAppointmentFactory.withSubmittedFeedback('late').build()
+
+        const draftAppointmentResult = draftAppointmentBookingFactory.build({
+          data: draftAppointment,
+        })
+        draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
+        const actionPlan = actionPlanFactory.build()
+        interventionsService.getActionPlan.mockResolvedValue(actionPlan)
+
+        await request(app)
+          .post(
+            `/service-provider/action-plan/${actionPlan.id}/appointment/${sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/submit`
+          )
+          .expect(302)
+          .expect(
+            'Location',
+            `/service-provider/referrals/81d754aa-d868-4347-9c0f-50690773014e/progress?showFeedbackBanner=true&notifyPP=false&dna=false`
+          )
+
+        expect(interventionsService.updateActionPlanAppointment).toHaveBeenCalledWith(
+          'token',
+          actionPlan.id,
+          sessionNumber,
+          {
+            appointmentTime: draftAppointment!.appointmentTime,
+            durationInMinutes: draftAppointment!.durationInMinutes,
+            appointmentDeliveryType: draftAppointment!.appointmentDeliveryType,
+            sessionType: draftAppointment!.sessionType,
+            appointmentDeliveryAddress: draftAppointment!.appointmentDeliveryAddress,
+            npsOfficeCode: draftAppointment!.npsOfficeCode,
+            attendanceFeedback: { ...draftAppointment!.session!.attendanceFeedback },
+            sessionFeedback: { ...draftAppointment!.session!.sessionFeedback },
+          }
+        )
+      })
+      it("updates the appointment without any session feedback when attended is set to 'no'", async () => {
+        const sessionNumber = 2
+
+        const draftAppointment: DraftAppointment = draftAppointmentFactory.withSubmittedFeedback('no').build()
+
+        const draftAppointmentResult = draftAppointmentBookingFactory.build({
+          data: draftAppointment,
+        })
+        draftsService.fetchDraft.mockResolvedValue(draftAppointmentResult)
+        const actionPlan = actionPlanFactory.build()
+        interventionsService.getActionPlan.mockResolvedValue(actionPlan)
+
+        await request(app)
+          .post(
+            `/service-provider/action-plan/${actionPlan.id}/appointment/${sessionNumber}/post-session-feedback/edit/${draftAppointmentResult.id}/submit`
+          )
+          .expect(302)
+          .expect(
+            'Location',
+            `/service-provider/referrals/81d754aa-d868-4347-9c0f-50690773014e/progress?showFeedbackBanner=true&notifyPP=false&dna=true`
+          )
+
+        expect(interventionsService.updateActionPlanAppointment).toHaveBeenCalledWith(
+          'token',
+          actionPlan.id,
+          sessionNumber,
+          {
+            appointmentTime: draftAppointment!.appointmentTime,
+            durationInMinutes: draftAppointment!.durationInMinutes,
+            appointmentDeliveryType: draftAppointment!.appointmentDeliveryType,
+            sessionType: draftAppointment!.sessionType,
+            appointmentDeliveryAddress: draftAppointment!.appointmentDeliveryAddress,
+            npsOfficeCode: draftAppointment!.npsOfficeCode,
+            attendanceFeedback: { ...draftAppointment!.session!.attendanceFeedback },
+            sessionFeedback: null,
+          }
+        )
+      })
       it('marks the appointment as submitted and redirects to the progress page with the request params to show the confirmation banner', async () => {
         const sessionNumber = 2
 

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -683,7 +683,7 @@ export default class AppointmentsController {
           npsOfficeCode: draftAppointment.npsOfficeCode,
           attendanceFeedback: { ...draftAppointment.session.attendanceFeedback },
           sessionFeedback:
-            draftAppointment.session.attendanceFeedback.attended === 'yes'
+            draftAppointment.session.attendanceFeedback.attended !== 'no'
               ? { ...draftAppointment.session.sessionFeedback }
               : null,
         }
@@ -969,7 +969,7 @@ export default class AppointmentsController {
           npsOfficeCode: draftAppointment.npsOfficeCode,
           attendanceFeedback: { ...draftAppointment.session.attendanceFeedback },
           sessionFeedback:
-            draftAppointment.session.attendanceFeedback.attended === 'yes'
+            draftAppointment.session.attendanceFeedback.attended !== 'no'
               ? { ...draftAppointment.session.sessionFeedback }
               : null,
         }


### PR DESCRIPTION
## What does this pull request do?

Updates conditional statement so that session feedback is also included in the call to submit appointment feedback when attendance is set to late. 

## What is the intent behind these changes?

To fix NullPointerExceptions occurring when submitting feedback for historic appointments marked as late.
