### PR TITLE
Fix release date null check

### DIFF
--- a/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
+++ b/server/routes/makeAReferral/check-all-referral-information/checkAllReferralInformationPresenter.ts
@@ -344,7 +344,9 @@ export default class CheckAllReferralInformationPresenter {
       {
         key: 'Release date',
         lines: [
-          this.prisonerDetails !== null && this.prisonerDetails.releaseDate !== null
+          this.prisonerDetails !== null &&
+          this.prisonerDetails.releaseDate !== undefined &&
+          this.prisonerDetails.releaseDate !== null
             ? moment(this.prisonerDetails.releaseDate).format('D MMM YYYY [(]ddd[)]')
             : '---',
         ],

--- a/server/routes/shared/showReferralPresenter.ts
+++ b/server/routes/shared/showReferralPresenter.ts
@@ -686,7 +686,9 @@ export default class ShowReferralPresenter {
     return {
       key: 'Release date',
       lines: [
-        this.prisonerDetails !== null
+        this.prisonerDetails !== null &&
+        this.prisonerDetails.releaseDate !== undefined &&
+        this.prisonerDetails.releaseDate !== null
           ? moment(this.prisonerDetails.confirmedReleaseDate!).format('D MMM YYYY [(]ddd[)]')
           : '---',
       ],


### PR DESCRIPTION
## What does this pull request do?

Fixes the null check for displaying the release date

## What is the intent behind these changes?

To prevent the release date defaulting to showing today's date when there is no release date returned from nomis for community referrals.
