### PR TITLE
Remove reschedule details from attendance feedback form

### DIFF
--- a/server/routes/appointments/appointmentSummary.ts
+++ b/server/routes/appointments/appointmentSummary.ts
@@ -13,7 +13,8 @@ export default class AppointmentSummary {
     private readonly assignedCaseworker: AuthUserDetails | string | null = null,
     private readonly deliusOfficeLocation: DeliusOfficeLocation | null = null,
     private readonly feedbackSubmittedBy: AuthUserDetails | string | null = null,
-    private readonly formType: 'supplierAssessment' | 'actionPlan' | null = null
+    private readonly formType: 'supplierAssessment' | 'actionPlan' | null = null,
+    private hideRescheduleDetails: boolean | null = false
   ) {}
 
   private readonly appointmentDecorator = new AppointmentDecorator(this.appointment)
@@ -72,13 +73,13 @@ export default class AppointmentSummary {
         lines: this.inPersonMeetingProbationOfficeAddressLines(this.deliusOfficeLocation),
       })
     }
-    if (this.appointment.rescheduleRequestedBy) {
+    if (this.appointment.rescheduleRequestedBy && !this.hideRescheduleDetails) {
       summary.push({
         key: `${this.formType === 'supplierAssessment' ? 'Appointment' : 'Session'} change requested by`,
         lines: [this.appointment.rescheduleRequestedBy],
       })
     }
-    if (this.appointment.rescheduledReason) {
+    if (this.appointment.rescheduledReason && !this.hideRescheduleDetails) {
       summary.push({
         key: `Reason for ${this.formType === 'supplierAssessment' ? 'appointment' : 'session'} change`,
         lines: [this.appointment.rescheduledReason],

--- a/server/routes/appointments/appointmentsController.ts
+++ b/server/routes/appointments/appointmentsController.ts
@@ -323,7 +323,9 @@ export default class AppointmentsController {
     )
 
     const hasExistingScheduledAppointment =
-      appointment.appointmentId !== undefined && appointment.appointmentId !== null
+      appointment.appointmentId !== undefined &&
+      appointment.appointmentId !== null &&
+      !appointment.appointmentFeedback.submitted
 
     let userInputData: Record<string, unknown> | null = null
     let formError: FormValidationError | null = null
@@ -562,7 +564,8 @@ export default class AppointmentsController {
       accessToken,
       appointment,
       referral,
-      'supplierAssessment'
+      'supplierAssessment',
+      true
     )
     const presenter = new InitialAssessmentAttendanceFeedbackPresenter(
       appointment,
@@ -1030,7 +1033,13 @@ export default class AppointmentsController {
       return
     }
     const serviceUser = await this.ramDeliusApiService.getCaseDetailsByCrn(referral.referral.serviceUser.crn)
-    const appointmentSummary = await this.createAppointmentSummary(accessToken, appointment, referral)
+    const appointmentSummary = await this.createAppointmentSummary(
+      accessToken,
+      appointment,
+      referral,
+      'actionPlan',
+      true
+    )
     const presenter = new ActionPlanPostSessionAttendanceFeedbackPresenter(
       appointment,
       serviceUser,
@@ -1203,7 +1212,13 @@ export default class AppointmentsController {
     }
 
     const serviceUser = await this.ramDeliusApiService.getCaseDetailsByCrn(referral.referral.serviceUser.crn)
-    const appointmentSummary = await this.createAppointmentSummary(accessToken, appointment, referral, 'actionPlan')
+    const appointmentSummary = await this.createAppointmentSummary(
+      accessToken,
+      appointment,
+      referral,
+      'actionPlan',
+      true
+    )
     const presenter = new ActionPlanPostSessionFeedbackCheckAnswersPresenter(
       appointment,
       serviceUser,
@@ -1462,7 +1477,8 @@ export default class AppointmentsController {
     accessToken: string,
     appointment: ActionPlanAppointment | InitialAssessmentAppointment,
     referral: SentReferral,
-    formType: 'supplierAssessment' | 'actionPlan' | null = null
+    formType: 'supplierAssessment' | 'actionPlan' | null = null,
+    hideRescheduleDetails: boolean | null = false
   ): Promise<AppointmentSummary> {
     const [deliusOfficeLocation, assignedCaseworker, feedbackSubmittedByCaseworker] = await Promise.all([
       this.deliusOfficeLocationFilter.findOfficeByAppointment(appointment),
@@ -1474,7 +1490,8 @@ export default class AppointmentsController {
       assignedCaseworker,
       deliusOfficeLocation,
       feedbackSubmittedByCaseworker,
-      formType
+      formType,
+      hideRescheduleDetails
     )
   }
 


### PR DESCRIPTION
## What does this pull request do?

- Removes reschedule details from attendance feedback form
- Removes reschedule fields from reschedule form for delivery sessions

## What is the intent behind these changes?

- Removes reschedule details from attendance feedback form
- Removes reschedule fields from reschedule form for delivery sessions
