### PR TITLE
Display service outage banner

### DIFF
--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -37,7 +37,7 @@ export default class DashboardView {
 
   get serviceOutageBannerArgs(): NotificationBannerArgs | null {
     const text =
-      'Refer and monitor an intervention will not be available between 10am on Saturday 10 June and 9am on Sunday 11 June 2023.'
+      'Refer and monitor an intervention will not be available between 10am on Saturday 09 September and 9am on Sunday 10 September 2023.'
 
     const html = `<p class="govuk-notification-banner__heading">${text}</p>
                   <p><a class="govuk-notification-banner__link" href= ${this.presenter.closeHref}>Close</a></p>`

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -56,7 +56,7 @@ export default class DashboardView {
 
   get serviceOutageBannerArgs(): NotificationBannerArgs {
     const text =
-      'Refer and monitor an intervention will not be available between 10am on Saturday 10 June and 9am on Sunday 11 June 2023.'
+      'Refer and monitor an intervention will not be available between 10am on Saturday 09 September and 9am on Sunday 10 September 2023.'
 
     const html = `<p class="govuk-notification-banner__heading">${text}</p>
                   <p><a class="govuk-notification-banner__link" href= ${this.presenter.closeHref}>Close</a></p>`

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -13,6 +13,9 @@
 {% endblock %}
 
 {% block pageContent %}
+{% if presenter.disableDowntimeBanner != true %}
+    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
+{% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,6 +12,9 @@
 {% endblock %}
 
 {% block pageContent %}
+{% if presenter.disableDowntimeBanner != true %}
+    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
+{% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>


### PR DESCRIPTION
## What does this pull request do?

Displays the downtime banner with the following message:
"Refer and monitor an intervention will not be available between 10am on Saturday 09 September and 9am on Sunday 10 September 2023."

## What is the intent behind these changes?

To notify users of planned downtime from Saturday 9th September from 10am as nDelius will be shut down and moved into read only access for the introduction of new improvements. As a result Refer and Monitor MAY be impacted.
