### PR TITLE
capturing the reason for referral before allocation

### DIFF
--- a/integration_tests/integration/referralUnAllocatedCom.cy.js
+++ b/integration_tests/integration/referralUnAllocatedCom.cy.js
@@ -101,8 +101,17 @@ describe('Referral form', () => {
         interventionId: draftReferral.interventionId,
       })
 
+      const completedReferralReason = draftReferralFactory.filledReasonForReferralCreationBeforeAllocation().build({
+        id: draftReferral.id,
+        serviceCategoryIds: [accommodationServiceCategory.id],
+        serviceProvider: {
+          name: 'Harmony Living',
+        },
+        interventionId: draftReferral.interventionId,
+      })
+
       const completedNeedsAndRequirementsDraftReferral = draftReferralFactory
-        .filledMainPointOfContactDetails()
+        .filledReasonForReferralCreationBeforeAllocation()
         .filledFormUpToNeedsAndRequirements([accommodationServiceCategory], false, true)
         .build({
           id: draftReferral.id,
@@ -126,7 +135,7 @@ describe('Referral form', () => {
         })
 
       const completedExpectedProbationOfficeDraftReferral = draftReferralFactory
-        .filledMainPointOfContactDetails()
+        .filledReasonForReferralCreationBeforeAllocation()
         .filledFormUpToExpectedProbationOffice(CurrentLocationType.custody)
         .build({
           id: draftReferral.id,
@@ -151,7 +160,7 @@ describe('Referral form', () => {
         })
 
       const completedDraftReferral = draftReferralFactory
-        .filledMainPointOfContactDetails()
+        .filledReasonForReferralCreationBeforeAllocation()
         .filledFormUpToExpectedProbationOffice()
         .filledFormUpToFurtherInformation([accommodationServiceCategory], 'Some information about Alex')
         .build({
@@ -293,6 +302,15 @@ describe('Referral form', () => {
       cy.get('[type="radio"]').check('establishment')
       cy.get('#prison-select').type('Bedford (HMP & YOI)')
       cy.stubGetDraftReferral(draftReferral.id, completedPPDetails)
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/reason-for-referral-before-allocation`)
+      cy.contains(`Alex River (CRN: ${completedPPDetails.serviceUser.crn})`)
+      cy.contains(
+        'Enter reason why referral is being made before a probation practitioner has been allocated (if known'
+      )
+      cy.get('#referral-creation-reason-before-allocation').type('some reason')
+      cy.stubGetDraftReferral(draftReferral.id, completedReferralReason)
       cy.contains('Save and continue').click()
 
       ReferralSectionVerifier.verifySection
@@ -768,7 +786,19 @@ describe('Referral form', () => {
 
       const completedPPDetails = draftReferralFactory
         .filledPersonalCurrentLocationType(CurrentLocationType.custody)
-        .filledMainPointOfContactDetails(false)
+        .filledReasonForReferralCreationBeforeAllocation(false)
+        .build({
+          id: draftReferral.id,
+          serviceCategoryIds: [accommodationServiceCategory.id],
+          serviceProvider: {
+            name: 'Harmony Living',
+          },
+          interventionId: draftReferral.interventionId,
+        })
+
+      const completedReferralReason = draftReferralFactory
+        .filledPersonalCurrentLocationType(CurrentLocationType.custody)
+        .filledReasonForReferralCreationBeforeAllocation('some reason', false)
         .build({
           id: draftReferral.id,
           serviceCategoryIds: [accommodationServiceCategory.id],
@@ -780,7 +810,7 @@ describe('Referral form', () => {
 
       const completedNeedsAndRequirementsDraftReferral = draftReferralFactory
         .filledPersonalCurrentLocationType(CurrentLocationType.custody)
-        .filledMainPointOfContactDetails(false)
+        .filledReasonForReferralCreationBeforeAllocation('some reason', false)
         .filledFormUpToNeedsAndRequirements([accommodationServiceCategory])
         .build({
           id: draftReferral.id,
@@ -794,7 +824,7 @@ describe('Referral form', () => {
 
       const completedEstablishmentDraftReferral = draftReferralFactory
         .filledPersonalCurrentLocationType(CurrentLocationType.custody)
-        .filledMainPointOfContactDetails(false)
+        .filledReasonForReferralCreationBeforeAllocation(false)
         .filledFormUpToCurrentLocationForUnallocatedCOM(false)
         .build({
           id: draftReferral.id,
@@ -807,7 +837,7 @@ describe('Referral form', () => {
 
       const completedDraftReferral = draftReferralFactory
         .filledPersonalCurrentLocationType(CurrentLocationType.custody)
-        .filledMainPointOfContactDetails(false)
+        .filledReasonForReferralCreationBeforeAllocation('some reason', false)
         .filledFormUpToFurtherInformation([accommodationServiceCategory], 'Some information about Alex')
         .build({
           id: draftReferral.id,
@@ -942,6 +972,15 @@ describe('Referral form', () => {
       cy.get('[type="radio"]').check('establishment')
       cy.get('#prison-select').type('Bedford (HMP & YOI)')
       cy.stubGetDraftReferral(draftReferral.id, completedPPDetails)
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/reason-for-referral-before-allocation`)
+      cy.contains(`Alex River (CRN: ${completedPPDetails.serviceUser.crn})`)
+      cy.contains(
+        'Enter reason why referral is being made before a probation practitioner has been allocated (if known'
+      )
+      cy.get('#referral-creation-reason-before-allocation').type('some reason')
+      cy.stubGetDraftReferral(draftReferral.id, completedReferralReason)
       cy.contains('Save and continue').click()
 
       ReferralSectionVerifier.verifySection
@@ -1417,8 +1456,17 @@ describe('Referral form', () => {
         interventionId: draftReferral.interventionId,
       })
 
+      const completedReferralReason = draftReferralFactory.filledReasonForReferralCreationBeforeAllocation().build({
+        id: draftReferral.id,
+        serviceCategoryIds: [accommodationServiceCategory.id],
+        serviceProvider: {
+          name: 'Harmony Living',
+        },
+        interventionId: draftReferral.interventionId,
+      })
+
       const completedNeedsAndRequirementsDraftReferral = draftReferralFactory
-        .filledMainPointOfContactDetails()
+        .filledReasonForReferralCreationBeforeAllocation()
         .filledFormUpToNeedsAndRequirements([accommodationServiceCategory, socialInclusionServiceCategory], false, true)
         .build({
           id: draftReferral.id,
@@ -1453,7 +1501,7 @@ describe('Referral form', () => {
         })
 
       const completedExpectedProbationOfficeDraftReferral = draftReferralFactory
-        .filledMainPointOfContactDetails()
+        .filledReasonForReferralCreationBeforeAllocation()
         .filledFormUpToExpectedProbationOffice(CurrentLocationType.custody)
         .build({
           id: draftReferral.id,
@@ -1466,7 +1514,7 @@ describe('Referral form', () => {
         })
 
       const completedDraftReferral = draftReferralFactory
-        .filledMainPointOfContactDetails()
+        .filledReasonForReferralCreationBeforeAllocation()
         .filledFormUpToExpectedProbationOffice()
         .filledFormUpToFurtherInformation(
           [accommodationServiceCategory, socialInclusionServiceCategory],
@@ -1612,6 +1660,15 @@ describe('Referral form', () => {
       cy.get('[type="radio"]').check('establishment')
       cy.get('#prison-select').type('Bedford (HMP & YOI)')
       cy.stubGetDraftReferral(draftReferral.id, completedPPDetails)
+      cy.contains('Save and continue').click()
+
+      cy.location('pathname').should('equal', `/referrals/${draftReferral.id}/reason-for-referral-before-allocation`)
+      cy.contains(`Alex River (CRN: ${completedPPDetails.serviceUser.crn})`)
+      cy.contains(
+        'Enter reason why referral is being made before a probation practitioner has been allocated (if known'
+      )
+      cy.get('#referral-creation-reason-before-allocation').type('some reason')
+      cy.stubGetDraftReferral(draftReferral.id, completedReferralReason)
       cy.contains('Save and continue').click()
 
       ReferralSectionVerifier.verifySection

--- a/server/models/draftReferral.ts
+++ b/server/models/draftReferral.ts
@@ -50,6 +50,7 @@ export interface ReferralFields {
   ppLocationType: string | null
   allocatedCommunityPP: boolean | null
   reasonForReferral: string | null
+  reasonForReferralCreationBeforeAllocation: string | null
 }
 
 export enum CurrentLocationType {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -208,6 +208,12 @@ function probationPractitionerRoutesWithoutPrefix(router: Router, services: Serv
   post(router, '/referrals/:id/expected-probation-office-unknown', (req, res) =>
     makeAReferralController.submitExpectedProbationOfficeUnknown(req, res)
   )
+  get(router, '/referrals/:id/reason-for-referral-before-allocation', (req, res) =>
+    makeAReferralController.viewReasonForReferralBeforePpAllocation(req, res)
+  )
+  post(router, '/referrals/:id/reason-for-referral-before-allocation', (req, res) =>
+    makeAReferralController.submitReasonForReferralBeforePpAllocation(req, res)
+  )
   get(router, '/referrals/:id/confirm-probation-practitioner-details', (req, res) =>
     makeAReferralController.viewConfirmProbationPractitionerDetails(req, res)
   )

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
@@ -225,6 +225,66 @@ describe(CheckAllReferralInformationPresenter, () => {
             },
           ])
         })
+        it('returns the main point of contact details summary', () => {
+          const referralWithUnAllocatedCom = parameterisedDraftReferralFactory.build({
+            personCurrentLocationType: CurrentLocationType.custody,
+            ndeliusPPName: 'Victor Drake',
+            ndeliusPPEmailAddress: 'a.b@xyz.com',
+            ndeliusPDU: 'London',
+            ndeliusPhoneNumber: '075950243221',
+            ndeliusTeamPhoneNumber: '020456734343',
+            ppName: null,
+            ppEmailAddress: null,
+            ppPdu: null,
+            ppProbationOffice: 'London',
+            ppPhoneNumber: '045890232322',
+            hasValidDeliusPPDetails: null,
+            roleOrJobTitle: 'probation practitioner',
+            reasonForReferralCreationBeforeAllocation: 'some reason',
+            isReferralReleasingIn12Weeks: true,
+          })
+          const referralWithUnAllocatedComPresenter = new CheckAllReferralInformationPresenter(
+            referralWithUnAllocatedCom,
+            interventionFactory.build({ serviceCategories }),
+            loggedInUser,
+            conviction,
+            deliusServiceUser,
+            prisonsAndSecuredChildAgencies,
+            prisonerDetails
+          )
+          expect(referralWithUnAllocatedComPresenter.mainPointOfContactDetailsSection?.summary).toEqual([
+            {
+              key: 'Name',
+              lines: ['Victor Drake'],
+              changeLink: `/referrals/${referralWithUnAllocatedCom.id}/confirm-main-point-of-contact?amendPPDetails=true`,
+            },
+            {
+              key: 'Role / job title',
+              lines: ['probation practitioner'],
+              changeLink: `/referrals/${referralWithUnAllocatedCom.id}/confirm-main-point-of-contact?amendPPDetails=true`,
+            },
+            {
+              key: 'Email address',
+              lines: ['a.b@xyz.com'],
+              changeLink: `/referrals/${referralWithUnAllocatedCom.id}/confirm-main-point-of-contact?amendPPDetails=true`,
+            },
+            {
+              key: 'Reason why referral is being made before probation practitioner allocated',
+              lines: ['some reason'],
+              changeLink: `/referrals/${referralWithUnAllocatedCom.id}/reason-for-referral-before-allocation?amendPPDetails=true`,
+            },
+            {
+              key: 'Phone number',
+              lines: ['045890232322'],
+              changeLink: `/referrals/${referralWithUnAllocatedCom.id}/confirm-main-point-of-contact?amendPPDetails=true`,
+            },
+            {
+              key: 'Probation office',
+              lines: ['London'],
+              changeLink: `/referrals/${referralWithUnAllocatedCom.id}/confirm-main-point-of-contact?amendPPDetails=true`,
+            },
+          ])
+        })
       })
     })
 

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
@@ -239,6 +239,11 @@ export default class CheckAllReferralInformationPresenter {
           changeLink: `/referrals/${this.referral.id}/confirm-main-point-of-contact?amendPPDetails=true`,
         },
         {
+          key: 'Reason why referral is being made before probation practitioner allocated',
+          lines: [this.referral.reasonForReferralCreationBeforeAllocation || ''],
+          changeLink: `/referrals/${this.referral.id}/reason-for-referral-before-allocation?amendPPDetails=true`,
+        },
+        {
           key: 'Phone number',
           lines: [this.referral.ppPhoneNumber || 'Not found'],
           changeLink: `/referrals/${this.referral.id}/confirm-main-point-of-contact?amendPPDetails=true`,

--- a/server/routes/makeAReferral/makeAReferralController.test.ts
+++ b/server/routes/makeAReferral/makeAReferralController.test.ts
@@ -1611,7 +1611,7 @@ describe('POST /referrals/:id/confirm-main-point-of-contact', () => {
         'probation-practitioner-pdu': '',
       })
       .expect(302)
-      .expect('Location', '/referrals/1/form')
+      .expect('Location', '/referrals/1/reason-for-referral-before-allocation')
 
     expect(interventionsService.patchDraftReferral.mock.calls[0]).toEqual([
       'token',

--- a/server/routes/makeAReferral/referral-creation-reason/referralCreationReasonForm.test.ts
+++ b/server/routes/makeAReferral/referral-creation-reason/referralCreationReasonForm.test.ts
@@ -1,0 +1,15 @@
+import TestUtils from '../../../../testutils/testUtils'
+import ReferralCreationReasonForm from './referralCreationReasonForm'
+
+describe(ReferralCreationReasonForm, () => {
+  describe('when a expected release date is not known', () => {
+    it('returns a paramsForUpdate with the reason for why the release date is not known', async () => {
+      const request = TestUtils.createRequest({
+        'referral-creation-reason-before-allocation': 'for a quick assessment',
+      })
+      const data = await new ReferralCreationReasonForm(request).data()
+
+      expect(data.paramsForUpdate?.reasonForReferralCreationBeforeAllocation).toEqual('for a quick assessment')
+    })
+  })
+})

--- a/server/routes/makeAReferral/referral-creation-reason/referralCreationReasonForm.ts
+++ b/server/routes/makeAReferral/referral-creation-reason/referralCreationReasonForm.ts
@@ -1,0 +1,16 @@
+import { Request } from 'express'
+import DraftReferral from '../../../models/draftReferral'
+import { FormData } from '../../../utils/forms/formData'
+
+export default class ReferralCreationReasonForm {
+  constructor(private readonly request: Request) {}
+
+  async data(): Promise<FormData<Partial<DraftReferral>>> {
+    return {
+      paramsForUpdate: {
+        reasonForReferralCreationBeforeAllocation: this.request.body['referral-creation-reason-before-allocation'],
+      },
+      error: null,
+    }
+  }
+}

--- a/server/routes/makeAReferral/referral-creation-reason/referralCreationReasonPresenter.test.ts
+++ b/server/routes/makeAReferral/referral-creation-reason/referralCreationReasonPresenter.test.ts
@@ -1,0 +1,20 @@
+import draftReferralFactory from '../../../../testutils/factories/draftReferral'
+import ReferralCreationReasonPresenter from './referralCreationReasonPresenter'
+
+describe('ReferralCreationReasonPresenter', () => {
+  describe('text', () => {
+    it('returns content to be displayed on the page', () => {
+      const referral = draftReferralFactory
+        .serviceCategorySelected()
+        .serviceUserSelected()
+        .build({ serviceUser: { firstName: 'Geoffrey' } })
+      const presenter = new ReferralCreationReasonPresenter(referral)
+
+      expect(presenter.backLinkUrl).toBe(`/referrals/${referral.id}/confirm-main-point-of-contact`)
+      expect(presenter.text).toEqual({
+        title: `Enter reason why referral is being made before a probation practitioner has been allocated (if known)`,
+        label: 'Geoffrey River (CRN: X123456)',
+      })
+    })
+  })
+})

--- a/server/routes/makeAReferral/referral-creation-reason/referralCreationReasonPresenter.ts
+++ b/server/routes/makeAReferral/referral-creation-reason/referralCreationReasonPresenter.ts
@@ -1,0 +1,30 @@
+import DraftReferral from '../../../models/draftReferral'
+import PresenterUtils from '../../../utils/presenterUtils'
+
+export default class ReferralCreationReasonPresenter {
+  readonly backLinkUrl: string
+
+  constructor(
+    private readonly referral: DraftReferral,
+    private readonly amendPPDetails: boolean | null = null,
+    private readonly userInputData: Record<string, unknown> | null = null
+  ) {
+    this.backLinkUrl = amendPPDetails
+      ? `/referrals/${referral.id}/check-all-referral-information`
+      : `/referrals/${referral.id}/confirm-main-point-of-contact`
+  }
+
+  readonly text = {
+    label: `${this.referral.serviceUser?.firstName} ${this.referral.serviceUser?.lastName} (CRN: ${this.referral.serviceUser?.crn})`,
+    title: 'Enter reason why referral is being made before a probation practitioner has been allocated (if known)',
+  }
+
+  private readonly utils = new PresenterUtils(this.userInputData)
+
+  readonly fields = {
+    referralCreationReasonBeforeAllocation: this.utils.stringValue(
+      this.referral.reasonForReferralCreationBeforeAllocation,
+      'referral-creation-reason-before-allocation'
+    ),
+  }
+}

--- a/server/routes/makeAReferral/referral-creation-reason/referralCreationReasonView.ts
+++ b/server/routes/makeAReferral/referral-creation-reason/referralCreationReasonView.ts
@@ -1,0 +1,27 @@
+import { TextareaArgs } from '../../../utils/govukFrontendTypes'
+import ReferralCreationReasonPresenter from './referralCreationReasonPresenter'
+
+export default class ReferralCreationReasonView {
+  constructor(private readonly presenter: ReferralCreationReasonPresenter) {}
+
+  private get reasonForReferralCreationBeforeAllocationReasonArgs(): TextareaArgs {
+    return {
+      id: 'referral-creation-reason-before-allocation',
+      name: 'referral-creation-reason-before-allocation',
+      label: {},
+      value: this.presenter.fields.referralCreationReasonBeforeAllocation,
+    }
+  }
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'makeAReferral/referralCreationReasonBeforeAllocation',
+      {
+        presenter: this.presenter,
+        reasonForReferralCreationBeforeAllocationReasonArgs: this.reasonForReferralCreationBeforeAllocationReasonArgs,
+        backLinkArgs: { href: this.presenter.backLinkUrl },
+        suppressServiceUserBanner: true,
+      },
+    ]
+  }
+}

--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -548,6 +548,10 @@ describe(ShowReferralPresenter, () => {
         { key: 'Name', lines: ['Bernard Beaks'] },
         { key: 'Role / job title', lines: ['PP'] },
         { key: 'Email address', lines: ['bernard.beaks@justice.gov.uk'] },
+        {
+          key: 'Reason why referral is being made before probation practitioner allocated',
+          lines: ['for quick assessment'],
+        },
         { key: 'Phone number', lines: ['072121212125'] },
         { key: 'Establishment', lines: ['London'] },
       ])
@@ -589,6 +593,10 @@ describe(ShowReferralPresenter, () => {
         { key: 'Name', lines: ['Bernard Beaks'] },
         { key: 'Role / job title', lines: ['PP'] },
         { key: 'Email address', lines: ['bernard.beaks@justice.gov.uk'] },
+        {
+          key: 'Reason why referral is being made before probation practitioner allocated',
+          lines: ['for quick assessment'],
+        },
         { key: 'Phone number', lines: ['1234554321'] },
         { key: 'Probation office', lines: ['Leeds'] },
       ])

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -277,6 +277,10 @@ export default class ShowReferralPresenter {
       },
       { key: 'Email address', lines: [this.deriveEmailAddress] },
       {
+        key: 'Reason why referral is being made before probation practitioner allocated',
+        lines: [this.sentReferral.referral.reasonForReferralCreationBeforeAllocation || ''],
+      },
+      {
         key: 'Phone number',
         lines: [this.sentReferral.referral.ppPhoneNumber || 'Not found'],
       },

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1579,6 +1579,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
       ppLocationType: null,
       allocatedCommunityPP: true,
       reasonForReferral: 'for crs',
+      reasonForReferralCreationBeforeAllocation: 'for quick assessment',
     },
   }
 

--- a/server/views/makeAReferral/referralCreationReasonBeforeAllocation.njk
+++ b/server/views/makeAReferral/referralCreationReasonBeforeAllocation.njk
@@ -1,0 +1,33 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "Make a referral" %}
+{% set pageSubTitle = "Expected probation office" %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukBackLink(backLinkArgs) }}
+      <br>
+      <br>
+      <p class="govuk-caption-xl">{{ presenter.text.label }} </p>
+      <h1 class="govuk-heading-xl">{{ presenter.text.title }}</h1>
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+        {{ govukTextarea(reasonForReferralCreationBeforeAllocationReasonArgs) }}
+        <br>
+        <br>
+        {{ govukButton({ text: "Save and continue", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/testutils/factories/draftReferral.ts
+++ b/testutils/factories/draftReferral.ts
@@ -107,7 +107,7 @@ class DraftReferralFactory extends Factory<DraftReferral> {
     isReferralReleasingIn12Weeks = true,
     currentLocationType: CurrentLocationType = CurrentLocationType.custody
   ) {
-    return this.filledMainPointOfContactDetails(isReferralReleasingIn12Weeks).params({
+    return this.filledReasonForReferralCreationBeforeAllocation('some reason', isReferralReleasingIn12Weeks).params({
       personCurrentLocationType: currentLocationType,
       personCustodyPrisonId: currentLocationType === CurrentLocationType.custody ? 'abc' : null,
     })
@@ -139,6 +139,15 @@ class DraftReferralFactory extends Factory<DraftReferral> {
       ppPhoneNumber,
       ppEstablishment,
       roleOrJobTitle,
+    })
+  }
+
+  filledReasonForReferralCreationBeforeAllocation(
+    reasonForReferralCreationBeforeAllocation = 'some reason',
+    isReferralReleasingIn12Weeks = true
+  ) {
+    return this.filledMainPointOfContactDetails(isReferralReleasingIn12Weeks).params({
+      reasonForReferralCreationBeforeAllocation,
     })
   }
 
@@ -289,4 +298,5 @@ export default DraftReferralFactory.define(({ sequence }) => ({
   allocatedCommunityPP: null,
   reasonForReferral: null,
   withdrawalState: null,
+  reasonForReferralCreationBeforeAllocation: null,
 }))

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -77,6 +77,7 @@ const exampleReferralFields = () => {
     ppLocationType: null,
     allocatedCommunityPP: true,
     reasonForReferral: 'For crs',
+    reasonForReferralCreationBeforeAllocation: 'for quick assessment',
   }
 }
 


### PR DESCRIPTION
## What does this pull request do?

- adding a new page to capture reason for referral creation before allocation
- This is only for referrals with unallocated com

## What is the intent behind these changes?

- this is due to a new requirement where the pp wants to input the reason for referral creation for unallocated referral
