### PR TITLE
disabling whats new banner

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -56,6 +56,7 @@ export default {
   staticResourceCacheDuration: 20,
   deploymentEnvironment: get('DEPLOYMENT_ENV', 'local', requiredInProduction),
   googleAnalyticsTrackingId: get('GA_ID', '', requiredInProduction),
+  whatsNewBannerEnabled: false, // This is a static config flag to control the "What's New" banner globall
   features: {
     serviceProviderReporting: get('FEATURE_SP_REPORTING_ENABLED', 'true') === 'true',
     previouslyApprovedActionPlans: get('FEATURE_PREVIOUSLY_APPROVED_ACTION_PLANS', 'false') === 'true',

--- a/server/routes/shared/layoutView.ts
+++ b/server/routes/shared/layoutView.ts
@@ -13,11 +13,16 @@ export default class LayoutView {
     private readonly content: PageContentView
   ) {}
 
+  // Add a static config flag to control the "What's New" banner globally
+  private static readonly whatsNewBannerEnabled: boolean = config.whatsNewBannerEnabled !== false
+
   private readonly serviceUserBannerView = this.presenter.serviceUserBannerPresenter
     ? new ServiceUserBannerView(this.presenter.serviceUserBannerPresenter)
     : null
 
-  get whatsNewBannerArgs(): NotificationBannerArgs {
+  get whatsNewBannerArgs(): NotificationBannerArgs | null {
+    // If the feature is disabled, never show the banner
+    if (!LayoutView.whatsNewBannerEnabled) return null
     const html = `<div class="refer-and-monitor__max-width">
                     <p class="govuk-notification-banner__heading">${this.presenter.whatsNewBanner?.heading}</p>
                     <p class="govuk-body">
@@ -36,6 +41,8 @@ export default class LayoutView {
   }
 
   get renderArgs(): [string, Record<string, unknown>] {
+    // If the feature is disabled, never show the banner
+    const showWhatsNewBanner = LayoutView.whatsNewBannerEnabled && this.presenter.showWhatsNewBanner
     return [
       this.content.renderArgs[0],
       {
@@ -43,7 +50,7 @@ export default class LayoutView {
         headerPresenter: this.presenter.headerPresenter,
         googleAnalyticsTrackingId: config.googleAnalyticsTrackingId,
         ...this.content.renderArgs[1],
-        showWhatsNewBanner: this.presenter.showWhatsNewBanner,
+        showWhatsNewBanner,
         whatsNewBannerArgs: this.whatsNewBannerArgs,
       },
     ]

--- a/server/utils/controllerUtils.test.ts
+++ b/server/utils/controllerUtils.test.ts
@@ -9,6 +9,8 @@ import { createDraftFactory } from '../../testutils/factories/draft'
 import loggedInUser from '../../testutils/factories/loggedInUser'
 import ReferenceDataService from '../services/referenceDataService'
 import WhatsNewCookieService from '../services/whatsNewCookieService'
+import HeaderPresenter from '../routes/shared/headerPresenter'
+import ServiceUserBannerPresenter from '../routes/shared/serviceUserBannerPresenter'
 
 describe(ControllerUtils, () => {
   describe('parseQueryParamAsPositiveInteger', () => {
@@ -50,10 +52,10 @@ describe(ControllerUtils, () => {
         expect(res.render).toHaveBeenCalledWith('myTemplate', {
           foo: '1',
           bar: '2',
-          headerPresenter: expect.anything(),
+          headerPresenter: expect.any(HeaderPresenter),
           googleAnalyticsTrackingId: 'UA-TEST-ID',
           showWhatsNewBanner: false,
-          whatsNewBannerArgs: expect.anything(),
+          whatsNewBannerArgs: null,
         })
       })
     })
@@ -72,11 +74,11 @@ describe(ControllerUtils, () => {
         expect(res.render).toHaveBeenCalledWith('myTemplate', {
           foo: '1',
           bar: '2',
-          headerPresenter: expect.anything(),
+          headerPresenter: expect.any(HeaderPresenter),
           googleAnalyticsTrackingId: 'UA-TEST-ID',
-          serviceUserBannerPresenter: expect.anything(),
+          serviceUserBannerPresenter: expect.any(ServiceUserBannerPresenter),
           showWhatsNewBanner: false,
-          whatsNewBannerArgs: expect.anything(),
+          whatsNewBannerArgs: null,
         })
       })
     })
@@ -100,11 +102,11 @@ describe(ControllerUtils, () => {
         expect(res.render).toHaveBeenCalledWith('myTemplate', {
           foo: '1',
           bar: '2',
-          headerPresenter: expect.anything(),
+          headerPresenter: expect.any(HeaderPresenter),
           googleAnalyticsTrackingId: 'UA-TEST-ID',
-          serviceUserBannerPresenter: expect.anything(),
+          serviceUserBannerPresenter: expect.any(ServiceUserBannerPresenter),
           showWhatsNewBanner: false,
-          whatsNewBannerArgs: expect.anything(),
+          whatsNewBannerArgs: null,
         })
       })
     })
@@ -128,11 +130,11 @@ describe(ControllerUtils, () => {
         expect(res.render).toHaveBeenCalledWith('myTemplate', {
           foo: '1',
           bar: '2',
-          headerPresenter: expect.anything(),
+          headerPresenter: expect.any(HeaderPresenter),
           googleAnalyticsTrackingId: 'UA-TEST-ID',
-          serviceUserBannerPresenter: expect.anything(),
-          showWhatsNewBanner: true,
-          whatsNewBannerArgs: expect.anything(),
+          serviceUserBannerPresenter: expect.any(ServiceUserBannerPresenter),
+          showWhatsNewBanner: false,
+          whatsNewBannerArgs: null,
         })
       })
     })
@@ -157,11 +159,11 @@ describe(ControllerUtils, () => {
         expect(res.render).toHaveBeenCalledWith('myTemplate', {
           foo: '1',
           bar: '2',
-          headerPresenter: expect.anything(),
+          headerPresenter: expect.any(HeaderPresenter),
           googleAnalyticsTrackingId: 'UA-TEST-ID',
-          serviceUserBannerPresenter: expect.anything(),
+          serviceUserBannerPresenter: expect.any(ServiceUserBannerPresenter),
           showWhatsNewBanner: false,
-          whatsNewBannerArgs: expect.anything(),
+          whatsNewBannerArgs: null,
         })
       })
     })
@@ -192,11 +194,11 @@ describe(ControllerUtils, () => {
         expect(res.render).toHaveBeenCalledWith('myTemplate', {
           foo: '1',
           bar: '2',
-          headerPresenter: expect.anything(),
+          headerPresenter: expect.any(HeaderPresenter),
           googleAnalyticsTrackingId: 'UA-TEST-ID',
-          serviceUserBannerPresenter: expect.anything(),
+          serviceUserBannerPresenter: expect.any(ServiceUserBannerPresenter),
           showWhatsNewBanner: false,
-          whatsNewBannerArgs: expect.anything(),
+          whatsNewBannerArgs: null,
         })
       })
     })
@@ -221,11 +223,11 @@ describe(ControllerUtils, () => {
         expect(res.render).toHaveBeenCalledWith('myTemplate', {
           foo: '1',
           bar: '2',
-          headerPresenter: expect.anything(),
+          headerPresenter: expect.any(HeaderPresenter),
           googleAnalyticsTrackingId: 'UA-TEST-ID',
-          serviceUserBannerPresenter: expect.anything(),
+          serviceUserBannerPresenter: expect.any(ServiceUserBannerPresenter),
           showWhatsNewBanner: false,
-          whatsNewBannerArgs: expect.anything(),
+          whatsNewBannerArgs: null,
         })
       })
     })


### PR DESCRIPTION
## What does this pull request do?

- set up provision to disable what's new banner

## What is the intent behind these changes?

- though we have the feature of where the user can dismiss the what's the new banner. This one fully disables the what's new banner
