### PR TITLE
Change link text from Edit to Add session details

### DIFF
--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.test.ts
@@ -154,7 +154,7 @@ describe(InterventionProgressPresenter, () => {
     })
 
     describe('when a session exists but an appointment has not yet been scheduled', () => {
-      it('populates the table with formatted session information, with the "Edit session details" link displayed', () => {
+      it('populates the table with formatted session information, with the "Add session details" link displayed', () => {
         const referral = sentReferralFactory.build()
         const intervention = interventionFactory.build()
         const actionPlan = actionPlanFactory.submitted().build({ id: '77923562-755c-48d9-a74c-0c8565aac9a2' })
@@ -177,7 +177,7 @@ describe(InterventionProgressPresenter, () => {
             links: [
               {
                 href: '/service-provider/action-plan/77923562-755c-48d9-a74c-0c8565aac9a2/sessions/1/edit/start',
-                text: 'Edit session details',
+                text: 'Add session details',
               },
             ],
           },

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -202,6 +202,14 @@ export default class InterventionProgressPresenter {
           },
         ]
         break
+      case SessionStatus.notScheduled:
+        links = [
+          {
+            text: 'Add session details',
+            href: editHref,
+          },
+        ]
+        break
       case SessionStatus.scheduled:
         links = [
           {


### PR DESCRIPTION
## What does this pull request do?

Changes the link text displayed when a session's status is not scheduled from 'Edit session details' to 'Add session details'

## What is the intent behind these changes?

To change the link text displayed when a session's status is not scheduled from 'Edit session details' to 'Add session details'
