### PR TITLE
expected probation office not known

### DIFF
--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
@@ -679,6 +679,49 @@ describe(CheckAllReferralInformationPresenter, () => {
       })
     })
 
+    describe('probation office not known and release details for a pre-release with no com custody referral', () => {
+      const referral = parameterisedDraftReferralFactory.build({
+        personCurrentLocationType: CurrentLocationType.custody,
+        isReferralReleasingIn12Weeks: true,
+        expectedProbationOffice: null,
+        expectedProbationOfficeUnKnownReason: 'some reason',
+        ppProbationOffice: 'Derbyshire: Buxton Probation Office',
+        expectedReleaseDate: '04-04-2024',
+        personCustodyPrisonId: 'ccc',
+      })
+      const presenter = new CheckAllReferralInformationPresenter(
+        referral,
+        interventionFactory.build({ serviceCategories }),
+        loggedInUser,
+        conviction,
+        deliusServiceUser,
+        prisonsAndSecuredChildAgencies,
+        prisonerDetails
+      )
+      it('returns the location and release details summary', () => {
+        expect(presenter.currentLocationAndReleaseDetailsSection).toEqual({
+          title: `Alex River’s current location and expected release date`,
+          summary: [
+            {
+              key: 'Location at time of referral',
+              lines: ['Aylesbury (HMYOI)'],
+              changeLink: `/referrals/${referral.id}/submit-current-location?amendPPDetails=true`,
+            },
+            {
+              key: 'Expected release date',
+              lines: [`4 Apr 2024 (Thu)`],
+              changeLink: `/referrals/${referral.id}/expected-release-date?amendPPDetails=true`,
+            },
+            {
+              key: 'Reason why expected probation office is not known',
+              lines: ['some reason'],
+              changeLink: `/referrals/${referral.id}/expected-probation-office?amendPPDetails=true`,
+            },
+          ],
+        })
+      })
+    })
+
     describe('current location and release details for a pre-release with no com and in prison', () => {
       const referral = parameterisedDraftReferralFactory.build({
         personCurrentLocationType: CurrentLocationType.custody,

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
@@ -173,7 +173,14 @@ export default class CheckAllReferralInformationPresenter {
   }
 
   private derivePduOrProbationOffice(probationOfficeHeading: string, pduHeading: string): SummaryListItem {
-    if (this.referral.isReferralReleasingIn12Weeks !== null && !this.referral.isReferralReleasingIn12Weeks) {
+    if (this.referral.isReferralReleasingIn12Weeks !== null) {
+      if (this.referral.expectedProbationOfficeUnKnownReason !== null) {
+        return {
+          key: 'Reason why expected probation office is not known',
+          lines: [this.referral.expectedProbationOfficeUnKnownReason],
+          changeLink: `/referrals/${this.referral.id}/expected-probation-office?amendPPDetails=true`,
+        }
+      }
       return {
         key: probationOfficeHeading,
         lines: [this.referral.expectedProbationOffice || '---'],

--- a/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownForm.test.ts
+++ b/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownForm.test.ts
@@ -10,6 +10,7 @@ describe(ExpectedProbationOfficeUnknownForm, () => {
       const data = await new ExpectedProbationOfficeUnknownForm(request).data()
 
       expect(data.paramsForUpdate?.expectedProbationOfficeUnKnownReason).toEqual('data not received from nDelius')
+      expect(data.paramsForUpdate?.expectedProbationOffice).toBeNull()
     })
   })
 

--- a/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownForm.ts
+++ b/server/routes/makeAReferral/expected-probation-office/expected-probation-office-unknown/expectedProbationOfficeUnknownForm.ts
@@ -25,6 +25,7 @@ export default class ExpectedProbationOfficeUnknownForm {
       : {
           paramsForUpdate: {
             expectedProbationOfficeUnKnownReason: this.request.body['probation-office-unknown-reason'],
+            expectedProbationOffice: null,
           },
           error: null,
         }

--- a/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficeForm.test.ts
+++ b/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficeForm.test.ts
@@ -11,6 +11,7 @@ describe(SelectExpectedProbationOfficeForm, () => {
         const data = await SelectExpectedProbationOfficeForm.createForm(request)
 
         expect(data.paramsForUpdate?.expectedProbationOffice).toEqual('London')
+        expect(data.paramsForUpdate?.expectedProbationOfficeUnKnownReason).toBeNull()
       })
     })
   })

--- a/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficeForm.ts
+++ b/server/routes/makeAReferral/expected-probation-office/select-probation-office/selectExpectedProbationOfficeForm.ts
@@ -22,6 +22,7 @@ export default class SelectExpectedProbationOfficeForm {
   get paramsForUpdate(): Partial<DraftReferral> {
     return {
       expectedProbationOffice: this.request.body['expected-probation-office'],
+      expectedProbationOfficeUnKnownReason: null,
     }
   }
 

--- a/server/routes/makeAReferral/makeAReferralController.ts
+++ b/server/routes/makeAReferral/makeAReferralController.ts
@@ -1100,7 +1100,8 @@ export default class MakeAReferralController {
     const deliusOfficeLocations = await this.referenceDataService.getProbationOffices()
     const serviceUser = await this.ramDeliusApiService.getCaseDetailsByCrn(referral.serviceUser.crn)
 
-    const presenter = new SelectExpectedProbationOfficePresenter(referral, deliusOfficeLocations)
+    const amendPPDetails = req.query.amendPPDetails === 'true'
+    const presenter = new SelectExpectedProbationOfficePresenter(referral, deliusOfficeLocations, amendPPDetails)
     const view = new SelectExpectedProbationOfficeView(presenter)
 
     await ControllerUtils.renderWithLayout(req, res, view, serviceUser, 'probation-practitioner')

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -819,6 +819,47 @@ describe(ShowReferralPresenter, () => {
       ])
     })
 
+    it('returns a summary list for an unallocated COM who does not know the probation office', () => {
+      const referralParamsWithCustodyDetails = {
+        referral: {
+          serviceCategoryId: serviceCategory.id,
+          serviceCategoryIds: [serviceCategory.id],
+          serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+          personCurrentLocationType: CurrentLocationType.custody,
+          expectedReleaseDate: moment().add(2, 'days').format('YYYY-MM-DD'),
+          expectedProbationOffice: null,
+          expectedProbationOfficeUnKnownReason: 'Some reason',
+          isReferralReleasingIn12Weeks: true,
+        },
+      }
+      const sentReferral = sentReferralFactory.build(referralParamsWithCustodyDetails)
+      const presenter = new ShowReferralPresenter(
+        sentReferral,
+        intervention,
+        deliusConviction,
+        supplementaryRiskInformation,
+        deliusUser,
+        prisonsAndSecuredChildAgencies,
+        null,
+        null,
+        'service-provider',
+        true,
+        deliusServiceUser,
+        riskSummary,
+        deliusRoOfficer,
+        prisonerDetails
+      )
+
+      expect(presenter.serviceUserLocationDetails).toEqual([
+        { key: 'Prison establishment', lines: ['London'] },
+        {
+          key: 'Expected release date',
+          lines: [moment().add(2, 'days').format('D MMM YYYY [(]ddd[)]')],
+        },
+        { key: 'Reason why expected probation office is not known', lines: ['Some reason'] },
+      ])
+    })
+
     it('returns a summary list for an unallocated COM with unknown release date and probation office', () => {
       const referralParamsWithCustodyDetails = {
         referral: {

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -604,6 +604,12 @@ export default class ShowReferralPresenter {
 
     if (personCurrentLocationType === CurrentLocationType.custody) {
       if (this.sentReferral.referral.isReferralReleasingIn12Weeks !== null) {
+        if (this.sentReferral.referral.expectedProbationOfficeUnKnownReason !== null) {
+          return {
+            key: 'Reason why expected probation office is not known',
+            lines: [this.sentReferral.referral.expectedProbationOfficeUnKnownReason],
+          }
+        }
         return {
           key: 'Expected probation office',
           lines: [this.sentReferral.referral.expectedProbationOffice || '---'],


### PR DESCRIPTION
## What does this pull request do?

- delivers a page where user can enter the reason why the expected probation office is not known

## What is the intent behind these changes?

- The PP who is creating the referral is allowed to enter to reason why he does not know the expected probation office
