### PR TITLE
Amend tests based on expected date following turn of the new year

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.cy.js
+++ b/integration_tests/integration/probationPractitionerReferrals.cy.js
@@ -472,7 +472,7 @@ describe('Probation practitioner referrals dashboard', () => {
       .should('contain', 'English')
       .should('contain', 'Male')
       .should('contain', 'Agnostic')
-      .should('contain', '1 Jan 1980 (43 years old)')
+      .should('contain', '1 Jan 1980 (44 years old)')
 
     cy.contains(`Jenny Jones's address and contact details`)
       .parent()
@@ -697,7 +697,7 @@ describe('Probation practitioner referrals dashboard', () => {
       .should('contain', 'English')
       .should('contain', 'Male')
       .should('contain', 'Agnostic')
-      .should('contain', '1 Jan 1980 (43 years old)')
+      .should('contain', '1 Jan 1980 (44 years old)')
 
     cy.contains(`Jenny Jones's address and contact details`)
       .parent()

--- a/integration_tests/integration/probationPractitionerReferrals.cy.js
+++ b/integration_tests/integration/probationPractitionerReferrals.cy.js
@@ -462,6 +462,8 @@ describe('Probation practitioner referrals dashboard', () => {
       .should('contain', 'Expected release date')
       .should('contain', moment().add(1, 'days').format('D MMM YYYY'))
 
+    const yearsElapsed = moment().diff('1980-01-01', 'years')
+
     cy.contains(`Jenny Jones's personal details`)
       .parent()
       .parent()
@@ -472,7 +474,7 @@ describe('Probation practitioner referrals dashboard', () => {
       .should('contain', 'English')
       .should('contain', 'Male')
       .should('contain', 'Agnostic')
-      .should('contain', '1 Jan 1980 (44 years old)')
+      .should('contain', `1 Jan 1980 (${yearsElapsed} years old)`)
 
     cy.contains(`Jenny Jones's address and contact details`)
       .parent()
@@ -687,6 +689,7 @@ describe('Probation practitioner referrals dashboard', () => {
       .should('contain', 'Location at time of referral')
       .should('contain', 'Community')
 
+    const yearsElapsed = moment().diff('1980-01-01', 'years')
     cy.contains(`Jenny Jones's personal details`)
       .parent()
       .parent()
@@ -697,7 +700,7 @@ describe('Probation practitioner referrals dashboard', () => {
       .should('contain', 'English')
       .should('contain', 'Male')
       .should('contain', 'Agnostic')
-      .should('contain', '1 Jan 1980 (44 years old)')
+      .should('contain', `1 Jan 1980 (${yearsElapsed} years old)`)
 
     cy.contains(`Jenny Jones's address and contact details`)
       .parent()

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -262,7 +262,7 @@ describe('Service provider referrals dashboard', () => {
       .should('contain', 'English')
       .should('contain', 'Male')
       .should('contain', 'Agnostic')
-      .should('contain', '1 Jan 1980 (43 years old)')
+      .should('contain', '1 Jan 1980 (44 years old)')
 
     cy.contains(`Jenny Jones's address and contact details`)
       .parent()

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -252,6 +252,8 @@ describe('Service provider referrals dashboard', () => {
       .should('contain', 'Expected release date')
       .should('contain', moment().add(1, 'days').format('D MMM YYYY'))
 
+    const yearsElapsed = moment().diff('1980-01-01', 'years')
+
     cy.contains(`Jenny Jones's personal details`)
       .parent()
       .parent()
@@ -262,7 +264,7 @@ describe('Service provider referrals dashboard', () => {
       .should('contain', 'English')
       .should('contain', 'Male')
       .should('contain', 'Agnostic')
-      .should('contain', '1 Jan 1980 (44 years old)')
+      .should('contain', `1 Jan 1980 (${yearsElapsed} years old)`)
 
     cy.contains(`Jenny Jones's address and contact details`)
       .parent()

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
@@ -58,7 +58,7 @@ describe(CheckAllReferralInformationPresenter, () => {
         expect(presenter.serviceUserDetailsSection.summary).toEqual([
           { key: 'First name', lines: ['Alex'] },
           { key: 'Last name(s)', lines: ['River'] },
-          { key: 'Date of birth', lines: ['1 Jan 1980 (43 years old)'] },
+          { key: 'Date of birth', lines: ['1 Jan 1980 (44 years old)'] },
           { key: 'Gender', lines: ['Male'] },
           {
             key: 'Address',

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone'
 import CheckAllReferralInformationPresenter from './checkAllReferralInformationPresenter'
 import draftReferralFactory from '../../../../testutils/factories/draftReferral'
 import serviceCategoryFactory from '../../../../testutils/factories/serviceCategory'
@@ -55,10 +56,12 @@ describe(CheckAllReferralInformationPresenter, () => {
 
     describe('summary', () => {
       it('returns the service user’s details', () => {
+        const yearsElapsed = moment().diff('1980-01-01', 'years')
+
         expect(presenter.serviceUserDetailsSection.summary).toEqual([
           { key: 'First name', lines: ['Alex'] },
           { key: 'Last name(s)', lines: ['River'] },
-          { key: 'Date of birth', lines: ['1 Jan 1980 (44 years old)'] },
+          { key: 'Date of birth', lines: [`1 Jan 1980 (${yearsElapsed} years old)`] },
           { key: 'Gender', lines: ['Male'] },
           {
             key: 'Address',

--- a/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.test.ts
@@ -97,7 +97,7 @@ describe(ServiceUserDetailsPresenter, () => {
         { key: 'Title', lines: ['Mr'] },
         { key: 'First name', lines: ['Alex'] },
         { key: 'Last name', lines: ['River'] },
-        { key: 'Date of birth', lines: ['1 January 1980 (43 years old)'] },
+        { key: 'Date of birth', lines: ['1 January 1980 (44 years old)'] },
         {
           key: 'Address',
           lines: ['Flat 10 Test Walk', 'London', 'City of London', 'Greater London', 'SW16 1AQ'],
@@ -188,7 +188,7 @@ describe(ServiceUserDetailsPresenter, () => {
       expect(presenter.personalDetailsSummary).toEqual([
         { key: 'First name', lines: ['Alex'] },
         { key: 'Last name(s)', lines: ['River'] },
-        { key: 'Date of birth', lines: ['1 Jan 1980 (43 years old)'] },
+        { key: 'Date of birth', lines: ['1 Jan 1980 (44 years old)'] },
         { key: 'Gender', lines: ['Male'] },
         { key: 'Ethnicity', lines: ['British'] },
         { key: 'Preferred language', lines: ['English'] },

--- a/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.test.ts
+++ b/server/routes/makeAReferral/service-user-details/serviceUserDetailsPresenter.test.ts
@@ -92,12 +92,14 @@ describe(ServiceUserDetailsPresenter, () => {
         tomorrow.format('YYYY-MM-DD')
       )
 
+      const yearsElapsed = moment().diff('1980-01-01', 'years')
+
       expect(presenter.summary).toEqual([
         { key: 'CRN', lines: ['X862134'] },
         { key: 'Title', lines: ['Mr'] },
         { key: 'First name', lines: ['Alex'] },
         { key: 'Last name', lines: ['River'] },
-        { key: 'Date of birth', lines: ['1 January 1980 (44 years old)'] },
+        { key: 'Date of birth', lines: [`1 January 1980 (${yearsElapsed} years old)`] },
         {
           key: 'Address',
           lines: ['Flat 10 Test Walk', 'London', 'City of London', 'Greater London', 'SW16 1AQ'],
@@ -185,10 +187,12 @@ describe(ServiceUserDetailsPresenter, () => {
         tomorrow.format('YYYY-MM-DD')
       )
 
+      const yearsElapsed = moment().diff('1980-01-01', 'years')
+
       expect(presenter.personalDetailsSummary).toEqual([
         { key: 'First name', lines: ['Alex'] },
         { key: 'Last name(s)', lines: ['River'] },
-        { key: 'Date of birth', lines: ['1 Jan 1980 (44 years old)'] },
+        { key: 'Date of birth', lines: [`1 Jan 1980 (${yearsElapsed} years old)`] },
         { key: 'Gender', lines: ['Male'] },
         { key: 'Ethnicity', lines: ['British'] },
         { key: 'Preferred language', lines: ['English'] },

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -1372,10 +1372,12 @@ describe(ShowReferralPresenter, () => {
         deliusRoOfficer
       )
 
+      const yearsElapsed = moment().diff('1980-01-01', 'years')
+
       expect(presenter.personalDetailSummary).toEqual([
         { key: 'First name', lines: ['Jenny'] },
         { key: 'Last name(s)', lines: ['Jones'] },
-        { key: 'Date of birth', lines: ['1 Jan 1980 (44 years old)'] },
+        { key: 'Date of birth', lines: [`1 Jan 1980 (${yearsElapsed} years old)`] },
         { key: 'Gender', lines: ['Male'] },
         { key: 'Ethnicity', lines: ['British'] },
         { key: 'Preferred language', lines: ['English'] },

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -1375,7 +1375,7 @@ describe(ShowReferralPresenter, () => {
       expect(presenter.personalDetailSummary).toEqual([
         { key: 'First name', lines: ['Jenny'] },
         { key: 'Last name(s)', lines: ['Jones'] },
-        { key: 'Date of birth', lines: ['1 Jan 1980 (43 years old)'] },
+        { key: 'Date of birth', lines: ['1 Jan 1980 (44 years old)'] },
         { key: 'Gender', lines: ['Male'] },
         { key: 'Ethnicity', lines: ['British'] },
         { key: 'Preferred language', lines: ['English'] },


### PR DESCRIPTION
## What does this pull request do?

Fixes failing tests due to change of year

## What is the intent behind these changes?

Keep mainline build working / passing tests
