### PR TITLE
Add option for sending case note emails to probation practitioners

### DIFF
--- a/server/models/caseNote.ts
+++ b/server/models/caseNote.ts
@@ -7,4 +7,5 @@ export interface CaseNote {
   body: string
   sentBy: User
   sentAt: string
+  sendEmail: string
 }

--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.ts
@@ -8,6 +8,7 @@ interface CaseNotesSummary {
   time: string
   from: string
   body: string
+  sendEmail: string
 }
 
 export default class AddCaseNoteCheckAnswersPresenter {
@@ -19,6 +20,8 @@ export default class AddCaseNoteCheckAnswersPresenter {
     private caseNote: CaseNote
   ) {}
 
+  readonly caseNoteDetailsHeading = 'Case note details'
+
   backLinkHref = `/${this.loggedInUserType}/referrals/${this.referralId}/add-case-note/${this.draftId}/details`
 
   submitHref = `/${this.loggedInUserType}/referrals/${this.referralId}/add-case-note/${this.draftId}/submit`
@@ -29,5 +32,6 @@ export default class AddCaseNoteCheckAnswersPresenter {
     time: DateUtils.formattedTime(new Date()),
     from: this.loggedInUser.name,
     body: this.caseNote.body,
+    sendEmail: this.caseNote.sendEmail === 'true' ? 'Yes' : 'No',
   }
 }

--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersView.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersView.ts
@@ -11,14 +11,23 @@ export default class AddCaseNoteCheckAnswersView {
   }
 
   private get caseNoteSummaryListArgs(): SummaryListArgs {
-    return ViewUtils.summaryListArgs(
+    return ViewUtils.summaryListArgsWithSummaryCard(
       [
         { key: 'Subject', lines: [this.presenter.caseNoteSummary.subject] },
         { key: 'Date', lines: [this.presenter.caseNoteSummary.date] },
         { key: 'Time', lines: [this.presenter.caseNoteSummary.time] },
         { key: 'From', lines: [this.presenter.caseNoteSummary.from] },
+        {
+          key: 'Notes about the intervention or the person on probation',
+          lines: [this.presenter.caseNoteSummary.body],
+        },
+        {
+          key: 'Would you like the probation practitioner to get an email about this case note?',
+          lines: [this.presenter.caseNoteSummary.sendEmail],
+        },
       ],
-      { showBorders: false }
+      this.presenter.caseNoteDetailsHeading,
+      { showBorders: true, showTitle: true }
     )
   }
 
@@ -29,7 +38,6 @@ export default class AddCaseNoteCheckAnswersView {
         presenter: this.presenter,
         backLinkArgs: this.backLinkArgs,
         caseNoteSummaryListArgs: this.caseNoteSummaryListArgs,
-        caseNoteBody: this.presenter.caseNoteSummary.body,
       },
     ]
   }

--- a/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationPresenter.ts
+++ b/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationPresenter.ts
@@ -14,7 +14,7 @@ export default class AddCaseNoteConfirmationPresenter {
   caseNotesHref = `/${this.loggedInUserType}/referrals/${this.referral.id}/case-notes`
 
   text = {
-    whatHappensNext: `The ${this.targetUserType} will now be able to view the case note.`,
+    whatHappensNext: `The ${this.targetUserType} can now view this case note in the service.`,
   }
 
   readonly serviceUserSummary: SummaryListItem[] = [

--- a/server/views/caseNotes/addNewCaseNoteConfirmation.njk
+++ b/server/views/caseNotes/addNewCaseNoteConfirmation.njk
@@ -13,11 +13,13 @@
 
       {{ govukSummaryList(summaryListArgs) }}
 
+      <h2 class="govuk-heading-m">What happens next</h2>
+
       <p class="govuk-body">
         {{ presenter.text.whatHappensNext }}
       </p>
 
-      <a href="{{ presenter.caseNotesHref }}" class="govuk-button">Return to intervention</a>
+      <a href="{{ presenter.caseNotesHref }}" class="govuk-link govuk-body">Return to intervention</a>
     </div>
   </div>
 {% endblock %}

--- a/server/views/caseNotes/checkAnswers.njk
+++ b/server/views/caseNotes/checkAnswers.njk
@@ -10,9 +10,6 @@
     {{ govukBackLink(backLinkArgs) }}
     <h1 class="govuk-heading-l">Review case note</h1>
     {{ govukSummaryList(caseNoteSummaryListArgs) }}
-    <p class="govuk-body">
-        {{ caseNoteBody | escape | nl2br }}
-    </p>
 
     <form method="post" action="{{ presenter.submitHref }}">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">


### PR DESCRIPTION
## What does this pull request do?

Adds a radio button to select whether or not to send an email to the probation practitioner when adding a case note.

## What is the intent behind these changes?

To avoid probation practitioners from getting too many emails.
