### PR TITLE
redirecting correctly when changing the reason for referral

### DIFF
--- a/integration_tests/integration/referral.cy.js
+++ b/integration_tests/integration/referral.cy.js
@@ -651,7 +651,7 @@ describe('Referral form', () => {
         .should('contain', 'Some information about Alex')
         .next()
         .contains('Change')
-        .should('have.attr', 'href', `/referrals/${draftReferral.id}/reason-for-referral`)
+        .should('have.attr', 'href', `/referrals/${draftReferral.id}/reason-for-referral?amendPPDetails=true`)
 
       // Accommodation referral details
       cy.contains('Accommodation referral details')

--- a/integration_tests/integration/referralUnAllocatedCom.cy.js
+++ b/integration_tests/integration/referralUnAllocatedCom.cy.js
@@ -643,7 +643,7 @@ describe('Referral form', () => {
         .should('contain', 'Some information about Alex')
         .next()
         .contains('Change')
-        .should('have.attr', 'href', `/referrals/${draftReferral.id}/reason-for-referral`)
+        .should('have.attr', 'href', `/referrals/${draftReferral.id}/reason-for-referral?amendPPDetails=true`)
 
       // Accommodation referral details
       cy.contains('Accommodation referral details')
@@ -1224,7 +1224,7 @@ describe('Referral form', () => {
         .should('contain', 'Some information about Alex')
         .next()
         .contains('Change')
-        .should('have.attr', 'href', `/referrals/${draftReferral.id}/reason-for-referral`)
+        .should('have.attr', 'href', `/referrals/${draftReferral.id}/reason-for-referral?amendPPDetails=true`)
 
       // Accommodation referral details
       cy.contains('Accommodation referral details')

--- a/integration_tests/integration/updatePPDetails.cy.js
+++ b/integration_tests/integration/updatePPDetails.cy.js
@@ -802,7 +802,7 @@ describe('Referral form', () => {
         .should('contain', 'Some reason')
         .next()
         .contains('Change')
-        .should('have.attr', 'href', `/referrals/${draftReferral.id}/reason-for-referral`)
+        .should('have.attr', 'href', `/referrals/${draftReferral.id}/reason-for-referral?amendPPDetails=true`)
 
       // Accommodation referral details
       cy.contains('Accommodation referral details')

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
@@ -791,7 +791,7 @@ describe(CheckAllReferralInformationPresenter, () => {
           {
             key: 'Further information for the service provider',
             lines: ['Some reason'],
-            changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/reason-for-referral',
+            changeLink: '/referrals/03e9e6cd-a45f-4dfc-adad-06301349042e/reason-for-referral?amendPPDetails=true',
           },
         ],
       })

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
@@ -443,7 +443,7 @@ export default class CheckAllReferralInformationPresenter {
         {
           key: 'Further information for the service provider',
           lines: [determineFurtherInformation(this.referral)],
-          changeLink: `/referrals/${this.referral.id}/reason-for-referral`,
+          changeLink: `/referrals/${this.referral.id}/reason-for-referral?amendPPDetails=true`,
         },
       ],
     }

--- a/server/routes/makeAReferral/makeAReferralController.ts
+++ b/server/routes/makeAReferral/makeAReferralController.ts
@@ -106,12 +106,6 @@ import UpdateProbationPractitionerTeamPhoneNumberForm from './update/probation-p
 import ReasonForReferralPresenter from './reason-for-referral/reasonForReferralPresenter'
 import ReasonForReferralView from './reason-for-referral/reasonForReferralView'
 import ReasonForReferralForm from './reason-for-referral/reasonForReferralForm'
-// import DeleteProbationPractitionerPhoneNumberPresenter from './delete/probation-practioner-phone-number/deleteProbationPractitionerPhoneNumberPresenter'
-// import DeleteProbationPractitionerPhoneNumberView from './delete/probation-practioner-phone-number/deleteProbationPractitionerPhoneNumberView'
-// import DeleteProbationPractitionerPhoneNumberForm from './delete/probation-practioner-phone-number/deleteProbationPractitionerPhoneNumberForm'
-// import DeleteProbationPractitionerView from './delete/probation-practitioner-email/deleteProbationPractitionerView'
-// import DeleteProbationPractitionerPresenter from './delete/probation-practitioner-email/deleteProbationPractitionerPresenter'
-// import DeleteProbationPractitionerForm from './delete/probation-practitioner-email/deleteProbationPractitionerForm'
 
 export default class MakeAReferralController {
   constructor(
@@ -1431,7 +1425,10 @@ export default class MakeAReferralController {
 
     const serviceUser = await this.ramDeliusApiService.getCaseDetailsByCrn(referral.serviceUser.crn)
 
-    const presenter = new ReasonForReferralPresenter(referral)
+    const amendPPDetails = req.query.amendPPDetails === 'true'
+    const amendReferralDetails = req.query.amendRefDetails === 'true'
+
+    const presenter = new ReasonForReferralPresenter(referral, amendPPDetails, amendReferralDetails)
     const view = new ReasonForReferralView(presenter)
 
     await ControllerUtils.renderWithLayout(req, res, view, serviceUser, 'probation-practitioner')
@@ -1458,12 +1455,19 @@ export default class MakeAReferralController {
       error = form.error
     }
 
-    if (error === null) {
+    const amendPPDetails = req.query.amendPPDetails === 'true'
+    const amendReferralDetails = req.query.amendRefDetails === 'true'
+
+    if (error === null && amendPPDetails) {
+      res.redirect(`/referrals/${req.params.id}/check-all-referral-information`)
+    } else if (error === null && amendReferralDetails) {
+      res.redirect(`/probation-practitioner/referrals/${req.params.id}/details`)
+    } else if (error === null) {
       res.redirect(`/referrals/${req.params.id}/form`)
     } else {
       const serviceUser = await this.ramDeliusApiService.getCaseDetailsByCrn(referral.serviceUser.crn)
 
-      const presenter = new ReasonForReferralPresenter(referral, error)
+      const presenter = new ReasonForReferralPresenter(referral, amendPPDetails, amendReferralDetails, error)
       const view = new ReasonForReferralView(presenter)
 
       res.status(400)

--- a/server/routes/makeAReferral/reason-for-referral/reasonForReferralPresenter.test.ts
+++ b/server/routes/makeAReferral/reason-for-referral/reasonForReferralPresenter.test.ts
@@ -38,7 +38,7 @@ describe('ReasonForReferralPresenter', () => {
 
     describe('when an error is passed in', () => {
       it('returns an error message', () => {
-        const presenter = new ReasonForReferralPresenter(referral, {
+        const presenter = new ReasonForReferralPresenter(referral, false, false, {
           errors: [
             {
               formFields: ['reason-for-referral'],
@@ -64,7 +64,7 @@ describe('ReasonForReferralPresenter', () => {
 
     describe('when an error is passed in', () => {
       it('returns error information', () => {
-        const presenter = new ReasonForReferralPresenter(referral, {
+        const presenter = new ReasonForReferralPresenter(referral, false, false, {
           errors: [
             {
               formFields: ['reason-for-referral'],
@@ -110,11 +110,27 @@ describe('ReasonForReferralPresenter', () => {
 
       describe('when there is a user input data then the already set ndelius pp name is changed', () => {
         it('uses that value as the field value', () => {
-          const presenter = new ReasonForReferralPresenter(referral, null, {
+          const presenter = new ReasonForReferralPresenter(referral, false, false, null, {
             'reason-for-referral': 'To allocating the referral through CRS',
           })
 
           expect(presenter.fields.reasonForReferral).toEqual('To allocating the referral through CRS')
+        })
+      })
+      describe('when the reason for referral is called from check all referral information page', () => {
+        it('uses that value as the field value', () => {
+          const presenter = new ReasonForReferralPresenter(referral, true, false, null, {
+            'reason-for-referral': 'To allocating the referral through CRS',
+          })
+          expect(presenter.backLinkUrl).toEqual(`/referrals/${referral.id}/check-all-referral-information`)
+        })
+      })
+      describe('when the reason for referral is called from referral details page', () => {
+        it('uses that value as the field value', () => {
+          const presenter = new ReasonForReferralPresenter(referral, false, true, null, {
+            'reason-for-referral': 'To allocating the referral through CRS',
+          })
+          expect(presenter.backLinkUrl).toEqual(`/probation-practitioner/referrals/${referral.id}/details`)
         })
       })
     })

--- a/server/routes/makeAReferral/reason-for-referral/reasonForReferralPresenter.ts
+++ b/server/routes/makeAReferral/reason-for-referral/reasonForReferralPresenter.ts
@@ -7,10 +7,12 @@ export default class ReasonForReferralPresenter {
 
   constructor(
     readonly referral: DraftReferral,
+    private readonly amendPPDetails: boolean = false,
+    private readonly amendReferralDetails: boolean = false,
     private readonly error: FormValidationError | null = null,
     private readonly userInputData: Record<string, unknown> | null = null
   ) {
-    this.backLinkUrl = `/referrals/${referral.id}/form`
+    this.backLinkUrl = this.determinBackUpLink
   }
 
   readonly text = {
@@ -28,5 +30,15 @@ export default class ReasonForReferralPresenter {
 
   readonly fields = {
     reasonForReferral: this.utils.stringValue(this.referral.reasonForReferral, 'reason-for-referral'),
+  }
+
+  private get determinBackUpLink(): string {
+    if (this.amendPPDetails) {
+      return `/referrals/${this.referral.id}/check-all-referral-information`
+    }
+    if (this.amendReferralDetails) {
+      return `/probation-practitioner/referrals/${this.referral.id}/details`
+    }
+    return `/referrals/${this.referral.id}/form`
   }
 }

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -1379,7 +1379,7 @@ describe(ShowReferralPresenter, () => {
           {
             key: 'Reason for the referral and further information for the service provider',
             lines: ['For crs'],
-            changeLink: `/referrals/${referral.id}/reason-for-referral`,
+            changeLink: `/referrals/${referral.id}/reason-for-referral?amendRefDetails=true`,
           },
           expect.objectContaining({
             key: 'Complexity level',
@@ -1420,7 +1420,7 @@ describe(ShowReferralPresenter, () => {
           {
             key: 'Reason for the referral and further information for the service provider',
             lines: ['For crs'],
-            changeLink: `/referrals/${referral.id}/reason-for-referral`,
+            changeLink: `/referrals/${referral.id}/reason-for-referral?amendRefDetails=true`,
           },
           expect.objectContaining({
             key: 'Complexity level',
@@ -1504,7 +1504,7 @@ describe(ShowReferralPresenter, () => {
           {
             key: 'Reason for the referral and further information for the service provider',
             lines: ['For crs'],
-            changeLink: `/referrals/${referral.id}/reason-for-referral`,
+            changeLink: `/referrals/${referral.id}/reason-for-referral?amendRefDetails=true`,
           },
           {
             key: 'Complexity level',
@@ -1549,7 +1549,7 @@ describe(ShowReferralPresenter, () => {
           {
             key: 'Reason for the referral and further information for the service provider',
             lines: ['For crs'],
-            changeLink: `/referrals/${referral.id}/reason-for-referral`,
+            changeLink: `/referrals/${referral.id}/reason-for-referral?amendRefDetails=true`,
           },
           {
             key: 'Complexity level',

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -365,7 +365,7 @@ export default class ShowReferralPresenter {
       lines: [this.sentReferral.referral.reasonForReferral || this.sentReferral.referral.furtherInformation || 'N/A'],
       changeLink:
         this.userType === 'probation-practitioner'
-          ? `/referrals/${this.sentReferral.id}/reason-for-referral`
+          ? `/referrals/${this.sentReferral.id}/reason-for-referral?amendRefDetails=true`
           : undefined,
     })
     const complexityLevel = this.getReferralComplexityLevelForServiceCategory(serviceCategory)


### PR DESCRIPTION
## What does this pull request do?

- fixing the issue of accessing reason for referral when change link
- The change link is present in check all referral information page and referral details page

## What is the intent behind these changes?

- a bug was reported that changing the reason for referral is not redirecting to the right page
