### PR TITLE
downtime banner for 17July

### DIFF
--- a/server/routes/probationPractitionerReferrals/dashboardView.ts
+++ b/server/routes/probationPractitionerReferrals/dashboardView.ts
@@ -37,7 +37,7 @@ export default class DashboardView {
 
   get serviceOutageBannerArgs(): NotificationBannerArgs | null {
     const text =
-      'Please be advised that Refer & Monitor will be offline from 5pm until 6:30pm on Monday 8 July, due to planned maintenance being carried out in nDelius.'
+      'Please be advised that R & M will be offline between the hours of 5.00pm and 6.00pm on Wednesday 17 July, due to planned maintenance being carried out in nDelius.'
 
     const html = `<p class="govuk-notification-banner__heading">${text}</p>
                   <p><a class="govuk-notification-banner__link" href= ${this.presenter.closeHref}>Close</a></p>`

--- a/server/routes/serviceProviderReferrals/dashboardView.ts
+++ b/server/routes/serviceProviderReferrals/dashboardView.ts
@@ -56,7 +56,7 @@ export default class DashboardView {
 
   get serviceOutageBannerArgs(): NotificationBannerArgs {
     const text =
-      'Please be advised that Refer & Monitor will be offline from 5pm until 6:30pm on Monday 8 July, due to planned maintenance being carried out in nDelius.'
+      'Please be advised that R & M will be offline between the hours of 5.00pm and 6.00pm on Wednesday 17 July, due to planned maintenance being carried out in nDelius.'
 
     const html = `<p class="govuk-notification-banner__heading">${text}</p>
                   <p><a class="govuk-notification-banner__link" href= ${this.presenter.closeHref}>Close</a></p>`

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -13,6 +13,9 @@
 {% endblock %}
 
 {% block pageContent %}
+  {% if presenter.disableDowntimeBanner != true %}
+      {{ govukNotificationBanner(serviceOutageBannerArgs) }}
+  {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,6 +12,9 @@
 {% endblock %}
 
 {% block pageContent %}
+  {% if presenter.disableDowntimeBanner != true %}
+      {{ govukNotificationBanner(serviceOutageBannerArgs) }}
+  {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>


### PR DESCRIPTION
## What does this pull request do?

- sets downtime banner for 17July

## What is the intent behind these changes?

- Delius is down between 5pm-6pm tomorrow. So, we need to set the downtime banner to indicate the users
