### PR TITLE
Prevent AP submission before SAA complete

### DIFF
--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -486,7 +486,7 @@ describe('Service provider referrals dashboard', () => {
     })
   })
 
-  it('User creates an action plan and submits it for approval', () => {
+  it('Displays an error when user creates an action plan and submits it for approval without a completed supplier assessment appointment', () => {
     const desiredOutcomes = [
       {
         id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
@@ -551,6 +551,161 @@ describe('Service provider referrals dashboard', () => {
     cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
     cy.stubGetActionPlanAppointments(draftActionPlan.id, actionPlanAppointments)
     cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.build())
+    cy.stubGetApprovedActionPlanSummaries(assignedReferral.id, [])
+
+    cy.login()
+
+    cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
+    cy.get('#action-plan-status').contains('Not submitted')
+    cy.contains('Create action plan').click()
+
+    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activity/1`)
+
+    cy.contains('Add activity 1 to action plan')
+    cy.contains('Referred outcomes for Alex')
+    cy.contains(desiredOutcomes[0].description)
+    cy.contains(desiredOutcomes[1].description)
+
+    const draftActionPlanWithActivity = {
+      ...draftActionPlan,
+      activities: [
+        {
+          id: '1',
+          description: 'Attend training course',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    }
+
+    cy.stubGetActionPlan(draftActionPlan.id, draftActionPlanWithActivity)
+    cy.stubUpdateDraftActionPlan(draftActionPlan.id, draftActionPlanWithActivity)
+
+    cy.get('#description').type('Attend training course')
+    cy.contains('Save and add activity 1').click()
+
+    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activity/2`)
+
+    const draftActionPlanWithAllActivities = {
+      ...draftActionPlanWithActivity,
+      activities: [
+        ...draftActionPlanWithActivity.activities,
+        {
+          id: '2',
+          description: 'Create appointment with local authority',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    }
+
+    cy.stubGetActionPlan(draftActionPlan.id, draftActionPlanWithAllActivities)
+    cy.stubUpdateDraftActionPlan(draftActionPlan.id, draftActionPlanWithAllActivities)
+
+    cy.get('#description').type('Create appointment with local authority')
+    cy.contains('Save and add activity 2').click()
+
+    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/add-activity/3`)
+
+    cy.contains('Continue without adding other activities').click()
+
+    const draftActionPlanWithNumberOfSessions = { ...draftActionPlanWithAllActivities, numberOfSessions: 4 }
+
+    cy.stubGetActionPlan(draftActionPlan.id, draftActionPlanWithNumberOfSessions)
+    cy.stubUpdateDraftActionPlan(draftActionPlan.id, draftActionPlanWithNumberOfSessions)
+
+    cy.contains('Add number of sessions for Alex’s action plan')
+    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/number-of-sessions`)
+    cy.contains('Number of sessions').type('4')
+
+    cy.contains('Save and continue').click()
+
+    const referralWithActionPlanId = { ...assignedReferral, actionPlanId: draftActionPlan.id }
+    const submittedActionPlan = { ...draftActionPlanWithNumberOfSessions, submittedAt: new Date(2021, 7, 18) }
+
+    cy.stubGetSentReferral(assignedReferral.id, referralWithActionPlanId)
+    cy.stubSubmitActionPlan(draftActionPlan.id, submittedActionPlan)
+    cy.stubGetActionPlan(draftActionPlan.id, submittedActionPlan)
+
+    cy.contains('Confirm action plan')
+    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/review`)
+    cy.contains('Activity 1')
+    cy.contains('Attend training course')
+    cy.contains('Activity 2')
+    cy.contains('Create appointment with local authority')
+    cy.contains('Submit for approval').click()
+
+    cy.location('pathname').should('equal', `/service-provider/action-plan/${draftActionPlan.id}/review`)
+    cy.contains('There is a problem')
+      .next()
+      .contains(
+        'You cannot submit an action plan yet. First you need to hold the supplier assessment appointment and then give feedback on it.'
+      )
+  })
+
+  it('User creates an action plan and submits it for approval', () => {
+    const desiredOutcomes = [
+      {
+        id: '301ead30-30a4-4c7c-8296-2768abfb59b5',
+        description:
+          'All barriers, as identified in the Service user action plan (for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation are successfully removed',
+      },
+      {
+        id: '65924ac6-9724-455b-ad30-906936291421',
+        description: 'Service user makes progress in obtaining accommodation',
+      },
+      {
+        id: '9b30ffad-dfcb-44ce-bdca-0ea49239a21a',
+        description: 'Service user is helped to secure social or supported housing',
+      },
+      {
+        id: 'e7f199de-eee1-4f57-a8c9-69281ea6cd4d',
+        description: 'Service user is helped to secure a tenancy in the private rented sector (PRS)',
+      },
+    ]
+
+    const serviceCategory = serviceCategoryFactory.build({ name: 'accommodation', desiredOutcomes })
+    const accommodationIntervention = interventionFactory.build({
+      contractType: { code: 'SOC', name: 'Social inclusion' },
+      serviceCategories: [serviceCategory],
+    })
+
+    const selectedDesiredOutcomesIds = [desiredOutcomes[0].id, desiredOutcomes[1].id]
+    const referralParams = {
+      referral: {
+        interventionId: accommodationIntervention.id,
+        serviceCategoryIds: [serviceCategory.id],
+        desiredOutcomes: [{ serviceCategoryId: serviceCategory.id, desiredOutcomesIds: selectedDesiredOutcomesIds }],
+      },
+    }
+    const deliusServiceUser = deliusServiceUserFactory.build()
+    const deliusUser = ramDeliusUserFactory.build()
+    const hmppsAuthUser = hmppsAuthUserFactory.build({ firstName: 'John', lastName: 'Smith', username: 'john.smith' })
+    const assignedReferral = sentReferralFactory
+      .assigned()
+      .build({ ...referralParams, assignedTo: { username: hmppsAuthUser.username } })
+
+    const assignedReferralSummaries = sentReferralForSummaries
+      .assigned()
+      .build({ assignedTo: { username: hmppsAuthUser.username } })
+
+    const draftActionPlan = actionPlanFactory.justCreated(assignedReferral.id).build()
+    const actionPlanAppointments = [
+      actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 1 }),
+      actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 2 }),
+      actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 3 }),
+      actionPlanAppointmentFactory.newlyCreated().build({ sessionNumber: 4 }),
+    ]
+
+    cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent([assignedReferralSummaries]).build())
+    cy.stubGetActionPlan(draftActionPlan.id, draftActionPlan)
+    cy.stubCreateDraftActionPlan(draftActionPlan)
+    cy.stubGetServiceCategory(serviceCategory.id, serviceCategory)
+    cy.stubGetIntervention(accommodationIntervention.id, accommodationIntervention)
+    cy.stubGetSentReferral(assignedReferral.id, assignedReferral)
+    cy.stubGetCaseDetailsByCrn(assignedReferral.referral.serviceUser.crn, deliusServiceUser)
+    cy.stubGetUserByUsername(deliusUser.username, deliusUser)
+    cy.stubGetAuthUserByUsername(hmppsAuthUser.username, hmppsAuthUser)
+    cy.stubGetActionPlanAppointments(draftActionPlan.id, actionPlanAppointments)
+    cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.withAttendedAppointment.build())
     cy.stubGetApprovedActionPlanSummaries(assignedReferral.id, [])
 
     cy.login()
@@ -735,6 +890,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubGetActionPlan(submittedActionPlan.id, submittedActionPlan)
       cy.stubGetApprovedActionPlanSummaries(assignedReferral.id, [])
       cy.stubGetActionPlanAppointments(submittedActionPlan.id, [])
+      cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.withAttendedAppointment.build())
 
       cy.visit(`/service-provider/referrals/${assignedReferral.id}/progress`)
       cy.get('#action-plan-status').contains('Awaiting approval')
@@ -831,6 +987,7 @@ describe('Service provider referrals dashboard', () => {
       cy.stubCreateDraftActionPlan(newActionPlanVersion)
       cy.stubGetActionPlan(newActionPlanVersion.id, newActionPlanVersion)
       cy.stubGetSentReferral(newActionPlanVersion.referralId, assignedReferral)
+      cy.stubGetSupplierAssessment(assignedReferral.id, supplierAssessmentFactory.withAttendedAppointment.build())
 
       cy.contains('Confirm and continue').click()
 

--- a/server/routes/service-provider/action-plan/review/reviewActionPlanPresenter.test.ts
+++ b/server/routes/service-provider/action-plan/review/reviewActionPlanPresenter.test.ts
@@ -38,7 +38,7 @@ describe(ReviewActionPlanPresenter, () => {
       const actionPlan = actionPlanFactory.justCreated(sentReferral.id).build()
       const presenter = new ReviewActionPlanPresenter(sentReferral, serviceCategories, actionPlan)
 
-      expect(presenter.submitFormAction).toEqual(`/service-provider/action-plan/${actionPlan.id}/submit`)
+      expect(presenter.submitFormAction).toEqual(`/service-provider/action-plan/${actionPlan.id}/review`)
     })
   })
 

--- a/server/routes/service-provider/action-plan/review/reviewActionPlanPresenter.ts
+++ b/server/routes/service-provider/action-plan/review/reviewActionPlanPresenter.ts
@@ -2,6 +2,8 @@ import ActionPlan from '../../../../models/actionPlan'
 import SentReferral from '../../../../models/sentReferral'
 import ServiceCategory from '../../../../models/serviceCategory'
 import ActionPlanPresenter from '../../../shared/action-plan/actionPlanPresenter'
+import { FormValidationError } from '../../../../utils/formValidationError'
+import PresenterUtils from '../../../../utils/presenterUtils'
 
 export default class ReviewActionPlanPresenter {
   actionPlanPresenter: ActionPlanPresenter
@@ -9,14 +11,17 @@ export default class ReviewActionPlanPresenter {
   constructor(
     private readonly sentReferral: SentReferral,
     private readonly serviceCategories: ServiceCategory[],
-    private readonly actionPlan: ActionPlan
+    private readonly actionPlan: ActionPlan,
+    private readonly error: FormValidationError | null = null
   ) {
     this.actionPlanPresenter = new ActionPlanPresenter(sentReferral, actionPlan, serviceCategories, 'service-provider')
   }
 
+  readonly errorSummary = PresenterUtils.errorSummary(this.error)
+
   readonly actionPlanId = this.actionPlan.id
 
-  readonly submitFormAction = `/service-provider/action-plan/${this.actionPlan.id}/submit`
+  readonly submitFormAction = `/service-provider/action-plan/${this.actionPlan.id}/review`
 
   readonly text = {
     title: 'Confirm action plan',

--- a/server/routes/service-provider/action-plan/review/reviewActionPlanView.ts
+++ b/server/routes/service-provider/action-plan/review/reviewActionPlanView.ts
@@ -1,5 +1,6 @@
 import ReviewActionPlanPresenter from './reviewActionPlanPresenter'
 import ActionPlanView from '../../../shared/action-plan/actionPlanView'
+import ViewUtils from '../../../../utils/viewUtils'
 
 export default class ReviewActionPlanView {
   actionPlanView: ActionPlanView
@@ -20,6 +21,7 @@ export default class ReviewActionPlanView {
         presenter: this.presenter,
         insetTextArgs: this.actionPlanView.insetTextActivityArgs,
         backLinkArgs: this.backLinkArgs,
+        errorSummaryArgs: ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary),
       },
     ]
   }

--- a/server/routes/serviceProviderRoutes.ts
+++ b/server/routes/serviceProviderRoutes.ts
@@ -98,7 +98,8 @@ export default function serviceProviderRoutes(
     serviceProviderReferralsController.finaliseActionPlanActivities(req, res)
   )
   get(router, '/action-plan/:id/review', (req, res) => serviceProviderReferralsController.reviewActionPlan(req, res))
-  post(router, '/action-plan/:id/submit', (req, res) => serviceProviderReferralsController.submitActionPlan(req, res))
+  post(router, '/action-plan/:id/review', (req, res) => serviceProviderReferralsController.reviewActionPlan(req, res))
+
   get(router, '/action-plan/:id/confirmation', (req, res) =>
     serviceProviderReferralsController.showActionPlanConfirmation(req, res)
   )

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -176,6 +176,10 @@ export default {
   actionPlanApproval: {
     notConfirmed: 'Select the checkbox to confirm before you approve the action plan',
   },
+  reviewActionPlan: {
+    supplierAssessmentAppointmentIncomplete:
+      'You cannot submit an action plan yet. First you need to hold the supplier assessment appointment and then give feedback on it.',
+  },
   attendedAppointment: {
     empty: 'Select whether they attended or not',
   },


### PR DESCRIPTION
## What does this pull request do?

Displays an error message when attempting to submit an action plan before a supplier assessment appointment has been attended and feedback has been submitted.

## What is the intent behind these changes?

To prevent service providers from submitting an Action Plan before a Supplier Assessment Appointment has been attended and feedback has been submitted.
