### PR TITLE
adapting to the new dashboard queries and removing the deprecated das…

### DIFF
--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -105,10 +105,6 @@ export default on => {
       return interventionsService.stubGetSentReferralsForUserTokenPaged(arg.responseJson)
     },
 
-    stubGetServiceProviderSentReferralsSummaryForUserToken: arg => {
-      return interventionsService.stubGetServiceProviderSentReferralsSummaryForUserToken(arg.responseJson)
-    },
-
     stubAssignSentReferral: arg => {
       return interventionsService.stubAssignSentReferral(arg.id, arg.responseJson)
     },

--- a/integration_tests/support/interventionsServiceStubs.js
+++ b/integration_tests/support/interventionsServiceStubs.js
@@ -42,10 +42,6 @@ Cypress.Commands.add('stubGetSentReferralsForUserTokenPaged', responseJson => {
   cy.task('stubGetSentReferralsForUserTokenPaged', { responseJson })
 })
 
-Cypress.Commands.add('stubGetServiceProviderSentReferralsSummaryForUserToken', responseJson => {
-  cy.task('stubGetServiceProviderSentReferralsSummaryForUserToken', { responseJson })
-})
-
 Cypress.Commands.add('stubAssignSentReferral', (id, responseJson) => {
   cy.task('stubAssignSentReferral', { id, responseJson })
 })

--- a/mockApis/interventionsService.ts
+++ b/mockApis/interventionsService.ts
@@ -189,22 +189,6 @@ export default class InterventionsServiceMocks {
     })
   }
 
-  stubGetServiceProviderSentReferralsSummaryForUserToken = async (responseJson: unknown): Promise<unknown> => {
-    return this.wiremock.stubFor({
-      request: {
-        method: 'GET',
-        urlPathPattern: `${this.mockPrefix}/sent-referrals/summary/service-provider`,
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        jsonBody: responseJson,
-      },
-    })
-  }
-
   stubAssignSentReferral = async (id: string, responseJson: Record<string, unknown>): Promise<unknown> => {
     return this.wiremock.stubFor({
       request: {

--- a/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardPresenter.ts
@@ -58,19 +58,19 @@ export default class DashboardPresenter {
     },
     {
       columnName: 'Person',
-      sortField: 'serviceUserData.lastName',
+      sortField: 'serviceUserLastName',
     },
     {
       columnName: 'Intervention type',
-      sortField: 'intervention.title',
+      sortField: 'interventionTitle',
     },
     {
       columnName: 'Provider',
-      sortField: 'intervention.dynamicFrameworkContract.primeProvider.name',
+      sortField: 'serviceProviderName',
     },
     {
       columnName: 'Caseworker',
-      sortField: 'assignments.assignedTo.userName',
+      sortField: 'assignedUserName',
     },
     {
       columnName: 'Action',

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.ts
@@ -101,7 +101,7 @@ export default class ProbationPractitionerReferralsController {
       config.userData.ppDashboardSortOrder.storageDurationInSeconds,
       tablePersistentId,
       DashboardPresenter.headingsAndSortFields.map(it => it.sortField).filter(it => it) as string[],
-      'serviceUserData.lastName,ASC',
+      'serviceUserLastName,ASC',
       'sentAt,ASC'
     )
 

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.test.ts
@@ -58,9 +58,9 @@ describe(DashboardPresenter, () => {
         prisons
       )
       expect(presenter.tableHeadings.map(headers => headers.persistentId)).toEqual([
-        'serviceUserData.lastName',
+        'serviceUserLastName',
         'referenceNumber',
-        'intervention.title',
+        'interventionTitle',
         'sentAt',
       ])
     })

--- a/server/routes/serviceProviderReferrals/dashboardPresenter.ts
+++ b/server/routes/serviceProviderReferrals/dashboardPresenter.ts
@@ -82,11 +82,11 @@ export default class DashboardPresenter {
   static readonly headingsAndSortFields = [
     {
       columnName: 'Name/CRN',
-      sortField: 'serviceUserData.lastName',
+      sortField: 'serviceUserLastName',
     },
     {
       columnName: 'Expected release date',
-      sortField: 'referralLocation.expectedReleaseDate',
+      sortField: 'expectedReleaseDate',
     },
     {
       columnName: 'Location',
@@ -97,11 +97,11 @@ export default class DashboardPresenter {
     },
     {
       columnName: 'Intervention type',
-      sortField: 'intervention.title',
+      sortField: 'interventionTitle',
     },
     {
       columnName: 'Caseworker',
-      sortField: 'assignments.assignedTo.userName',
+      sortField: 'assignedUserName',
     },
     {
       columnName: 'Date received',

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -4,7 +4,6 @@ import querystring from 'querystring'
 import InterventionsService, {
   GetSentReferralsFilterParams,
   InterventionsServiceError,
-  SPDashboardType,
 } from '../../services/interventionsService'
 import ActionPlan from '../../models/actionPlan'
 import HmppsAuthService from '../../services/hmppsAuthService'
@@ -102,14 +101,7 @@ export default class ServiceProviderReferralsController {
         'spMyCases',
         pageSize
       )
-      return
     }
-
-    const referralsSummary = await this.interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
-      res.locals.user.token.accessToken,
-      SPDashboardType.MyCases
-    )
-    await this.renderDashboardWithoutPagination(req, res, referralsSummary, 'My cases')
   }
 
   private handlePaginatedSearchText(req: Request) {
@@ -142,14 +134,7 @@ export default class ServiceProviderReferralsController {
         'spAllOpenCases',
         pageSize
       )
-      return
     }
-
-    const referralsSummary = await this.interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
-      res.locals.user.token.accessToken,
-      SPDashboardType.OpenCases
-    )
-    await this.renderDashboardWithoutPagination(req, res, referralsSummary, 'All open cases')
   }
 
   async showUnassignedCasesDashboard(req: Request, res: Response): Promise<void> {
@@ -167,14 +152,7 @@ export default class ServiceProviderReferralsController {
         'spUnassignedCases',
         pageSize
       )
-      return
     }
-
-    const referralsSummary = await this.interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
-      res.locals.user.token.accessToken,
-      SPDashboardType.UnassignedCases
-    )
-    await this.renderDashboardWithoutPagination(req, res, referralsSummary, 'Unassigned cases')
   }
 
   async showCompletedCasesDashboard(req: Request, res: Response): Promise<void> {
@@ -192,14 +170,7 @@ export default class ServiceProviderReferralsController {
         'spCompletedCases',
         pageSize
       )
-      return
     }
-
-    const referralsSummary = await this.interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
-      res.locals.user.token.accessToken,
-      SPDashboardType.CompletedCases
-    )
-    await this.renderDashboardWithoutPagination(req, res, referralsSummary, 'Completed cases')
   }
 
   private async renderDashboard(

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1944,55 +1944,6 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       })
     })
   })
-
-  describe('getServiceProviderSentReferralsSummaryForUserToken', () => {
-    it('returns a list of sent referrals', async () => {
-      const spUserWithAccess = oauth2TokenFactory
-        .transient({
-          authSource: 'auth',
-          userID: '608955ae-52ed-44cc-884c-011597a77949',
-          username: 'AUTH_USER',
-          roles: ['ROLE_CRS_PROVIDER', 'INT_SP_HARMONY_LIVING'],
-        })
-        .build()
-      const sentReferralSummary = {
-        referralId: '4afb07a0-e50b-490c-a8c1-c858d5a1e912',
-        referenceNumber: 'JS18726AC',
-        interventionTitle: 'Accommodation Services - West Midlands',
-        assignedToUserName: 'AUTH_USER',
-        serviceUserFirstName: 'George',
-        serviceUserLastName: 'Michael',
-        endOfServiceReportSubmitted: false,
-      }
-      await provider.addInteraction({
-        state:
-          'There is an existing sent referral with ID of 2f4e91bf-5f73-4ca8-ad84-afee3f12ed8e, and it has a caseworker assigned',
-        uponReceiving: 'a request for all sent referral summaries',
-        withRequest: {
-          method: 'GET',
-          path: '/sent-referrals/summary/service-provider',
-          headers: { Accept: 'application/json', Authorization: `Bearer ${spUserWithAccess}` },
-        },
-        willRespondWith: {
-          status: 200,
-          body: Matchers.like([sentReferralSummary]),
-          headers: { 'Content-Type': 'application/json' },
-        },
-      })
-      const summaryResult = await interventionsService.getServiceProviderSentReferralsSummaryForUserToken(
-        spUserWithAccess
-      )
-      expect(summaryResult.length).toEqual(1)
-      expect(summaryResult[0].referralId).toEqual(sentReferralSummary.referralId)
-      expect(summaryResult[0].referenceNumber).toEqual(sentReferralSummary.referenceNumber)
-      expect(summaryResult[0].interventionTitle).toEqual(sentReferralSummary.interventionTitle)
-      expect(summaryResult[0].assignedToUserName).toEqual(sentReferralSummary.assignedToUserName)
-      expect(summaryResult[0].serviceUserFirstName).toEqual(sentReferralSummary.serviceUserFirstName)
-      expect(summaryResult[0].serviceUserLastName).toEqual(sentReferralSummary.serviceUserLastName)
-      expect(summaryResult[0].endOfServiceReportSubmitted).toEqual(sentReferralSummary.endOfServiceReportSubmitted)
-    })
-  })
-
   describe('getReferralsForUserToken', () => {
     it('returns a list of sent referrals', async () => {
       await provider.addInteraction({

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -376,19 +376,6 @@ export default class InterventionsService {
     })) as Page<SentReferralSummaries>
   }
 
-  async getServiceProviderSentReferralsSummaryForUserToken(
-    token: string,
-    dashboardType?: SPDashboardType
-  ): Promise<ServiceProviderSentReferralSummary[]> {
-    const restClient = this.createRestClient(token)
-    const query = dashboardType ? { dashboardType } : undefined
-    return (await restClient.get({
-      path: `/sent-referrals/summary/service-provider`,
-      query,
-      headers: { Accept: 'application/json' },
-    })) as ServiceProviderSentReferralSummary[]
-  }
-
   async getServiceProviderSentReferralsSummaryForUserTokenWithSearchText(
     token: string,
     searchText: string,


### PR DESCRIPTION
…hboard sp api

## What does this pull request do?

- updates the dashboard request to service inline with the new dashboard queries
- removes the deprecated `/sent-referral/service-provider/summary` api

## What is the intent behind these changes?

- Dashboard query is generally slow and was pulling lots of unwanted data. So we have to come up with optimised approach of queries
