### PR TITLE
changing the response when deactivated user

### DIFF
--- a/server/services/hmppsAuthService.test.ts
+++ b/server/services/hmppsAuthService.test.ts
@@ -219,25 +219,13 @@ describe('hmppsAuthService', () => {
     })
 
     it('should return stub user if not required and response is 404', async () => {
-      const response = {
-        userId: undefined,
-        username: 'Deactivated R&M account',
-        email: 'Deactivated R&M account',
-        firstName: undefined,
-        lastName: undefined,
-        locked: undefined,
-        enabled: undefined,
-        verified: undefined,
-        lastLoggedIn: undefined,
-      }
-
       fakeManagerUsersApi
         .get('/externalusers/MISSING')
         .matchHeader('authorization', `Bearer ${token.access_token}`)
         .reply(404, {})
 
       const output = await hmppsAuthService.getSPUserByUsername(token.access_token, 'MISSING')
-      expect(output).toEqual(response)
+      expect(output).toEqual('Deactivated R&M account')
     })
 
     it('raises an error if not required but response is non-404 4xx', async () => {

--- a/server/services/hmppsAuthService.ts
+++ b/server/services/hmppsAuthService.ts
@@ -104,7 +104,7 @@ export default class HmppsAuthService {
       .get({ path: `/externalusers/${username}` })
       .catch(error => {
         if (error.status !== 404) throw error
-        else return { username: 'Deactivated R&M account', email: 'Deactivated R&M account' }
+        else return 'Deactivated R&M account'
       })) as AuthUserDetails
   }
 


### PR DESCRIPTION
## What does this pull request do?

- when the user is deactivated, just show the name

## What is the intent behind these changes?

- when the user is deactivated, just show the name
