### PR TITLE
Fix notify PP of concerns for draft feedback when session didn't happen

### DIFF
--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -1386,10 +1386,10 @@ export default class AppointmentsController {
       }
       if (attended === 'no') {
         draftAppointment.session.sessionFeedback.noAttendanceInformation = paramsForUpdate.noAttendanceInformation!
-        draftAppointment.session.sessionFeedback.notifyProbationPractitioner =
-          paramsForUpdate.notifyProbationPractitioner!
+        draftAppointment.session.sessionFeedback.notifyProbationPractitionerOfConcerns =
+          paramsForUpdate.notifyProbationPractitionerOfConcerns!
         draftAppointment.session.sessionFeedback.sessionConcerns =
-          paramsForUpdate.notifyProbationPractitioner === true ? paramsForUpdate.sessionConcerns! : null
+          paramsForUpdate.notifyProbationPractitionerOfConcerns === true ? paramsForUpdate.sessionConcerns! : null
       }
     } else {
       throw new Error('Draft appointment data is missing.')


### PR DESCRIPTION

## What does this pull request do?

Correctly updates DraftAppointment object with notifyProbationPractitionerOfConcerns  when session didn't happen

## What is the intent behind these changes?

Notifies PP of concerns via email as expected when session concerns is selected
