### PR TITLE
add saa history to pp progress page

### DIFF
--- a/integration_tests/integration/probationPractitionerReferrals.cy.js
+++ b/integration_tests/integration/probationPractitionerReferrals.cy.js
@@ -221,8 +221,8 @@ describe('Probation practitioner referrals dashboard', () => {
               .contains('The appointment has been scheduled by the supplier')
               .next()
               .within(() => {
-                cy.contains('Appointment status').next().contains('needs feedback')
-                cy.contains('To do').next().contains('View appointment details').click()
+                cy.contains('needs feedback')
+                cy.contains('View appointment details').click()
                 cy.location('pathname').should(
                   'equal',
                   `/probation-practitioner/referrals/${assignedReferral.id}/supplier-assessment`
@@ -252,8 +252,8 @@ describe('Probation practitioner referrals dashboard', () => {
               .contains('The appointment has been scheduled by the supplier')
               .next()
               .within(() => {
-                cy.contains('Appointment status').next().contains('scheduled')
-                cy.contains('To do').next().contains('View appointment details').click()
+                cy.contains('scheduled')
+                cy.contains('View appointment details').click()
                 cy.location('pathname').should(
                   'equal',
                   `/probation-practitioner/referrals/${assignedReferral.id}/supplier-assessment`
@@ -276,8 +276,8 @@ describe('Probation practitioner referrals dashboard', () => {
             .contains('The initial assessment has been delivered and feedback added.')
             .next()
             .within(() => {
-              cy.contains('Appointment status').next().contains('completed')
-              cy.contains('To do').next().contains('View feedback').click()
+              cy.contains('completed')
+              cy.contains('View feedback').click()
               cy.location('pathname').should(
                 'equal',
                 `/probation-practitioner/referrals/${assignedReferral.id}/supplier-assessment/post-assessment-feedback`
@@ -299,8 +299,8 @@ describe('Probation practitioner referrals dashboard', () => {
             .contains('The initial assessment has been delivered and feedback added.')
             .next()
             .within(() => {
-              cy.contains('Appointment status').next().contains('did not attend')
-              cy.contains('To do').next().contains('View feedback').click()
+              cy.contains('did not attend')
+              cy.contains('View feedback').click()
               cy.location('pathname').should(
                 'equal',
                 `/probation-practitioner/referrals/${assignedReferral.id}/supplier-assessment/post-assessment-feedback`

--- a/server/routes/probationPractitionerReferrals/interventionProgressView.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressView.ts
@@ -1,4 +1,4 @@
-import { TagArgs, TableArgs, SummaryListArgs } from '../../utils/govukFrontendTypes'
+import { TagArgs, TableArgs } from '../../utils/govukFrontendTypes'
 import ViewUtils from '../../utils/viewUtils'
 
 import InterventionProgressPresenter from './interventionProgressPresenter'
@@ -11,30 +11,23 @@ export default class InterventionProgressView {
     this.actionPlanProgressView = new ActionPlanProgressView(presenter.actionPlanProgressPresenter)
   }
 
-  private supplierAssessmentSummaryListArgs(tagMacro: (args: TagArgs) => string): SummaryListArgs | null {
-    if (!this.presenter.shouldDisplaySupplierAssessmentSummaryList) {
-      return null
-    }
-
+  private supplierAssessmentAppointmentsTableArgs(tagMacro: (args: TagArgs) => string): TableArgs {
     return {
-      rows: [
-        {
-          key: { text: 'Appointment status' },
-          value: {
-            html: ViewUtils.sessionStatusTagHtml(this.presenter.supplierAssessmentSessionStatusPresenter, args =>
-              tagMacro({ ...args, attributes: { ...(args.attributes ?? {}), id: 'supplier-assessment-status' } })
+      head: this.presenter.supplierAssessmentTableHeaders.map((header: string) => ({ text: header })),
+      rows: this.presenter.supplierAssessmentTableRows.map(row => {
+        return [
+          { text: row.dateAndTime },
+          {
+            html: ViewUtils.sessionStatusTagHtml(row.statusPresenter, args =>
+              tagMacro({ ...args, attributes: { id: 'supplier-assessment-status' } })
             ),
           },
-        },
-        this.presenter.supplierAssessmentLink
-          ? {
-              key: { text: 'To do' },
-              value: {
-                html: ViewUtils.linkHtml([this.presenter.supplierAssessmentLink]),
-              },
-            }
-          : null,
-      ].flatMap(val => (val === null ? [] : [val])),
+          {
+            html: ViewUtils.linkHtml(row.action),
+          },
+        ]
+      }),
+      attributes: { 'data-cy': 'supplier-assessment-table' },
     }
   }
 
@@ -65,7 +58,7 @@ export default class InterventionProgressView {
         presenter: this.presenter,
         backLinkArgs: this.backLinkArgs,
         subNavArgs: this.presenter.referralOverviewPagePresenter.subNavArgs,
-        supplierAssessmentSummaryListArgs: this.supplierAssessmentSummaryListArgs.bind(this),
+        supplierAssessmentAppointmentsTableArgs: this.supplierAssessmentAppointmentsTableArgs.bind(this),
         endOfServiceReportTableArgs: this.endOfServiceReportTableArgs.bind(this),
         actionPlanTableArgs: this.actionPlanProgressView.tableArgs.bind(this.actionPlanProgressView),
       },

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -228,6 +228,9 @@ export default function probationPractitionerRoutes(router: Router, services: Se
   get(router, '/referrals/:referralId/supplier-assessment/post-assessment-feedback', (req, res) =>
     appointmentsController.viewSupplierAssessmentFeedback(req, res, 'probation-practitioner')
   )
+  get(router, '/referrals/:referralId/supplier-assessment/post-assessment-feedback/:appointmentId', (req, res) =>
+    appointmentsController.viewSupplierAssessmentFeedback(req, res, 'probation-practitioner')
+  )
   get(router, '/referrals/:id/action-plan', (req, res) =>
     probationPractitionerReferralsController.viewLatestActionPlan(req, res)
   )

--- a/server/views/probationPractitionerReferrals/interventionProgress.njk
+++ b/server/views/probationPractitionerReferrals/interventionProgress.njk
@@ -17,8 +17,8 @@
 <p class="govuk-body">
   {{ presenter.supplierAssessmentMessage }}
 </p>
-{% if supplierAssessmentSummaryListArgs(govukTag) !== null %}
-{{ govukSummaryList(supplierAssessmentSummaryListArgs(govukTag)) }}
+{% if supplierAssessmentAppointmentsTableArgs(govukTag) !== null %}
+{{ govukTable(supplierAssessmentAppointmentsTableArgs(govukTag)) }}
 {% endif %}
 <h2 class="govuk-heading-m">Action plan</h2>
 <p class="govuk-body">


### PR DESCRIPTION
## What does this pull request do?

Shows saa appointment history on the pp progress page.

## What is the intent behind these changes?

Shows more information to the pp's about appointments that have taken place.
