### PR TITLE
setting access key and secret access key to null

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -59,8 +59,8 @@ export default {
       region: 'eu-west-2',
       apiVersion: '2006-03-01',
       signatureVersion: 'v4',
-      accessKeyId: null,
-      secretAccessKey: null,
+      accessKeyId: undefined,
+      secretAccessKey: undefined,
       endpoint: production ? undefined : 'http://localhost:4566',
     },
     bucket: {

--- a/server/config.ts
+++ b/server/config.ts
@@ -59,6 +59,8 @@ export default {
       region: 'eu-west-2',
       apiVersion: '2006-03-01',
       signatureVersion: 'v4',
+      accessKeyId: null,
+      secretAccessKey: null,
       endpoint: production ? undefined : 'http://localhost:4566',
     },
     bucket: {


### PR DESCRIPTION
## What does this pull request do?

- sets the access key and secret access key to null in the S3 bucket configuration
## What is the intent behind these changes?

- Testing if the s3 creates a correct presigned url 
