### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.5.0
+  hmpps: ministryofjustice/hmpps@7
   node: circleci/node@4.1.0
 
 executors:
@@ -9,16 +9,17 @@ executors:
     docker:
       - image: cimg/node:16.20-browsers
       - image: rodolpheche/wiremock:2.31.0-alpine
-        command: ["--port", "9091"]
+        command: [ "--port", "9091" ]
       - image: bitnami/redis:6.2
-        command: ["/opt/bitnami/scripts/redis/run.sh", "--port", "6380"]
+        command: [ "/opt/bitnami/scripts/redis/run.sh", "--port", "6380" ]
         environment:
           ALLOW_EMPTY_PASSWORD: "yes"
 
 jobs:
   build:
     environment:
-      PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
+      PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.serv\
+        ice.justice.gov.uk"
       PACT_BROKER_USERNAME: "interventions"
     executor:
       name: hmpps/node
@@ -44,7 +45,8 @@ jobs:
 
   tag_pact_version:
     environment:
-      PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
+      PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.serv\
+        ice.justice.gov.uk"
       PACT_BROKER_USERNAME: "interventions"
     executor:
       name: hmpps/node
@@ -68,7 +70,8 @@ jobs:
           version: 7.5.4
       - node/install-packages
       - run: npm run build
-      - run: # Run linter after build because the integration test code depends on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depends on compiled typescript...
           command: npm run lint
       - run:
           command: npm run start:test
@@ -84,7 +87,7 @@ workflows:
   build_test_and_deploy:
     jobs:
       - build:
-          context: [hmpps-common-vars]
+          context: [ hmpps-common-vars ]
       - integration_test
       - hmpps/helm_lint
       - hmpps/build_docker:
@@ -109,7 +112,7 @@ workflows:
                 - /hotfix\/.*/
       - hmpps/trivy_pipeline_scan:
           name: vulnerability_scan
-          requires: [build_docker, build_docker_publish]
+          requires: [ build_docker, build_docker_publish ]
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"
@@ -132,8 +135,8 @@ workflows:
       - tag_pact_version:
           name: "tag_pact_version_dev"
           tag: "deployed:dev"
-          requires: [deploy_dev]
-          context: [hmpps-common-vars]
+          requires: [ deploy_dev ]
+          context: [ hmpps-common-vars ]
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"
@@ -148,8 +151,8 @@ workflows:
       - tag_pact_version:
           name: "tag_pact_version_preprod"
           tag: "deployed:preprod"
-          requires: [deploy_preprod]
-          context: [hmpps-common-vars]
+          requires: [ deploy_preprod ]
+          context: [ hmpps-common-vars ]
       - approve_prod:
           type: approval
           requires:
@@ -168,8 +171,8 @@ workflows:
       - tag_pact_version:
           name: "tag_pact_version_prod"
           tag: "deployed:prod"
-          requires: [deploy_prod]
-          context: [hmpps-common-vars]
+          requires: [ deploy_prod ]
+          context: [ hmpps-common-vars ]
 
   nightly:
     triggers:
@@ -182,7 +185,7 @@ workflows:
     jobs:
       - hmpps/npm_security_audit:
           slack_channel: "interventions-dev-notifications"
-          context: [hmpps-common-vars]
+          context: [ hmpps-common-vars ]
       - hmpps/veracode_policy_scan:
           teams: hmpps-interventions
           slack_channel: "interventions-dev-notifications"
@@ -191,4 +194,4 @@ workflows:
             - veracode-credentials
       - hmpps/trivy_latest_scan:
           slack_channel: "interventions-dev-notifications"
-          context: [hmpps-common-vars]
+          context: [ hmpps-common-vars ]

--- a/helm_deploy/hmpps-interventions-ui/Chart.yaml
+++ b/helm_deploy/hmpps-interventions-ui/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.2.0
 
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

0 allowlist(s) have been detected that can be migrated.


