### PR TITLE
prison com check all information summary changes

### DIFF
--- a/integration_tests/integration/referralUnAllocatedCom.cy.js
+++ b/integration_tests/integration/referralUnAllocatedCom.cy.js
@@ -1250,16 +1250,12 @@ describe('Referral form', () => {
         .contains('Change')
         .should('have.attr', 'href', `/referrals/${draftReferral.id}/confirm-main-point-of-contact?amendPPDetails=true`)
 
-      cy.contains('Reason why referral is being made before probation practitioner allocated')
+      cy.contains('Prison establishment')
         .next()
-        .should('contain', 'some reason')
+        .should('contain', 'Bedford (HMP & YOI)')
         .next()
         .contains('Change')
-        .should(
-          'have.attr',
-          'href',
-          `/referrals/${draftReferral.id}/reason-for-referral-before-allocation?amendPPDetails=true`
-        )
+        .should('have.attr', 'href', `/referrals/${draftReferral.id}/confirm-main-point-of-contact?amendPPDetails=true`)
 
       // Alex's needs and requirements
       cy.contains('Identify needs')

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.test.ts
@@ -275,6 +275,56 @@ describe(CheckAllReferralInformationPresenter, () => {
             },
           ])
         })
+        it('returns the main point of contact details summary for prison', () => {
+          const referralWithUnAllocatedCom = parameterisedDraftReferralFactory.build({
+            personCurrentLocationType: CurrentLocationType.custody,
+            ndeliusPPName: 'Victor Drake',
+            ndeliusPPEmailAddress: 'a.b@xyz.com',
+            ndeliusPDU: 'London',
+            ndeliusPhoneNumber: '075950243221',
+            ndeliusTeamPhoneNumber: '020456734343',
+            ppName: null,
+            ppEmailAddress: null,
+            ppPdu: null,
+            ppProbationOffice: 'London',
+            ppPhoneNumber: '045890232322',
+            hasValidDeliusPPDetails: null,
+            roleOrJobTitle: 'probation practitioner',
+            reasonForReferralCreationBeforeAllocation: 'some reason',
+            isReferralReleasingIn12Weeks: false,
+          })
+          const referralWithUnAllocatedComPresenter = new CheckAllReferralInformationPresenter(
+            referralWithUnAllocatedCom,
+            interventionFactory.build({ serviceCategories }),
+            loggedInUser,
+            conviction,
+            deliusServiceUser,
+            prisonsAndSecuredChildAgencies,
+            prisonerDetails
+          )
+          expect(referralWithUnAllocatedComPresenter.mainPointOfContactDetailsSection?.summary).toEqual([
+            {
+              key: 'Name',
+              lines: ['Victor Drake'],
+              changeLink: `/referrals/${referralWithUnAllocatedCom.id}/confirm-main-point-of-contact?amendPPDetails=true`,
+            },
+            {
+              key: 'Role / job title',
+              lines: ['probation practitioner'],
+              changeLink: `/referrals/${referralWithUnAllocatedCom.id}/confirm-main-point-of-contact?amendPPDetails=true`,
+            },
+            {
+              key: 'Email address',
+              lines: ['a.b@xyz.com'],
+              changeLink: `/referrals/${referralWithUnAllocatedCom.id}/confirm-main-point-of-contact?amendPPDetails=true`,
+            },
+            {
+              key: 'Probation office',
+              lines: ['London'],
+              changeLink: `/referrals/${referralWithUnAllocatedCom.id}/confirm-main-point-of-contact?amendPPDetails=true`,
+            },
+          ])
+        })
       })
     })
 

--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
@@ -238,13 +238,20 @@ export default class CheckAllReferralInformationPresenter {
           lines: [this.deriveEmailAddress],
           changeLink: `/referrals/${this.referral.id}/confirm-main-point-of-contact?amendPPDetails=true`,
         },
-        {
-          key: 'Reason why referral is being made before probation practitioner allocated',
-          lines: [this.referral.reasonForReferralCreationBeforeAllocation || ''],
-          changeLink: `/referrals/${this.referral.id}/reason-for-referral-before-allocation?amendPPDetails=true`,
-        },
+        this.determineElementForMainPointOfContacts,
       ],
     }
+  }
+
+  private get determineElementForMainPointOfContacts(): SummaryListItem {
+    if (this.referral.isReferralReleasingIn12Weeks) {
+      return {
+        key: 'Reason why referral is being made before probation practitioner allocated',
+        lines: [this.referral.reasonForReferralCreationBeforeAllocation || ''],
+        changeLink: `/referrals/${this.referral.id}/reason-for-referral-before-allocation?amendPPDetails=true`,
+      }
+    }
+    return this.establishmentOrProbationOffice
   }
 
   get backupContactDetails(): { title: string; summary: SummaryListItem[] } | null {
@@ -273,7 +280,7 @@ export default class CheckAllReferralInformationPresenter {
   private get establishmentOrProbationOffice(): SummaryListItem {
     if (this.referral.ppEstablishment) {
       return {
-        key: 'Establishment',
+        key: 'Prison establishment',
         lines: [this.prisonName(this.referral.ppEstablishment)],
         changeLink: `/referrals/${this.referral.id}/confirm-main-point-of-contact?amendPPDetails=true`,
       }

--- a/server/routes/makeAReferral/makeAReferralController.test.ts
+++ b/server/routes/makeAReferral/makeAReferralController.test.ts
@@ -1595,8 +1595,10 @@ describe('POST /referrals/:id/confirm-main-point-of-contact', () => {
       ppEmailAddress: 'a.b@xyz.com',
       roleOrJobTitle: 'Probation Practitioner',
       ppProbationOffice: 'London',
+      isReferralReleasingIn12Weeks: true,
     })
 
+    interventionsService.getDraftReferral.mockResolvedValue(updatedReferral)
     interventionsService.patchDraftReferral.mockResolvedValue(updatedReferral)
 
     await request(app)

--- a/server/routes/makeAReferral/makeAReferralController.ts
+++ b/server/routes/makeAReferral/makeAReferralController.ts
@@ -1902,8 +1902,10 @@ export default class MakeAReferralController {
 
     if (error === null && amendPPDetails) {
       res.redirect(`/referrals/${req.params.id}/check-all-referral-information`)
-    } else if (error === null && !amendPPDetails) {
+    } else if (error === null && referral.isReferralReleasingIn12Weeks && !amendPPDetails) {
       res.redirect(`/referrals/${req.params.id}/reason-for-referral-before-allocation`)
+    } else if (error === null && !referral.isReferralReleasingIn12Weeks && !amendPPDetails) {
+      res.redirect(`/referrals/${req.params.id}/form`)
     } else {
       const serviceUser = await this.ramDeliusApiService.getCaseDetailsByCrn(referral.serviceUser.crn)
 


### PR DESCRIPTION
## What does this pull request do?

- Prison No COM check all referral information summary page
- excluding prison no com from filling referral reason creation

## What is the intent behind these changes?

- changing the summary card of check all referral information based on the design
