### PR TITLE
Display full month of expected release date

### DIFF
--- a/server/routes/makeAReferral/expected-release-date/select-expected-release-date/selectExpectedReleaseDatePresenter.test.ts
+++ b/server/routes/makeAReferral/expected-release-date/select-expected-release-date/selectExpectedReleaseDatePresenter.test.ts
@@ -56,7 +56,7 @@ describe('SelectExpectedReleaseDatePresenter', () => {
         const presenter = new SelectExpectedReleaseDatePresenter(referral, false, releaseDate)
 
         expect(presenter.fields.hasMatchingReleaseDate).toBe(null)
-        expect(presenter.fields.releaseDate).toBe('1 Jan 2025 (Wednesday)')
+        expect(presenter.fields.releaseDate).toBe('1 January 2025 (Wednesday)')
       })
     })
 
@@ -69,7 +69,7 @@ describe('SelectExpectedReleaseDatePresenter', () => {
         const presenter = new SelectExpectedReleaseDatePresenter(referral, false, releaseDate)
 
         expect(presenter.fields.hasMatchingReleaseDate).toBe(false)
-        expect(presenter.fields.releaseDate).toBe('1 Jan 2025 (Wednesday)')
+        expect(presenter.fields.releaseDate).toBe('1 January 2025 (Wednesday)')
       })
     })
   })

--- a/server/routes/makeAReferral/expected-release-date/select-expected-release-date/selectExpectedReleaseDatePresenter.ts
+++ b/server/routes/makeAReferral/expected-release-date/select-expected-release-date/selectExpectedReleaseDatePresenter.ts
@@ -47,7 +47,7 @@ export default class SelectExpectedReleaseDatePresenter {
       errorMessage: this.errorMessageForField('expected-release-date'),
     },
     hasMatchingReleaseDate: this.matchesExpectedReleaseDate(),
-    releaseDate: moment(this.releaseDate).format('D MMM YYYY [(]dddd[)]'),
+    releaseDate: moment(this.releaseDate).format('D MMMM YYYY [(]dddd[)]'),
   }
 
   matchesExpectedReleaseDate(): boolean | null {


### PR DESCRIPTION
## What does this pull request do?

Updates expected release date format on the expected release date page.

## What is the intent behind these changes?

To display the month of the expected release date in full.
