### PR TITLE
Stub getRisksSummary ARN requests

### DIFF
--- a/mocks.ts
+++ b/mocks.ts
@@ -66,8 +66,9 @@ export default async function setUpMocks(): Promise<void> {
       },
     })
   await Promise.all([
-    assessRisksAndNeedsApiMocks.stubGetRiskSummary('CRN24', riskSummaryFactory.build()),
-    assessRisksAndNeedsApiMocks.stubGetRiskSummary('X320741', riskSummaryFactory.build()),
+    ['CRN24', 'X320741'].forEach(crn =>
+      assessRisksAndNeedsApiMocks.stubGetRiskSummary(crn, riskSummaryFactory.build())
+    ),
     assessRisksAndNeedsApiMocks.stubGetSupplementaryRiskInformation(
       '5f2debc5-4c6a-4972-84ce-0689b8f9ec52',
       supplementaryRiskInformationFactory.build()

--- a/mocks.ts
+++ b/mocks.ts
@@ -67,6 +67,7 @@ export default async function setUpMocks(): Promise<void> {
     })
   await Promise.all([
     assessRisksAndNeedsApiMocks.stubGetRiskSummary('CRN24', riskSummaryFactory.build()),
+    assessRisksAndNeedsApiMocks.stubGetRiskSummary('X320741', riskSummaryFactory.build()),
     assessRisksAndNeedsApiMocks.stubGetSupplementaryRiskInformation(
       '5f2debc5-4c6a-4972-84ce-0689b8f9ec52',
       supplementaryRiskInformationFactory.build()


### PR DESCRIPTION
## What does this pull request do?

Adds a Wiremock stub for the assess-risks-and-needs getRiskSummary requests.  

## What is the intent behind these changes?

To prevent assess-risks-and-needs service causing issues developing locally.
