### PR TITLE
adding a query parameter to intervention api

### DIFF
--- a/server/routes/findInterventions/findInterventionsController.ts
+++ b/server/routes/findInterventions/findInterventionsController.ts
@@ -44,7 +44,8 @@ export default class FindInterventionsController {
   async viewInterventionDetails(req: Request, res: Response): Promise<void> {
     const intervention = await this.interventionsService.getIntervention(
       res.locals.user.token.accessToken,
-      req.params.id
+      req.params.id,
+      true
     )
 
     const presenter = new InterventionDetailsPresenter(intervention, res.locals.user)

--- a/server/services/interventionsService.ts
+++ b/server/services/interventionsService.ts
@@ -566,12 +566,13 @@ export default class InterventionsService {
     })) as Intervention[]
   }
 
-  async getIntervention(token: string, id: string): Promise<Intervention> {
+  async getIntervention(token: string, id: string, checkEndDate = false): Promise<Intervention> {
     const restClient = this.createRestClient(token)
 
     return (await restClient.get({
       path: `/intervention/${id}`,
       headers: { Accept: 'application/json' },
+      ...(checkEndDate ? { query: { checkEndDate: 'true' } } : {}),
     })) as Intervention
   }
 


### PR DESCRIPTION
## What does this pull request do?

- adding a query parameter check end date to intervention api to make
- pass the query parameter only when I call find intervention page

## What is the intent behind these changes?

- This is to fix the issue caused by introducing referral end date 
