### PR TITLE
add withdrawal comments to intervention ended notification box

### DIFF
--- a/server/models/sentReferral.ts
+++ b/server/models/sentReferral.ts
@@ -19,6 +19,7 @@ export default interface SentReferral {
   concludedAt: string | null
   withdrawalState: WithdrawalState | null
   withdrawalCode: string | null
+  withdrawalComments: string | null
 }
 
 export enum WithdrawalState {

--- a/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressPresenter.ts
@@ -19,6 +19,7 @@ interface EndedFields {
   endRequestedComments: string | null
   endRequestedReason: string | null
   withdrawalCode: string | null
+  withdrawalComments: string | null
 }
 
 interface ProgressSessionTableRow {
@@ -107,6 +108,7 @@ export default class InterventionProgressPresenter {
       endRequestedComments: this.referral.endRequestedComments,
       endRequestedReason: this.referral.endRequestedReason,
       withdrawalCode: this.referral.withdrawalCode,
+      withdrawalComments: this.referral.withdrawalComments,
     }
   }
 

--- a/server/routes/serviceProviderReferrals/interventionProgressView.ts
+++ b/server/routes/serviceProviderReferrals/interventionProgressView.ts
@@ -20,6 +20,7 @@ export default class InterventionProgressView {
 
   private get withdrawnBannerArgs(): NotificationBannerArgs {
     let endingDateHtml = ''
+    let withdrawalCommentsHTML = ''
 
     if (this.presenter.referralEndedFields.endRequestedAt) {
       const formattedEndDate = DateUtils.formattedDate(this.presenter.referralEndedFields.endRequestedAt)
@@ -28,7 +29,14 @@ export default class InterventionProgressView {
 
     const withdrawalReasonHtml = `<p>${this.presenter.withdrawalEndedBannerText}</p>`
 
-    const html = `<div>${endingDateHtml}${withdrawalReasonHtml}</div>`
+    if (this.presenter.referralEndedFields.withdrawalComments) {
+      withdrawalCommentsHTML = `
+        <p>
+            Additional information: ${ViewUtils.escape(this.presenter.referralEndedFields.withdrawalComments)}
+        </p>`
+    }
+
+    const html = `<div>${endingDateHtml}${withdrawalReasonHtml}${withdrawalCommentsHTML}</div>`
     return {
       titleText: 'Intervention ended',
       html,

--- a/server/services/interventionsService.test.ts
+++ b/server/services/interventionsService.test.ts
@@ -1521,6 +1521,7 @@ pactWith({ consumer: 'Interventions UI', provider: 'Interventions Service' }, pr
     supplementaryRiskId: 'a1f5ce02-53a3-47c4-bc71-45f1bdbf504c',
     withdrawalState: WithdrawalState.preICA,
     withdrawalCode: null,
+    withdrawalComments: null,
     referral: {
       createdAt: '2021-01-11T10:32:12.382884Z',
       completionDeadline: '2021-04-01',

--- a/testutils/factories/sentReferral.ts
+++ b/testutils/factories/sentReferral.ts
@@ -144,4 +144,5 @@ export default SentReferralFactory.define(({ sequence }) => ({
   concludedAt: null,
   withdrawalState: WithdrawalState.preICA,
   withdrawalCode: null,
+  withdrawalComments: null,
 }))


### PR DESCRIPTION
## What does this pull request do?

add withdrawal comments to intervention ended notification box.

## What is the intent behind these changes?

Current notification box does not include the comments added when withdrawing a referral