### PR TITLE
change bernard beaks mock to lowercase

### DIFF
--- a/mocks.ts
+++ b/mocks.ts
@@ -107,6 +107,6 @@ export default async function setUpMocks(): Promise<void> {
     ['CRN24', 'X320741'].forEach(crn =>
       referAndMonitorAndDeliusMocks.stubGetCaseDetailsByCrn(crn, deliusServiceUser.build())
     ),
-    referAndMonitorAndDeliusMocks.stubGetUserByUsername('BERNARD.BEAKS', deliusUser.build()),
+    referAndMonitorAndDeliusMocks.stubGetUserByUsername('bernard.beaks', deliusUser.build()),
   ])
 }


### PR DESCRIPTION
## What does this pull request do?

Updates the mock to expect lower case bernard beaks.

## What is the intent behind these changes?

This was stopping the referral details page from loading locally.
