### PR TITLE
fixing pact test for has already know prison name

### DIFF
--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1552,7 +1552,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       maximumEnforceableDays: 10,
       personCurrentLocationType: CurrentLocationType.custody,
       personCustodyPrisonId: 'aaa',
-      alreadyKnowPrisonName: false,
+      alreadyKnowPrisonName: null,
       expectedReleaseDate: moment().add(1, 'days').format('YYYY-MM-DD'),
       expectedReleaseDateMissingReason: null,
       hasExpectedReleaseDate: null,


### PR DESCRIPTION
## What does this pull request do?

- fixing the pact test after introducing `alreadyKnowPrisonName`

## What is the intent behind these changes?

- fixing the pact test after introducing `alreadyKnowPrisonName`
