### PR TITLE
IPB-1320: Remove 14th March downtime banner

### DIFF
--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -13,9 +13,6 @@
 {% endblock %}
 
 {% block pageContent %}
-  {% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-  {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,9 +12,6 @@
 {% endblock %}
 
 {% block pageContent %}
-  {% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-  {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>


### PR DESCRIPTION
## What does this pull request do?

This pr removes the downtime banner from the ui as the downtime period has ended.

## What is the intent behind these changes?

To remove the downtime banner as there is no currently scheduled downtime
