### PR TITLE
enabling info level to test the reporting

### DIFF
--- a/log.ts
+++ b/log.ts
@@ -4,7 +4,7 @@ import config from './server/config'
 
 const level = (() => {
   if (config.production) {
-    return 'warn'
+    return 'info'
   }
   if (config.testMode) {
     return 'fatal'

--- a/server/routes/reporting/reportingController.ts
+++ b/server/routes/reporting/reportingController.ts
@@ -9,6 +9,7 @@ import ReportingForm from './performanceReport/reportingForm'
 import PerformanceReportConfirmationView from './performanceReport/confirmation/performanceReportConfirmationView'
 import config from '../../config'
 import InterventionsService from '../../services/interventionsService'
+import log from '../../../log'
 
 export default class ReportingController {
   s3Service: S3
@@ -60,6 +61,8 @@ export default class ReportingController {
       Key: `reports/service-provider/performance/${filename}`,
       Expires: 60 * 15, // 15 minutes - the page can load without the download starting
     })
+
+    log.info(`The download Url for the performance dashboard is  ${downloadUrl}`)
 
     ControllerUtils.renderWithLayout(
       res,


### PR DESCRIPTION
## What does this pull request do?

- Enable level to info to check the s3 bucket url

## What is the intent behind these changes?

- The report is not downloading properly. we need to check what is the url generated for s3
