### PR TITLE
Show expected PDU when expected probation office not selected

### DIFF
--- a/server/routes/shared/showReferralPresenter.test.ts
+++ b/server/routes/shared/showReferralPresenter.test.ts
@@ -754,6 +754,46 @@ describe(ShowReferralPresenter, () => {
         { key: 'Expected probation office', lines: ['London'] },
       ])
     })
+
+    it('returns a summary list for a referral custody location with Expected PDU when expected probation office was not provided', () => {
+      const referralParamsWithCustodyDetails = {
+        referral: {
+          serviceCategoryId: serviceCategory.id,
+          serviceCategoryIds: [serviceCategory.id],
+          serviceUser: { firstName: 'Jenny', lastName: 'Jones' },
+          personCurrentLocationType: CurrentLocationType.custody,
+          expectedReleaseDate: moment().add(2, 'days').format('YYYY-MM-DD'),
+          isReferralReleasingIn12Weeks: null,
+          expectedProbationOffice: null,
+          ppPdu: 'City',
+        },
+      }
+      const sentReferral = sentReferralFactory.build(referralParamsWithCustodyDetails)
+      const presenter = new ShowReferralPresenter(
+        sentReferral,
+        intervention,
+        deliusConviction,
+        supplementaryRiskInformation,
+        deliusUser,
+        prisonsAndSecuredChildAgencies,
+        null,
+        null,
+        'service-provider',
+        true,
+        deliusServiceUser,
+        riskSummary,
+        deliusRoOfficer,
+        prisonerDetails
+      )
+      expect(presenter.serviceUserLocationDetails).toEqual([
+        { key: 'Prison establishment', lines: ['London'] },
+        {
+          key: 'Expected release date',
+          lines: [moment.tz('Europe/London').add(2, 'days').format('D MMM YYYY [(]ddd[)]')],
+        },
+        { key: 'Expected PDU (Probation Delivery Unit)', lines: ['City'] },
+      ])
+    })
     it('returns a summary list for an unallocated COM with expected probation office', () => {
       const referralParamsWithCustodyDetails = {
         referral: {

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -631,10 +631,12 @@ export default class ShowReferralPresenter {
             },
           ]
         }
+      }
+      if (this.sentReferral.referral.expectedProbationOffice) {
         return [
           {
             key: 'Expected probation office',
-            lines: [this.sentReferral.referral.expectedProbationOffice || '---'],
+            lines: [this.sentReferral.referral.expectedProbationOffice],
             changeLink:
               this.userType === 'probation-practitioner'
                 ? `/probation-practitioner/referrals/${this.sentReferral.id}/confirm-amend-expected-probation-office`
@@ -642,16 +644,6 @@ export default class ShowReferralPresenter {
           },
         ]
       }
-      return [
-        {
-          key: 'Expected probation office',
-          lines: [this.sentReferral.referral.expectedProbationOffice || '---'],
-          changeLink:
-            this.userType === 'probation-practitioner'
-              ? `/probation-practitioner/referrals/${this.sentReferral.id}/confirm-amend-expected-probation-office`
-              : undefined,
-        },
-      ]
       return [
         {
           key: 'Expected PDU (Probation Delivery Unit)',


### PR DESCRIPTION
## What does this pull request do?

Show the expected PDU instead of the expected probation office in the show referral view when the expected probation office was not provided in the referral creation.

## What is the intent behind these changes?

Show the expected PDU instead of the expected probation office in the show referral view when the expected probation office was not provided in the referral creation.
