### PR TITLE
IPB-1552: Removed call to display downtime banner

### DIFF
--- a/server/views/crsHome/index.njk
+++ b/server/views/crsHome/index.njk
@@ -7,9 +7,6 @@
 {% set mainClasses = "app-container govuk-body dashboard__main" %}
 
 {% block pageContent %}
-  {% if disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-  {% endif %}
 
   {{ govukBackLink(backLinkArgs) }}
   

--- a/server/views/findInterventions/searchResults.njk
+++ b/server/views/findInterventions/searchResults.njk
@@ -11,9 +11,6 @@
 
 
 {% block pageContent %}
-  {% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-  {% endif %}
   <div class="govuk-grid-row app-grid-container">
     <div class="govuk-grid-column-one-half">
         {{ govukBackLink(backLinkArgs) }}

--- a/server/views/probationPractitionerReferrals/dashboard.njk
+++ b/server/views/probationPractitionerReferrals/dashboard.njk
@@ -12,9 +12,6 @@
 
 
 {% block pageContent %}
-  {% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-  {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <div class="govuk-grid-row app-grid-container">

--- a/server/views/serviceProviderReferrals/dashboard.njk
+++ b/server/views/serviceProviderReferrals/dashboard.njk
@@ -12,9 +12,6 @@
 {% endblock %}
 
 {% block pageContent %}
-  {% if presenter.disableDowntimeBanner != true %}
-    {{ govukNotificationBanner(serviceOutageBannerArgs) }}
-  {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ presenter.title }}</h1>


### PR DESCRIPTION
## What does this pull request do?

Removes downtime banner from the UI

## What is the intent behind these changes?

To no longer display the downtime banner as normal service is resumed
