### PR TITLE
IPB-1503: Updated navigation when starting or accessing Draft Referrals

### DIFF
--- a/server/routes/makeAReferral/community-allocated-form/communityAllocatedPresenter.test.ts
+++ b/server/routes/makeAReferral/community-allocated-form/communityAllocatedPresenter.test.ts
@@ -36,7 +36,7 @@ describe('CommunityAllocatedPresenter', () => {
         .serviceCategorySelected()
         .serviceUserSelected()
         .build({ serviceUser: { firstName: 'Geoffrey', lastName: 'Blue' } })
-      const presenter = new CommunityAllocatedPresenter(referral)
+      const presenter = new CommunityAllocatedPresenter(referral, null, null, true)
 
       expect(presenter.backLinkUrl).toBe(`/intervention/${referral.interventionId}/refer?`)
       expect(presenter.text).toEqual({

--- a/server/routes/makeAReferral/community-allocated-form/communityAllocatedPresenter.ts
+++ b/server/routes/makeAReferral/community-allocated-form/communityAllocatedPresenter.ts
@@ -5,12 +5,17 @@ import PresenterUtils from '../../../utils/presenterUtils'
 export default class CommunityAllocatedPresenter {
   readonly backLinkUrl: string
 
+  readonly caseIdentifierPage = `/intervention/${this.referral.interventionId}/refer?`
+
+  readonly draftTabPage = `/probation-practitioner/dashboard/draft-cases`
+
   constructor(
     readonly referral: DraftReferral,
     private readonly error: FormValidationError | null = null,
-    private readonly userInputData: Record<string, unknown> | null = null
+    private readonly userInputData: Record<string, unknown> | null = null,
+    readonly startReferral: boolean = false
   ) {
-    this.backLinkUrl = `/intervention/${referral.interventionId}/refer?`
+    this.backLinkUrl = startReferral ? this.caseIdentifierPage : this.draftTabPage
   }
 
   private errorMessageForField(field: string): string | null {

--- a/server/routes/makeAReferral/form/referralFormPresenter.ts
+++ b/server/routes/makeAReferral/form/referralFormPresenter.ts
@@ -15,18 +15,28 @@ export default class ReferralFormPresenter {
 
   readonly backLinkUrl: string
 
+  readonly prisonReleaseFormPage = `/referrals/${this.referral.id}/prison-release-form`
+
+  readonly prisonReleaseFormPageWithParams = `${this.prisonReleaseFormPage}?startReferral=true`
+
+  readonly referralTypeFormPage = `/referrals/${this.referral.id}/referral-type-form`
+
+  readonly referralTypeFormPageWithParams = `${this.referralTypeFormPage}?startReferral=true`
+
   constructor(
     private readonly referral: DraftReferral,
     private readonly intervention: Intervention,
-    private readonly draftOasysRiskInformation: DraftOasysRiskInformation | null = null
+    private readonly draftOasysRiskInformation: DraftOasysRiskInformation | null = null,
+    readonly startReferral: boolean = false
   ) {
     this.taskValues = new TaskValues(referral, draftOasysRiskInformation)
     this.sectionValues = new SectionValues(this.taskValues)
     this.formSectionBuilder = new FormSectionBuilder(referral, intervention, this.taskValues, this.sectionValues)
-    this.backLinkUrl =
-      this.referral.isReferralReleasingIn12Weeks !== null
-        ? `/referrals/${referral.id}/prison-release-form`
-        : `/referrals/${referral.id}/referral-type-form`
+    if (this.referral.isReferralReleasingIn12Weeks !== null) {
+      this.backLinkUrl = startReferral ? this.prisonReleaseFormPageWithParams : this.prisonReleaseFormPage
+    } else {
+      this.backLinkUrl = startReferral ? this.referralTypeFormPageWithParams : this.referralTypeFormPage
+    }
   }
 
   readonly crnDescription = `${this.referral.serviceUser?.firstName} ${this.referral.serviceUser?.lastName} (CRN: ${this.referral.serviceUser?.crn})`

--- a/server/routes/makeAReferral/makeAReferralController.test.ts
+++ b/server/routes/makeAReferral/makeAReferralController.test.ts
@@ -136,7 +136,7 @@ describe('POST /intervention/:id/refer', () => {
         .post(`/intervention/${interventionId}/refer`)
         .send({ 'service-user-crn': serviceUserCRN })
         .expect(301)
-        .expect('Location', '/referrals/1/community-allocated-form')
+        .expect('Location', '/referrals/1/community-allocated-form?startReferral=true')
 
       expect(auditService.logSearchServiceUser).toHaveBeenCalledWith({
         details: { identifier: 'X123456' },
@@ -178,7 +178,7 @@ describe('POST /intervention/:id/refer', () => {
         .post(`/intervention/${interventionId}/refer`)
         .send({ 'service-user-crn': serviceUserCRN })
         .expect(301)
-        .expect('Location', '/referrals/1/community-allocated-form')
+        .expect('Location', '/referrals/1/community-allocated-form?startReferral=true')
 
       expect(auditService.logSearchServiceUser).toHaveBeenCalledWith({
         details: { identifier: 'X123456' },
@@ -215,7 +215,7 @@ describe('POST /intervention/:id/refer', () => {
           .post(`/intervention/${interventionId}/refer`)
           .send({ 'service-user-crn': serviceUserCRN })
           .expect(301)
-          .expect('Location', '/referrals/1/community-allocated-form')
+          .expect('Location', '/referrals/1/community-allocated-form?startReferral=true')
 
         expect(ramDeliusApiService.getCaseDetailsByCrn).toHaveBeenCalledWith(serviceUserCRNTrimmed)
         expect(interventionsService.createDraftReferral).toHaveBeenCalledWith(
@@ -235,7 +235,7 @@ describe('POST /intervention/:id/refer', () => {
           .post(`/intervention/${interventionId}/refer`)
           .send({ 'service-user-crn': serviceUserCRN })
           .expect(301)
-          .expect('Location', '/referrals/1/community-allocated-form')
+          .expect('Location', '/referrals/1/community-allocated-form?startReferral=true')
 
         expect(ramDeliusApiService.getCaseDetailsByCrn).toHaveBeenCalledWith(serviceUserCRNTransformed)
         expect(interventionsService.createDraftReferral).toHaveBeenCalledWith(

--- a/server/routes/makeAReferral/prison-release-form/prisonReleasePresenter.ts
+++ b/server/routes/makeAReferral/prison-release-form/prisonReleasePresenter.ts
@@ -5,12 +5,17 @@ import PresenterUtils from '../../../utils/presenterUtils'
 export default class PrisonReleasePresenter {
   readonly backLinkUrl: string
 
+  readonly communityAllocatedPage = `/referrals/${this.referral.id}/community-allocated-form`
+
+  readonly communityAllocatedPageWithParams = `${this.communityAllocatedPage}?startReferral=true`
+
   constructor(
     readonly referral: DraftReferral,
     private readonly error: FormValidationError | null = null,
-    private readonly userInputData: Record<string, unknown> | null = null
+    private readonly userInputData: Record<string, unknown> | null = null,
+    readonly startReferral: boolean = false
   ) {
-    this.backLinkUrl = `/referrals/${referral.id}/community-allocated-form`
+    this.backLinkUrl = startReferral ? this.communityAllocatedPageWithParams : this.communityAllocatedPage
   }
 
   private errorMessageForField(field: string): string | null {

--- a/server/routes/makeAReferral/referral-type-form/referralTypePresenter.ts
+++ b/server/routes/makeAReferral/referral-type-form/referralTypePresenter.ts
@@ -5,12 +5,17 @@ import PresenterUtils from '../../../utils/presenterUtils'
 export default class ReferralTypePresenter {
   readonly backLinkUrl: string
 
+  readonly communityAllocatedPage = `/referrals/${this.referral.id}/community-allocated-form`
+
+  readonly communityAllocatedPageWithParams = `${this.communityAllocatedPage}?startReferral=true`
+
   constructor(
     readonly referral: DraftReferral,
     private readonly error: FormValidationError | null = null,
-    private readonly userInputData: Record<string, unknown> | null = null
+    private readonly userInputData: Record<string, unknown> | null = null,
+    readonly startReferral: boolean = false
   ) {
-    this.backLinkUrl = `/referrals/${referral.id}/community-allocated-form`
+    this.backLinkUrl = startReferral ? this.communityAllocatedPageWithParams : this.communityAllocatedPage
   }
 
   private errorMessageForField(field: string): string | null {

--- a/server/routes/makeAReferral/start/referralStartPresenter.ts
+++ b/server/routes/makeAReferral/start/referralStartPresenter.ts
@@ -2,10 +2,16 @@ import { FormValidationError } from '../../../utils/formValidationError'
 import PresenterUtils from '../../../utils/presenterUtils'
 
 export default class ReferralStartPresenter {
+  readonly backLinkUrl: string
+
+  readonly interventionDetailsPage = `/find-interventions/intervention/${this.interventionId}`
+
   constructor(
     private readonly interventionId: string,
     private readonly error: FormValidationError | null = null
-  ) {}
+  ) {
+    this.backLinkUrl = this.interventionDetailsPage
+  }
 
   readonly text = {
     errorMessage: PresenterUtils.errorMessage(this.error, 'service-user-crn'),

--- a/server/routes/makeAReferral/start/referralStartView.ts
+++ b/server/routes/makeAReferral/start/referralStartView.ts
@@ -25,6 +25,7 @@ export default class ReferralStartView {
       {
         presenter: this.presenter,
         crnInputArgs: this.crnInputArgs(),
+        backLinkArgs: { href: this.presenter.backLinkUrl },
       },
     ]
   }

--- a/server/views/makeAReferral/start.njk
+++ b/server/views/makeAReferral/start.njk
@@ -1,5 +1,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -7,6 +9,8 @@
 {% set pageSubTitle = "Enter the person's case identifier" %}
 
 {% block pageContent %}
+  {{ govukBackLink(backLinkArgs) }}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
@@ -15,20 +19,26 @@
 
       <p class="govuk-body-l">This will retrieve the person on probation's record</p>
 
-      <form action="{{presenter.hrefStartReferral}}" method="POST">
-        <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      {% set href = presenter.hrefStartReferral or '' %}
+      <form action="{{ href.split('?')[0] }}" method="POST">
+          <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
-        {{govukInput(crnInputArgs)}}
+          {{govukInput(crnInputArgs)}}
 
-        <p>These details will be imported</p>
+          <p>These details will be imported</p>
 
-        <button role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button" data-prevent-double-click="true">
-          Continue
-          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" aria-hidden="true" focusable="false">
-            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
-          </svg>
-        </button>
+          {% if href and '?' in href %}
+              {% set queryString = href.split('?')[1] %}
+              {% for param in queryString.split('&') %}
+                  {% set pair = param.split('=') %}
+                  <input type="hidden" name="{{ pair[0] }}" value="{{ pair[1] }}">
+              {% endfor %}
+          {% endif %}
+
+          {{ govukButton({ text: "Continue" }) }}
       </form>
+
+
   </div>
 
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Updates the flow of accessing Draft referrals from 2 Entry points - When making a Referral and how a Draft referral can routed back to the draft page where it may have been initially selected.

## What is the intent behind these changes?

To enhance the user experience when complete a Referral over multiple visits of the service
