### PR TITLE
add old attendance failure information to view feedback page

### DIFF
--- a/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
+++ b/server/routes/shared/appointment/feedback/submittedFeedbackPresenter.ts
@@ -55,6 +55,12 @@ export default class SubmittedFeedbackPresenter {
         lines: [this.feedbackAnswersPresenter.additionalAttendanceAnswers.answer],
       })
     }
+    if (this.feedbackAnswersPresenter.attendanceFailureInformationAnswers) {
+      sessionAttendanceDetails.push({
+        key: this.feedbackAnswersPresenter.attendanceFailureInformationAnswers.question,
+        lines: [this.feedbackAnswersPresenter.attendanceFailureInformationAnswers.answer],
+      })
+    }
     return sessionAttendanceDetails
   }
 


### PR DESCRIPTION
## What does this pull request do?

add old attendance failure information to view feedback page

## What is the intent behind these changes?

add old attendance failure information to view feedback page
