### PR TITLE
Updated assignment of case-search-text to fix TypeError

### DIFF
--- a/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
+++ b/server/routes/serviceProviderReferrals/serviceProviderReferralsController.ts
@@ -116,7 +116,9 @@ export default class ServiceProviderReferralsController {
 
   private handlePaginatedSearchText(req: Request) {
     if (req.method === 'GET' && req.query.paginatedSearch === 'true') {
-      req.body['case-search-text'] = req.session.searchText
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      req.body?.['case-search-text'] = req.session.searchText
     }
 
     if (req.method === 'GET' && req.query.paginatedSearch === undefined) {


### PR DESCRIPTION
## What does this pull request do?

To update how case-search-text gets assigned.

## What is the intent behind these changes?

To provide a fix on resolving a number of alerts on Production highlighting a TypeError - `Cannot set properties of undefined (setting 'case-search-text').`
