### PR TITLE
down time banner for 24th July

### DIFF
--- a/server/utils/content.ts
+++ b/server/utils/content.ts
@@ -16,7 +16,7 @@ const content: Content = {
      * To turn on banner: uncomment and modify the content in below "text: 'content'" line
      * To turn off the banner: remove or comment out below "text: xxx" line
      */
-    //text: 'Refer and monitor an intervention will be unavailable between 6pm on Friday 20 March and 8am on Monday 23 March. This is due to planned maintenance in NDelius.',
+    text: 'Refer and monitor an intervention will be unavailable between 6pm on Friday 24 July and 8am on Monday 27 July. This is due to planned maintenance in NDelius.',
   },
 }
 export default content


### PR DESCRIPTION
## What does this pull request do?

- Enables the down time banner for apps to be down by 24th July and will be back by 27th July

## What is the intent behind these changes?

- Delius is down on maintenance during that period
