### PR TITLE
remove access key and secret key

### DIFF
--- a/helm_deploy/hmpps-interventions-ui/values.yaml
+++ b/helm_deploy/hmpps-interventions-ui/values.yaml
@@ -32,8 +32,6 @@ generic-service:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "connection_string"
     storage-s3-bucket:
       AWS_S3_BUCKET_NAME: "bucket_name"
-      AWS_S3_ACCESSKEYID: "access_key_id"
-      AWS_S3_SECRETACCESSKEY: "secret_access_key"
 
   poddisruptionbudget:
     enabled: false

--- a/server/config.ts
+++ b/server/config.ts
@@ -57,8 +57,6 @@ export default {
   s3: {
     service: {
       region: 'eu-west-2',
-      accessKeyId: get('AWS_S3_ACCESSKEYID', 'test', requiredInProduction),
-      secretAccessKey: get('AWS_S3_SECRETACCESSKEY', 'test', requiredInProduction),
       apiVersion: '2006-03-01',
       signatureVersion: 'v4',
       endpoint: production ? undefined : 'http://localhost:4566',


### PR DESCRIPTION
## What does this pull request do?

- Removes secret and access key from S3 bucket config as we are moving towards short lived credentials

## What is the intent behind these changes?

- Since we are moving towards short lived credentials, we need to remove the secret and access key from S3 bucket config
