### PR TITLE
sp dashboard completed to show unassigned referrals

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -189,7 +189,7 @@ export default class ServiceProviderReferralsController {
       await this.renderDashboard(
         req,
         res,
-        { concluded: true, unassigned: false, search: searchText?.trim() },
+        { concluded: true, search: searchText?.trim() },
         'Completed cases',
         'spCompletedCases',
         pageSize


### PR DESCRIPTION
## What does this pull request do?

- show unassigned referrals in sp dashboard completed tab

## What is the intent behind these changes?

- after withdrawn feature is introduced , we need to show the cancelled referrals in the sp completed view irrespective of whether its assigned or not
