### PR TITLE
Revert "downtime banner 13th May 2026 (#2571)"

### DIFF
--- a/server/utils/content.ts
+++ b/server/utils/content.ts
@@ -16,7 +16,7 @@ const content: Content = {
      * To turn on banner: uncomment and modify the content in below "text: 'content'" line
      * To turn off the banner: remove or comment out below "text: xxx" line
      */
-    text: 'Refer and monitor an intervention will be unavailable between 5:30pm on Friday 15 May and 8am on Monday 18 May. This is due to planned maintenance in NDelius.',
+    //text: 'Refer and monitor an intervention will be unavailable between 6pm on Friday 20 March and 8am on Monday 23 March. This is due to planned maintenance in NDelius.',
   },
 }
 export default content


### PR DESCRIPTION
This reverts commit c9324a58f371c94fb650b87bb0d06022462fdd0c.

## What does this pull request do?

- removes the downtime banner

## What is the intent behind these changes?

- delius outage is cancelled. removing the downtime banner
