### PR TITLE
add service user banner to case note check your answers page

### DIFF
--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -249,6 +249,10 @@ describe.each([
       })
       draftsService.fetchDraft.mockResolvedValue(draftCaseNote)
       hmppsAuthService.getUserDetails.mockResolvedValue(userDetailsFactory.build())
+
+      interventionsService.getSentReferral.mockResolvedValue(sentReferral)
+      ramDeliusApiService.getCaseDetailsByCrn.mockResolvedValue(deliusServiceUserFactory.build())
+
       await request(app)
         .get(`/${user.userType}/referrals/${sentReferral.id}/add-case-note/${draftCaseNote.id}/check-answers`)
         .expect(200)
@@ -276,6 +280,7 @@ describe.each([
     it('should show confirmation of case note added', async () => {
       interventionsService.getSentReferral.mockResolvedValue(sentReferralFactory.build())
       interventionsService.getIntervention.mockResolvedValue(interventionFactory.build({}))
+
       await request(app)
         .get(`/${user.userType}/referrals/${sentReferral.id}/add-case-note/confirmation`)
         .expect(200)

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -178,6 +178,8 @@ export default class CaseNotesController {
     }
 
     const loggedInUser = await this.hmppsAuthService.getUserDetails(accessToken)
+    const referral = await Promise.resolve(this.interventionsService.getSentReferral(accessToken, referralId))
+    const serviceUser = await this.ramDeliusApiService.getCaseDetailsByCrn(referral.referral.serviceUser.crn)
     const presenter = new CheckAddCaseNoteAnswersPresenter(
       referralId,
       draft.id,
@@ -186,7 +188,7 @@ export default class CaseNotesController {
       draft.data
     )
     const view = new CheckAddCaseNoteAnswersView(presenter)
-    ControllerUtils.renderWithLayout(res, view, null)
+    ControllerUtils.renderWithLayout(res, view, serviceUser)
   }
 
   async submitCaseNote(


### PR DESCRIPTION
## What does this pull request do?

Adds the blue service user banner to the check your answers page when adding a case note.

## What is the intent behind these changes?

The banner is currently missing.
