### PR TITLE
Add option for sending case note emails to probation practitioners

### DIFF
--- a/integration_tests/integration/case-notes.cy.js
+++ b/integration_tests/integration/case-notes.cy.js
@@ -10,13 +10,13 @@ context('Case notes', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubLogin')
-    cy.task('stubServiceProviderToken')
-    cy.task('stubServiceProviderAuthUser')
   })
 
   describe('when viewing case notes for a referral', () => {
     describe('when there is a case note made by a PP', () => {
       it('should display "Probation Practitioner" as the user type', () => {
+        cy.task('stubServiceProviderToken')
+        cy.task('stubServiceProviderAuthUser')
         const sentReferral = sentReferralFactory.build()
         cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent([]).build())
         cy.stubGetPrisons(prisonFactory.build())
@@ -45,8 +45,10 @@ context('Case notes', () => {
       })
     })
 
-    describe('when there is a case note made by a PP', () => {
+    describe('when there is a case note made by a SP', () => {
       it('should display "Service Provider" as the user type', () => {
+        cy.task('stubServiceProviderToken')
+        cy.task('stubServiceProviderAuthUser')
         const sentReferral = sentReferralFactory.build()
         cy.stubGetSentReferralsForUserToken([])
         cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent([]).build())
@@ -73,6 +75,65 @@ context('Case notes', () => {
           .should(tableData => {
             expect(tableData[0].Details).to.contain('service provider')
           })
+      })
+    })
+  })
+
+  describe('when adding a case note for a referral', () => {
+    describe('as a PP', () => {
+      it('should not display the option to choose whether or not to send an email', () => {
+        cy.task('stubProbationPractitionerToken')
+        cy.task('stubProbationPractitionerAuthUser')
+
+        const sentReferral = sentReferralFactory.build()
+        cy.stubGetSentReferralsForUserToken([])
+        cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent([]).build())
+        cy.login()
+
+        const ppCaseNote = caseNoteFactory.build({
+          sentBy: {
+            username: 'BERNARD.BEAKS',
+            userId: 'userId',
+            authSource: 'auth',
+          },
+        })
+
+        cy.stubGetSentReferral(sentReferral.id, sentReferral)
+        cy.stubGetIntervention(sentReferral.referral.interventionId, interventionFactory.build())
+        cy.stubGetCaseDetailsByCrn(sentReferral.referral.serviceUser.crn, deliusServiceUserFactory.build())
+        cy.stubGetCaseNotes(sentReferral.id, pageFactory.build({ content: [ppCaseNote] }))
+        cy.visit(`/probation-practitioner/referrals/${sentReferral.id}/case-notes`)
+        cy.contains('Add case note').click()
+        cy.get('#send-case-note-email').should('not.exist')
+      })
+    })
+
+    describe('as an SP', () => {
+      it('should display the option to choose whether or not to send an email', () => {
+        cy.task('stubServiceProviderToken')
+        cy.task('stubServiceProviderAuthUser')
+
+        const sentReferral = sentReferralFactory.build()
+        cy.stubGetSentReferralsForUserToken([])
+        cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent([]).build())
+        cy.login()
+
+        const ppCaseNote = caseNoteFactory.build({
+          sentBy: {
+            username: 'BERNARD.BEAKS',
+            userId: 'userId',
+            authSource: 'auth',
+          },
+        })
+
+        cy.stubGetSentReferral(sentReferral.id, sentReferral)
+        cy.stubGetIntervention(sentReferral.referral.interventionId, interventionFactory.build())
+        cy.stubGetCaseDetailsByCrn(sentReferral.referral.serviceUser.crn, deliusServiceUserFactory.build())
+        cy.stubGetCaseNotes(sentReferral.id, pageFactory.build({ content: [ppCaseNote] }))
+        cy.visit(`/service-provider/referrals/${sentReferral.id}/case-notes`)
+        cy.contains('Add case note').click()
+        cy.contains('Would you like the probation practitioner to get an email about this case note?')
+        cy.get('#send-case-note-email').should('exist')
       })
     })
   })

--- a/integration_tests/integration/case-notes.cy.js
+++ b/integration_tests/integration/case-notes.cy.js
@@ -116,6 +116,8 @@ context('Case notes', () => {
         const sentReferral = sentReferralFactory.build()
         cy.stubGetSentReferralsForUserToken([])
         cy.stubGetSentReferralsForUserTokenPaged(pageFactory.pageContent([]).build())
+        cy.stubGetPrisons(prisonFactory.build())
+        cy.stubGetSecuredChildAgencies(secureChildrenAgenciesFactory.build())
         cy.login()
 
         const ppCaseNote = caseNoteFactory.build({

--- a/reference-data/whats-new-banner-sp.csv
+++ b/reference-data/whats-new-banner-sp.csv
@@ -1,3 +1,4 @@
 version, heading, text, link_text
 1, "Changes to making a referral", "We have improved the functionality of 3 types of referrals in Refer and monitor an intervention...", "Read more about the changes to these referrals"
 2, "Sharing better information about session delivery", "You can now give more information about the SAA and delivery sessions...", "Read more about changes to session feedback"
+3, "Helping to reduce emails to probation practitioners", "You can now add a case note without it sending an email to the probation practitioner.", "Read more about changes to case notes emails"

--- a/server/models/caseNote.ts
+++ b/server/models/caseNote.ts
@@ -7,5 +7,5 @@ export interface CaseNote {
   body: string
   sentBy: User
   sentAt: string
-  sendEmail: string
+  sendEmail: boolean
 }

--- a/server/models/caseNote.ts
+++ b/server/models/caseNote.ts
@@ -7,4 +7,5 @@ export interface CaseNote {
   body: string
   sentBy: User
   sentAt: string
+  sendEmail: string
 }

--- a/server/routes/caseNotes/add/AddNewCaseNoteForm.ts
+++ b/server/routes/caseNotes/add/AddNewCaseNoteForm.ts
@@ -7,16 +7,21 @@ import { FormData } from '../../../utils/forms/formData'
 import { CaseNote } from '../../../models/caseNote'
 
 export default class AddNewCaseNoteForm {
-  constructor(private readonly request: Request) {}
+  constructor(
+    private readonly request: Request,
+    private readonly loggedInUserType: 'service-provider' | 'probation-practitioner'
+  ) {}
 
   static readonly caseNoteSubjectFormId = 'case-note-subject'
 
   static readonly caseNoteBodyFormId = 'case-note-body'
 
+  static readonly sendCaseNoteEmailId = 'send-case-note-email'
+
   async data(referralId: string): Promise<FormData<Partial<CaseNote>>> {
     const validationResult = await FormUtils.runValidations({
       request: this.request,
-      validations: AddNewCaseNoteForm.validations,
+      validations: AddNewCaseNoteForm.validations(this.loggedInUserType),
     })
 
     const error = this.error(validationResult)
@@ -32,13 +37,14 @@ export default class AddNewCaseNoteForm {
         referralId,
         subject: this.request.body[AddNewCaseNoteForm.caseNoteSubjectFormId],
         body: this.request.body[AddNewCaseNoteForm.caseNoteBodyFormId],
+        sendEmail: this.request.body[AddNewCaseNoteForm.sendCaseNoteEmailId],
       },
       error: null,
     }
   }
 
-  static get validations(): ValidationChain[] {
-    return [
+  private static validations(loggedInUserType: string): ValidationChain[] {
+    const validationChain = [
       body(AddNewCaseNoteForm.caseNoteSubjectFormId)
         .notEmpty({ ignore_whitespace: true })
         .withMessage(errorMessages.caseNote.subject.empty),
@@ -46,6 +52,12 @@ export default class AddNewCaseNoteForm {
         .notEmpty({ ignore_whitespace: true })
         .withMessage(errorMessages.caseNote.body.empty),
     ]
+
+    const sendCaseNoteEmailValidation = body(AddNewCaseNoteForm.sendCaseNoteEmailId)
+      .notEmpty({ ignore_whitespace: true })
+      .withMessage(errorMessages.caseNote.sendCaseNoteEmail.empty)
+
+    return loggedInUserType === 'service-provider' ? [...validationChain, sendCaseNoteEmailValidation] : validationChain
   }
 
   get isValid(): boolean {

--- a/server/routes/caseNotes/add/addCaseNotePresenter.test.ts
+++ b/server/routes/caseNotes/add/addCaseNotePresenter.test.ts
@@ -27,17 +27,19 @@ describe('AddCaseNotePresenter', () => {
         expect(presenter.fields).toEqual({
           subject: { errorMessage: null, value: '' },
           body: { errorMessage: null, value: '' },
+          sendCaseNoteEmail: { errorMessage: null },
         })
       })
     })
 
     describe('when a case note draft has been provided', () => {
       it('should show case note values for case note fields', () => {
-        const caseNote = caseNoteFactory.build({ subject: 'subject', body: 'body' })
+        const caseNote = caseNoteFactory.build({ subject: 'subject', body: 'body', sendEmail: false })
         const presenter = new AddCaseNotePresenter(referralId, 'service-provider', caseNote)
         expect(presenter.fields).toEqual({
           subject: { errorMessage: null, value: 'subject' },
           body: { errorMessage: null, value: 'body' },
+          sendCaseNoteEmail: { errorMessage: null },
         })
       })
     })
@@ -52,12 +54,18 @@ describe('AddCaseNotePresenter', () => {
               message: 'subject error',
             },
             { formFields: ['case-note-body'], errorSummaryLinkedField: 'case-note-body', message: 'body error' },
+            {
+              formFields: ['send-case-note-email'],
+              errorSummaryLinkedField: 'send-case-note-email',
+              message: 'send case note email error',
+            },
           ],
         }
         const presenter = new AddCaseNotePresenter(referralId, 'service-provider', null, error)
         expect(presenter.fields).toEqual({
           subject: { errorMessage: 'subject error', value: '' },
           body: { errorMessage: 'body error', value: '' },
+          sendCaseNoteEmail: { errorMessage: 'send case note email error' },
         })
       })
     })

--- a/server/routes/caseNotes/add/addCaseNotePresenter.ts
+++ b/server/routes/caseNotes/add/addCaseNotePresenter.ts
@@ -31,5 +31,8 @@ export default class AddCaseNotePresenter {
       ),
       errorMessage: PresenterUtils.errorMessage(this.error, AddNewCaseNoteForm.caseNoteBodyFormId),
     },
+    sendCaseNoteEmail: {
+      errorMessage: PresenterUtils.errorMessage(this.error, AddNewCaseNoteForm.sendCaseNoteEmailId),
+    },
   }
 }

--- a/server/routes/caseNotes/add/addCaseNoteView.ts
+++ b/server/routes/caseNotes/add/addCaseNoteView.ts
@@ -46,6 +46,37 @@ export default class AddCaseNoteView {
     }
   }
 
+  private get sendEmailRadioButtonArgs(): Record<string, unknown> {
+    return {
+      classes: 'govuk-radios',
+      idPrefix: 'send-case-note-email',
+      name: 'send-case-note-email',
+      fieldset: {
+        legend: {
+          html: `<legend class=govuk-fieldset__legend--m> ${ViewUtils.escape(
+            'Would you like the probation practitioner to get an email about this case note?'
+          )}</legend><p class=govuk-hint>${ViewUtils.escape(
+            "If you select yes, they'll get an email with a link to this case note."
+          )}</p>`,
+          isPageHeading: false,
+        },
+      },
+      items: [
+        {
+          value: true,
+          text: 'Yes',
+          checked: false,
+        },
+        {
+          value: false,
+          text: 'No',
+          checked: true,
+        },
+      ],
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.sendCaseNoteEmail.errorMessage),
+    }
+  }
+
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'caseNotes/addNewCaseNote',
@@ -55,6 +86,7 @@ export default class AddCaseNoteView {
         subjectInputArgs: this.subjectInputArgs,
         bodyInputArgs: this.bodyInputArgs,
         detailsArgs: this.detailsArgs,
+        sendEmailRadioButtonArgs: this.sendEmailRadioButtonArgs,
       },
     ]
   }

--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.ts
@@ -32,6 +32,6 @@ export default class AddCaseNoteCheckAnswersPresenter {
     time: DateUtils.formattedTime(new Date()),
     from: this.loggedInUser.name,
     body: this.caseNote.body,
-    sendEmail: this.caseNote.sendEmail === 'true' ? 'Yes' : 'No',
+    sendEmail: this.caseNote.sendEmail ? 'Yes' : 'No',
   }
 }

--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.ts
@@ -8,6 +8,7 @@ interface CaseNotesSummary {
   time: string
   from: string
   body: string
+  sendEmail: string
 }
 
 export default class AddCaseNoteCheckAnswersPresenter {
@@ -19,6 +20,8 @@ export default class AddCaseNoteCheckAnswersPresenter {
     private caseNote: CaseNote
   ) {}
 
+  readonly caseNoteDetailsHeading = 'Case note details'
+
   backLinkHref = `/${this.loggedInUserType}/referrals/${this.referralId}/add-case-note/${this.draftId}/details`
 
   submitHref = `/${this.loggedInUserType}/referrals/${this.referralId}/add-case-note/${this.draftId}/submit`
@@ -29,5 +32,6 @@ export default class AddCaseNoteCheckAnswersPresenter {
     time: DateUtils.formattedTime(new Date()),
     from: this.loggedInUser.name,
     body: this.caseNote.body,
+    sendEmail: this.caseNote.sendEmail === 'true' ? 'Yes' : 'No',
   }
 }

--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersView.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersView.ts
@@ -11,14 +11,23 @@ export default class AddCaseNoteCheckAnswersView {
   }
 
   private get caseNoteSummaryListArgs(): SummaryListArgs {
-    return ViewUtils.summaryListArgs(
+    return ViewUtils.summaryListArgsWithSummaryCard(
       [
         { key: 'Subject', lines: [this.presenter.caseNoteSummary.subject] },
         { key: 'Date', lines: [this.presenter.caseNoteSummary.date] },
         { key: 'Time', lines: [this.presenter.caseNoteSummary.time] },
         { key: 'From', lines: [this.presenter.caseNoteSummary.from] },
+        {
+          key: 'Notes about the intervention or the person on probation',
+          lines: [this.presenter.caseNoteSummary.body],
+        },
+        {
+          key: 'Would you like the probation practitioner to get an email about this case note?',
+          lines: [this.presenter.caseNoteSummary.sendEmail],
+        },
       ],
-      { showBorders: false }
+      this.presenter.caseNoteDetailsHeading,
+      { showBorders: true, showTitle: true }
     )
   }
 
@@ -29,7 +38,6 @@ export default class AddCaseNoteCheckAnswersView {
         presenter: this.presenter,
         backLinkArgs: this.backLinkArgs,
         caseNoteSummaryListArgs: this.caseNoteSummaryListArgs,
-        caseNoteBody: this.presenter.caseNoteSummary.body,
       },
     ]
   }

--- a/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationPresenter.test.ts
+++ b/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationPresenter.test.ts
@@ -31,7 +31,7 @@ describe('AddCaseNotePresenter', () => {
         'service-provider'
       )
       expect(presenter.text.whatHappensNext).toEqual(
-        'The probation practitioner will now be able to view the case note.'
+        'The probation practitioner can now view this case note in the service.'
       )
     })
 
@@ -41,7 +41,7 @@ describe('AddCaseNotePresenter', () => {
         interventionFactory.build(),
         'probation-practitioner'
       )
-      expect(presenter.text.whatHappensNext).toEqual('The service provider will now be able to view the case note.')
+      expect(presenter.text.whatHappensNext).toEqual('The service provider can now view this case note in the service.')
     })
   })
 })

--- a/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationPresenter.ts
+++ b/server/routes/caseNotes/add/confirmation/addCaseNoteConfirmationPresenter.ts
@@ -14,7 +14,7 @@ export default class AddCaseNoteConfirmationPresenter {
   caseNotesHref = `/${this.loggedInUserType}/referrals/${this.referral.id}/case-notes`
 
   text = {
-    whatHappensNext: `The ${this.targetUserType} will now be able to view the case note.`,
+    whatHappensNext: `The ${this.targetUserType} can now view this case note in the service.`,
   }
 
   readonly serviceUserSummary: SummaryListItem[] = [

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -232,7 +232,7 @@ describe.each([
         await request(app)
           .post(`/${user.userType}/referrals/${sentReferral.id}/add-case-note/${draftCaseNote.id}/details`)
           .type('form')
-          .send({ 'case-note-subject': 'subject', 'case-note-body': 'body' })
+          .send({ 'case-note-subject': 'subject', 'case-note-body': 'body', 'send-case-note-email': false })
           .expect(302)
           .expect(
             'Location',

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -110,7 +110,7 @@ export default class CaseNotesController {
     let error: FormValidationError | null = null
     let userInputData: Record<string, string> | null = null
     if (req.method === 'POST') {
-      const data = await new AddNewCaseNoteForm(req).data(referralId)
+      const data = await new AddNewCaseNoteForm(req, loggedInUserType).data(referralId)
       if (!data.error) {
         try {
           await this.draftsService.updateDraft(draftCaseNote.id, data.paramsForUpdate, {

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -308,6 +308,9 @@ export default {
     body: {
       empty: 'Enter some details about your case note',
     },
+    sendCaseNoteEmail: {
+      empty: 'Select yes if you want the probation practitioner to get an email about this case note',
+    },
   },
   oasysRiskInformation: {
     edit: {

--- a/server/views/caseNotes/addNewCaseNote.njk
+++ b/server/views/caseNotes/addNewCaseNote.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -26,6 +27,9 @@
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {{ govukInput(subjectInputArgs) }}
         {{ govukTextarea(bodyInputArgs) }}
+        {% if presenter.loggedInUserType == 'service-provider' %}
+            {{ govukRadios(sendEmailRadioButtonArgs) }}
+        {% endif %}
         {{ govukButton({ text: "Continue" , preventDoubleClick: true}) }}
       </form>
     </div>

--- a/server/views/caseNotes/addNewCaseNoteConfirmation.njk
+++ b/server/views/caseNotes/addNewCaseNoteConfirmation.njk
@@ -13,11 +13,13 @@
 
       {{ govukSummaryList(summaryListArgs) }}
 
+      <h2 class="govuk-heading-m">What happens next</h2>
+
       <p class="govuk-body">
         {{ presenter.text.whatHappensNext }}
       </p>
 
-      <a href="{{ presenter.caseNotesHref }}" class="govuk-button">Return to intervention</a>
+      <a href="{{ presenter.caseNotesHref }}" class="govuk-link govuk-body">Return to intervention</a>
     </div>
   </div>
 {% endblock %}

--- a/server/views/caseNotes/checkAnswers.njk
+++ b/server/views/caseNotes/checkAnswers.njk
@@ -10,9 +10,6 @@
     {{ govukBackLink(backLinkArgs) }}
     <h1 class="govuk-heading-l">Review case note</h1>
     {{ govukSummaryList(caseNoteSummaryListArgs) }}
-    <p class="govuk-body">
-        {{ caseNoteBody | escape | nl2br }}
-    </p>
 
     <form method="post" action="{{ presenter.submitHref }}">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">

--- a/server/views/probationPractitionerReferrals/whatsNew.njk
+++ b/server/views/probationPractitionerReferrals/whatsNew.njk
@@ -11,6 +11,13 @@
       <h1 class="govuk-heading-l">What's new</h1>
       <p>Find out about recent changes to Refer and monitor an intervention.</p>
 
+    {% set whatsNewVersion4Html %}
+        <p>When service providers create a case note on Refer and monitor an intervention, they’re now asked if you need an email about it.</p>
+
+        <h3 class="govuk-heading-s">Why we’ve made the change</h2>
+        <p>This is in response to your feedback. It’s so that you’re only emailed about things which are important or urgent. Please <a href="https://eu.surveymonkey.com/r/H6K5JG3">share your feedback in this survey</a>.</p>
+    {% endset %}
+
     {% set whatsNewVersion3Html %}
         <h3 class="govuk-heading-s">New functionality</h3>
         <p>
@@ -72,6 +79,16 @@
 
       {{ mojTimeline({
         items: [
+          {
+            label: {
+                text: "Helping to reduce your emails"
+            },
+            html: whatsNewVersion4Html,
+            datetime: {
+              timestamp: "2023-12-07",
+              type: "date"
+            }
+          },
           {
             label: {
               text: "Get better information about sessions"

--- a/server/views/probationPractitionerReferrals/whatsNew.njk
+++ b/server/views/probationPractitionerReferrals/whatsNew.njk
@@ -85,7 +85,7 @@
             },
             html: whatsNewVersion4Html,
             datetime: {
-              timestamp: "2023-12-07",
+              timestamp: "2023-02-27",
               type: "date"
             }
           },

--- a/server/views/serviceProviderReferrals/whatsNew.njk
+++ b/server/views/serviceProviderReferrals/whatsNew.njk
@@ -69,7 +69,7 @@
                       },
                       html: whatsNewVersion3Html,
                       datetime: {
-                        timestamp: "2023-12-07",
+                        timestamp: "2024-02-27",
                         type: "date"
                       }
                     },
@@ -79,7 +79,7 @@
                       },
                       html: whatsNewVersion2Html,
                       datetime: {
-                        timestamp: "2023-12-14",
+                        timestamp: "2024-01-04",
                         type: "date"
                       }
                     },

--- a/server/views/serviceProviderReferrals/whatsNew.njk
+++ b/server/views/serviceProviderReferrals/whatsNew.njk
@@ -11,6 +11,15 @@
       <h1 class="govuk-heading-l">What's new</h1>
       <p>Find out about recent changes to Refer and monitor an intervention.</p>
 
+      {% set whatsNewVersion3Html %}
+        <p>When you create a case note you now need to choose whether the probation practitioner needs an email with a link to it. They’re still able to read all case notes in the service. </p>
+        <p>This is to help reduce the amount of case note emails we send to probation practitioners.</p>
+        <p>You may choose not to send an email about case notes of email threads, or session reminders you’ve sent to people on probation. This is to help probation practitioners identify what’s important or urgent.</p>
+
+        <h3 class="govuk-heading-s">Why we’ve made the change</h2>
+        <p>This is in response to your feedback. It’s so that you’re only emailed about things which are important or urgent. Please <a href="https://eu.surveymonkey.com/r/H6K5JG3">share your feedback in this survey</a>.</p>
+      {% endset %}
+
         {% set whatsNewVersion2Html %}
             <h3 class="govuk-heading-s">New functionality</h3>
             <p>
@@ -54,6 +63,16 @@
 
           {{ mojTimeline({
                   items: [
+                    {
+                      label: {
+                        text: "Helping to reduce emails to probation practitioners"
+                      },
+                      html: whatsNewVersion3Html,
+                      datetime: {
+                        timestamp: "2023-12-07",
+                        type: "date"
+                      }
+                    },
                     {
                       label: {
                         text: "Sharing better information about session delivery"

--- a/testutils/factories/caseNote.ts
+++ b/testutils/factories/caseNote.ts
@@ -13,4 +13,5 @@ export default Factory.define<CaseNote>(({ sequence }) => ({
     authSource: 'delius',
   },
   sentAt: '2021-01-01T09:45:21.986389Z',
+  sendEmail: false,
 }))


### PR DESCRIPTION
## What does this pull request do?

Adds a radio button to select whether or not to send an email to the probation practitioner when adding a case note.

## What is the intent behind these changes?

To avoid probation practitioners from getting too many emails.
