### PR TITLE
adding new the role required to access the api

### DIFF
--- a/testutils/factories/oauth2Token.ts
+++ b/testutils/factories/oauth2Token.ts
@@ -15,7 +15,7 @@ class Oauth2TokenFactory extends Factory<string, TokenParams> {
       authSource: 'delius',
       userID: '2500128586',
       username: 'joe.smith',
-      roles: ['ROLE_PROBATION'],
+      roles: ['ROLE_PROBATION', 'ROLE_INTERVENTIONS_SERVICE'],
     })
   }
 
@@ -24,7 +24,7 @@ class Oauth2TokenFactory extends Factory<string, TokenParams> {
       authSource: 'auth',
       userID: '6c4036b7-e87d-44fb-864f-5a06c1c492f3',
       username: 'TEST_INTERVENTIONS_SP_1',
-      roles: ['ROLE_CRS_PROVIDER'],
+      roles: ['ROLE_CRS_PROVIDER', 'ROLE_INTERVENTIONS_SERVICE'],
     })
   }
 }


### PR DESCRIPTION
## What does this pull request do?

- Adding the new role `INTERVENTIONS_SERVICE` for accessing the api end point

## What is the intent behind these changes?

- There is move across MOJ to protect the resources with access based roles
