### PR TITLE
remove the email opt in summary for PP

### DIFF
--- a/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersView.ts
+++ b/server/routes/caseNotes/add/checkAnswers/addCaseNoteCheckAnswersView.ts
@@ -1,4 +1,5 @@
 import { SummaryListArgs } from '../../../../utils/govukFrontendTypes'
+import { SummaryListItem } from '../../../../utils/summaryList'
 import ViewUtils from '../../../../utils/viewUtils'
 import AddCaseNoteCheckAnswersPresenter from './addCaseNoteCheckAnswersPresenter'
 
@@ -11,24 +12,29 @@ export default class AddCaseNoteCheckAnswersView {
   }
 
   private get caseNoteSummaryListArgs(): SummaryListArgs {
-    return ViewUtils.summaryListArgsWithSummaryCard(
-      [
-        { key: 'Subject', lines: [this.presenter.caseNoteSummary.subject] },
-        { key: 'Date', lines: [this.presenter.caseNoteSummary.date] },
-        { key: 'Time', lines: [this.presenter.caseNoteSummary.time] },
-        { key: 'From', lines: [this.presenter.caseNoteSummary.from] },
-        {
-          key: 'Notes about the intervention or the person on probation',
-          lines: [this.presenter.caseNoteSummary.body],
-        },
-        {
-          key: 'Would you like the probation practitioner to get an email about this case note?',
-          lines: [this.presenter.caseNoteSummary.sendEmail],
-        },
-      ],
-      this.presenter.caseNoteDetailsHeading,
-      { showBorders: true, showTitle: true }
+    const caseNotesSummaryListItem: SummaryListItem[] = []
+
+    caseNotesSummaryListItem.push(
+      { key: 'Subject', lines: [this.presenter.caseNoteSummary.subject] },
+      { key: 'Date', lines: [this.presenter.caseNoteSummary.date] },
+      { key: 'Time', lines: [this.presenter.caseNoteSummary.time] },
+      { key: 'From', lines: [this.presenter.caseNoteSummary.from] },
+      {
+        key: 'Notes about the intervention or the person on probation',
+        lines: [this.presenter.caseNoteSummary.body],
+      }
     )
+    if (this.presenter.loggedInUserType === 'service-provider') {
+      caseNotesSummaryListItem.push({
+        key: 'Would you like the probation practitioner to get an email about this case note?',
+        lines: [this.presenter.caseNoteSummary.sendEmail],
+      })
+    }
+
+    return ViewUtils.summaryListArgsWithSummaryCard(caseNotesSummaryListItem, this.presenter.caseNoteDetailsHeading, {
+      showBorders: true,
+      showTitle: true,
+    })
   }
 
   get renderArgs(): [string, Record<string, unknown>] {


### PR DESCRIPTION
## What does this pull request do?

- hide email opt in summary in case notes for PP

## What is the intent behind these changes?

- That message is intended for PP, so we don't need to show it in case notes summary created by PP
