### PR TITLE
updates intervention ended banner to include withdrawal reasons

### DIFF
--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -18,6 +18,7 @@ interface EndedFields {
   endRequestedAt: string | null
   endRequestedComments: string | null
   endRequestedReason: string | null
+  withdrawalCode: string | null
 }
 
 interface ProgressSessionTableRow {
@@ -105,7 +106,31 @@ export default class InterventionProgressPresenter {
       endRequestedAt: this.referral.endRequestedAt,
       endRequestedComments: this.referral.endRequestedComments,
       endRequestedReason: this.referral.endRequestedReason,
+      withdrawalCode: this.referral.withdrawalCode,
     }
+  }
+
+  get withdrawalEndedBannerText(): string | null {
+    if (this.referral.withdrawalCode) {
+      return this.withdrawalCodeDisplayTextMap[this.referral.withdrawalCode]
+    }
+    return null
+  }
+
+  private withdrawalCodeDisplayTextMap = {
+    INE: `This is because it was an ineligible referral.`,
+    MIS: `This is because it was a mistaken or duplicate referral.`,
+    NOT: `This is because ${this.serviceUser.name.forename} ${this.serviceUser.name.surname} was not engaged in the intervention.`,
+    NEE: `This is because ${this.serviceUser.name.forename} ${this.serviceUser.name.surname}’s needs are being met through another route.`,
+    MOV: `This is because ${this.serviceUser.name.forename} ${this.serviceUser.name.surname} has moved out of the service area.`,
+    WOR: `This is due to ${this.serviceUser.name.forename} ${this.serviceUser.name.surname}’s work or caring responsibilities.`,
+    USE: `This is because ${this.serviceUser.name.forename} ${this.serviceUser.name.surname} has died.`,
+    ACQ: `This is because ${this.serviceUser.name.forename} ${this.serviceUser.name.surname} was acquitted on appeal.`,
+    RET: `This is because ${this.serviceUser.name.forename} ${this.serviceUser.name.surname} has returned to custody.`,
+    SER: `This is because ${this.serviceUser.name.forename} ${this.serviceUser.name.surname}’s sentence was revoked.`,
+    SEE: `This is because ${this.serviceUser.name.forename} ${this.serviceUser.name.surname}’s sentence expired.`,
+    EAR: `It has been closed early because the intervention has been completed.`,
+    ANO: `This is due to a change of circumstance.`,
   }
 
   get isConcluded(): boolean {

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -18,7 +18,32 @@ export default class InterventionProgressView {
     this.actionPlanProgressView = new ActionPlanProgressView(presenter.actionPlanProgressPresenter)
   }
 
-  get cancelledReferralNotificationBannerArgs(): NotificationBannerArgs {
+  private get withdrawnBannerArgs(): NotificationBannerArgs {
+    let endingDateHtml = ''
+
+    if (this.presenter.referralEndedFields.endRequestedAt) {
+      const formattedEndDate = DateUtils.formattedDate(this.presenter.referralEndedFields.endRequestedAt)
+      endingDateHtml = `<p>The probation practitioner ended this intervention on ${formattedEndDate}.</p>`
+    }
+
+    const withdrawalReasonHtml = `<p>${this.presenter.withdrawalEndedBannerText}</p>`
+
+    const html = `<div>${endingDateHtml}${withdrawalReasonHtml}</div>`
+    return {
+      titleText: 'Intervention ended',
+      html,
+      classes: 'govuk-notification-banner--warning',
+    }
+  }
+
+  get interventionEndedNotificationBannerArgs(): NotificationBannerArgs {
+    if (this.presenter.referralEndedFields.endRequestedAt && this.presenter.referralEndedFields.withdrawalCode) {
+      return this.withdrawnBannerArgs
+    }
+    return this.cancelledReferralNotificationBannerArgs
+  }
+
+  private get cancelledReferralNotificationBannerArgs(): NotificationBannerArgs {
     let cancellationReasonHTML = ''
     let cancellationCommentsHTML = ''
     let notConcludedWarningHTML = ''
@@ -141,7 +166,7 @@ export default class InterventionProgressView {
         actionPlanTableArgs: this.actionPlanProgressView.tableArgs.bind(this.actionPlanProgressView),
         backLinkArgs: this.backLinkArgs,
         endOfServiceReportSummaryListArgs: this.endOfServiceReportSummaryListArgs.bind(this),
-        cancelledReferralNotificationBannerArgs: this.cancelledReferralNotificationBannerArgs,
+        interventionEndedNotificationBannerArgs: this.interventionEndedNotificationBannerArgs,
         sessionFeedbackAddedNotificationBannerArgs: this.sessionFeedbackAddedNotificationBannerArgs,
       },
     ]

--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.test.ts
@@ -1193,6 +1193,7 @@ describe('GET /service-provider/referrals/:id/progress', () => {
       firstName: 'caseWorkerFirstName',
       lastName: 'caseWorkerLastName',
     })
+    const deliusServiceUser = deliusServiceUserFactory.build()
 
     const sentReferral = sentReferralFactory.assigned().build({
       referral: { interventionId: intervention.id },
@@ -1203,6 +1204,7 @@ describe('GET /service-provider/referrals/:id/progress', () => {
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessmentFactory.build())
     hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    ramDeliusApiService.getCaseDetailsByCrn.mockResolvedValue(deliusServiceUser)
     interventionsService.getApprovedActionPlanSummaries.mockResolvedValue([])
 
     await request(app)
@@ -1221,6 +1223,7 @@ describe('GET /service-provider/referrals/:id/progress', () => {
       firstName: 'caseWorkerFirstName',
       lastName: 'caseWorkerLastName',
     })
+    const deliusServiceUser = deliusServiceUserFactory.build()
     const appointment = actionPlanAppointmentFactory.attended('yes').build({
       sessionNumber: 1,
       appointmentTime: `Thu Jun 18 2022 17:20`,
@@ -1266,6 +1269,7 @@ describe('GET /service-provider/referrals/:id/progress', () => {
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessment)
     hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    ramDeliusApiService.getCaseDetailsByCrn.mockResolvedValue(deliusServiceUser)
     interventionsService.getApprovedActionPlanSummaries.mockResolvedValue([])
     interventionsService.getActionPlanAppointments.mockResolvedValue([appointment, appointmentDuplicate3])
     interventionsService.getActionPlan.mockResolvedValue(actionPlan)
@@ -1289,6 +1293,7 @@ describe('GET /service-provider/referrals/:id/progress', () => {
       firstName: 'caseWorkerFirstName',
       lastName: 'caseWorkerLastName',
     })
+    const deliusServiceUser = deliusServiceUserFactory.build()
     const actionPlan = actionPlanFactory.build()
     const sentReferral = sentReferralFactory.assigned().build({
       referral: { interventionId: intervention.id },
@@ -1313,6 +1318,7 @@ describe('GET /service-provider/referrals/:id/progress', () => {
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessmentFactory.build())
     hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    ramDeliusApiService.getCaseDetailsByCrn.mockResolvedValue(deliusServiceUser)
     interventionsService.getApprovedActionPlanSummaries.mockResolvedValue(approvedSummaries)
     interventionsService.getActionPlanAppointments.mockResolvedValue(actionPlanAppointments)
     interventionsService.getActionPlan.mockResolvedValue(actionPlan)
@@ -1430,6 +1436,7 @@ describe('GET /service-provider/referrals/:id/progress', () => {
       firstName: 'caseWorkerFirstName',
       lastName: 'caseWorkerLastName',
     })
+    const deliusServiceUser = deliusServiceUserFactory.build()
     const actionPlan = actionPlanFactory.build()
     const sentReferral = sentReferralFactory.assigned().build({
       referral: { interventionId: intervention.id },
@@ -1472,6 +1479,7 @@ describe('GET /service-provider/referrals/:id/progress', () => {
     interventionsService.getSentReferral.mockResolvedValue(sentReferral)
     interventionsService.getSupplierAssessment.mockResolvedValue(supplierAssessmentFactory.build())
     hmppsAuthService.getSPUserByUsername.mockResolvedValue(hmppsAuthUser)
+    ramDeliusApiService.getCaseDetailsByCrn.mockResolvedValue(deliusServiceUser)
     interventionsService.getApprovedActionPlanSummaries.mockResolvedValue(approvedSummaries)
     interventionsService.getActionPlanAppointments.mockResolvedValue(actionPlanAppointments)
     interventionsService.getActionPlan.mockResolvedValue(actionPlan)

--- a/server/views/serviceProviderReferrals/interventionProgress.njk
+++ b/server/views/serviceProviderReferrals/interventionProgress.njk
@@ -7,7 +7,7 @@
 {% set pageSubTitle = "Progress" %}
 {% block referralPageSection %}
 {% if presenter.referralEnded %}
-{{ govukNotificationBanner(cancelledReferralNotificationBannerArgs) }}
+{{ govukNotificationBanner(interventionEndedNotificationBannerArgs) }}
 {% endif %}
 {% if presenter.showFeedbackBanner %}
 {{ govukNotificationBanner(sessionFeedbackAddedNotificationBannerArgs) }}


### PR DESCRIPTION
## What does this pull request do?

updates intervention ended banner to include withdrawal reasons.

## What is the intent behind these changes?

The banner currently is empty if a referral is withdrawn.
