### PR TITLE
capturing expected probation office and expected office unknown reason

### DIFF
--- a/integration_tests/integration/make_a_referral/referralSectionVerifier.js
+++ b/integration_tests/integration/make_a_referral/referralSectionVerifier.js
@@ -34,6 +34,34 @@ class _ReferralSectionChecker {
       .contains('Expected release date')
       .next()
       .contains(activeLinks.expectedReleaseDateStatus, { matchCase: false })
+
+    return this
+  }
+
+  reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice(activeLinks) {
+    cy.get('[data-cy=url]').contains('Current location').should(hrefAttrChainer(activeLinks.establishment), 'href')
+    cy.get('[data-cy=url]')
+      .contains('Current location')
+      .next()
+      .contains(activeLinks.establishmentStatus, { matchCase: false })
+
+    cy.get('[data-cy=url]')
+      .contains('Expected release date')
+      .should(hrefAttrChainer(activeLinks.expectedReleaseDate), 'href')
+
+    cy.get('[data-cy=url]')
+      .contains('Expected release date')
+      .next()
+      .contains(activeLinks.expectedReleaseDateStatus, { matchCase: false })
+
+    cy.get('[data-cy=url]')
+      .contains('Expected probation office')
+      .should(hrefAttrChainer(activeLinks.expectedProbationOffice), 'href')
+
+    cy.get('[data-cy=url]')
+      .contains('Expected probation office')
+      .next()
+      .contains(activeLinks.expectedProbationOfficeStatus, { matchCase: false })
     return this
   }
 

--- a/integration_tests/integration/referralUnAllocatedCom.cy.js
+++ b/integration_tests/integration/referralUnAllocatedCom.cy.js
@@ -102,7 +102,8 @@ describe('Referral form', () => {
       })
 
       const completedNeedsAndRequirementsDraftReferral = draftReferralFactory
-        .filledFormUpToNeedsAndRequirements([accommodationServiceCategory])
+        .filledMainPointOfContactDetails()
+        .filledFormUpToNeedsAndRequirements([accommodationServiceCategory], false, true)
         .build({
           id: draftReferral.id,
           serviceCategoryIds: [accommodationServiceCategory.id],
@@ -121,6 +122,20 @@ describe('Referral form', () => {
           serviceProvider: {
             name: 'Harmony Living',
           },
+          isReferralReleasingIn12Weeks: true,
+        })
+
+      const completedExpectedProbationOfficeDraftReferral = draftReferralFactory
+        .filledMainPointOfContactDetails()
+        .filledFormUpToExpectedProbationOffice(CurrentLocationType.custody)
+        .build({
+          id: draftReferral.id,
+          serviceCategoryIds: [accommodationServiceCategory.id],
+          interventionId: draftReferral.interventionId,
+          serviceProvider: {
+            name: 'Harmony Living',
+          },
+          isReferralReleasingIn12Weeks: true,
         })
 
       const completedEstablishmentDraftReferral = draftReferralFactory
@@ -132,10 +147,12 @@ describe('Referral form', () => {
           serviceProvider: {
             name: 'Harmony Living',
           },
+          isReferralReleasingIn12Weeks: true,
         })
 
       const completedDraftReferral = draftReferralFactory
         .filledMainPointOfContactDetails()
+        .filledFormUpToExpectedProbationOffice()
         .filledFormUpToFurtherInformation([accommodationServiceCategory], 'Some information about Alex')
         .build({
           id: draftReferral.id,
@@ -230,11 +247,13 @@ describe('Referral form', () => {
           ppDetails: true,
           ppDetailsStatus: 'NOT STARTED',
         })
-        .reviewCurrentLocationAndExpectedReleaseDate({
+        .reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice({
           establishment: false,
           establishmentStatus: 'NOT STARTED',
           expectedReleaseDate: false,
           expectedReleaseDateStatus: 'NOT STARTED',
+          expectedProbationOffice: false,
+          expectedProbationOfficeStatus: 'NOT STARTED',
         })
         .reviewServiceUserInformation({
           confirmServiceUserDetails: false,
@@ -281,14 +300,16 @@ describe('Referral form', () => {
           ppDetails: true,
           ppDetailsStatus: 'COMPLETED',
         })
-        .reviewCurrentLocationAndExpectedReleaseDate({
+        .reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice({
           establishment: true,
           establishmentStatus: 'NOT STARTED',
           expectedReleaseDate: false,
           expectedReleaseDateStatus: 'NOT STARTED',
+          expectedProbationOffice: false,
+          expectedProbationOfficeStatus: 'NOT STARTED',
         })
 
-      cy.contains('Establishment').click()
+      cy.contains('Current location').click()
       // Submit current location Page
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/submit-current-location`)
       cy.contains(`Alex River (CRN: ${completedPPDetails.serviceUser.crn})`)
@@ -301,7 +322,6 @@ describe('Referral form', () => {
       cy.get('#prison-select').type('Aylesbury (HMYOI)')
       cy.stubGetDraftReferral(draftReferral.id, completedEstablishmentDraftReferral)
       cy.contains('Save and continue').click()
-
       // Submit expected release date
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/expected-release-date`)
       cy.get('h1').contains(`Confirm Alex River's expected release date`)
@@ -316,16 +336,31 @@ describe('Referral form', () => {
       cy.stubGetDraftReferral(draftReferral.id, completedExpectedReleaseDateDraftReferral)
       cy.contains('Save and continue').click()
 
+      // submit expected probation office
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/expected-probation-office`)
+      cy.contains(`Alex River (CRN: ${completedPPDetails.serviceUser.crn})`)
+      cy.get('h1').contains(
+        `Confirm ${completedPPDetails.serviceUser.firstName} ${completedPPDetails.serviceUser.lastName}'s expected probation office`
+      )
+      cy.contains('Probation office')
+
+      cy.contains('Start typing then choose probation office from the list')
+      cy.get('#expected-probation-office').type('Chelmsford: Chelmsford Probation Office')
+      cy.stubGetDraftReferral(draftReferral.id, completedExpectedProbationOfficeDraftReferral)
+      cy.contains('Save and continue').click()
+
       ReferralSectionVerifier.verifySection
         .reviewPPDetails({
           ppDetails: true,
           ppDetailsStatus: 'COMPLETED',
         })
-        .reviewCurrentLocationAndExpectedReleaseDate({
+        .reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice({
           establishment: true,
           establishmentStatus: 'COMPLETED',
           expectedReleaseDate: true,
           expectedReleaseDateStatus: 'COMPLETED',
+          expectedProbationOffice: true,
+          expectedProbationOfficeStatus: 'COMPLETED',
         })
         .reviewServiceUserInformation({
           confirmServiceUserDetails: true,
@@ -339,7 +374,7 @@ describe('Referral form', () => {
       cy.contains('Personal details').click()
 
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/service-user-details`)
-      cy.contains(`Alex River (CRN: ${completedExpectedReleaseDateDraftReferral.serviceUser.crn})`)
+      cy.contains(`Alex River (CRN: ${completedExpectedProbationOfficeDraftReferral.serviceUser.crn})`)
       cy.get('h1').contains("Review Alex River's information")
       cy.contains('X123456')
       cy.contains('River')
@@ -400,11 +435,13 @@ describe('Referral form', () => {
           ppDetails: true,
           ppDetailsStatus: 'COMPLETED',
         })
-        .reviewCurrentLocationAndExpectedReleaseDate({
+        .reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice({
           establishment: true,
           establishmentStatus: 'COMPLETED',
           expectedReleaseDate: true,
           expectedReleaseDateStatus: 'COMPLETED',
+          expectedProbationOffice: true,
+          expectedProbationOfficeStatus: 'COMPLETED',
         })
         .reviewServiceUserInformation({
           confirmServiceUserDetails: true,
@@ -493,11 +530,13 @@ describe('Referral form', () => {
           ppDetails: true,
           ppDetailsStatus: 'COMPLETED',
         })
-        .reviewCurrentLocationAndExpectedReleaseDate({
+        .reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice({
           establishment: true,
           establishmentStatus: 'COMPLETED',
           expectedReleaseDate: true,
           expectedReleaseDateStatus: 'COMPLETED',
+          expectedProbationOffice: true,
+          expectedProbationOfficeStatus: 'COMPLETED',
         })
         .reviewServiceUserInformation({
           confirmServiceUserDetails: true,
@@ -1379,7 +1418,8 @@ describe('Referral form', () => {
       })
 
       const completedNeedsAndRequirementsDraftReferral = draftReferralFactory
-        .filledFormUpToNeedsAndRequirements([accommodationServiceCategory, socialInclusionServiceCategory])
+        .filledMainPointOfContactDetails()
+        .filledFormUpToNeedsAndRequirements([accommodationServiceCategory, socialInclusionServiceCategory], false, true)
         .build({
           id: draftReferral.id,
           serviceCategoryIds: [accommodationServiceCategory.id, socialInclusionServiceCategory.id],
@@ -1398,6 +1438,7 @@ describe('Referral form', () => {
           serviceProvider: {
             name: 'Harmony Living',
           },
+          isReferralReleasingIn12Weeks: true,
         })
 
       const completedEstablishmentDraftReferral = draftReferralFactory
@@ -1411,8 +1452,22 @@ describe('Referral form', () => {
           },
         })
 
+      const completedExpectedProbationOfficeDraftReferral = draftReferralFactory
+        .filledMainPointOfContactDetails()
+        .filledFormUpToExpectedProbationOffice(CurrentLocationType.custody)
+        .build({
+          id: draftReferral.id,
+          serviceCategoryIds: [accommodationServiceCategory.id],
+          interventionId: draftReferral.interventionId,
+          serviceProvider: {
+            name: 'Harmony Living',
+          },
+          isReferralReleasingIn12Weeks: true,
+        })
+
       const completedDraftReferral = draftReferralFactory
         .filledMainPointOfContactDetails()
+        .filledFormUpToExpectedProbationOffice()
         .filledFormUpToFurtherInformation(
           [accommodationServiceCategory, socialInclusionServiceCategory],
           'Some information about Alex'
@@ -1431,9 +1486,10 @@ describe('Referral form', () => {
         .filledFormUpToNeedsAndRequirements(
           [accommodationServiceCategory, socialInclusionServiceCategory],
           false,
+          true,
           CurrentLocationType.custody
         )
-        .selectedServiceCategories([accommodationServiceCategory, socialInclusionServiceCategory])
+        .selectedServiceCategories([accommodationServiceCategory, socialInclusionServiceCategory], true)
         .build({
           id: draftReferral.id,
           interventionId: intervention.id,
@@ -1523,11 +1579,13 @@ describe('Referral form', () => {
           ppDetails: true,
           ppDetailsStatus: 'NOT STARTED',
         })
-        .reviewCurrentLocationAndExpectedReleaseDate({
+        .reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice({
           establishment: false,
           establishmentStatus: 'NOT STARTED',
           expectedReleaseDate: false,
           expectedReleaseDateStatus: 'NOT STARTED',
+          expectedProbationOffice: false,
+          expectedProbationOfficeStatus: 'NOT STARTED',
         })
         .reviewServiceUserInformation({
           confirmServiceUserDetails: false,
@@ -1561,14 +1619,16 @@ describe('Referral form', () => {
           ppDetails: true,
           ppDetailsStatus: 'COMPLETED',
         })
-        .reviewCurrentLocationAndExpectedReleaseDate({
+        .reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice({
           establishment: true,
           establishmentStatus: 'NOT STARTED',
           expectedReleaseDate: false,
           expectedReleaseDateStatus: 'NOT STARTED',
+          expectedProbationOffice: false,
+          expectedProbationOfficeStatus: 'NOT STARTED',
         })
 
-      cy.contains('Establishment').click()
+      cy.contains('Current location').click()
       // Submit current location Page
       cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/submit-current-location`)
       cy.contains(`Alex River (CRN: ${completedPPDetails.serviceUser.crn})`)
@@ -1596,16 +1656,31 @@ describe('Referral form', () => {
       cy.stubGetDraftReferral(draftReferral.id, completedExpectedReleaseDateDraftReferral)
       cy.contains('Save and continue').click()
 
+      // submit expected probation office
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/expected-probation-office`)
+      cy.contains(`Alex River (CRN: ${completedPPDetails.serviceUser.crn})`)
+      cy.get('h1').contains(
+        `Confirm ${completedPPDetails.serviceUser.firstName} ${completedPPDetails.serviceUser.lastName}'s expected probation office`
+      )
+      cy.contains('Probation office')
+
+      cy.contains('Start typing then choose probation office from the list')
+      cy.get('#expected-probation-office').type('Chelmsford: Chelmsford Probation Office')
+      cy.stubGetDraftReferral(draftReferral.id, completedExpectedProbationOfficeDraftReferral)
+      cy.contains('Save and continue').click()
+
       ReferralSectionVerifier.verifySection
         .reviewPPDetails({
           ppDetails: true,
           ppDetailsStatus: 'COMPLETED',
         })
-        .reviewCurrentLocationAndExpectedReleaseDate({
+        .reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice({
           establishment: true,
           establishmentStatus: 'COMPLETED',
           expectedReleaseDate: true,
           expectedReleaseDateStatus: 'COMPLETED',
+          expectedProbationOffice: true,
+          expectedProbationOfficeStatus: 'COMPLETED',
         })
         .reviewServiceUserInformation({
           confirmServiceUserDetails: true,
@@ -1679,11 +1754,13 @@ describe('Referral form', () => {
           ppDetails: true,
           ppDetailsStatus: 'COMPLETED',
         })
-        .reviewCurrentLocationAndExpectedReleaseDate({
+        .reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice({
           establishment: true,
           establishmentStatus: 'COMPLETED',
           expectedReleaseDate: true,
           expectedReleaseDateStatus: 'COMPLETED',
+          expectedProbationOffice: true,
+          expectedProbationOfficeStatus: 'COMPLETED',
         })
         .reviewServiceUserInformation({
           confirmServiceUserDetails: true,
@@ -1801,11 +1878,13 @@ describe('Referral form', () => {
           ppDetails: true,
           ppDetailsStatus: 'COMPLETED',
         })
-        .reviewCurrentLocationAndExpectedReleaseDate({
+        .reviewCurrentLocationAndExpectedReleaseDateAndExpectedProbationOffice({
           establishment: true,
           establishmentStatus: 'COMPLETED',
           expectedReleaseDate: true,
           expectedReleaseDateStatus: 'COMPLETED',
+          expectedProbationOffice: true,
+          expectedProbationOfficeStatus: 'COMPLETED',
         })
         .reviewServiceUserInformation({
           confirmServiceUserDetails: true,

--- a/server/app.ts
+++ b/server/app.ts
@@ -113,6 +113,8 @@ export default function createApp(
             "'sha256-mVhB0scNdTtTt/aOmRKykONFOV4hJa+aNdQO2Obzqig='",
             "'sha256-DWY4ZjS+wfkiCnvHmqAv42nwL2SgDelOl9jdsr8bGF0='",
             "'sha256-T8GG0mM7xjlF3v8OUaEoJYxlIf7UxMsiPqzKf4nDq5M='",
+            "'sha256-1cKzDM/GsErWIInvbcYrPPfVrsi2bLJKL43qOwMja1E='",
+            "'sha256-5JS2PkGWbRcUgQsFF0ABm71FY0rNntJ6wE5+r3Ky9d4='",
             'https://www.google-analytics.com',
             'https://ssl.google-analytics.com',
             'https://www.googletagmanager.com/',

--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -29,6 +29,8 @@ export interface ReferralFields {
   hasExpectedReleaseDate: boolean | null
   expectedReleaseDate: string | null
   expectedReleaseDateMissingReason: string | null
+  expectedProbationOffice: string | null
+  expectedProbationOfficeUnKnownReason: string | null
   ndeliusPPName: string | null
   ndeliusPPEmailAddress: string | null
   ndeliusPDU: string | null

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -196,6 +196,18 @@ function probationPractitionerRoutesWithoutPrefix(router: Router, services: Serv
   post(router, '/referrals/:id/expected-release-date-unknown', (req, res) =>
     makeAReferralController.submitExpectedReleaseDateUnknown(req, res)
   )
+  get(router, '/referrals/:id/expected-probation-office', (req, res) =>
+    makeAReferralController.viewExpectedProbationOffice(req, res)
+  )
+  post(router, '/referrals/:id/expected-probation-office', (req, res) =>
+    makeAReferralController.submitExpectedProbationOffice(req, res)
+  )
+  get(router, '/referrals/:id/expected-probation-office-unknown', (req, res) =>
+    makeAReferralController.viewExpectedProbationOfficeUnknown(req, res)
+  )
+  post(router, '/referrals/:id/expected-probation-office-unknown', (req, res) =>
+    makeAReferralController.submitExpectedProbationOfficeUnknown(req, res)
+  )
   get(router, '/referrals/:id/confirm-probation-practitioner-details', (req, res) =>
     makeAReferralController.viewConfirmProbationPractitionerDetails(req, res)
   )

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
@@ -619,7 +619,7 @@ describe(CheckAllReferralInformationPresenter, () => {
             },
             {
               key: 'Expected release date',
-              lines: [`Not known`],
+              lines: [`---`],
               changeLink: `/referrals/${referral.id}/expected-release-date?amendPPDetails=true`,
             },
             {
@@ -631,6 +631,90 @@ describe(CheckAllReferralInformationPresenter, () => {
               key: 'Expected probation office',
               lines: ['Derbyshire: Buxton Probation Office'],
               changeLink: `/referrals/${referral.id}/update-probation-practitioner-office?amendPPDetails=true`,
+            },
+          ],
+        })
+      })
+    })
+
+    describe('current location and release details for a pre-release with no com custody referral', () => {
+      const referral = parameterisedDraftReferralFactory.build({
+        personCurrentLocationType: CurrentLocationType.custody,
+        isReferralReleasingIn12Weeks: true,
+        expectedProbationOffice: 'London',
+        ppProbationOffice: 'Derbyshire: Buxton Probation Office',
+        expectedReleaseDate: '04-04-2024',
+        personCustodyPrisonId: 'ccc',
+      })
+      const presenter = new CheckAllReferralInformationPresenter(
+        referral,
+        interventionFactory.build({ serviceCategories }),
+        loggedInUser,
+        conviction,
+        deliusServiceUser,
+        prisonsAndSecuredChildAgencies,
+        prisonerDetails
+      )
+      it('returns the location and release details summary', () => {
+        expect(presenter.currentLocationAndReleaseDetailsSection).toEqual({
+          title: `Alex River’s current location and expected release date`,
+          summary: [
+            {
+              key: 'Location at time of referral',
+              lines: ['Aylesbury (HMYOI)'],
+              changeLink: `/referrals/${referral.id}/submit-current-location?amendPPDetails=true`,
+            },
+            {
+              key: 'Expected release date',
+              lines: [`4 Apr 2024 (Thu)`],
+              changeLink: `/referrals/${referral.id}/expected-release-date?amendPPDetails=true`,
+            },
+            {
+              key: 'Expected probation office',
+              lines: ['London'],
+              changeLink: `/referrals/${referral.id}/expected-probation-office?amendPPDetails=true`,
+            },
+          ],
+        })
+      })
+    })
+
+    describe('current location and release details for a pre-release with no com and in prison', () => {
+      const referral = parameterisedDraftReferralFactory.build({
+        personCurrentLocationType: CurrentLocationType.custody,
+        isReferralReleasingIn12Weeks: false,
+        expectedProbationOffice: null,
+        ppProbationOffice: 'Derbyshire: Buxton Probation Office',
+        expectedReleaseDate: null,
+        personCustodyPrisonId: 'ccc',
+      })
+      const presenter = new CheckAllReferralInformationPresenter(
+        referral,
+        interventionFactory.build({ serviceCategories }),
+        loggedInUser,
+        conviction,
+        deliusServiceUser,
+        prisonsAndSecuredChildAgencies,
+        prisonerDetails
+      )
+      it('returns the location and release details summary', () => {
+        expect(presenter.currentLocationAndReleaseDetailsSection).toEqual({
+          title: `Alex River’s current location and expected release date`,
+          summary: [
+            {
+              key: 'Location at time of referral',
+              lines: ['Aylesbury (HMYOI)'],
+              changeLink: `/referrals/${referral.id}/submit-current-location?amendPPDetails=true`,
+            },
+            {
+              key: 'Expected release date',
+              lines: [`---`],
+              changeLink: `/referrals/${referral.id}/expected-release-date?amendPPDetails=true`,
+            },
+            {
+              key: 'Expected probation office',
+              lines: ['---'],
+              changeLink: `/referrals/${referral.id}/expected-probation-office?amendPPDetails=true`,
             },
           ],
         })

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
@@ -173,16 +173,25 @@ export default class CheckAllReferralInformationPresenter {
   }
 
   private derivePduOrProbationOffice(probationOfficeHeading: string, pduHeading: string): SummaryListItem {
-    if (this.referral.ppProbationOffice) {
+    if (this.referral.isReferralReleasingIn12Weeks !== null && !this.referral.isReferralReleasingIn12Weeks) {
       return {
         key: probationOfficeHeading,
-        lines: [this.referral.ppProbationOffice || 'Not provided'],
-        changeLink: `/referrals/${this.referral.id}/update-probation-practitioner-office?amendPPDetails=true`,
+        lines: [this.referral.expectedProbationOffice || '---'],
+        changeLink: `/referrals/${this.referral.id}/expected-probation-office?amendPPDetails=true`,
+      }
+    }
+    if (this.referral.expectedProbationOffice || this.referral.ppProbationOffice) {
+      return {
+        key: probationOfficeHeading,
+        lines: [this.referral.expectedProbationOffice || this.referral.ppProbationOffice || 'Not provided'],
+        changeLink: this.checkIfUnAllocatedCOM
+          ? `/referrals/${this.referral.id}/expected-probation-office?amendPPDetails=true`
+          : `/referrals/${this.referral.id}/update-probation-practitioner-office?amendPPDetails=true`,
       }
     }
     return {
       key: pduHeading,
-      lines: [this.referral.ppPdu || this.referral.ndeliusPDU || ''],
+      lines: [this.referral.ppPdu || this.referral.ndeliusPDU || '---'],
       changeLink: `/referrals/${this.referral.id}/update-probation-practitioner-pdu?amendPPDetails=true`,
     }
   }
@@ -268,7 +277,7 @@ export default class CheckAllReferralInformationPresenter {
     const expectedReleaseInfo: string =
       this.referral.expectedReleaseDate !== null
         ? moment(this.referral.expectedReleaseDate!).format('D MMM YYYY [(]ddd[)]')
-        : 'Not known'
+        : '---'
 
     const currentLocationAndReleaseDetails: SummaryListItem[] = [
       {
@@ -290,11 +299,9 @@ export default class CheckAllReferralInformationPresenter {
         changeLink: `/referrals/${this.referral.id}/expected-release-date-unknown?amendPPDetails=true`,
       })
     }
-    if (!this.checkIfUnAllocatedCOM) {
-      currentLocationAndReleaseDetails.push(
-        this.derivePduOrProbationOffice('Expected probation office', 'Expected PDU (Probation Delivery Unit)')
-      )
-    }
+    currentLocationAndReleaseDetails.push(
+      this.derivePduOrProbationOffice('Expected probation office', 'Expected PDU (Probation Delivery Unit)')
+    )
     return {
       title: `${this.serviceUserNameForServiceCategory}’s current location and expected release date`,
       summary: currentLocationAndReleaseDetails,

--- a/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownForm.test.ts
+++ b/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownForm.test.ts
@@ -1,0 +1,34 @@
+import TestUtils from '../../../../../testutils/testUtils'
+import ExpectedProbationOfficeUnknownForm from './expectedProbationOfficeUnknownForm'
+
+describe(ExpectedProbationOfficeUnknownForm, () => {
+  describe('when a expected probation office is not known', () => {
+    it('returns a paramsForUpdate with the reason for why the probation office is not known', async () => {
+      const request = TestUtils.createRequest({
+        'probation-office-unknown-reason': 'data not received from nDelius',
+      })
+      const data = await new ExpectedProbationOfficeUnknownForm(request).data()
+
+      expect(data.paramsForUpdate?.expectedProbationOfficeUnKnownReason).toEqual('data not received from nDelius')
+    })
+  })
+
+  describe('when an reason for not knowing the expected date is not filled', () => {
+    it('returns a validation error with the appropriate error message', async () => {
+      const request = TestUtils.createRequest({
+        'probation-office-unknown-reason': '',
+      })
+      const data = await new ExpectedProbationOfficeUnknownForm(request).data()
+
+      expect(data.error).toEqual({
+        errors: [
+          {
+            errorSummaryLinkedField: 'probation-office-unknown-reason',
+            formFields: ['probation-office-unknown-reason'],
+            message: 'Enter a reason why the expected probation office is not known',
+          },
+        ],
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownForm.ts
+++ b/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownForm.ts
@@ -1,0 +1,68 @@
+import { Request } from 'express'
+import { body, Result, ValidationChain, ValidationError } from 'express-validator'
+import DraftReferral from '../../../../models/draftReferral'
+import errorMessages from '../../../../utils/errorMessages'
+import { FormData } from '../../../../utils/forms/formData'
+import FormUtils from '../../../../utils/formUtils'
+import { FormValidationError } from '../../../../utils/formValidationError'
+import { FormValidationResult } from '../../../../utils/forms/formValidationResult'
+
+export default class ExpectedProbationOfficeUnknownForm {
+  constructor(private readonly request: Request) {}
+
+  static readonly probationOfficeUnknownReason = 'probation-office-unknown-reason'
+
+  async data(): Promise<FormData<Partial<DraftReferral>>> {
+    const validationResult = await ExpectedProbationOfficeUnknownForm.validate(this.request)
+
+    return validationResult.error
+      ? {
+          paramsForUpdate: null,
+          error: {
+            errors: validationResult!.error ? [...(validationResult!.error?.errors ?? [])] : [],
+          },
+        }
+      : {
+          paramsForUpdate: {
+            expectedProbationOfficeUnKnownReason: this.request.body['probation-office-unknown-reason'],
+          },
+          error: null,
+        }
+  }
+
+  static get validations(): ValidationChain[] {
+    return [
+      body('probation-office-unknown-reason').notEmpty().withMessage(errorMessages.probationOfficeUnknownReason.empty),
+    ]
+  }
+
+  static async validate(request: Request): Promise<FormValidationResult<DraftReferral>> {
+    const validationResult = await FormUtils.runValidations({
+      request,
+      validations: ExpectedProbationOfficeUnknownForm.validations,
+    })
+
+    const error = ExpectedProbationOfficeUnknownForm.error(validationResult)
+    if (error) {
+      return { value: null, error }
+    }
+    return {
+      value: request.body[ExpectedProbationOfficeUnknownForm.probationOfficeUnknownReason],
+      error: null,
+    }
+  }
+
+  public static error(validationResult: Result<ValidationError>): FormValidationError | null {
+    if (validationResult.isEmpty()) {
+      return null
+    }
+
+    return {
+      errors: validationResult.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
+  }
+}

--- a/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownPresenter.test.ts
+++ b/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownPresenter.test.ts
@@ -1,0 +1,75 @@
+import draftReferralFactory from '../../../../../testutils/factories/draftReferral'
+import ExpectedProbationOfficeUnknownPresenter from './expectedProbationOfficeUnknownPresenter'
+
+describe('ExpectedProbationOfficeUnknownPresenter', () => {
+  describe('errorSummary', () => {
+    describe('when error is null', () => {
+      it('returns null', () => {
+        const referral = draftReferralFactory.build()
+        const presenter = new ExpectedProbationOfficeUnknownPresenter(referral)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+
+    describe('when error is not null', () => {
+      it('returns a summary of the errors sorted into the order their fields appear on the page', () => {
+        const referral = draftReferralFactory.build()
+        const presenter = new ExpectedProbationOfficeUnknownPresenter(referral, {
+          errors: [
+            {
+              formFields: ['probation-office-unknown-reason'],
+              errorSummaryLinkedField: 'probation-office-unknown-reason',
+              message: 'probation-office-unknown-reason msg',
+            },
+          ],
+        })
+
+        expect(presenter.errorSummary).toEqual([
+          { field: 'probation-office-unknown-reason', message: 'probation-office-unknown-reason msg' },
+        ])
+      })
+    })
+  })
+
+  describe('text', () => {
+    it('returns content to be displayed on the page', () => {
+      const referral = draftReferralFactory
+        .serviceCategorySelected()
+        .serviceUserSelected()
+        .build({ serviceUser: { firstName: 'Geoffrey' } })
+      const presenter = new ExpectedProbationOfficeUnknownPresenter(referral)
+
+      expect(presenter.backLinkUrl).toBe(`/referrals/${referral.id}/expected-probation-office`)
+      expect(presenter.text).toEqual({
+        title: `Enter why the expected probation office is not known`,
+        label: 'Geoffrey River (CRN: X123456)',
+        probationOfficeUnknownReason: {
+          errorMessage: null,
+        },
+      })
+    })
+  })
+
+  describe('fields', () => {
+    describe('when there is no data on the referral', () => {
+      it('replays empty answers', () => {
+        const referral = draftReferralFactory.build()
+        const presenter = new ExpectedProbationOfficeUnknownPresenter(referral)
+
+        expect(presenter.fields.probationOfficeUnknownReason).toBe('')
+      })
+    })
+
+    describe('when there is data on the referral', () => {
+      it('replays the data from the referral', () => {
+        const referral = draftReferralFactory.build({
+          expectedProbationOfficeUnKnownReason: 'reason',
+        })
+        const presenter = new ExpectedProbationOfficeUnknownPresenter(referral)
+
+        expect(presenter.fields.probationOfficeUnknownReason).toBe('reason')
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownPresenter.ts
+++ b/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownPresenter.ts
@@ -1,0 +1,40 @@
+import DraftReferral from '../../../../models/draftReferral'
+import { FormValidationError } from '../../../../utils/formValidationError'
+import PresenterUtils from '../../../../utils/presenterUtils'
+
+export default class ExpectedProbationOfficeUnknownPresenter {
+  readonly backLinkUrl: string
+
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {
+    this.backLinkUrl = `/referrals/${referral.id}/expected-probation-office`
+  }
+
+  private errorMessageForField(field: string): string | null {
+    return PresenterUtils.errorMessage(this.error, field)
+  }
+
+  readonly text = {
+    label: `${this.referral.serviceUser?.firstName} ${this.referral.serviceUser?.lastName} (CRN: ${this.referral.serviceUser?.crn})`,
+    title: 'Enter why the expected probation office is not known',
+    probationOfficeUnknownReason: {
+      errorMessage: this.errorMessageForField('probation-office-unknown-reason'),
+    },
+  }
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error, {
+    fieldOrder: ['probation-office-unknown-reason'],
+  })
+
+  private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly fields = {
+    probationOfficeUnknownReason: this.utils.stringValue(
+      this.referral.expectedProbationOfficeUnKnownReason,
+      'probation-office-unknown-reason'
+    ),
+  }
+}

--- a/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownView.ts
+++ b/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownView.ts
@@ -1,0 +1,32 @@
+import ViewUtils from '../../../../utils/viewUtils'
+import { TextareaArgs } from '../../../../utils/govukFrontendTypes'
+import ExpectedProbationOfficeUnknownPresenter from './expectedProbationOfficeUnknownPresenter'
+
+export default class ExpectedProbationOfficeUnknownView {
+  constructor(private readonly presenter: ExpectedProbationOfficeUnknownPresenter) {}
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+
+  private get probationOfficeUnknownReasonArgs(): TextareaArgs {
+    return {
+      id: 'probation-office-unknown-reason',
+      name: 'probation-office-unknown-reason',
+      label: {},
+      value: this.presenter.fields.probationOfficeUnknownReason,
+      errorMessage: ViewUtils.govukErrorMessage(this.presenter.text.probationOfficeUnknownReason.errorMessage),
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'makeAReferral/expectedProbationOfficeUnknown',
+      {
+        presenter: this.presenter,
+        errorSummaryArgs: this.errorSummaryArgs,
+        probationOfficeUnknownReasonArgs: this.probationOfficeUnknownReasonArgs,
+        backLinkArgs: { href: this.presenter.backLinkUrl },
+        suppressServiceUserBanner: true,
+      },
+    ]
+  }
+}

--- a/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficeForm.test.ts
+++ b/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficeForm.test.ts
@@ -1,0 +1,17 @@
+import TestUtils from '../../../../../testutils/testUtils'
+import SelectExpectedProbationOfficeForm from './selectExpectedProbationOfficeForm'
+
+describe(SelectExpectedProbationOfficeForm, () => {
+  describe('data', () => {
+    describe('when a valid expected probation office is passed', () => {
+      it('returns a paramsForUpdate with the expected probation office', async () => {
+        const request = TestUtils.createRequest({
+          'expected-probation-office': 'London',
+        })
+        const data = await SelectExpectedProbationOfficeForm.createForm(request)
+
+        expect(data.paramsForUpdate?.expectedProbationOffice).toEqual('London')
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficeForm.ts
+++ b/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficeForm.ts
@@ -1,0 +1,49 @@
+import { Request } from 'express'
+import { Result } from 'express-validator/src/validation-result'
+import { ValidationChain, ValidationError, body } from 'express-validator'
+import DraftReferral from '../../../../models/draftReferral'
+import FormUtils from '../../../../utils/formUtils'
+import errorMessages from '../../../../utils/errorMessages'
+import { FormValidationError } from '../../../../utils/formValidationError'
+
+export default class SelectExpectedProbationOfficeForm {
+  constructor(
+    private readonly request: Request,
+    private readonly result: Result<ValidationError>
+  ) {}
+
+  static async createForm(request: Request): Promise<SelectExpectedProbationOfficeForm> {
+    return new SelectExpectedProbationOfficeForm(
+      request,
+      await FormUtils.runValidations({ request, validations: this.validations() })
+    )
+  }
+
+  get paramsForUpdate(): Partial<DraftReferral> {
+    return {
+      expectedProbationOffice: this.request.body['expected-probation-office'],
+    }
+  }
+
+  static validations(): ValidationChain[] {
+    return [
+      body('expected-probation-office')
+        .notEmpty({ ignore_whitespace: true })
+        .withMessage(errorMessages.expectedProbationOffice.empty),
+    ]
+  }
+
+  get error(): FormValidationError | null {
+    if (this.result.isEmpty()) {
+      return null
+    }
+
+    return {
+      errors: this.result.array().map(validationError => ({
+        formFields: [validationError.param],
+        errorSummaryLinkedField: validationError.param,
+        message: validationError.msg,
+      })),
+    }
+  }
+}

--- a/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficePresenter.test.ts
+++ b/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficePresenter.test.ts
@@ -1,0 +1,124 @@
+import SelectExpectedProbationOfficePresenter from './selectExpectedProbationOfficePresenter'
+import draftReferralFactory from '../../../../../testutils/factories/draftReferral'
+
+describe(SelectExpectedProbationOfficePresenter, () => {
+  const referral = draftReferralFactory.build({
+    expectedProbationOffice: 'Norfolk',
+    serviceUser: {
+      crn: 'crn',
+      title: null,
+      firstName: 'David',
+      lastName: 'Blake',
+      dateOfBirth: null,
+      gender: null,
+      ethnicity: null,
+      preferredLanguage: null,
+      religionOrBelief: null,
+      disabilities: null,
+    },
+  })
+  describe('text', () => {
+    it('contains a title and hint text', () => {
+      const presenter = new SelectExpectedProbationOfficePresenter(
+        referral,
+        [
+          {
+            probationOfficeId: 1,
+            name: 'London',
+            address: '1A cross street',
+            probationRegionId: '3',
+            govUkURL: 'url',
+            deliusCRSLocationId: '1',
+          },
+        ],
+        false,
+        null,
+        null
+      )
+
+      expect(presenter.text.title).toEqual(`Confirm David Blake's expected probation office`)
+      expect(presenter.text.label).toEqual('David Blake (CRN: crn)')
+      expect(presenter.text.inputHeading).toEqual('Probation office')
+      expect(presenter.text.hint).toEqual('Start typing then choose probation office from the list')
+    })
+  })
+
+  describe('errorMessage', () => {
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
+        const presenter = new SelectExpectedProbationOfficePresenter(referral, [], false, null, null)
+
+        expect(presenter.errorMessage).toBeNull()
+      })
+    })
+  })
+
+  describe('errorSummary', () => {
+    describe('when no error is passed in', () => {
+      it('returns null', () => {
+        const presenter = new SelectExpectedProbationOfficePresenter(referral, [], false, null, null)
+
+        expect(presenter.errorSummary).toBeNull()
+      })
+    })
+  })
+
+  describe('fields', () => {
+    describe('updateProbationPractitionerOffice', () => {
+      describe('when no probation practitioner office have been set', () => {
+        const referralWithNoPPOffice = draftReferralFactory.build({
+          expectedProbationOffice: '',
+          serviceUser: {
+            crn: 'crn',
+            title: null,
+            firstName: 'David',
+            lastName: 'Blake',
+            dateOfBirth: null,
+            gender: null,
+            ethnicity: null,
+            preferredLanguage: null,
+            religionOrBelief: null,
+            disabilities: null,
+          },
+        })
+        it('uses an empty string value as the field value', () => {
+          const presenter = new SelectExpectedProbationOfficePresenter(referralWithNoPPOffice, [], false, null, null)
+
+          expect(presenter.fields.expectedProbationOffice).toEqual('')
+        })
+      })
+
+      describe('when the probation office is set', () => {
+        it('when the referral already has set pp probation office and there is no user input data', () => {
+          const presenter = new SelectExpectedProbationOfficePresenter(
+            referral,
+            [
+              {
+                probationOfficeId: 1,
+                name: 'London',
+                address: '1A cross street',
+                probationRegionId: '3',
+                govUkURL: 'url',
+                deliusCRSLocationId: '1',
+              },
+            ],
+            false,
+            null,
+            null
+          )
+
+          expect(presenter.fields.expectedProbationOffice).toEqual('Norfolk')
+        })
+      })
+
+      describe('when the referral already has nDelius probation practitioner probation office is set and uses that value as the field value', () => {
+        it('the pp probation office value is not changed', () => {
+          const presenter = new SelectExpectedProbationOfficePresenter(referral, [], false, null, {
+            'expected-probation-office': 'London',
+          })
+          expect(presenter.fields.expectedProbationOffice).toEqual('London')
+        })
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficePresenter.ts
+++ b/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficePresenter.ts
@@ -1,0 +1,45 @@
+import DeliusOfficeLocation from '../../../../models/deliusOfficeLocation'
+import DraftReferral from '../../../../models/draftReferral'
+import { FormValidationError } from '../../../../utils/formValidationError'
+import PresenterUtils from '../../../../utils/presenterUtils'
+
+export default class SelectExpectedProbationOfficePresenter {
+  backLinkUrl: string
+
+  readonly probationOfficeUnknownUrl: string
+
+  constructor(
+    private readonly referral: DraftReferral,
+    readonly deliusOfficeLocations: DeliusOfficeLocation[],
+    private readonly amendPPDetails: boolean = false,
+    private readonly error: FormValidationError | null = null,
+    private readonly userInputData: Record<string, string> | null = null
+  ) {
+    this.backLinkUrl = amendPPDetails
+      ? `/referrals/${referral.id}/check-all-referral-information`
+      : `/referrals/${referral.id}/expected-release-date`
+    this.probationOfficeUnknownUrl = `/referrals/${referral.id}/expected-probation-office-unknown${
+      this.amendPPDetails ? '?amendPPDetails=true' : ''
+    }`
+  }
+
+  readonly text = {
+    title: `Confirm ${this.referral.serviceUser.firstName} ${this.referral.serviceUser.lastName}'s expected probation office`,
+    label: `${this.referral.serviceUser.firstName} ${this.referral.serviceUser.lastName} (CRN: ${this.referral.serviceUser.crn})`,
+    inputHeading: 'Probation office',
+    hint: `Start typing then choose probation office from the list`,
+  }
+
+  readonly errorMessage = PresenterUtils.errorMessage(this.error, 'expected-probation-office')
+
+  readonly errorSummary = PresenterUtils.errorSummary(this.error)
+
+  private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly fields = {
+    expectedProbationOffice: this.utils.stringValue(
+      this.referral.expectedProbationOffice!,
+      'expected-probation-office'
+    ),
+  }
+}

--- a/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficeView.ts
+++ b/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficeView.ts
@@ -1,0 +1,52 @@
+import { SelectArgs, SelectArgsItem } from '../../../../utils/govukFrontendTypes'
+import ViewUtils from '../../../../utils/viewUtils'
+import SelectExpectedProbationOfficePresenter from './selectExpectedProbationOfficePresenter'
+
+export default class SelectExpectedProbationOfficeView {
+  constructor(private readonly presenter: SelectExpectedProbationOfficePresenter) {}
+
+  private readonly errorSummaryArgs = ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary)
+
+  private get expectedProbationOfficeSelectArgs(): SelectArgs {
+    const officeLocationItems: SelectArgsItem[] = this.presenter.deliusOfficeLocations.map(officeLocation => ({
+      text: officeLocation.name,
+      value: officeLocation.name.toString(),
+      selected: this.presenter.fields.expectedProbationOffice
+        ? this.presenter.fields.expectedProbationOffice === officeLocation.name
+        : false,
+    }))
+
+    const items: SelectArgsItem[] = [
+      {
+        text: '-- Select a Probation Office --',
+      },
+    ]
+
+    items.push(...officeLocationItems)
+
+    return {
+      id: 'expected-probation-office',
+      name: 'expected-probation-office',
+      classes: 'confirm-probation-office',
+      items,
+      label: {
+        text: this.presenter.text.inputHeading,
+      },
+      hint: {
+        text: this.presenter.text.hint,
+      },
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'makeAReferral/expectedProbationOffice',
+      {
+        presenter: this.presenter,
+        errorSummaryArgs: this.errorSummaryArgs,
+        backLinkArgs: { href: this.presenter.backLinkUrl },
+        expectedProbationOfficeSelectArgs: this.expectedProbationOfficeSelectArgs,
+      },
+    ]
+  }
+}

--- a/server/routes/makeAReferral/form/referralFormPresenter.test.ts
+++ b/server/routes/makeAReferral/form/referralFormPresenter.test.ts
@@ -105,7 +105,7 @@ describe('ReferralFormPresenter', () => {
                 firstName: 'Bob',
                 lastName: 'Wills',
               },
-              personCurrentLocationType: CurrentLocationType.community,
+              personCurrentLocationType: CurrentLocationType.custody,
               isReferralReleasingIn12Weeks: true,
             })
             const presenter = new ReferralFormPresenter(referral, nonCohortIntervention)
@@ -118,7 +118,8 @@ describe('ReferralFormPresenter', () => {
                 )
                 .build(),
               referralFormSectionFactory
-                .confirmCurrentLocationAndExpectedReleaseDate(
+                .confirmCurrentLocationAndExpectedReleaseDateForPreReleaseNoCom(
+                  ReferralFormStatus.NotStarted,
                   ReferralFormStatus.NotStarted,
                   ReferralFormStatus.NotStarted,
                   referral.serviceUser.firstName,
@@ -132,13 +133,13 @@ describe('ReferralFormPresenter', () => {
                   ReferralFormStatus.NotStarted,
                   referral.serviceUser.firstName,
                   referral.serviceUser.lastName,
-                  '2'
+                  '3'
                 )
                 .build(),
               referralFormSectionFactory
-                .interventionDetails('accommodation', '3', ReferralFormStatus.CannotStartYet)
+                .interventionDetails('accommodation', '4', ReferralFormStatus.CannotStartYet)
                 .build(),
-              referralFormSectionFactory.checkAllReferralInformation(ReferralFormStatus.CannotStartYet, '4').build(),
+              referralFormSectionFactory.checkAllReferralInformation(ReferralFormStatus.CannotStartYet, '5').build(),
             ]
             expect(presenter.sections).toEqual(expected)
           })

--- a/server/routes/makeAReferral/form/referralFormPresenter.ts
+++ b/server/routes/makeAReferral/form/referralFormPresenter.ts
@@ -176,24 +176,46 @@ class FormSectionBuilder {
         `${this.referral.serviceUser.firstName} ${this.referral.serviceUser.lastName}`
       )}'s current location and expected release date`,
       number: '2',
-      tasks: [
-        {
-          title: 'Establishment',
-          url: this.calculateTaskUrl(
-            'submit-current-location',
-            this.referral.isReferralReleasingIn12Weeks === null
-              ? this.taskValues.probationPractitionerDetails
-              : this.taskValues.mainPointOfContactDetails
-          ),
-          status: this.calculateStatus(this.taskValues.currentLocationDetails),
-        },
-        {
-          title: 'Expected release date',
-          url: this.calculateTaskUrl('expected-release-date', this.taskValues.currentLocationDetails),
-          status: this.calculateStatus(this.taskValues.expectedReleaseDateDetails),
-        },
-      ],
+      tasks: this.buildCurrentLocationAndExpectedReleaseTaskList(),
     }
+  }
+
+  private buildCurrentLocationAndExpectedReleaseTaskList(): ReferralFormTaskPresenter[] {
+    let title
+    if (this.referral.isReferralReleasingIn12Weeks !== null && this.referral.isReferralReleasingIn12Weeks) {
+      title = 'Current location'
+    } else {
+      title = 'Establishment'
+    }
+
+    const referralTaskPresenter: ReferralFormTaskPresenter[] = []
+
+    referralTaskPresenter.push(
+      {
+        title,
+        url: this.calculateTaskUrl(
+          'submit-current-location',
+          this.referral.isReferralReleasingIn12Weeks === null
+            ? this.taskValues.probationPractitionerDetails
+            : this.taskValues.mainPointOfContactDetails
+        ),
+        status: this.calculateStatus(this.taskValues.currentLocationDetails),
+      },
+      {
+        title: 'Expected release date',
+        url: this.calculateTaskUrl('expected-release-date', this.taskValues.currentLocationDetails),
+        status: this.calculateStatus(this.taskValues.expectedReleaseDateDetails),
+      }
+    )
+    if (this.referral.isReferralReleasingIn12Weeks !== null && this.referral.isReferralReleasingIn12Weeks) {
+      referralTaskPresenter.push({
+        title: 'Expected probation office',
+        url: this.calculateTaskUrl('expected-probation-office', this.taskValues.expectedReleaseDateDetails),
+        status: this.calculateStatus(this.taskValues.expectedProbationOfficeDetails),
+      })
+    }
+
+    return referralTaskPresenter
   }
 
   private buildCurrentLocationSection(): ReferralFormSingleListSectionPresenter {
@@ -601,6 +623,10 @@ class TaskValues {
 
   get expectedReleaseDateDetails(): DraftReferralValues {
     return [this.referral.expectedReleaseDate || this.referral.expectedReleaseDateMissingReason ? true : null]
+  }
+
+  get expectedProbationOfficeDetails(): DraftReferralValues {
+    return [this.referral.expectedProbationOffice || this.referral.expectedProbationOfficeUnKnownReason ? true : null]
   }
 
   // TODO: remove this.referral.additionalRiskInformation once switched over to full risk information

--- a/server/routes/makeAReferral/makeAReferralController.test.ts
+++ b/server/routes/makeAReferral/makeAReferralController.test.ts
@@ -1012,7 +1012,7 @@ describe('POST /referrals/:id/expected-release-date/submit', () => {
         'release-date-year': tomorrow.format('YYYY'),
       })
       .expect(302)
-      .expect('Location', '/referrals/1/form')
+      .expect('Location', '/referrals/1/expected-probation-office')
 
     expect(interventionsService.patchDraftReferral.mock.calls[0]).toEqual([
       'token',
@@ -1042,7 +1042,7 @@ describe('POST /referrals/:id/expected-release-date/submit', () => {
         'release-date-unknown-reason': 'yet to receive the information from prison',
       })
       .expect(302)
-      .expect('Location', '/referrals/1/form')
+      .expect('Location', '/referrals/1/expected-probation-office')
 
     expect(interventionsService.patchDraftReferral.mock.calls[0]).toEqual([
       'token',

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -741,7 +741,46 @@ describe(ShowReferralPresenter, () => {
         { key: 'Expected probation office', lines: ['London'] },
       ])
     })
-    it('returns a summary list for a unallocated COM who knows the release date', () => {
+    it('returns a summary list for an unallocated COM with expected probation office', () => {
+      const referralParamsWithCustodyDetails = {
+        referral: {
+          serviceCategoryId: serviceCategory.id,
+          serviceCategoryIds: [serviceCategory.id],
+          serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+          personCurrentLocationType: CurrentLocationType.custody,
+          expectedReleaseDate: moment().add(2, 'days').format('YYYY-MM-DD'),
+          isReferralReleasingIn12Weeks: true,
+          expectedProbationOffice: 'Sheffield',
+        },
+      }
+      const sentReferral = sentReferralFactory.build(referralParamsWithCustodyDetails)
+      const presenter = new ShowReferralPresenter(
+        sentReferral,
+        intervention,
+        deliusConviction,
+        supplementaryRiskInformation,
+        deliusUser,
+        prisonsAndSecuredChildAgencies,
+        null,
+        null,
+        'service-provider',
+        true,
+        deliusServiceUser,
+        riskSummary,
+        deliusRoOfficer,
+        prisonerDetails
+      )
+
+      expect(presenter.serviceUserLocationDetails).toEqual([
+        { key: 'Prison establishment', lines: ['London'] },
+        {
+          key: 'Expected release date',
+          lines: [moment().add(2, 'days').format('D MMM YYYY [(]ddd[)]')],
+        },
+        { key: 'Expected probation office', lines: ['Sheffield'] },
+      ])
+    })
+    it('returns a summary list for an unallocated COM who knows the release date', () => {
       const referralParamsWithCustodyDetails = {
         referral: {
           serviceCategoryId: serviceCategory.id,
@@ -775,6 +814,45 @@ describe(ShowReferralPresenter, () => {
         {
           key: 'Expected release date',
           lines: [moment().add(2, 'days').format('D MMM YYYY [(]ddd[)]')],
+        },
+        { key: 'Expected probation office', lines: ['London'] },
+      ])
+    })
+
+    it('returns a summary list for an unallocated COM with unknown release date and probation office', () => {
+      const referralParamsWithCustodyDetails = {
+        referral: {
+          serviceCategoryId: serviceCategory.id,
+          serviceCategoryIds: [serviceCategory.id],
+          serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+          personCurrentLocationType: CurrentLocationType.custody,
+          expectedReleaseDate: moment().add(2, 'days').format('YYYY-MM-DD'),
+          isReferralReleasingIn12Weeks: false,
+        },
+      }
+      const sentReferral = sentReferralFactory.build(referralParamsWithCustodyDetails)
+      const presenter = new ShowReferralPresenter(
+        sentReferral,
+        intervention,
+        deliusConviction,
+        supplementaryRiskInformation,
+        deliusUser,
+        prisonsAndSecuredChildAgencies,
+        null,
+        null,
+        'service-provider',
+        true,
+        deliusServiceUser,
+        riskSummary,
+        deliusRoOfficer,
+        prisonerDetails
+      )
+
+      expect(presenter.serviceUserLocationDetails).toEqual([
+        { key: 'Prison establishment', lines: ['London'] },
+        {
+          key: 'Expected release date',
+          lines: ['---'],
         },
         { key: 'Expected probation office', lines: ['London'] },
       ])

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -602,32 +602,36 @@ export default class ShowReferralPresenter {
   private get determineOfficeLocation(): SummaryListItem {
     const { personCurrentLocationType } = this.sentReferral.referral
 
-    let location: string
-
     if (personCurrentLocationType === CurrentLocationType.custody) {
+      if (this.sentReferral.referral.isReferralReleasingIn12Weeks !== null) {
+        return {
+          key: 'Expected probation office',
+          lines: [this.sentReferral.referral.expectedProbationOffice || '---'],
+        }
+      }
       if (
         this.sentReferral.referral.ppProbationOffice !== null &&
         this.sentReferral.referral.ppProbationOffice !== ''
       ) {
-        location = 'Expected probation office'
-      } else {
-        location = 'Expected PDU (Probation Delivery Unit)'
+        return {
+          key: 'Expected probation office',
+          lines: [this.sentReferral.referral.ppProbationOffice],
+        }
       }
-    } else if (
-      this.sentReferral.referral.ppProbationOffice !== null &&
-      this.sentReferral.referral.ppProbationOffice !== ''
-    ) {
-      location = 'Probation office'
-    } else {
-      location = 'PDU (Probation Delivery Unit)'
+      return {
+        key: 'Expected PDU (Probation Delivery Unit)',
+        lines: [this.sentReferral.referral.ppPdu || this.sentReferral.referral.ndeliusPDU || '---'],
+      }
+    }
+    if (this.sentReferral.referral.ppProbationOffice !== null && this.sentReferral.referral.ppProbationOffice !== '') {
+      return {
+        key: 'Probation office',
+        lines: [this.sentReferral.referral.ppProbationOffice],
+      }
     }
     return {
-      key: location,
-      lines: [
-        this.sentReferral.referral.ppProbationOffice !== null && this.sentReferral.referral.ppProbationOffice !== ''
-          ? this.sentReferral.referral.ppProbationOffice
-          : this.sentReferral.referral.ppPdu || this.sentReferral.referral.ndeliusPDU || '---',
-      ],
+      key: 'PDU (Probation Delivery Unit)',
+      lines: [this.sentReferral.referral.ppPdu || this.sentReferral.referral.ndeliusPDU || '---'],
     }
   }
 

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1555,6 +1555,8 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       alreadyKnowPrisonName: null,
       expectedReleaseDate: moment().add(1, 'days').format('YYYY-MM-DD'),
       expectedReleaseDateMissingReason: null,
+      expectedProbationOffice: 'London',
+      expectedProbationOfficeUnKnownReason: null,
       hasExpectedReleaseDate: null,
       ndeliusPPName: 'Bob',
       ndeliusPPEmailAddress: 'bob@example.com',

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -175,6 +175,12 @@ export default {
   releaseDateUnknownReason: {
     empty: `Enter a reason why the expected release date is not known`,
   },
+  expectedProbationOffice: {
+    empty: `Select a probation office from the list`,
+  },
+  probationOfficeUnknownReason: {
+    empty: `Enter a reason why the expected probation office is not known`,
+  },
   hasAdditionalResponsibilities: {
     empty: (name: string) => `Select yes if ${name} has caring or employment responsibilities`,
   },

--- a/server/views/makeAReferral/checkAllReferralInformation.njk
+++ b/server/views/makeAReferral/checkAllReferralInformation.njk
@@ -32,7 +32,7 @@
         {{ govukSummaryList(communityLocationAndReleaseDetailsSummaryListArgs) }}
       {% endif %}
 
-      {% if expectedReleaseDateDetailsSummaryListArgs and (presenter.checkIfExpectedReleaseDateIsAvailable) %}
+      {% if expectedReleaseDateDetailsSummaryListArgs %}
         {{ govukSummaryList(expectedReleaseDateDetailsSummaryListArgs) }}
       {% endif %}
 
@@ -58,10 +58,6 @@
 
       {% if mainPointOfContactDetailsSummaryListArgs and (presenter.checkIfUnAllocatedCOM) %}
         {{ govukSummaryList(mainPointOfContactDetailsSummaryListArgs) }}
-      {% endif %}
-      
-      {% if locationDetailsSummaryListArgs and (not presenter.checkIfExpectedReleaseDateIsAvailable) %}
-        {{ govukSummaryList(locationDetailsSummaryListArgs) }}
       {% endif %}
 
       {{ govukSummaryList(lastKnownAddressAndContactDetailsSummaryListArgs) }}

--- a/server/views/makeAReferral/expectedProbationOffice.njk
+++ b/server/views/makeAReferral/expectedProbationOffice.njk
@@ -1,0 +1,58 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Update probation practitioner office" %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if backLinkArgs %}
+        {{ govukBackLink(backLinkArgs) }}
+      {% endif %}
+
+      <p class="govuk-caption-l">{{ presenter.text.label }} </p>
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      <form method="post" novalidate>
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+
+        {% if errorSummaryArgs !== null %}
+          {{ govukErrorSummary(errorSummaryArgs) }}
+        {% endif %}
+
+        {{ govukSelect(expectedProbationOfficeSelectArgs) }}
+          <script src="/assets/accessible-autocomplete.min.js"></script>
+          <script>
+              accessibleAutocomplete.enhanceSelectElement({
+                defaultValue: '',
+                selectElement: document.querySelector('#expected-probation-office')
+              })
+          </script>
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ presenter.probationOfficeUnknownUrl }}">I don't know the expected probation office</a>
+        </p>                
+        {{ govukButton({ classes: "confirm-pp-details",text: "Save and continue", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+  <script>
+    $(function () {
+      $('.confirm-pp-details').on('click', function () {
+        if (!$.trim($('#expected-probation-office').val()).length) {
+          $('.confirm-probation-office').val('')
+          $('.confirm-probation-office').selected = false
+        }
+    })
+  })     
+  </script>  
+{% endblock %}

--- a/server/views/makeAReferral/expectedProbationOfficeUnknown.njk
+++ b/server/views/makeAReferral/expectedProbationOfficeUnknown.njk
@@ -1,0 +1,38 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Expected probation office" %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukBackLink(backLinkArgs) }}
+      <br>
+      <br>
+      {% if errorSummaryArgs !== null %}
+        {{ govukErrorSummary(errorSummaryArgs) }}
+      {% endif %}
+
+
+      <p class="govuk-caption-xl">{{ presenter.text.label }} </p>
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+        {{ govukTextarea(probationOfficeUnknownReasonArgs) }}
+        <br>
+        <br>
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -53,28 +53,37 @@ class DraftReferralFactory extends Factory<DraftReferral> {
     })
   }
 
-  selectedServiceCategories(serviceCategories: ServiceCategory[]) {
+  selectedServiceCategories(serviceCategories: ServiceCategory[], unallocatedCOM = false) {
     const resolvedServiceCategoryIds = serviceCategories.map(serviceCategory => serviceCategory.id)
+    if (unallocatedCOM) {
+      return this.filledFormUpToExpectedProbationOffice().params({
+        serviceCategoryIds: resolvedServiceCategoryIds,
+      })
+    }
     return this.filledFormUpToExpectedReleaseDate().params({
       serviceCategoryIds: resolvedServiceCategoryIds,
     })
   }
 
-  filledFormUpToRiskInformation(serviceCategories: ServiceCategory[] = [serviceCategoryFactory.build()]) {
-    return this.selectedServiceCategories(serviceCategories).params({
+  filledFormUpToRiskInformation(
+    serviceCategories: ServiceCategory[] = [serviceCategoryFactory.build()],
+    unallocatedCOM = false
+  ) {
+    return this.selectedServiceCategories(serviceCategories, unallocatedCOM).params({
       additionalRiskInformation: 'A danger to the elderly',
     })
   }
 
   filledFormUpToNeedsAndRequirements(
     serviceCategories: ServiceCategory[] = [serviceCategoryFactory.build()],
-    skipAdditionalRiskInformation = false
+    skipAdditionalRiskInformation = false,
+    unallocatedCOM = false
   ) {
     let filledForm: this
     if (skipAdditionalRiskInformation) {
-      filledForm = this.selectedServiceCategories(serviceCategories)
+      filledForm = this.selectedServiceCategories(serviceCategories, unallocatedCOM)
     } else {
-      filledForm = this.filledFormUpToRiskInformation(serviceCategories)
+      filledForm = this.filledFormUpToRiskInformation(serviceCategories, unallocatedCOM)
     }
     return filledForm.params({
       additionalNeedsInformation: 'Alex is currently sleeping on her aunt’s sofa',
@@ -153,6 +162,12 @@ class DraftReferralFactory extends Factory<DraftReferral> {
     const tomorrow = moment().add(1, 'days')
     return this.filledFormUpToCurrentLocation().params({
       expectedReleaseDate: tomorrow.format('YYYY-MM-DD'),
+    })
+  }
+
+  filledFormUpToExpectedProbationOffice() {
+    return this.filledFormUpToExpectedReleaseDate().params({
+      expectedProbationOffice: 'Chelmsford: Chelmsford Probation Office',
     })
   }
 
@@ -248,6 +263,8 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   hasExpectedReleaseDate: null,
   expectedReleaseDate: null,
   expectedReleaseDateMissingReason: null,
+  expectedProbationOffice: null,
+  expectedProbationOfficeUnKnownReason: null,
   contractTypeName: interventionFactory.build().contractType.name,
   personCurrentLocationType: null,
   personCustodyPrisonId: null,

--- a/testutils/factories/referralFormSection.ts
+++ b/testutils/factories/referralFormSection.ts
@@ -40,6 +40,34 @@ class ReferralFormSectionFactory extends Factory<ReferralFormSingleListSectionPr
     })
   }
 
+  confirmCurrentLocationAndExpectedReleaseDateForPreReleaseNoCom(
+    establishmentReferralFormStatus: ReferralFormStatus = ReferralFormStatus.NotStarted,
+    expectedReleaseDateReferralFormStatus: ReferralFormStatus = ReferralFormStatus.NotStarted,
+    expectedProbationOfficeReferralFormStatus: ReferralFormStatus = ReferralFormStatus.NotStarted,
+    userFirstName: string | null = null,
+    userLastName: string | null = null,
+    establishmentUrl: string | null = null,
+    expectedReleaseDateUrl: string | null = null,
+    expectedProbationOfficeUrl: string | null = null
+  ) {
+    return this.params({
+      type: 'single',
+      title: `Confirm ${utils.convertToTitleCase(
+        `${userFirstName} ${userLastName}`
+      )}'s current location and expected release date`,
+      number: '2',
+      tasks: [
+        { title: 'Current location', url: establishmentUrl, status: establishmentReferralFormStatus },
+        { title: 'Expected release date', url: expectedReleaseDateUrl, status: expectedReleaseDateReferralFormStatus },
+        {
+          title: 'Expected probation office',
+          url: expectedProbationOfficeUrl,
+          status: expectedProbationOfficeReferralFormStatus,
+        },
+      ],
+    })
+  }
+
   confirmCurrentLocation(
     establishmentReferralFormStatus: ReferralFormStatus = ReferralFormStatus.NotStarted,
     userFirstName: string | null = null,

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -55,6 +55,8 @@ const exampleReferralFields = () => {
     alreadyKnowPrisonName: null,
     expectedReleaseDate: moment().add(1, 'days').format('YYYY-MM-DD'),
     expectedReleaseDateMissingReason: null,
+    expectedProbationOffice: 'London',
+    expectedProbationOfficeUnKnownReason: null,
     hasExpectedReleaseDate: null,
     ndeliusPPName: 'John Davies',
     ndeliusPPEmailAddress: 'john@example.com',


### PR DESCRIPTION
## What does this pull request do?

- capturing the expected probation office for the referral
- capturing the expected probation unknown reason for the referral
- displaying the captured information in summary and referral details page

## What is the intent behind these changes?

- PP needs to input the expected probation office where there referral is going to go
- This will help SP to gain information about the referral