### PR TITLE
removing survey monkey url from the referral confirmation page

### DIFF
--- a/server/views/makeAReferral/confirmation.njk
+++ b/server/views/makeAReferral/confirmation.njk
@@ -23,9 +23,6 @@
       {{ presenter.text.whatHappensNext }}
       </p>
 
-      <p class="govuk-body">
-      <a href="https://eu.surveymonkey.com/r/369L5GL" class="govuk-link">What do you think of this process?</a> This takes a few minutes.
-      </p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

- removes survey monkey url from the referral confirmation page

## What is the intent behind these changes?

- The draft referral submission has a survey monkey link which needs to be removed
