### PR TITLE
Enabling accessibility for pp details screen

### DIFF
--- a/server/routes/makeAReferral/confirm-probation-practitioner-details/confirmProbationPractitionerDetailsPresenter.test.ts
+++ b/server/routes/makeAReferral/confirm-probation-practitioner-details/confirmProbationPractitionerDetailsPresenter.test.ts
@@ -135,6 +135,7 @@ describe('ConfirmProbationPractitionerDetailsPresenter', () => {
           key: 'Name',
           lines: ['Alex River'],
           changeLink: `/referrals/${referral.id}/update-probation-practitioner-name`,
+          hiddenText: 'Name',
         },
         {
           key: 'Email address',
@@ -142,6 +143,7 @@ describe('ConfirmProbationPractitionerDetailsPresenter', () => {
           changeLink: `/referrals/${referral.id}/update-probation-practitioner-email-address`,
           deleteLink: `/referrals/${referral.id}/delete-probation-practitioner/email-address`,
           valueLink: undefined,
+          hiddenText: 'Email address',
         },
         {
           key: 'Phone number',
@@ -149,11 +151,13 @@ describe('ConfirmProbationPractitionerDetailsPresenter', () => {
           changeLink: `/referrals/${referral.id}/update-probation-practitioner-phone-number`,
           deleteLink: `/referrals/${referral.id}/delete-probation-practitioner/phone-number`,
           valueLink: undefined,
+          hiddenText: 'Phone number',
         },
         {
           key: 'PDU (Probation Delivery Unit)',
           lines: ['London'],
           changeLink: `/referrals/${referral.id}/update-probation-practitioner-pdu`,
+          hiddenText: 'PDU (Probation Delivery Unit)',
         },
         {
           key: 'Probation office',
@@ -161,6 +165,7 @@ describe('ConfirmProbationPractitionerDetailsPresenter', () => {
           changeLink: `/referrals/${referral.id}/update-probation-practitioner-office`,
           deleteLink: `/referrals/${referral.id}/delete-probation-practitioner/probation-office`,
           valueLink: undefined,
+          hiddenText: 'Probation office',
         },
         {
           key: 'Team phone number',
@@ -168,6 +173,7 @@ describe('ConfirmProbationPractitionerDetailsPresenter', () => {
           changeLink: `/referrals/${referral.id}/update-probation-practitioner-team-phone-number`,
           deleteLink: `/referrals/${referral.id}/delete-probation-practitioner/team-phone-number`,
           valueLink: undefined,
+          hiddenText: 'Team phone number',
         },
       ])
     })
@@ -209,38 +215,45 @@ describe('ConfirmProbationPractitionerDetailsPresenter', () => {
           key: 'Name',
           lines: ['Alex River'],
           changeLink: `/referrals/${referral.id}/update-probation-practitioner-name`,
+          hiddenText: 'Name',
         },
         {
           key: 'Email address',
           lines: [`Not found`],
           changeLink: undefined,
           deleteLink: undefined,
-          valueLink: `<a href="/referrals/${referral.id}/update-probation-practitioner-email-address" class="govuk-link">Enter email address</a>`,
+          valueLink:
+            '<a href="/referrals/6/update-probation-practitioner-email-address" class="govuk-link">Enter email address<span class="govuk-visually-hidden">Email address</span></a>',
+          hiddenText: 'Email address',
         },
         {
           key: 'Phone number',
           lines: [`Not found`],
           changeLink: undefined,
           deleteLink: undefined,
-          valueLink: `<a href="/referrals/${referral.id}/update-probation-practitioner-phone-number" class="govuk-link">Enter phone number</a>`,
+          hiddenText: 'Phone number',
+          valueLink: `<a href="/referrals/6/update-probation-practitioner-phone-number" class="govuk-link">Enter phone number<span class="govuk-visually-hidden">Phone number</span></a>`,
         },
         {
           key: 'PDU (Probation Delivery Unit)',
           lines: ['London'],
           changeLink: `/referrals/${referral.id}/update-probation-practitioner-pdu`,
+          hiddenText: 'PDU (Probation Delivery Unit)',
         },
         {
           key: 'Probation office',
           lines: [`Not found`],
           changeLink: undefined,
           deleteLink: undefined,
-          valueLink: `<a href="/referrals/${referral.id}/update-probation-practitioner-office" class="govuk-link">Enter probation office</a>`,
+          hiddenText: 'Probation office',
+          valueLink: `<a href="/referrals/6/update-probation-practitioner-office" class="govuk-link">Enter probation office<span class="govuk-visually-hidden">Probation office</span></a>`,
         },
         {
           key: 'Team phone number',
           lines: [`Not found`],
           changeLink: undefined,
-          valueLink: `<a href="/referrals/${referral.id}/update-probation-practitioner-team-phone-number" class="govuk-link">Enter team phone number</a>`,
+          hiddenText: 'Team phone number',
+          valueLink: `<a href="/referrals/6/update-probation-practitioner-team-phone-number" class="govuk-link">Enter team phone number<span class="govuk-visually-hidden">Team phone number</span></a>`,
           deleteLink: undefined,
         },
       ])

--- a/server/routes/makeAReferral/confirm-probation-practitioner-details/confirmProbationPractitionerDetailsPresenter.ts
+++ b/server/routes/makeAReferral/confirm-probation-practitioner-details/confirmProbationPractitionerDetailsPresenter.ts
@@ -33,6 +33,7 @@ export default class ConfirmProbationPractitionerDetailsPresenter {
             'Not found',
         ],
         changeLink: `/referrals/${this.referral.id}/update-probation-practitioner-name`,
+        hiddenText: 'Name',
       },
       {
         key: 'Email address',
@@ -47,8 +48,9 @@ export default class ConfirmProbationPractitionerDetailsPresenter {
             : undefined,
         valueLink:
           this.determineEmail() === 'Not found'
-            ? `<a href="/referrals/${this.referral.id}/update-probation-practitioner-email-address" class="govuk-link">Enter email address</a>`
+            ? `<a href="/referrals/${this.referral.id}/update-probation-practitioner-email-address" class="govuk-link">Enter email address<span class="govuk-visually-hidden">Email address</span></a>`
             : undefined,
+        hiddenText: 'Email address',
       },
       {
         key: 'Phone number',
@@ -59,24 +61,26 @@ export default class ConfirmProbationPractitionerDetailsPresenter {
             : undefined,
         valueLink:
           this.determinePhoneNumber() === 'Not found'
-            ? `<a href="/referrals/${this.referral.id}/update-probation-practitioner-phone-number" class="govuk-link">Enter phone number</a>`
+            ? `<a href="/referrals/${this.referral.id}/update-probation-practitioner-phone-number" class="govuk-link">Enter phone number<span class="govuk-visually-hidden">Phone number</span></a>`
             : undefined,
         deleteLink:
           this.determinePhoneNumber() !== 'Not found'
             ? `/referrals/${this.referral.id}/delete-probation-practitioner/phone-number`
             : undefined,
+        hiddenText: 'Phone number',
       },
       {
         key: 'PDU (Probation Delivery Unit)',
         lines: [this.referral.ppPdu || this.referral.ndeliusPDU || 'Not found'],
         changeLink: `/referrals/${this.referral.id}/update-probation-practitioner-pdu`,
+        hiddenText: 'PDU (Probation Delivery Unit)',
       },
       {
         key: 'Probation office',
         lines: [this.determineProbationOffice()],
         valueLink:
           this.determineProbationOffice() === 'Not found'
-            ? `<a href="/referrals/${this.referral.id}/update-probation-practitioner-office" class="govuk-link">Enter probation office</a>`
+            ? `<a href="/referrals/${this.referral.id}/update-probation-practitioner-office" class="govuk-link">Enter probation office<span class="govuk-visually-hidden">Probation office</span></a>`
             : undefined,
 
         changeLink:
@@ -87,6 +91,7 @@ export default class ConfirmProbationPractitionerDetailsPresenter {
           this.determineProbationOffice() !== 'Not found'
             ? `/referrals/${this.referral.id}/delete-probation-practitioner/probation-office`
             : undefined,
+        hiddenText: 'Probation office',
       },
       {
         key: 'Team phone number',
@@ -97,12 +102,13 @@ export default class ConfirmProbationPractitionerDetailsPresenter {
             : undefined,
         valueLink:
           this.determineTeamPhoneNumber() === 'Not found'
-            ? `<a href="/referrals/${this.referral.id}/update-probation-practitioner-team-phone-number" class="govuk-link">Enter team phone number</a>`
+            ? `<a href="/referrals/${this.referral.id}/update-probation-practitioner-team-phone-number" class="govuk-link">Enter team phone number<span class="govuk-visually-hidden">Team phone number</span></a>`
             : undefined,
         deleteLink:
           this.determineTeamPhoneNumber() !== 'Not found'
             ? `/referrals/${this.referral.id}/delete-probation-practitioner/team-phone-number`
             : undefined,
+        hiddenText: 'Team phone number',
       },
     ]
     return summary

--- a/server/utils/summaryList.ts
+++ b/server/utils/summaryList.ts
@@ -14,4 +14,5 @@ export interface SummaryListItem {
   changeLink?: string
   deleteLink?: string
   valueLink?: string
+  hiddenText?: string
 }

--- a/server/utils/viewUtils.test.ts
+++ b/server/utils/viewUtils.test.ts
@@ -115,6 +115,7 @@ describe('ViewUtils', () => {
                   href: '/risks',
                   text: 'Change',
                   attributes: { id: `change-link-0` },
+                  visuallyHiddenText: null,
                 },
               ],
             },

--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -111,6 +111,7 @@ export default class ViewUtils {
                   href: item.deleteLink,
                   text: 'Delete',
                   attributes: { id: `delete-link-${index}` },
+                  visuallyHiddenText: item.hiddenText || null,
                 })
               }
               if (item.changeLink) {
@@ -118,6 +119,7 @@ export default class ViewUtils {
                   href: item.changeLink,
                   text: 'Change',
                   attributes: { id: `change-link-${index}` },
+                  visuallyHiddenText: item.hiddenText || null,
                 })
               }
               return items


### PR DESCRIPTION
## What does this pull request do?

- introduces hidden texts for every link confirm pp details screen

## What is the intent behind these changes?

- introducing hidden texts will enable screen reader to read those lines for accessibility user
