### PR TITLE
update what's new content and view appointment details

### DIFF
--- a/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
@@ -66,6 +66,12 @@ export default class SubmittedFeedbackPresenter {
         lines: [this.feedbackAnswersPresenter.lateAnswers.answer],
       })
     }
+    if (this.feedbackAnswersPresenter.lateReasonAnswers) {
+      sessionFeedbackDetails.push({
+        key: this.feedbackAnswersPresenter.lateReasonAnswers.question,
+        lines: [this.feedbackAnswersPresenter.lateReasonAnswers.answer],
+      })
+    }
     if (this.feedbackAnswersPresenter.sessionSummaryAnswers) {
       sessionFeedbackDetails.push({
         key: this.feedbackAnswersPresenter.sessionSummaryAnswers.question,

--- a/server/views/serviceProviderReferrals/whatsNew.njk
+++ b/server/views/serviceProviderReferrals/whatsNew.njk
@@ -20,9 +20,8 @@
               <li>indicate if a session happened or not</li>
               <li>feed back on sessions where the person attended, but the session did not happen</li>
               <li>share details about lateness, such as how late someone was and any reason they gave</li>
-              <li>reschedule a session whilst you’re giving feedback, to save you time</li>
             </ul>
-            <p>You also have the option to outline what you have planned for the next session.</p>
+            <p>You also have the ability to outline what you have planned for the next session.</p>
 
             <h3 class="govuk-heading-s">Give feedback on the changes</h2>
             <p>We’d like to know what you think. Please <a href="https://eu.surveymonkey.com/r/H6K5JG3">complete this short survey</a>.</p>


### PR DESCRIPTION
## What does this pull request do?

Adds the late reason to the table of details for a selected appointment.
Removes information from the what's new text that is no longer relevant.

## What is the intent behind these changes?

Issues brought up in qa.
