### PR TITLE
changing the slack channel name for prod deployment notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ workflows:
           env: "prod"
           show_changelog: true
           slack_notification: true
-          slack_channel_name: "interventions"
+          slack_channel_name: "interventions-team"
           requires:
             - approve_prod
           context:


### PR DESCRIPTION
## What does this pull request do?

- updates the slack channel notification name to interventions-team

## What is the intent behind these changes?

- The name of the slack channel where prod notification goes changed