### PR TITLE
show expected probation office or pdu

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.cy.js
+++ b/integration_tests/integration/probationPractitionerReferrals.cy.js
@@ -479,7 +479,7 @@ describe('Probation practitioner referrals dashboard', () => {
       .children()
       .last()
       .children()
-      .should('contain', 'Location at time of referral')
+      .should('contain', 'Prison establishment')
       .should('contain', 'Expected release date')
       .should('contain', moment().add(1, 'days').format('D MMM YYYY'))
 

--- a/integration_tests/integration/serviceProviderReferrals.cy.js
+++ b/integration_tests/integration/serviceProviderReferrals.cy.js
@@ -268,7 +268,7 @@ describe('Service provider referrals dashboard', () => {
       .children()
       .last()
       .children()
-      .should('contain', 'Location at time of referral')
+      .should('contain', 'Prison establishment')
       .should('contain', 'Expected release date')
       .should('contain', moment().add(1, 'days').format('D MMM YYYY'))
 

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
@@ -540,6 +540,52 @@ describe(CheckAllReferralInformationPresenter, () => {
               lines: [`4 Apr 2024 (Thu)`],
               changeLink: `/referrals/${referral.id}/expected-release-date?amendPPDetails=true`,
             },
+            {
+              key: 'Expected probation office',
+              lines: ['Derbyshire: Buxton Probation Office'],
+              changeLink: `/referrals/${referral.id}/update-probation-practitioner-office?amendPPDetails=true`,
+            },
+          ],
+        })
+      })
+    })
+
+    describe('current location and release details for a custody referral with pdu', () => {
+      const referral = parameterisedDraftReferralFactory.build({
+        personCurrentLocationType: CurrentLocationType.custody,
+        ppPdu: 'London',
+        ppProbationOffice: null,
+        expectedReleaseDate: '04-04-2024',
+        personCustodyPrisonId: 'ccc',
+      })
+      const presenter = new CheckAllReferralInformationPresenter(
+        referral,
+        interventionFactory.build({ serviceCategories }),
+        loggedInUser,
+        conviction,
+        deliusServiceUser,
+        prisonsAndSecuredChildAgencies,
+        prisonerDetails
+      )
+      it('returns the location and release details summary', () => {
+        expect(presenter.currentLocationAndReleaseDetailsSection).toEqual({
+          title: `Alex River’s current location and expected release date`,
+          summary: [
+            {
+              key: 'Location at time of referral',
+              lines: ['Aylesbury (HMYOI)'],
+              changeLink: `/referrals/${referral.id}/submit-current-location?amendPPDetails=true`,
+            },
+            {
+              key: 'Expected release date',
+              lines: [`4 Apr 2024 (Thu)`],
+              changeLink: `/referrals/${referral.id}/expected-release-date?amendPPDetails=true`,
+            },
+            {
+              key: 'Expected PDU (Probation Delivery Unit)',
+              lines: ['London'],
+              changeLink: `/referrals/${referral.id}/update-probation-practitioner-pdu?amendPPDetails=true`,
+            },
           ],
         })
       })
@@ -580,6 +626,11 @@ describe(CheckAllReferralInformationPresenter, () => {
               key: 'Reason why expected release date is not known',
               lines: [`it will be known next week`],
               changeLink: `/referrals/${referral.id}/expected-release-date-unknown?amendPPDetails=true`,
+            },
+            {
+              key: 'Expected probation office',
+              lines: ['Derbyshire: Buxton Probation Office'],
+              changeLink: `/referrals/${referral.id}/update-probation-practitioner-office?amendPPDetails=true`,
             },
           ],
         })

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
@@ -162,7 +162,7 @@ export default class CheckAllReferralInformationPresenter {
           lines: [this.referral.ppPhoneNumber || this.referral.ndeliusPhoneNumber || 'Not provided'],
           changeLink: `/referrals/${this.referral.id}/update-probation-practitioner-phone-number?amendPPDetails=true`,
         },
-        this.derivePduOrProbationOffice,
+        this.derivePduOrProbationOffice('Probation office', 'PDU (Probation Delivery Unit)'),
         {
           key: 'Team phone number',
           lines: [this.referral.ppTeamPhoneNumber || this.referral.ndeliusTeamPhoneNumber || 'Not provided'],
@@ -172,16 +172,16 @@ export default class CheckAllReferralInformationPresenter {
     }
   }
 
-  private get derivePduOrProbationOffice(): SummaryListItem {
+  private derivePduOrProbationOffice(probationOfficeHeading: string, pduHeading: string): SummaryListItem {
     if (this.referral.ppProbationOffice) {
       return {
-        key: 'Probation office',
+        key: probationOfficeHeading,
         lines: [this.referral.ppProbationOffice || 'Not provided'],
         changeLink: `/referrals/${this.referral.id}/update-probation-practitioner-office?amendPPDetails=true`,
       }
     }
     return {
-      key: 'PDU (Probation Delivery Unit)',
+      key: pduHeading,
       lines: [this.referral.ppPdu || this.referral.ndeliusPDU || ''],
       changeLink: `/referrals/${this.referral.id}/update-probation-practitioner-pdu?amendPPDetails=true`,
     }
@@ -290,7 +290,11 @@ export default class CheckAllReferralInformationPresenter {
         changeLink: `/referrals/${this.referral.id}/expected-release-date-unknown?amendPPDetails=true`,
       })
     }
-
+    if (!this.checkIfUnAllocatedCOM) {
+      currentLocationAndReleaseDetails.push(
+        this.derivePduOrProbationOffice('Expected probation office', 'Expected PDU (Probation Delivery Unit)')
+      )
+    }
     return {
       title: `${this.serviceUserNameForServiceCategory}’s current location and expected release date`,
       summary: currentLocationAndReleaseDetails,
@@ -303,7 +307,7 @@ export default class CheckAllReferralInformationPresenter {
         key: 'Location at time of referral',
         lines: [`${utils.convertToProperCase(this.referral.personCurrentLocationType!)}`],
       },
-      this.derivePduOrProbationOffice,
+      this.derivePduOrProbationOffice('Probation office', 'PDU (Probation Delivery Unit)'),
       {
         key: 'Release date',
         lines: [

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -619,8 +619,8 @@ describe(ShowReferralPresenter, () => {
 
       expect(presenter.serviceUserLocationDetails).toEqual([
         { key: 'Location at time of referral', lines: ['Community'] },
-        { key: 'Probation Office', lines: ['London'] },
         { key: 'Release date', lines: ['1 May 2024 (Wed)'] },
+        { key: 'Probation office', lines: ['London'] },
       ])
     })
 
@@ -656,9 +656,9 @@ describe(ShowReferralPresenter, () => {
       )
 
       expect(presenter.serviceUserLocationDetails).toEqual([
-        { key: 'Location at time of referral', lines: ['London'] },
-        { key: 'Probation Office', lines: ['London'] },
+        { key: 'Prison establishment', lines: ['London'] },
         { key: 'Expected release date', lines: ['---'] },
+        { key: 'Expected probation office', lines: ['London'] },
       ])
     })
 
@@ -691,12 +691,12 @@ describe(ShowReferralPresenter, () => {
         prisonerDetails
       )
       expect(presenter.serviceUserLocationDetails).toEqual([
-        { key: 'Location at time of referral', lines: ['London'] },
-        { key: 'Probation Office', lines: ['London'] },
+        { key: 'Prison establishment', lines: ['London'] },
         {
           key: 'Expected release date',
           lines: [moment.tz('Europe/London').add(2, 'days').format('D MMM YYYY [(]ddd[)]')],
         },
+        { key: 'Expected probation office', lines: ['London'] },
       ])
     })
     it('returns a summary list when the release date is not known', () => {
@@ -729,8 +729,7 @@ describe(ShowReferralPresenter, () => {
         prisonerDetails
       )
       expect(presenter.serviceUserLocationDetails).toEqual([
-        { key: 'Location at time of referral', lines: ['London'] },
-        { key: 'Probation Office', lines: ['London'] },
+        { key: 'Prison establishment', lines: ['London'] },
         {
           key: 'Expected release date',
           lines: ['Not known'],
@@ -739,6 +738,7 @@ describe(ShowReferralPresenter, () => {
           key: 'Reason why expected release date is not known',
           lines: ['not in ndelius'],
         },
+        { key: 'Expected probation office', lines: ['London'] },
       ])
     })
     it('returns a summary list for a unallocated COM who knows the release date', () => {
@@ -771,12 +771,12 @@ describe(ShowReferralPresenter, () => {
       )
 
       expect(presenter.serviceUserLocationDetails).toEqual([
-        { key: 'Location at time of referral', lines: ['London'] },
-        { key: 'Probation Office', lines: ['London'] },
+        { key: 'Prison establishment', lines: ['London'] },
         {
           key: 'Expected release date',
           lines: [moment().add(2, 'days').format('D MMM YYYY [(]ddd[)]')],
         },
+        { key: 'Expected probation office', lines: ['London'] },
       ])
     })
   })

--- a/server/views/makeAReferral/checkAllReferralInformation.njk
+++ b/server/views/makeAReferral/checkAllReferralInformation.njk
@@ -32,6 +32,10 @@
         {{ govukSummaryList(communityLocationAndReleaseDetailsSummaryListArgs) }}
       {% endif %}
 
+      {% if expectedReleaseDateDetailsSummaryListArgs and (presenter.checkIfExpectedReleaseDateIsAvailable) %}
+        {{ govukSummaryList(expectedReleaseDateDetailsSummaryListArgs) }}
+      {% endif %}
+
       {{ govukSummaryList(sentenceInformationSummaryListArgs) }}
 
       {% if serviceCategoriesSummaryListArgs %}
@@ -55,15 +59,11 @@
       {% if mainPointOfContactDetailsSummaryListArgs and (presenter.checkIfUnAllocatedCOM) %}
         {{ govukSummaryList(mainPointOfContactDetailsSummaryListArgs) }}
       {% endif %}
-
-      {% if expectedReleaseDateDetailsSummaryListArgs and (presenter.checkIfExpectedReleaseDateIsAvailable) %}
-        {{ govukSummaryList(expectedReleaseDateDetailsSummaryListArgs) }}
-      {% endif %}
-
+      
       {% if locationDetailsSummaryListArgs and (not presenter.checkIfExpectedReleaseDateIsAvailable) %}
         {{ govukSummaryList(locationDetailsSummaryListArgs) }}
       {% endif %}
-      
+
       {{ govukSummaryList(lastKnownAddressAndContactDetailsSummaryListArgs) }}
 
       {{govukSummaryList(personalDetailsSummaryListArgs)}}


### PR DESCRIPTION
## What does this pull request do?

- show expected probation office in current location and expected release details section
- show expected pdu in current location and expected release details section

## What is the intent behind these changes?

- exposing the expected probation office and pdu for the referrals
