### PR TITLE
Remove Delivery Schedule link text from footer

### DIFF
--- a/integration_tests/integration/login.cy.js
+++ b/integration_tests/integration/login.cy.js
@@ -37,14 +37,6 @@ context('Login', () => {
       cy.contains('To report a problem with this digital service, please contact the helpdesk')
     })
 
-    it('the user can view the delivery schedule', () => {
-      cy.contains('Delivery schedule').click()
-      cy.location('pathname').should('equal', `/delivery-schedule`)
-      cy.contains(
-        'The Refer and monitor an intervention delivery schedule shows the things we’re working on and when we expect to have them ready for you to use.'
-      )
-    })
-
     it('the user can view the accessibility statement', () => {
       cy.contains('Accessibility').click()
       cy.location('pathname').should('equal', `/accessibility-statement`)
@@ -86,14 +78,6 @@ context('Login', () => {
       cy.contains('Report a problem').click()
       cy.location('pathname').should('equal', `/report-a-problem`)
       cy.contains('To report a problem with this digital service, please contact the helpdesk')
-    })
-
-    it('the user can view the delivery schedule', () => {
-      cy.contains('Delivery schedule').click()
-      cy.location('pathname').should('equal', `/delivery-schedule`)
-      cy.contains(
-        'The Refer and monitor an intervention delivery schedule shows the things we’re working on and when we expect to have them ready for you to use.'
-      )
     })
 
     it('the user can sign out', () => {

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -82,10 +82,6 @@
                            text: "Report a problem"
                          },
                          {
-                           href: "/delivery-schedule",
-                           text: "Delivery schedule"
-                         },
-                         {
                            href: "/accessibility-statement",
                            text: "Accessibility"
                          }


### PR DESCRIPTION
## What does this pull request do?

Removes the Delivery Schedule link text from footer

## What is the intent behind these changes?

Removes the Delivery Schedule link text from footer
