### PR TITLE
downtime banner between 22-23 june

### DIFF
--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -37,7 +37,7 @@ export default class DashboardView {
 
   get serviceOutageBannerArgs(): NotificationBannerArgs | null {
     const text =
-      'Refer and monitor an intervention will not be available this weekend. This is from 10am Saturday 28 October to midday Sunday 29 October 2023.'
+      'Please be advised that R & M will be offline from 6pm on Friday 21 June until 8am on Monday 24 June, due to planned maintenance being carried out in nDelius.'
 
     const html = `<p class="govuk-notification-banner__heading">${text}</p>
                   <p><a class="govuk-notification-banner__link" href= ${this.presenter.closeHref}>Close</a></p>`

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -56,7 +56,7 @@ export default class DashboardView {
 
   get serviceOutageBannerArgs(): NotificationBannerArgs {
     const text =
-      'Refer and monitor an intervention will not be available this weekend. This is from 10am Saturday 28 October to midday Sunday 29 October 2023.'
+      'Please be advised that R & M will be offline from 6pm on Friday 21 June until 8am on Monday 24 June, due to planned maintenance being carried out in nDelius.'
 
     const html = `<p class="govuk-notification-banner__heading">${text}</p>
                   <p><a class="govuk-notification-banner__link" href= ${this.presenter.closeHref}>Close</a></p>`

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -13,6 +13,9 @@
 {% endblock %}
 
 {% block pageContent %}
+{% if presenter.disableDowntimeBanner != true %}
+    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
+{% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,6 +12,9 @@
 {% endblock %}
 
 {% block pageContent %}
+{% if presenter.disableDowntimeBanner != true %}
+    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
+{% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>


### PR DESCRIPTION
## What does this pull request do?

- display down time banner for the outage between 6pm on Friday 21 June until 8am on Monday 24 June.

## What is the intent behind these changes?

- We have planned outage of delius which is leading us to bring R&M down.
