### PR TITLE
Filter out cancelled referrals from My Cases and Unassigned tabs

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -99,7 +99,7 @@ export default class ServiceProviderReferralsController {
       await this.renderDashboard(
         req,
         res,
-        { completed: false, assignedTo: res.locals.user.userId },
+        { completed: false, cancelled: false, assignedTo: res.locals.user.userId },
         'My cases',
         'spMyCases',
         pageSize
@@ -164,7 +164,7 @@ export default class ServiceProviderReferralsController {
       await this.renderDashboard(
         req,
         res,
-        { completed: false, unassigned: true, search: searchText?.trim() },
+        { completed: false, cancelled: false, unassigned: true, search: searchText?.trim() },
         'Unassigned cases',
         'spUnassignedCases',
         pageSize


### PR DESCRIPTION
## What does this pull request do?

Sets cancelled to false in GetSentReferralsFilterParams for the My Cases and Unassigned Cases dashboards

## What is the intent behind these changes?

To filter out cancelled referrals from the My Cases and Unassigned Cases dashboard tabs.
