### PR TITLE
Revert "Enable service outage banner for Auth outage 29th Feb"

### DIFF
--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -37,7 +37,7 @@ export default class DashboardView {
 
   get serviceOutageBannerArgs(): NotificationBannerArgs | null {
     const text =
-      'Refer and monitor an intervention will not be available for 30 minutes on Thursday 29 February 2024 from 6:30am to 7.00am'
+      'Refer and monitor an intervention will not be available this weekend. This is from 10am Saturday 28 October to midday Sunday 29 October 2023.'
 
     const html = `<p class="govuk-notification-banner__heading">${text}</p>
                   <p><a class="govuk-notification-banner__link" href= ${this.presenter.closeHref}>Close</a></p>`

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -56,7 +56,7 @@ export default class DashboardView {
 
   get serviceOutageBannerArgs(): NotificationBannerArgs {
     const text =
-      'Refer and monitor an intervention will not be available for 30 minutes on Thursday 29 February 2024 from 6:30am to 7.00am'
+      'Refer and monitor an intervention will not be available this weekend. This is from 10am Saturday 28 October to midday Sunday 29 October 2023.'
 
     const html = `<p class="govuk-notification-banner__heading">${text}</p>
                   <p><a class="govuk-notification-banner__link" href= ${this.presenter.closeHref}>Close</a></p>`

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -13,9 +13,6 @@
 {% endblock %}
 
 {% block pageContent %}
-{% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-{% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,9 +12,6 @@
 {% endblock %}
 
 {% block pageContent %}
-{% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-{% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>


### PR DESCRIPTION
This reverts commit 43d1f6c3e7cc878fa96c33969ba480180ecb0c5d. This reverts commit 948edf3122ccbaead1072805c26bfd1acd59dbfe.

## What does this pull request do?

- remove downtime banner created by hmpps auth outage

## What is the intent behind these changes?

- remove downtime banner created by hmpps auth outage
