### PR TITLE
disable downtime banner

### DIFF
--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -13,9 +13,6 @@
 {% endblock %}
 
 {% block pageContent %}
-{% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-{% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,9 +12,6 @@
 {% endblock %}
 
 {% block pageContent %}
-{% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-{% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>


### PR DESCRIPTION
## What does this pull request do?

- removes the downtime banner which was raised on 21st June 2024

## What is the intent behind these changes?

- removes the downtime banner as the application is back up
