### PR TITLE
capturing community allocated pp info

### DIFF
--- a/integration_tests/integration/referral.cy.js
+++ b/integration_tests/integration/referral.cy.js
@@ -176,6 +176,12 @@ describe('Referral form', () => {
 
       cy.contains('Continue').click()
 
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/community-allocated-form`)
+
+      cy.get('[type="radio"]').check('yes')
+
+      cy.contains('Save and continue').click()
+
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/referral-type-form`)
 
       cy.get('[type="radio"]').check('CUSTODY')
@@ -802,6 +808,12 @@ describe('Referral form', () => {
       cy.contains('The person’s CRN').type('X123456')
 
       cy.contains('Continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/community-allocated-form`)
+
+      cy.get('[type="radio"]').check('yes')
+
+      cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/referral-type-form`)
 

--- a/integration_tests/integration/referralUnAllocatedCom.cy.js
+++ b/integration_tests/integration/referralUnAllocatedCom.cy.js
@@ -204,6 +204,12 @@ describe('Referral form', () => {
 
       cy.contains('Continue').click()
 
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/community-allocated-form`)
+
+      cy.get('[type="radio"]').check('no')
+
+      cy.contains('Save and continue').click()
+
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/prison-release-form`)
 
       cy.get('[type="radio"]').check('yes')
@@ -794,6 +800,12 @@ describe('Referral form', () => {
       cy.stubGetDraftReferral(draftReferral.id, draftReferral)
 
       cy.contains('Continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/community-allocated-form`)
+
+      cy.get('[type="radio"]').check('no')
+
+      cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/prison-release-form`)
 
@@ -1440,6 +1452,12 @@ describe('Referral form', () => {
       cy.contains('The person’s CRN').type('X123456')
 
       cy.contains('Continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/community-allocated-form`)
+
+      cy.get('[type="radio"]').check('no')
+
+      cy.contains('Save and continue').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/prison-release-form`)
 

--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -41,6 +41,7 @@ export interface ReferralFields {
   roleOrJobTitle: string | null
   hasMainPointOfContactDetails: boolean | null
   ppLocationType: string | null
+  allocatedCommunityPP: boolean | null
 }
 
 export enum CurrentLocationType {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -101,6 +101,12 @@ function probationPractitionerRoutesWithoutPrefix(router: Router, services: Serv
   post(router, '/referrals/:id/prison-release-form', (req, res) =>
     makeAReferralController.submitPrisonReleaseForm(req, res)
   )
+  get(router, '/referrals/:id/community-allocated-form', (req, res) =>
+    makeAReferralController.viewCommunityAllocatedForm(req, res)
+  )
+  post(router, '/referrals/:id/community-allocated-form', (req, res) =>
+    makeAReferralController.submitCommunityAllocatedForm(req, res)
+  )
   get(router, '/referrals/:id/confirm-main-point-of-contact', (req, res) =>
     makeAReferralController.confirmMainPointOfContactDetails(req, res)
   )

--- a/server/routes/makeAReferral/community-allocated-form/communityAllocatedForm.test.ts
+++ b/server/routes/makeAReferral/community-allocated-form/communityAllocatedForm.test.ts
@@ -1,0 +1,78 @@
+import { Request } from 'express'
+import draftReferralFactory from '../../../../testutils/factories/draftReferral'
+import CommunityAllocatedForm from './communityAllocatedForm'
+
+describe('CommunityAllocatedForm', () => {
+  const referral = draftReferralFactory
+    .serviceCategorySelected()
+    .serviceUserSelected()
+    .build({ serviceUser: { firstName: 'Alex' } })
+
+  describe('errors', () => {
+    it('returns no error with all fields populated for community allocated', async () => {
+      const form = await CommunityAllocatedForm.createForm(
+        {
+          body: {
+            'community-allocated': 'yes',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.error).toBeNull()
+    })
+
+    it('returns an error when community allocated is not selected', async () => {
+      const form = await CommunityAllocatedForm.createForm(
+        {
+          body: {
+            'community-allocated': '',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.error).toEqual({
+        errors: [
+          {
+            formFields: ['community-allocated'],
+            errorSummaryLinkedField: 'community-allocated',
+            message: 'Select yes or no',
+          },
+        ],
+      })
+    })
+  })
+
+  describe('paramsForUpdate', () => {
+    it('returns an object to be used for updating the draft referral via the community allocated form', async () => {
+      const form = await CommunityAllocatedForm.createForm(
+        {
+          body: {
+            'community-allocated': 'yes',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.paramsForUpdate).toEqual({
+        allocatedCommunityPP: true,
+      })
+    })
+
+    it('returns an object to be used for updating the draft referral via the interventions service community is chosen', async () => {
+      const form = await CommunityAllocatedForm.createForm(
+        {
+          body: {
+            'community-allocated': 'no',
+          },
+        } as Request,
+        referral
+      )
+
+      expect(form.paramsForUpdate).toEqual({
+        allocatedCommunityPP: false,
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/community-allocated-form/communityAllocatedForm.ts
+++ b/server/routes/makeAReferral/community-allocated-form/communityAllocatedForm.ts
@@ -1,0 +1,50 @@
+import { Request } from 'express'
+import { body, Result, ValidationChain, ValidationError } from 'express-validator'
+import DraftReferral from '../../../models/draftReferral'
+import errorMessages from '../../../utils/errorMessages'
+import FormUtils from '../../../utils/formUtils'
+import { FormValidationError } from '../../../utils/formValidationError'
+
+export default class CommunityAllocatedForm {
+  private constructor(
+    private readonly request: Request,
+    private readonly result: Result<ValidationError>,
+    private readonly referral: DraftReferral
+  ) {}
+
+  static async createForm(request: Request, referral: DraftReferral): Promise<CommunityAllocatedForm> {
+    return new CommunityAllocatedForm(
+      request,
+      await FormUtils.runValidations({ request, validations: this.validations() }),
+      referral
+    )
+  }
+
+  static validations(): ValidationChain[] {
+    return [body('community-allocated').isIn(['yes', 'no']).withMessage(errorMessages.communityAllocated.emptyRadio)]
+  }
+
+  get isValid(): boolean {
+    return this.error == null
+  }
+
+  get paramsForUpdate(): Partial<DraftReferral> {
+    return {
+      allocatedCommunityPP: this.request.body['community-allocated'] === 'yes',
+    }
+  }
+
+  get error(): FormValidationError | null {
+    if (this.result.isEmpty()) {
+      return null
+    }
+
+    return {
+      errors: this.result.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
+  }
+}

--- a/server/routes/makeAReferral/community-allocated-form/communityAllocatedPresenter.test.ts
+++ b/server/routes/makeAReferral/community-allocated-form/communityAllocatedPresenter.test.ts
@@ -1,12 +1,12 @@
-import PrisonReleasePresenter from './prisonReleasePresenter'
+import CommunityAllocatedPresenter from './communityAllocatedPresenter'
 import draftReferralFactory from '../../../../testutils/factories/draftReferral'
 
-describe('PrisonReleasePresenter', () => {
+describe('CommunityAllocatedPresenter', () => {
   describe('errorSummary', () => {
     describe('when error is null', () => {
       it('returns null', () => {
         const referral = draftReferralFactory.serviceCategorySelected().build()
-        const presenter = new PrisonReleasePresenter(referral, null)
+        const presenter = new CommunityAllocatedPresenter(referral, null)
 
         expect(presenter.errorSummary).toBeNull()
       })
@@ -15,17 +15,17 @@ describe('PrisonReleasePresenter', () => {
     describe('when error is not null', () => {
       it('returns a summary of the errors sorted into the order their fields appear on the page', () => {
         const referral = draftReferralFactory.serviceCategorySelected().build()
-        const presenter = new PrisonReleasePresenter(referral, {
+        const presenter = new CommunityAllocatedPresenter(referral, {
           errors: [
             {
-              formFields: ['prison-release'],
-              errorSummaryLinkedField: 'prison-release',
-              message: 'prison-release msg',
+              formFields: ['community-allocated'],
+              errorSummaryLinkedField: 'community-allocated',
+              message: 'community-allocated msg',
             },
           ],
         })
 
-        expect(presenter.errorSummary).toEqual([{ field: 'prison-release', message: 'prison-release msg' }])
+        expect(presenter.errorSummary).toEqual([{ field: 'community-allocated', message: 'community-allocated msg' }])
       })
     })
   })
@@ -36,16 +36,16 @@ describe('PrisonReleasePresenter', () => {
         .serviceCategorySelected()
         .serviceUserSelected()
         .build({ serviceUser: { firstName: 'Geoffrey', lastName: 'Blue' } })
-      const presenter = new PrisonReleasePresenter(referral)
+      const presenter = new CommunityAllocatedPresenter(referral)
 
-      expect(presenter.backLinkUrl).toBe(`/referrals/${referral.id}/community-allocated-form`)
+      expect(presenter.backLinkUrl).toBe(`/intervention/${referral.interventionId}/refer?`)
       expect(presenter.text).toEqual({
-        title: 'Will Geoffrey Blue be released during the intervention?',
-        description: 'Geoffrey Blue (CRN: X123456)',
-        fromPrison: {
+        title: `Does Geoffrey Blue have an allocated community probation practitioner?`,
+        description: `Geoffrey Blue (CRN: X123456)`,
+        communityAllocated: {
           errorMessage: null,
-          notReleased: 'No - Geoffrey has just arrived in prison and has immediate intervention needs',
-          released: 'Yes',
+          allocated: `Yes`,
+          notAllocated: `No`,
         },
       })
     })
@@ -56,23 +56,23 @@ describe('PrisonReleasePresenter', () => {
           .serviceCategorySelected()
           .serviceUserSelected()
           .build({ serviceUser: { firstName: 'Geoffrey', lastName: 'Blue' } })
-        const presenter = new PrisonReleasePresenter(referral, {
+        const presenter = new CommunityAllocatedPresenter(referral, {
           errors: [
             {
-              formFields: ['prison-release'],
-              errorSummaryLinkedField: 'prison-release',
-              message: 'prison-release msg',
+              formFields: ['community-allocated'],
+              errorSummaryLinkedField: 'community-allocated',
+              message: 'community-allocated msg',
             },
           ],
         })
 
         expect(presenter.text).toEqual({
-          title: 'Will Geoffrey Blue be released during the intervention?',
-          description: 'Geoffrey Blue (CRN: X123456)',
-          fromPrison: {
-            errorMessage: 'prison-release msg',
-            notReleased: 'No - Geoffrey has just arrived in prison and has immediate intervention needs',
-            released: 'Yes',
+          title: `Does Geoffrey Blue have an allocated community probation practitioner?`,
+          description: `Geoffrey Blue (CRN: X123456)`,
+          communityAllocated: {
+            errorMessage: 'community-allocated msg',
+            allocated: `Yes`,
+            notAllocated: `No`,
           },
         })
       })

--- a/server/routes/makeAReferral/community-allocated-form/communityAllocatedPresenter.ts
+++ b/server/routes/makeAReferral/community-allocated-form/communityAllocatedPresenter.ts
@@ -2,7 +2,7 @@ import DraftReferral from '../../../models/draftReferral'
 import { FormValidationError } from '../../../utils/formValidationError'
 import PresenterUtils from '../../../utils/presenterUtils'
 
-export default class ReferralTypePresenter {
+export default class CommunityAllocatedPresenter {
   readonly backLinkUrl: string
 
   constructor(
@@ -10,7 +10,7 @@ export default class ReferralTypePresenter {
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {
-    this.backLinkUrl = `/referrals/${referral.id}/community-allocated-form`
+    this.backLinkUrl = `/intervention/${referral.interventionId}/refer?`
   }
 
   private errorMessageForField(field: string): string | null {
@@ -18,23 +18,22 @@ export default class ReferralTypePresenter {
   }
 
   readonly text = {
-    title: `What type of referral is this?`,
+    title: `Does ${this.referral.serviceUser?.firstName} ${this.referral.serviceUser?.lastName} have an allocated community probation practitioner?`,
     description: `${this.referral.serviceUser?.firstName} ${this.referral.serviceUser?.lastName} (CRN: ${this.referral.serviceUser?.crn})`,
-    currentLocation: {
-      label: `${this.referral.serviceUser?.firstName} ${this.referral.serviceUser?.lastName} is currently:`,
-      errorMessage: this.errorMessageForField('current-location'),
-      custodyLabel: `In prison (pre-release)`,
-      communityLabel: `In the community`,
+    communityAllocated: {
+      errorMessage: this.errorMessageForField('community-allocated'),
+      allocated: `Yes`,
+      notAllocated: `No`,
     },
   }
 
   readonly errorSummary = PresenterUtils.errorSummary(this.error, {
-    fieldOrder: ['current-location'],
+    fieldOrder: ['community-allocated'],
   })
 
   private readonly utils = new PresenterUtils(this.userInputData)
 
   readonly fields = {
-    currentLocation: this.utils.stringValue(this.referral.personCurrentLocationType, 'current-location'),
+    communityAllocated: this.utils.booleanValue(this.referral.allocatedCommunityPP, 'community-allocated'),
   }
 }

--- a/server/routes/makeAReferral/community-allocated-form/communityAllocatedView.ts
+++ b/server/routes/makeAReferral/community-allocated-form/communityAllocatedView.ts
@@ -1,0 +1,45 @@
+import ViewUtils from '../../../utils/viewUtils'
+import { RadiosArgs } from '../../../utils/govukFrontendTypes'
+import CommunityAllocatedPresenter from './communityAllocatedPresenter'
+
+export default class CommunityAllocatedView {
+  constructor(private readonly presenter: CommunityAllocatedPresenter) {}
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+
+  private submitCommunityAllocatedArgs(yesHtml: string): RadiosArgs {
+    return {
+      idPrefix: '',
+      name: 'community-allocated',
+      items: [
+        {
+          value: 'yes',
+          text: this.presenter.text.communityAllocated.allocated,
+          checked: this.presenter.referral.allocatedCommunityPP === true,
+          conditional: {
+            html: yesHtml,
+          },
+        },
+        {
+          value: 'no',
+          text: this.presenter.text.communityAllocated.notAllocated,
+          checked: this.presenter.referral.allocatedCommunityPP === false,
+        },
+      ],
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.communityAllocated.errorMessage),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'makeAReferral/submitCommunityAllocated',
+      {
+        presenter: this.presenter,
+        errorSummaryArgs: this.errorSummaryArgs,
+        submitCommunityAllocatedArgs: this.submitCommunityAllocatedArgs.bind(this),
+        backLinkArgs: { href: this.presenter.backLinkUrl },
+        suppressServiceUserBanner: true,
+      },
+    ]
+  }
+}

--- a/server/routes/makeAReferral/makeAReferralController.test.ts
+++ b/server/routes/makeAReferral/makeAReferralController.test.ts
@@ -111,7 +111,7 @@ describe('POST /intervention/:id/refer', () => {
         .post(`/intervention/${interventionId}/refer`)
         .send({ 'service-user-crn': serviceUserCRN })
         .expect(301)
-        .expect('Location', '/referrals/1/referral-type-form')
+        .expect('Location', '/referrals/1/community-allocated-form')
 
       expect(interventionsService.createDraftReferral).toHaveBeenCalledWith('token', serviceUserCRN, interventionId)
     })
@@ -147,7 +147,7 @@ describe('POST /intervention/:id/refer', () => {
         .post(`/intervention/${interventionId}/refer`)
         .send({ 'service-user-crn': serviceUserCRN })
         .expect(301)
-        .expect('Location', '/referrals/1/prison-release-form')
+        .expect('Location', '/referrals/1/community-allocated-form')
 
       expect(interventionsService.createDraftReferral).toHaveBeenCalledWith('token', serviceUserCRN, interventionId)
     })
@@ -178,7 +178,7 @@ describe('POST /intervention/:id/refer', () => {
           .post(`/intervention/${interventionId}/refer`)
           .send({ 'service-user-crn': serviceUserCRN })
           .expect(301)
-          .expect('Location', '/referrals/1/referral-type-form')
+          .expect('Location', '/referrals/1/community-allocated-form')
 
         expect(ramDeliusApiService.getCaseDetailsByCrn).toHaveBeenCalledWith(serviceUserCRNTrimmed)
         expect(interventionsService.createDraftReferral).toHaveBeenCalledWith(
@@ -198,7 +198,7 @@ describe('POST /intervention/:id/refer', () => {
           .post(`/intervention/${interventionId}/refer`)
           .send({ 'service-user-crn': serviceUserCRN })
           .expect(301)
-          .expect('Location', '/referrals/1/referral-type-form')
+          .expect('Location', '/referrals/1/community-allocated-form')
 
         expect(ramDeliusApiService.getCaseDetailsByCrn).toHaveBeenCalledWith(serviceUserCRNTransformed)
         expect(interventionsService.createDraftReferral).toHaveBeenCalledWith(

--- a/server/routes/makeAReferral/prison-release-form/prisonReleasePresenter.ts
+++ b/server/routes/makeAReferral/prison-release-form/prisonReleasePresenter.ts
@@ -10,7 +10,7 @@ export default class PrisonReleasePresenter {
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {
-    this.backLinkUrl = `/intervention/${referral.interventionId}/refer?`
+    this.backLinkUrl = `/referrals/${referral.id}/community-allocated-form`
   }
 
   private errorMessageForField(field: string): string | null {

--- a/server/routes/makeAReferral/referral-type-form/referralTypePresenter.test.ts
+++ b/server/routes/makeAReferral/referral-type-form/referralTypePresenter.test.ts
@@ -38,7 +38,7 @@ describe('ReferralTypePresenter', () => {
         .build({ serviceUser: { firstName: 'Geoffrey', lastName: 'Blue' } })
       const presenter = new ReferralTypePresenter(referral)
 
-      expect(presenter.backLinkUrl).toBe(`/intervention/${referral.interventionId}/refer?`)
+      expect(presenter.backLinkUrl).toBe(`/referrals/${referral.id}/community-allocated-form`)
       expect(presenter.text).toEqual({
         title: 'What type of referral is this?',
         description: 'Geoffrey Blue (CRN: X123456)',

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1568,6 +1568,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       roleOrJobTitle: 'Probation Practitioner',
       hasMainPointOfContactDetails: false,
       ppLocationType: null,
+      allocatedCommunityPP: true,
     },
   }
 

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -132,6 +132,9 @@ export default {
   prisonRelease: {
     emptyRadio: 'Select yes or no',
   },
+  communityAllocated: {
+    emptyRadio: 'Select yes or no',
+  },
   confirmProbationPractitionerDetails: {
     emptyRadio: 'Select yes or no',
     emptyName: `Enter name of probation practitioner`,

--- a/server/views/makeAReferral/submitCommunityAllocated.njk
+++ b/server/views/makeAReferral/submitCommunityAllocated.njk
@@ -1,0 +1,40 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Submit Community Allocated" %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukBackLink(backLinkArgs) }}
+      <br>
+      <br>
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
+      <p class="govuk-caption-xl">{{ presenter.text.description }} </p>
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {{ govukRadios(submitCommunityAllocatedArgs(submitLocationHtml)) }}
+
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -257,4 +257,5 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   roleOrJobTitle: null,
   hasMainPointOfContactDetails: null,
   ppLocationType: null,
+  allocatedCommunityPP: null,
 }))

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -68,6 +68,7 @@ const exampleReferralFields = () => {
     roleOrJobTitle: 'Probabation Practitioner',
     hasMainPointOfContactDetails: false,
     ppLocationType: null,
+    allocatedCommunityPP: false,
   }
 }
 


### PR DESCRIPTION
## What does this pull request do?

- capturing the information of whether the referral has community allocated PP in a new page

## What is the intent behind these changes?

- This is to mitigate the unstable data from community api. To mitigate the issue, we are capturing the information in R&M itself.
