### PR TITLE
Fix case note email answer

### DIFF
--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.test.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.test.ts
@@ -47,11 +47,33 @@ describe('AddCaseNoteCheckAnswersPresenter', () => {
         draftId,
         'service-provider',
         userDetailsFactory.build({ name: 'firstName lastName' }),
-        caseNoteFactory.build({ subject: 'subject', body: 'body' })
+        caseNoteFactory.build({ subject: 'subject', body: 'body', sendEmail: true })
       )
       expect(presenter.caseNoteSummary.body).toEqual('body')
       expect(presenter.caseNoteSummary.subject).toEqual('subject')
       expect(presenter.caseNoteSummary.from).toEqual('firstName lastName')
+    })
+
+    it('Case note with sendEmail set to true should evaluate to Yes', () => {
+      const presenter = new AddCaseNoteCheckAnswersPresenter(
+        referralId,
+        draftId,
+        'service-provider',
+        userDetailsFactory.build({ name: 'firstName lastName' }),
+        caseNoteFactory.build({ sendEmail: true })
+      )
+      expect(presenter.caseNoteSummary.sendEmail).toEqual('Yes')
+    })
+
+    it('Case note with sendEmail set to false should evaluate to No', () => {
+      const presenter = new AddCaseNoteCheckAnswersPresenter(
+        referralId,
+        draftId,
+        'service-provider',
+        userDetailsFactory.build({ name: 'firstName lastName' }),
+        caseNoteFactory.build({ sendEmail: false })
+      )
+      expect(presenter.caseNoteSummary.sendEmail).toEqual('No')
     })
   })
 })

--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersPresenter.ts
@@ -32,6 +32,6 @@ export default class AddCaseNoteCheckAnswersPresenter {
     time: DateUtils.formattedTime(new Date()),
     from: this.loggedInUser.name,
     body: this.caseNote.body,
-    sendEmail: this.caseNote.sendEmail ? 'Yes' : 'No',
+    sendEmail: String(this.caseNote.sendEmail) === 'true' ? 'Yes' : 'No',
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Fixes an issue where the case note answer for whether or not to send an email doesn't match what was actually selected.

## What is the intent behind these changes?

Fixes an issue where the case note answer for whether or not to send an email doesn't match what was actually selected.
