### PR TITLE
do not show deactivated users name

### DIFF
--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -1357,7 +1357,7 @@ export default class AppointmentsController {
       const interventionsServiceError = e as InterventionsServiceError
       if (interventionsServiceError.status === 404) {
         logger.warn(`Auth user details not found for user ${username}".`)
-        return username
+        return 'Deactivated R&M account'
       }
       throw e
     }

--- a/server/routes/caseNotes/caseNotesController.test.ts
+++ b/server/routes/caseNotes/caseNotesController.test.ts
@@ -1,5 +1,6 @@
 import { Express } from 'express'
 import request from 'supertest'
+import createError from 'http-errors'
 import appWithAllRoutes, { AppSetupUserType } from '../testutils/appSetup'
 import InterventionsService from '../../services/interventionsService'
 import apiConfig from '../../config'
@@ -107,15 +108,13 @@ describe.each([
         interventionsService.getSentReferral.mockResolvedValue(sentReferral)
         interventionsService.getCaseNotes.mockResolvedValue(caseNotePage)
         interventionsService.getIntervention.mockResolvedValue(interventionFactory.build())
-        hmppsAuthService.getUserDetailsByUsername.mockImplementation(() => {
-          return Promise.reject()
-        })
+        hmppsAuthService.getUserDetailsByUsername.mockRejectedValue(createError(404))
         ramDeliusApiService.getCaseDetailsByCrn.mockResolvedValue(deliusServiceUserFactory.build())
         await request(app)
           .get(`/${user.userType}/referrals/${sentReferral.id}/case-notes`)
           .expect(200)
           .expect(res => {
-            expect(res.text).toContain('username')
+            expect(res.text).toContain('Deactivated R&M account')
           })
       })
     })

--- a/server/routes/caseNotes/caseNotesController.ts
+++ b/server/routes/caseNotes/caseNotesController.ts
@@ -60,6 +60,8 @@ export default class CaseNotesController {
                 return { username, fullName: userDetail.name }
               })
               .catch(error => {
+                const interventionsServiceError = error as InterventionsServiceError
+                if (interventionsServiceError.status === 404) return { username, fullName: 'Deactivated R&M account' }
                 return { username, fullName: undefined }
               })
           })


### PR DESCRIPTION
## What does this pull request do?

- Do not show the deactivated users
- show as `Deactived R&M account`

## What is the intent behind these changes?

- Due to GDPR issue, we should not show deactivated user name
