### PR TITLE
QA fixes for history of rescheduled session

### DIFF
--- a/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
+++ b/server/routes/probationPractitionerReferrals/interventionProgressPresenter.ts
@@ -151,7 +151,12 @@ export default class InterventionProgressPresenter {
         return a.sessionNumber - b.sessionNumber
       })
       .filter(
-        x => x.isParent || (!x.isParent && (x.tagArgs.text === 'did not attend' || x.tagArgs.text === 'did not happen'))
+        x =>
+          x.isParent ||
+          (!x.isParent &&
+            (x.tagArgs.text === 'did not attend' ||
+              x.tagArgs.text === 'did not happen' ||
+              x.tagArgs.text === 'rescheduled'))
       )
   }
 
@@ -183,6 +188,15 @@ export default class InterventionProgressPresenter {
           link: {
             text: 'View feedback form',
             href: `/probation-practitioner/referrals/${this.referral.id}/session/${appointment.sessionNumber}/appointment/${appointment.appointmentId}/post-session-feedback`,
+          },
+        }
+      case SessionStatus.rescheduled:
+        return {
+          text: presenter.text,
+          tagClass: presenter.tagClass,
+          link: {
+            text: 'View appointment details',
+            href: `/probation-practitioner/referrals/${this.referral.id}/session/${appointment.sessionNumber}/appointment/${appointment.appointmentId}/rescheduled`,
           },
         }
       case SessionStatus.awaitingFeedback:

--- a/server/utils/sessionStatus.ts
+++ b/server/utils/sessionStatus.ts
@@ -15,7 +15,7 @@ export default {
     if (appointment === null) {
       return SessionStatus.notScheduled
     }
-    if (appointment.superseded) {
+    if (appointment.superseded && appointment.appointmentFeedback.attendanceFeedback.attended === null) {
       return SessionStatus.rescheduled
     }
 


### PR DESCRIPTION
## What does this pull request do?

Includes rescheduled in the appointments filter to return rescheduled appointments for PP's and checks attendance is null in addition to the appointment superseded check when determining whether session status is rescheduled. 

## What is the intent behind these changes?

To fix the following issues:
- PP cannot see the history of rescheduled sessions
- For the delivery session, the status Did Not Attend and Did Not Happen is being overwritten by Rescheduled
