### PR TITLE
what's new banner content and what's new timeline addition for withdrawing and early closure referrals

### DIFF
--- a/reference-data/whats-new-banner-pp.csv
+++ b/reference-data/whats-new-banner-pp.csv
@@ -3,3 +3,4 @@ version, heading, text, link_text
 2, "Changes to ETE interventions", "From 1 January 2024, ETE referrals can only be made in Greater Manchester.", "Read more about the changes to ETE interventions"
 3, "Get better information about sessions", "You can now get more information about the SAA and delivery sessions...", "Read more about changes to session feedback"
 4, "Helping to reduce your emails", "Service providers can now add a case note without it sending you an email.", "Read more about changes to case notes emails"
+5, "Changes to withdrawing or closing a referral early", " If you need to withdraw or close an intervention referral early we have just released new functionality to make this easier to do.", "Read more about changes to withdrawing or closing referrals early"

--- a/server/views/probationPractitionerReferrals/whatsNew.njk
+++ b/server/views/probationPractitionerReferrals/whatsNew.njk
@@ -11,6 +11,18 @@
       <h1 class="govuk-heading-l">What's new</h1>
       <p>Find out about recent changes to Refer and monitor an intervention.</p>
 
+    {% set whatsNewVersion5Html %}
+        <h3 class="govuk-heading-s">Withdraw a referral</h3>
+        <p> If you submit a referral for an intervention but later discover a change in circumstance or a problem that means it should not continue, we’ve made it easier for you to withdraw the referral.
+        We have added a new button to the top of the case details screen that, once clicked, takes you to a list of withdrawal reasons.
+        The options range from a problem with the referral, to user-related issues and sentence/custody changes.
+        You need to select a reason and provide some more details. Once you have submitted the request, the referral will be withdrawn.</p>
+
+        <h3 class="govuk-heading-s"> Close a completed referral early</h3>
+        <p> If an intervention has been completed you may want to close the referral early. We have now added new functionality to make this easier for you to do. We have added a new button to the top of the case details screen. Once clicked, on the next screen under the heading ‘Early closure’ you should select ‘Intervention has been completed’. Once you have submitted the request, the referral will be closed early.</p>
+    {% endset %}
+
+
     {% set whatsNewVersion4Html %}
         <p>When service providers create a case note on Refer and monitor an intervention, they’re now asked if you need an email about it.</p>
 
@@ -81,11 +93,21 @@
         items: [
           {
             label: {
+                text: "Changes to withdrawing or closing a referral early"
+            },
+            html: whatsNewVersion5Html,
+            datetime: {
+              timestamp: "2024-06-13",
+              type: "date"
+            }
+          },
+          {
+            label: {
                 text: "Helping to reduce your emails"
             },
             html: whatsNewVersion4Html,
             datetime: {
-              timestamp: "2023-03-04",
+              timestamp: "2024-03-04",
               type: "date"
             }
           },


### PR DESCRIPTION
## What does this pull request do?

Adds a new what's new banner for pp's & updates the what's new timeline.

## What is the intent behind these changes?

Provide information for pp's about the new changes to R&M
