### PR TITLE
IPB-1489: Removed call to display downtime banner for Delius update

### DIFF
--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -13,11 +13,6 @@
 {% endblock %}
 
 {% block pageContent %}
-
-  {% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-  {% endif %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,11 +12,6 @@
 {% endblock %}
 
 {% block pageContent %}
-
-  {% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-  {% endif %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>


### PR DESCRIPTION
## What does this pull request do?

Removes call to downtime banner from main.

## What is the intent behind these changes?

To remove the downtime banner as it's no longer needed
