### PR TITLE
crs home page and redirections

### DIFF
--- a/integration_tests/integration/dashboards.cy.js
+++ b/integration_tests/integration/dashboards.cy.js
@@ -68,7 +68,7 @@ describe('Dashboards', () => {
     describe('Viewing the dashboard page', () => {
       it('shows a list of sent referrals', () => {
         cy.login()
-
+        cy.contains('a', 'View referrals').click()
         cy.get('h1').contains('Open cases')
 
         cy.get('table')
@@ -98,6 +98,7 @@ describe('Dashboards', () => {
       describe('Selecting "Unassigned cases"', () => {
         it('should see "Unassigned cases"', () => {
           cy.login()
+          cy.contains('a', 'View referrals').click()
           cy.get('h1').contains('Open cases')
           cy.contains('Unassigned cases').click()
           cy.get('h1').contains('Unassigned cases')
@@ -127,6 +128,7 @@ describe('Dashboards', () => {
       describe('Selecting "Completed cases"', () => {
         it('should see "Completed cases"', () => {
           cy.login()
+          cy.contains('a', 'View referrals').click()
           cy.get('h1').contains('Open cases')
           cy.contains('Completed cases').click()
           cy.get('h1').contains('Completed cases')
@@ -158,6 +160,7 @@ describe('Dashboards', () => {
       describe('Selecting "Cancelled cases"', () => {
         it('should see "Cancelled cases"', () => {
           cy.login()
+          cy.contains('a', 'View referrals').click()
           cy.get('h1').contains('Open cases')
           cy.contains('Cancelled cases').click()
           cy.get('h1').contains('Cancelled cases')
@@ -189,8 +192,6 @@ describe('Dashboards', () => {
       describe('Selecting "Draft cases"', () => {
         it('should see "Draft cases"', () => {
           cy.login()
-          // check if the page is accessible from the CRS homepage
-          cy.visit('/crs-homepage')
           cy.contains('a', 'View referrals').click()
           cy.get('h1').contains('Open cases')
           cy.contains('Draft cases').click()
@@ -228,6 +229,7 @@ describe('Dashboards', () => {
         headings.forEach(heading => {
           it(`when sorted by ${heading} sort direction should be set on header`, () => {
             cy.login()
+            cy.contains('a', 'View referrals').click()
             cy.get('h1').contains('Open cases')
 
             cy.get('table').within(() => cy.contains('button', heading).click())

--- a/integration_tests/integration/findInterventions.cy.js
+++ b/integration_tests/integration/findInterventions.cy.js
@@ -16,17 +16,6 @@ context('Find an intervention', () => {
     cy.login()
   })
 
-  it('Probation practitioner clicks the find interventions tab', () => {
-    cy.visit('/probation-practitioner/find')
-
-    cy.get('[data-cy=download-interventions-header]').contains('Download structured interventions')
-
-    cy.get('[data-cy=download-interventions-content]').contains(
-      'You can download information about structured interventions. You cannot use this service to search for (or refer) to these interventions. This list was updated in April 2022.'
-    )
-    cy.get('[data-cy=find-interventions-button]').contains('Find interventions')
-  })
-
   it('Probation practitioner views a list of search results', () => {
     const thinkingAndBehaviourInterventionId = '6bf9d895-0d61-4b99-af91-f343befbc9a3'
 
@@ -82,12 +71,5 @@ context('Find an intervention', () => {
 
     cy.get('h1').contains('Better solutions (anger management)')
     cy.contains('Thinking and behaviour')
-
-    // check if the page is accessible from the CRS homepage
-    cy.visit('/crs-homepage')
-    cy.contains('a', 'Find a CRS intervention and make a referral').click()
-
-    cy.get('h1').contains('Find interventions')
-    cy.contains('2 results found')
   })
 })

--- a/integration_tests/integration/login.cy.js
+++ b/integration_tests/integration/login.cy.js
@@ -27,7 +27,7 @@ context('Login', () => {
     })
 
     it('the user is redirected to the referral start page', () => {
-      cy.location('pathname').should('equal', '/probation-practitioner/dashboard')
+      cy.location('pathname').should('equal', '/crs-homepage')
     })
 
     it('the user name is visible in the header', () => {
@@ -46,7 +46,7 @@ context('Login', () => {
     })
 
     it('the user can sign out', () => {
-      cy.location('pathname').should('eq', '/probation-practitioner/dashboard')
+      cy.location('pathname').should('eq', '/crs-homepage')
       cy.get('[data-qa=sign-out]').click()
       cy.location('pathname').should('eq', '/sign-out/success')
     })

--- a/integration_tests/integration/probationPractitionerReferrals.cy.js
+++ b/integration_tests/integration/probationPractitionerReferrals.cy.js
@@ -65,7 +65,7 @@ describe('Probation practitioner referrals dashboard', () => {
     cy.stubGetSentReferralsForUserTokenPaged(page)
 
     cy.login()
-
+    cy.contains('a', 'View referrals').click()
     cy.get('h1').contains('Open cases')
 
     cy.get('table')
@@ -1164,6 +1164,7 @@ describe('Probation practitioner referrals dashboard', () => {
         cy.stubGetPrisonerDetails(referral.referral.serviceUser.crn, prisoner.build())
 
         cy.login()
+        cy.contains('a', 'View referrals').click()
 
         cy.get('a').contains(table.dashboardType).click()
         cy.location('pathname').should('equal', `/probation-practitioner/dashboard/${table.pathname}`)

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -14,7 +14,7 @@ describe('GET /', () => {
   describe('when logged in as a probation practitioner', () => {
     it('redirects to the referral start page', () => {
       const app = appWithAllRoutes({ userType: AppSetupUserType.probationPractitioner })
-      return request(app).get('/').expect(302).expect('Location', '/probation-practitioner/dashboard')
+      return request(app).get('/').expect(302).expect('Location', '/crs-homepage')
     })
   })
 
@@ -36,11 +36,11 @@ describe('check response headers are set correctly', () => {
     const response = await request(app).get('/')
     expect(response.header).toMatchObject({
       connection: 'close',
-      'content-length': '55',
+      'content-length': '35',
       'content-security-policy': expect.any(String),
       'content-type': 'text/plain; charset=utf-8',
       date: expect.any(String),
-      location: '/probation-practitioner/dashboard',
+      location: '/crs-homepage',
       'referrer-policy': 'no-referrer',
       'strict-transport-security': 'max-age=31536000; includeSubDomains',
       vary: 'Accept',

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -47,7 +47,7 @@ export default function routes(router: Router, services: Services): Router {
   get(router, '/', (req, res, next) => {
     const { authSource } = res.locals.user
     if (authSource === 'delius') {
-      res.redirect('/probation-practitioner/dashboard')
+      res.redirect('/crs-homepage')
     } else {
       res.redirect('/service-provider/dashboard')
     }

--- a/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
+++ b/server/routes/probationPractitionerReferrals/probationPractitionerReferralsController.test.ts
@@ -125,12 +125,9 @@ describe('GET /probation-practitioner/find', () => {
 
     await request(app)
       .get('/probation-practitioner/find')
-      .expect(200)
+      .expect(302)
       .expect(res => {
-        expect(res.text).toContain('Refer and monitor an intervention')
-        expect(res.text).toContain('Find interventions')
-        expect(res.text).toContain('Alex River')
-        expect(res.text).toContain('Accommodation')
+        expect(res.text).toContain('Found. Redirecting to /crs-homepage')
       })
   })
 })

--- a/server/routes/probationPractitionerRoutes.ts
+++ b/server/routes/probationPractitionerRoutes.ts
@@ -53,7 +53,7 @@ export default function probationPractitionerRoutes(router: Router, services: Se
   )
   get(router, '/dashboard/draft-cases', (req, res) => probationPractitionerReferralsController.showDraftCases(req, res))
 
-  get(router, '/find', (req, res) => probationPractitionerReferralsController.showFindStartPage(req, res))
+  get(router, '/find', (req, res) => res.redirect('/crs-homepage'))
 
   get(router, '/referrals/:id/progress', (req, res) =>
     probationPractitionerReferralsController.showInterventionProgress(req, res)

--- a/server/views/crsHome/index.njk
+++ b/server/views/crsHome/index.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
+{% set mainTitle = "Interventions" %}
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitleOverride = "Commissioned Rehabilitative Service" %}

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -8,7 +8,7 @@
         <span id="hmpps-title">
           HMPPS
         </span>
-        <span id="main-title">Refer and monitor an intervention</span>
+        <span id="main-title">{{ mainTitle or "Refer and monitor an intervention" }}</span>
       </div>
     </a>
 


### PR DESCRIPTION
## What does this pull request do?

- CRS home page
- Redirection of find-interventions to crs home page
- redirection of successful login to crs home page

## What is the intent behind these changes?

- We now have CRS home page which should be the landing page for the clients
